### PR TITLE
Ensure admin hooks load by instantiating RTBCB_Admin

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -60,6 +60,7 @@ class Real_Treasury_BCB {
         require_once RTBCB_DIR . 'inc/class-rtbcb-portal-integration.php';
         require_once RTBCB_DIR . 'inc/class-rtbcb-leads.php';
         require_once RTBCB_DIR . 'admin/class-rtbcb-admin.php';
+        new RTBCB_Admin();
         // TODO: Add remaining includes as classes are created.
     }
 


### PR DESCRIPTION
## Summary
- instantiate `RTBCB_Admin` after including admin class so admin hooks register

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a74a0fe54c8331a45ab14dc1a80f30