### PR TITLE
Center wizard progress bar

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -919,7 +919,8 @@
 /* Progress Indicator - Glassmorphic */
 .rtbcb-wizard-progress {
     background: linear-gradient(135deg, rgba(248, 249, 255, 0.8), rgba(243, 244, 255, 0.9));
-    margin: -32px -40px 32px -40px;
+    max-width: 600px;
+    margin: -32px auto 32px;
     padding: 20px 40px;
     border-bottom: 1px solid rgba(114, 22, 244, 0.1);
     backdrop-filter: blur(10px);
@@ -927,7 +928,8 @@
 
 .rtbcb-progress-steps {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
+    gap: 40px;
     position: relative;
 }
 
@@ -1244,7 +1246,12 @@
         padding: 16px;
     }
 
-    .rtbcb-wizard-progress,
+    .rtbcb-wizard-progress {
+        margin: -32px auto 32px;
+        padding-left: 20px;
+        padding-right: 20px;
+    }
+
     .rtbcb-wizard-navigation {
         margin-left: -20px;
         margin-right: -20px;
@@ -1264,6 +1271,10 @@
 @media (max-width: 480px) {
     .rtbcb-modal-overlay {
         padding: 10px;
+    }
+
+    .rtbcb-progress-steps {
+        gap: 20px;
     }
 
     .rtbcb-progress-steps::before {


### PR DESCRIPTION
## Summary
- Center wizard progress bar and limit width to 600px
- Prevent progress steps from stretching by centering with spacing
- Maintain centered layout on small screens

## Testing
- `node tests/handle-submit-error.test.js`
- `php tests/json-output-lint.php`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68a7ce477e448331ae27c3075072add5