### PR TITLE
Silence runtime.lastError noise in Business Case Builder

### DIFF
--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -1,5 +1,15 @@
 /* Enhanced JavaScript for Real Treasury Business Case Builder plugin */
 
+(() => {
+    const originalError = console.error;
+    console.error = function(...args) {
+        if (args.some(arg => typeof arg === 'string' && arg.includes('Unchecked runtime.lastError'))) {
+            return;
+        }
+        originalError.apply(console, args);
+    };
+})();
+
 class BusinessCaseBuilder {
     constructor() {
         this.form = null;


### PR DESCRIPTION
## Summary
- Ignore Chrome's benign `Unchecked runtime.lastError` messages by wrapping `console.error` at script startup
- Preserve all other console errors for troubleshooting

## Testing
- `node - <<'NODE'
global.document = { addEventListener: () => {}, readyState: 'complete', getElementById: () => null, querySelector: () => null, body: { style: {} } };
global.window = {};
require('./public/js/rtbcb.js');
console.error('Unchecked runtime.lastError: sample message');
console.error('Visible error');
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a795ee62788331a204f6b35412190d