### PR TITLE
Improve OpenAI error propagation and user-facing messages

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -62,7 +62,7 @@
                     alert('RAG index rebuilt successfully');
                     location.reload();
                 } else {
-                    alert(rtbcbAdmin.strings.error);
+                    alert(data.data?.message || rtbcbAdmin.strings.error);
                 }
             } catch (err) {
                 alert(rtbcbAdmin.strings.error);
@@ -104,7 +104,7 @@
                     document.body.removeChild(a);
                     URL.revokeObjectURL(url);
                 } else {
-                    alert(rtbcbAdmin.strings.error);
+                    alert(data.data?.message || rtbcbAdmin.strings.error);
                 }
             } catch(err) {
                 alert(rtbcbAdmin.strings.error);

--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -620,6 +620,10 @@ class BusinessCaseBuilder {
         const scenarios = data.scenarios || {};
         const narrative = data.narrative || {};
 
+        if (narrative.error) {
+            this.showError(narrative.error);
+        }
+
         const html = `
             <div class="rtbcb-results-header">
                 <div class="rtbcb-results-badge">


### PR DESCRIPTION
## Summary
- Surface detailed OpenAI API errors by parsing response bodies and returning WP_Error messages
- Include sanitized API error excerpts in fallback LLM responses
- Display LLM and server errors in front-end and admin interfaces

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `php tests/json-output-lint.php`


------
https://chatgpt.com/codex/tasks/task_e_68a787a6231483319449a3490d0b696a