### PR TITLE
Improve wizard responsiveness for small screens

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -1048,8 +1048,9 @@
 }
 
 .rtbcb-step-content {
-    max-width: 420px;
-    margin: 0 auto;
+    max-width: 600px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 /* Form Fields - Compact styling */
@@ -1089,7 +1090,6 @@
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
-    min-width: 280px;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236b7280' d='M10.293 3.293L6 7.586 1.707 3.293A1 1 0 00.293 4.707l5 5a1 1 0 001.414 0l5-5a1 1 0 10-1.414-1.414z'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
     background-position: right 12px center;


### PR DESCRIPTION
## Summary
- Expand wizard step content container to a wider 600px max width while maintaining centering
- Allow select fields to shrink on small screens by dropping fixed 280px minimum width

## Testing
- `node - <<'NODE'
const fs = require('fs');
const css = fs.readFileSync('public/css/rtbcb.css', 'utf8');
const stepMatch = css.match(/\.rtbcb-step-content\s*{[^}]*max-width:\s*([^;]+);/m);
const selectMatch = css.match(/\.rtbcb-field select\s*{[^}]*min-width:\s*([^;]+);/m);
console.log('step-content max-width:', stepMatch ? stepMatch[1].trim() : 'not found');
console.log('select min-width:', selectMatch ? selectMatch[1].trim() : 'none');
NODE`
- `node - <<'NODE'
[480,768,1024].forEach(w=>console.log(`viewport ${w}px -> step width ${Math.min(w,600)}px`));
NODE`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a783334b288331b6fcada29e4260c6