### PR TITLE
Display success message and link after business case generation

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -650,6 +650,20 @@
     font-size: 16px;
 }
 
+.rtbcb-success-message {
+    background: #ecfdf5;
+    color: var(--success-green);
+    border: 2px solid var(--success-green);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin: 20px 0;
+}
+
+.rtbcb-success-message a {
+    color: var(--primary-purple);
+    text-decoration: underline;
+}
+
 /* Animations */
 @keyframes rtbcb-spin {
     to {

--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -473,6 +473,10 @@ class BusinessCaseBuilder {
             if (data.success) {
                 this.completeProgress();
                 this.displayResults(data.data);
+                this.showSuccess(data.data.download_url);
+                if (this.form) {
+                    this.form.style.display = 'none';
+                }
                 this.trackAnalytics('business_case_generated', {
                     category: data.data.recommendation?.recommended,
                     roi_base: data.data.scenarios?.base?.total_annual_benefit
@@ -572,6 +576,22 @@ class BusinessCaseBuilder {
         this.prevBtn.disabled = false;
         this.submitBtn.disabled = false;
         this.submitBtn.classList.remove('loading');
+    }
+
+    showSuccess(downloadUrl) {
+        const container = document.getElementById('rtbcbSuccessMessage');
+        if (!container) {
+            return;
+        }
+
+        let message = 'Your business case is ready!';
+        if (downloadUrl) {
+            const url = this.escapeHtml(downloadUrl);
+            message += ` <a href="${url}" target="_blank" rel="noopener noreferrer">Download your report</a>`;
+        }
+
+        container.innerHTML = message;
+        container.style.display = 'block';
     }
 
     showError(message) {

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -339,6 +339,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
         </div>
                 </form>
             </div>
+            <div id="rtbcbSuccessMessage" class="rtbcb-success-message" style="display:none"></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Add hidden success message container to business case modal
- Show success message with optional download link after generating results
- Style success message container for visibility

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a77daa5d388331b6169fd660839368