### PR TITLE
Unify select dropdown styling

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -525,15 +525,6 @@
     box-sizing: border-box;
 }
 
-.rtbcb-form select {
-    padding: 10px 8px;
-    line-height: 1.5;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-    overflow: visible;
-    background-size: 15px;
-}
 
 .rtbcb-form input:focus,
 .rtbcb-form select:focus {
@@ -1067,36 +1058,39 @@
 
 .rtbcb-field input,
 .rtbcb-field select {
-    width: 100%;
-    padding: 10px 12px;
-    border: 2px solid #e2e8f0;
-    border-radius: 6px;
-    font-size: 14px;
-    background: white;
-    transition: all 0.2s ease;
-    box-sizing: border-box;
-    position: relative;
-    z-index: 10;
-    line-height: 1.5;
-}
+     width: 100%;
+     padding: 12px 16px;
+     border: 2px solid #e2e8f0;
+     border-radius: 6px;
+     font-size: 16px;
+     background: white;
+     transition: all 0.2s ease;
+     box-sizing: border-box;
+     position: relative;
+     z-index: 10;
+     line-height: 1.4;
+ }
 
 .rtbcb-field input {
     color: #374151;
 }
-
+.rtbcb-form select,
 .rtbcb-field select {
-    color: var(--rtbcb-text-color, #000);
+    font-size: 16px;
+    line-height: 1.4;
+    padding: 12px 16px;
+    padding-right: 40px;
+    color: var(--rtbcb-text-color, var(--dark-text));
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
-    min-width: 280px;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236b7280' d='M10.293 3.293L6 7.586 1.707 3.293A1 1 0 00.293 4.707l5 5a1 1 0 001.414 0l5-5a1 1 0 10-1.414-1.414z'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
     background-position: right 12px center;
     background-size: 15px;
-    padding-right: 36px;
     overflow: visible;
 }
+
 
 .rtbcb-field input:focus,
 .rtbcb-field select:focus {


### PR DESCRIPTION
## Summary
- consolidate `.rtbcb-form select` and `.rtbcb-field select` into a single block
- apply consistent font-size, padding, and line-height for dropdowns
- ensure custom arrow and appearance reset for cross-browser support

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `php tests/json-output-lint.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a783328da48331a54d5dbf9a3b7d6e