### PR TITLE
Ensure rtbcb AJAX uses localized nonce

### DIFF
--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -459,11 +459,11 @@ class BusinessCaseBuilder {
 
             const formData = new FormData(this.form);
             formData.append('action', 'rtbcb_generate_case');
-            formData.append('nonce', RTBCB.nonce);
+            formData.set('rtbcb_nonce', ajaxObj.rtbcb_nonce);
 
             this.startProgressSimulation();
 
-            const response = await fetch(RTBCB.ajax_url, {
+            const response = await fetch(ajaxObj.ajax_url, {
                 method: 'POST',
                 body: new URLSearchParams(formData)
             });

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -356,24 +356,6 @@ class Real_Treasury_BCB {
             RTBCB_VERSION,
             true
         );
-        wp_localize_script(
-            'rtbcb-script',
-            'ajaxObj',
-            [
-                'ajax_url' => admin_url( 'admin-ajax.php' ),
-                'nonce'    => wp_create_nonce( 'my_action_nonce' ),
-                'strings'  => [
-                    'error'           => __( 'An error occurred. Please try again.', 'rtbcb' ),
-                    'generating'      => __( 'Generating your business case...', 'rtbcb' ),
-                    'invalid_email'   => __( 'Please enter a valid email address.', 'rtbcb' ),
-                    'required_field'  => __( 'This field is required.', 'rtbcb' ),
-                    'select_pain_points' => __( 'Please select at least one pain point.', 'rtbcb' ),
-                ],
-                'settings' => [
-                    'pdf_enabled' => get_option( 'rtbcb_pdf_enabled', true ),
-                ],
-            ]
-        );
 
         // Chart.js for results visualization
         wp_enqueue_script(
@@ -382,6 +364,26 @@ class Real_Treasury_BCB {
             [],
             '3.9.1',
             true
+        );
+
+        // Localize script
+        wp_localize_script(
+            'rtbcb-script',
+            'ajaxObj',
+            [
+                'ajax_url'    => admin_url( 'admin-ajax.php' ),
+                'rtbcb_nonce' => wp_create_nonce( 'rtbcb_generate' ),
+                'strings'     => [
+                    'error'              => __( 'An error occurred. Please try again.', 'rtbcb' ),
+                    'generating'         => __( 'Generating your business case...', 'rtbcb' ),
+                    'invalid_email'      => __( 'Please enter a valid email address.', 'rtbcb' ),
+                    'required_field'     => __( 'This field is required.', 'rtbcb' ),
+                    'select_pain_points' => __( 'Please select at least one pain point.', 'rtbcb' ),
+                ],
+                'settings'    => [
+                    'pdf_enabled' => get_option( 'rtbcb_pdf_enabled', true ),
+                ],
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary
- Replace RTBCB object usage with `ajaxObj` in AJAX submission, setting `rtbcb_nonce` before request
- Localize `ajaxObj` with `rtbcb_nonce` and enqueue Chart.js ahead of localization in PHP

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a784b6d9f08331bee43ca26b49ff3a