### PR TITLE
Improve error handling in AJAX case generation

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -638,9 +638,9 @@ class Real_Treasury_BCB {
                         ]
                     );
                     $lead_id = RTBCB_Leads::save_lead( $lead_data );
-                } catch ( Exception $e ) {
+                } catch ( Throwable $e ) {
                     // Don't fail the request for lead saving issues
-                    error_log( 'RTBCB: Failed to save lead - ' . $e->getMessage() );
+                    error_log( 'RTBCB: Failed to save lead - ' . $e->getMessage() . ' in ' . $e->getFile() . ' on line ' . $e->getLine() );
                 }
             }
 
@@ -656,9 +656,9 @@ class Real_Treasury_BCB {
                 ]
             );
 
-        } catch ( Exception $e ) {
-            error_log( 'RTBCB Error: ' . $e->getMessage() );
-            wp_send_json_error( __( 'An error occurred while generating your business case. Please try again.', 'rtbcb' ), 500 );
+        } catch ( Throwable $e ) {
+            error_log( 'RTBCB Error: ' . $e->getMessage() . ' in ' . $e->getFile() . ' on line ' . $e->getLine() );
+            wp_send_json_error( __( 'An unexpected error occurred. Please try again.', 'rtbcb' ), 500 );
         }
 
         exit; // Ensure no additional output


### PR DESCRIPTION
## Summary
- catch all throwables during lead save and main AJAX business case generation
- log detailed error information without exposing internal details
- return a generic user-facing error message on failure

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `php tests/json-output-lint.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7d495a45c8331974b22da552af61a