### PR TITLE
Expand modal width for improved responsiveness

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -825,8 +825,8 @@
     border: 2px solid rgba(199, 125, 255, 0.3);
     border-radius: 20px;
     box-shadow: 0 25px 50px rgba(0, 0, 0, 0.25), 0 8px 32px rgba(114, 22, 244, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.8);
-    width: 90%;
-    max-width: 600px;
+    width: 100%;
+    max-width: 900px;
     margin: 0 auto;
     height: auto;
     max-height: 90vh;
@@ -1235,7 +1235,7 @@
     }
 
     .rtbcb-modal-container {
-        max-width: 95vw;
+        width: 95vw;
     }
 
     .rtbcb-form-container {


### PR DESCRIPTION
## Summary
- widen modal container by increasing max-width and using full width
- adjust responsive rule so modals span 95vw on smaller screens

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a789b695388331bcc916002df8db60