### PR TITLE
Let modal container manage scrolling

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -907,7 +907,7 @@
 /* Modal Body - Scrollable content */
 .rtbcb-modal-body {
     max-height: calc(90vh - 80px);
-    overflow-y: auto;
+    overflow: visible;
 }
 
 .rtbcb-form-container {
@@ -995,7 +995,6 @@
 .rtbcb-wizard-steps {
     position: relative;
     overflow-x: hidden;
-    overflow-y: auto;
 }
 
 .rtbcb-wizard-step {


### PR DESCRIPTION
## Summary
- Let modal body overflow be visible so outer container handles scrolling
- Remove vertical overflow restriction from wizard steps to rely on container scrolling

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a789b3cd84833182301392ba4305ce