### PR TITLE
Allow modal wizard steps to scroll

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -878,7 +878,7 @@
 /* Modal Body - Scrollable content */
 .rtbcb-modal-body {
     max-height: calc(80vh - 100px);
-    overflow: visible;
+    overflow-y: auto;
 }
 
 .rtbcb-form-container {
@@ -965,8 +965,8 @@
 /* Steps Container - Fixed height and overflow */
 .rtbcb-wizard-steps {
     position: relative;
-    min-height: 300px;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 .rtbcb-wizard-step {


### PR DESCRIPTION
## Summary
- Let modal body scroll vertically so lengthy content isn't cut off
- Permit wizard steps container to scroll and remove fixed min-height

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a77d9b3cb88331a6ff0c606dc92a4b