### PR TITLE
Fix nonce mismatch for business case generation

### DIFF
--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -459,7 +459,7 @@ class BusinessCaseBuilder {
 
             const formData = new FormData(this.form);
             formData.append('action', 'rtbcb_generate_case');
-            formData.append('nonce', ajaxObj.nonce);
+            formData.set('rtbcb_nonce', ajaxObj.rtbcb_nonce);
 
             this.startProgressSimulation();
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -361,7 +361,7 @@ class Real_Treasury_BCB {
             'ajaxObj',
             [
                 'ajax_url' => admin_url( 'admin-ajax.php' ),
-                'nonce'    => wp_create_nonce( 'my_action_nonce' ),
+                'rtbcb_nonce' => wp_create_nonce( 'rtbcb_generate' ),
                 'strings'  => [
                     'error'           => __( 'An error occurred. Please try again.', 'rtbcb' ),
                     'generating'      => __( 'Generating your business case...', 'rtbcb' ),


### PR DESCRIPTION
## Summary
- localize script with `rtbcb_nonce` tied to `rtbcb_generate`
- submit correct nonce in front-end form to complete business case generation

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a782670f0083318b8a3a250695ee31