### PR TITLE
Simplify wizard step visibility

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -1001,21 +1001,17 @@
 }
 
 .rtbcb-wizard-step {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
     opacity: 0;
-    transform: translateX(100px);
     transition: all 0.4s ease;
     pointer-events: none;
     padding: 16px 0;
+    display: none;
 }
 
 .rtbcb-wizard-step.active {
     opacity: 1;
-    transform: translateX(0);
     pointer-events: all;
+    display: block;
 }
 
 .rtbcb-wizard-step.prev {


### PR DESCRIPTION
## Summary
- remove absolute positioning from wizard steps
- hide inactive steps by default and display active step

## Testing
- `node tests/handle-submit-error.test.js`
- `php tests/json-output-lint.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7ce46d1cc833184f66ca59f001740