### PR TITLE
Fix AJAX object reference in submission script

### DIFF
--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -459,11 +459,11 @@ class BusinessCaseBuilder {
 
             const formData = new FormData(this.form);
             formData.append('action', 'rtbcb_generate_case');
-            formData.append('nonce', ajaxObj.nonce);
+            formData.append('nonce', RTBCB.nonce);
 
             this.startProgressSimulation();
 
-            const response = await fetch(ajaxObj.ajax_url, {
+            const response = await fetch(RTBCB.ajax_url, {
                 method: 'POST',
                 body: new URLSearchParams(formData)
             });


### PR DESCRIPTION
## Summary
- use localized `RTBCB` object for nonce and AJAX URL in submission handler

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `php tests/json-output-lint.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7812e1aa4833187844acf38ab9e5c