### PR TITLE
docs: add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AI Coding Guidelines for Real Treasury Business Case Builder
+
+- Follow [WordPress PHP coding standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/).
+- Use four spaces for indentation.
+- Prefix global functions with `rtbcb_`.
+- Prefix class names with `RTBCB_`.
+- Sanitize and escape all input and output with the appropriate `esc_*` function.
+- Wrap user visible strings in translation functions like `__( 'text', 'rtbcb' )`.
+- Do not modify code in the `vendor/` directory; it contains third-party dependencies.
+- After making changes to PHP files, run `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l` to check for syntax errors.

--- a/admin/AGENTS.md
+++ b/admin/AGENTS.md
@@ -1,0 +1,6 @@
+# AI Instructions for admin/
+
+- Contains code for WordPress dashboard functionality.
+- Class files should use the `RTBCB_Admin` prefix.
+- Files ending in `-page.php` should render admin screens; escape all output.
+- Use WordPress nonce functions for form submissions.

--- a/inc/AGENTS.md
+++ b/inc/AGENTS.md
@@ -1,0 +1,6 @@
+# AI Instructions for inc/
+
+- Core PHP classes and helper functions live here.
+- Each class file should be named `class-rtbcb-{feature}.php` and declare a single `RTBCB_{Feature}` class.
+- Add PHPDoc blocks for classes, properties, and methods.
+- Helper functions belong in `helpers.php` and must be prefixed with `rtbcb_`.

--- a/public/AGENTS.md
+++ b/public/AGENTS.md
@@ -1,0 +1,5 @@
+# AI Instructions for public/
+
+- Front-end hooks and assets for the plugin belong here.
+- Use the `RTBCB_Public` prefix for classes.
+- Escape all output before rendering.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -1,0 +1,6 @@
+# AI Instructions for templates/
+
+- PHP template files included by the plugin live here.
+- Keep templates focused on markup; move heavy logic to classes.
+- Escape variables with appropriate `esc_*` functions.
+- Wrap translatable text in `__()` or `_e()` using the `rtbcb` text domain.

--- a/vendor/AGENTS.md
+++ b/vendor/AGENTS.md
@@ -1,0 +1,4 @@
+# AI Instructions for vendor/
+
+- Contains third-party libraries.
+- Do not modify files in this directory.


### PR DESCRIPTION
## Summary
- add repository-wide AI coding guidelines
- document coding conventions for `admin`, `inc`, `public`, and `templates`
- mark `vendor` as read-only third-party code

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a743ac976883318a4226ada5ad4abe