### PR TITLE
Ensure dropdown placeholders are fully visible

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -1052,6 +1052,7 @@
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
+    min-width: 280px;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236b7280' d='M10.293 3.293L6 7.586 1.707 3.293A1 1 0 00.293 4.707l5 5a1 1 0 001.414 0l5-5a1 1 0 10-1.414-1.414z'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
     background-position: right 12px center;


### PR DESCRIPTION
## Summary
- add a min-width to `.rtbcb-field select` so long placeholder text like "Select your company size..." shows entirely

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `node test-select-width-text.js`

------
https://chatgpt.com/codex/tasks/task_e_68a77d3e5a0083319812db16d0cd2f77