### PR TITLE
Bootstrap plugin and add ROI settings and calculator scaffolding

### DIFF
--- a/inc/class-rtbcb-calculator.php
+++ b/inc/class-rtbcb-calculator.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * ROI calculation utilities.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+
+/**
+ * Class RTBCB_Calculator.
+ */
+class RTBCB_Calculator {
+    /**
+     * Calculate ROI scenarios for given inputs.
+     *
+     * @param array $user_inputs User provided inputs.
+     * @return array
+     */
+    public static function calculate_roi( $user_inputs ) {
+        $settings = RTBCB_Settings::get_all();
+
+        // Calculate scenarios.
+        $scenarios = [];
+        foreach ( [ 'low', 'base', 'high' ] as $scenario ) {
+            $scenarios[ $scenario ] = self::calculate_scenario( $user_inputs, $settings, $scenario );
+        }
+
+        return $scenarios;
+    }
+
+    /**
+     * Calculate ROI for a scenario.
+     *
+     * @param array  $inputs        User inputs.
+     * @param array  $settings      Plugin settings.
+     * @param string $scenario_type Scenario type.
+     * @return array
+     */
+    private static function calculate_scenario( $inputs, $settings, $scenario_type ) {
+        $multipliers = [
+            'low'  => 0.8,
+            'base' => 1.0,
+            'high' => 1.2,
+        ];
+        $multiplier = $multipliers[ $scenario_type ];
+
+        // Labor cost savings.
+        $labor_savings = self::calculate_labor_savings( $inputs, $settings, $multiplier );
+
+        // Bank fee reduction.
+        $fee_savings = self::calculate_fee_savings( $inputs, $settings, $multiplier );
+
+        // Error reduction benefits.
+        $error_reduction = self::calculate_error_reduction( $inputs, $settings, $multiplier );
+
+        $total_annual_benefit = $labor_savings + $fee_savings + $error_reduction;
+
+        return [
+            'labor_savings'        => $labor_savings,
+            'fee_savings'          => $fee_savings,
+            'error_reduction'      => $error_reduction,
+            'total_annual_benefit' => $total_annual_benefit,
+            'assumptions'          => self::get_scenario_assumptions( $scenario_type, $multiplier ),
+        ];
+    }
+
+    // TODO: Implement the private calculation methods:
+    // - calculate_labor_savings( $inputs, $settings, $multiplier )
+    // - calculate_fee_savings( $inputs, $settings, $multiplier )
+    // - calculate_error_reduction( $inputs, $settings, $multiplier )
+    // - get_scenario_assumptions( $scenario_type, $multiplier )
+}

--- a/inc/class-rtbcb-settings.php
+++ b/inc/class-rtbcb-settings.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Settings management for default ROI assumptions.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+
+/**
+ * Class RTBCB_Settings.
+ */
+class RTBCB_Settings {
+    /**
+     * Default settings.
+     *
+     * @var array
+     */
+    const DEFAULTS = [
+        'labor_cost_per_hour'       => 100,
+        'efficiency_ranges'         => [
+            'cash_positioning'       => [ 'min' => 70, 'max' => 80 ],
+            'reconciliation'         => [ 'min' => 60, 'max' => 75 ],
+            'payments'               => [ 'min' => 40, 'max' => 60 ],
+            'forecast_error_reduction' => [ 'min' => 20, 'max' => 30 ],
+        ],
+        'bank_fee_reduction'        => [ 'min' => 5, 'max' => 10 ],
+        'baseline_bank_fee_multiplier' => 15000,
+    ];
+
+    /**
+     * Retrieve a setting value.
+     *
+     * @param string $key     Setting key.
+     * @param mixed  $default Default value.
+     * @return mixed
+     */
+    public static function get_setting( $key, $default = null ) {
+        $settings = get_option( 'rtbcb_settings', self::DEFAULTS );
+        return $settings[ $key ] ?? $default;
+    }
+
+    /**
+     * Retrieve all settings.
+     *
+     * @return array
+     */
+    public static function get_all() {
+        return get_option( 'rtbcb_settings', self::DEFAULTS );
+    }
+}

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1,15 +1,122 @@
 <?php
 /**
- * Plugin Name: Real Treasury Business Case Builder
- * Description: Provides tools to create and manage business case reports.
- * Version: 0.1.0
- * Author: Real Treasury
+ * Plugin Name: Real Treasury - Business Case Builder
+ * Description: ROI calculator and business case generator for treasury technology.
+ * Version: 1.0.0
+ * Requires PHP: 7.4
+ *
+ * @package RealTreasuryBusinessCaseBuilder
  */
 
-// Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-// Placeholder for plugin initialization code.
+define( 'RTBCB_VERSION', '1.0.0' );
+define( 'RTBCB_FILE', __FILE__ );
+define( 'RTBCB_URL', plugin_dir_url( RTBCB_FILE ) );
+define( 'RTBCB_DIR', plugin_dir_path( RTBCB_FILE ) );
 
+/**
+ * Main plugin class.
+ */
+class Real_Treasury_BCB {
+    /**
+     * Singleton instance.
+     *
+     * @var Real_Treasury_BCB|null
+     */
+    private static $instance = null;
+
+    /**
+     * Get plugin instance.
+     *
+     * @return Real_Treasury_BCB
+     */
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Constructor.
+     */
+    private function __construct() {
+        $this->includes();
+        $this->init_hooks();
+    }
+
+    /**
+     * Include required files.
+     *
+     * @return void
+     */
+    private function includes() {
+        require_once RTBCB_DIR . 'inc/class-rtbcb-settings.php';
+        require_once RTBCB_DIR . 'inc/class-rtbcb-calculator.php';
+        require_once RTBCB_DIR . 'inc/class-rtbcb-portal-integration.php';
+        require_once RTBCB_DIR . 'inc/class-rtbcb-leads.php';
+        require_once RTBCB_DIR . 'admin/class-rtbcb-admin.php';
+        // TODO: Add remaining includes as classes are created.
+    }
+
+    /**
+     * Initialize hooks.
+     *
+     * @return void
+     */
+    private function init_hooks() {
+        add_action( 'init', [ $this, 'init' ] );
+        add_shortcode( 'rt_business_case_builder', [ $this, 'shortcode_handler' ] );
+
+        // Portal integration hooks.
+        add_action( 'rt_portal_data_changed', [ $this, 'handle_portal_data_change' ] );
+    }
+
+    /**
+     * Shortcode handler.
+     *
+     * @param array $atts Shortcode attributes.
+     * @return string
+     */
+    public function shortcode_handler( $atts = [] ) {
+        wp_enqueue_style( 'rtbcb-style', RTBCB_URL . 'public/css/rtbcb.css' );
+        wp_enqueue_script( 'rtbcb-script', RTBCB_URL . 'public/js/rtbcb.js', [ 'jquery' ], RTBCB_VERSION, true );
+
+        wp_localize_script(
+            'rtbcb-script',
+            'RTBCB',
+            [
+                'ajax_url' => admin_url( 'admin-ajax.php' ),
+                'nonce'    => wp_create_nonce( 'rtbcb_nonce' ),
+            ]
+        );
+
+        ob_start();
+        include RTBCB_DIR . 'templates/business-case-form.php';
+        return ob_get_clean();
+    }
+
+    /**
+     * Plugin initialization.
+     *
+     * @return void
+     */
+    public function init() {
+        // Initialization tasks.
+    }
+
+    /**
+     * Handle portal data changes.
+     *
+     * @return void
+     */
+    public function handle_portal_data_change() {
+        // Logic to handle data changes from the portal.
+    }
+}
+
+Real_Treasury_BCB::instance();


### PR DESCRIPTION
## Summary
- Bootstrap main plugin file with constants, hook registration and shortcode handler
- Add settings class managing default ROI assumptions
- Add calculator class to generate ROI scenarios with placeholder methods

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a7444fd6408331a4492d278c8f0fa6