### PR TITLE
Localize AJAX data for frontend script

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -356,6 +356,24 @@ class Real_Treasury_BCB {
             RTBCB_VERSION,
             true
         );
+        wp_localize_script(
+            'rtbcb-script',
+            'ajaxObj',
+            [
+                'ajax_url' => admin_url( 'admin-ajax.php' ),
+                'nonce'    => wp_create_nonce( 'my_action_nonce' ),
+                'strings'  => [
+                    'error'           => __( 'An error occurred. Please try again.', 'rtbcb' ),
+                    'generating'      => __( 'Generating your business case...', 'rtbcb' ),
+                    'invalid_email'   => __( 'Please enter a valid email address.', 'rtbcb' ),
+                    'required_field'  => __( 'This field is required.', 'rtbcb' ),
+                    'select_pain_points' => __( 'Please select at least one pain point.', 'rtbcb' ),
+                ],
+                'settings' => [
+                    'pdf_enabled' => get_option( 'rtbcb_pdf_enabled', true ),
+                ],
+            ]
+        );
 
         // Chart.js for results visualization
         wp_enqueue_script(
@@ -365,22 +383,6 @@ class Real_Treasury_BCB {
             '3.9.1',
             true
         );
-
-        // Localize script
-        wp_localize_script( 'rtbcb-script', 'RTBCB', [
-            'ajax_url'     => admin_url( 'admin-ajax.php' ),
-            'nonce'        => wp_create_nonce( 'rtbcb_nonce' ),
-            'strings'      => [
-                'error'           => __( 'An error occurred. Please try again.', 'rtbcb' ),
-                'generating'      => __( 'Generating your business case...', 'rtbcb' ),
-                'invalid_email'   => __( 'Please enter a valid email address.', 'rtbcb' ),
-                'required_field'  => __( 'This field is required.', 'rtbcb' ),
-                'select_pain_points' => __( 'Please select at least one pain point.', 'rtbcb' ),
-            ],
-            'settings'     => [
-                'pdf_enabled' => get_option( 'rtbcb_pdf_enabled', true ),
-            ],
-        ] );
     }
 
     /**


### PR DESCRIPTION
## Summary
- Localize `rtbcb-script` immediately after enqueueing so JavaScript can access `ajax_url` and `nonce`
- Provide `ajaxObj` global with AJAX endpoint and `my_action_nonce`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `php tests/json-output-lint.php`


------
https://chatgpt.com/codex/tasks/task_e_68a77feeca448331bfca1abef2b7fad3