### PR TITLE
docs: add troubleshooting guidance for runtime.lastError warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ A: Ensure Chart.js is loading properly and check browser console for JavaScript 
 **Q: Lead data not saving**
 A: Check database permissions and ensure tables were created during plugin activation.
 
+### Troubleshooting
+
+If you encounter `Unchecked runtime.lastError` messages, they typically originate from WordPress.com scripts or browser extensions. Allow third-party cookies or disable the offending extension to resolve the issue.
+
 ### Performance Optimization
 - **Caching**: Use object caching for repeated calculations
 - **CDN Integration**: Host assets on CDN for faster loading


### PR DESCRIPTION
## Summary
- add troubleshooting section describing runtime.lastError messages from WordPress.com or browser extensions

## Testing
- `npx -y markdown-it README.md > /tmp/README.html`
- `sed -n '317,327p' /tmp/README.html`


------
https://chatgpt.com/codex/tasks/task_e_68a797f8b6ec83318504a32f48087328