### PR TITLE
refactor: chain handle submit fetch

### DIFF
--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -466,7 +466,7 @@ class BusinessCaseBuilder {
 
     // Continue with existing methods (handleSubmit, etc.)...
     // [Rest of the methods remain the same]
-    async handleSubmit(e) {
+    handleSubmit(e) {
         e.preventDefault();
 
         if (!this.validateCurrentStep()) {
@@ -475,105 +475,108 @@ class BusinessCaseBuilder {
 
         this.saveStepData();
 
-        try {
-            this.showProgressIndicator();
-            this.disableNavigation();
+        this.showProgressIndicator();
+        this.disableNavigation();
 
-            const formData = new FormData(this.form);
-            formData.append('action', 'rtbcb_generate_case');
-            formData.set('rtbcb_nonce', ajaxObj.rtbcb_nonce);
+        const formData = new FormData(this.form);
+        formData.append('action', 'rtbcb_generate_case');
+        formData.set('rtbcb_nonce', ajaxObj.rtbcb_nonce);
 
-            // Add debug logging
-            console.log('Submitting form to:', ajaxObj.ajax_url);
-            
-            this.startProgressSimulation();
+        // Add debug logging
+        console.log('Submitting form to:', ajaxObj.ajax_url);
 
-            const response = await fetch(ajaxObj.ajax_url, {
-                method: 'POST',
-                body: new URLSearchParams(formData),
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded'
+        this.startProgressSimulation();
+
+        let redirected = false;
+
+        return fetch(ajaxObj.ajax_url, {
+            method: 'POST',
+            body: new URLSearchParams(formData),
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            }
+        })
+            .then(response => {
+                console.log('Response status:', response.status);
+                redirected = response.redirected;
+                return response.text();
+            })
+            .then(responseText => {
+                console.log('Raw response:', responseText);
+
+                let result;
+                try {
+                    const cleanedResponse = responseText.trim();
+                    result = JSON.parse(cleanedResponse);
+                } catch (jsonError) {
+                    console.error('JSON Parse Error:', jsonError);
+                    console.error('Response that failed to parse:', responseText);
+                    this.showError('Server returned an invalid response. Please try again.');
+                    return;
+                }
+
+                console.log('Parsed result:', result);
+
+                // Check for WordPress error response
+                if (!result || typeof result !== 'object') {
+                    throw new Error('Invalid response format');
+                }
+
+                // Handle success/error from WordPress
+                if (result.success === false) {
+                    const errorMessage = result.data || 'An error occurred while generating your business case.';
+                    this.showError(errorMessage);
+                    return;
+                }
+
+                // Check for narrative error
+                const data = result.data || {};
+                const narrativeError = data?.narrative?.error;
+                if (narrativeError) {
+                    this.showError(narrativeError);
+                    return;
+                }
+
+                // Success - display results
+                this.completeProgress();
+                setTimeout(() => {
+                    this.displayResults(result.data);
+                    this.showSuccess(result.data.download_url);
+
+                    // Hide the form
+                    if (this.form) {
+                        this.form.style.display = 'none';
+                    }
+
+                    // Close the modal
+                    const modal = document.getElementById('rtbcbModalOverlay');
+                    if (modal) {
+                        setTimeout(() => {
+                            modal.classList.remove('active');
+                            document.body.style.overflow = '';
+                        }, 1000);
+                    }
+
+                    this.trackAnalytics('business_case_generated', {
+                        category: result.data.recommendation?.recommended,
+                        roi_base: result.data.scenarios?.base?.total_annual_benefit
+                    });
+                }, 500);
+            })
+            .catch(error => {
+                console.error('Submission Error:', error);
+                this.showError('A network error occurred. Please check your connection and try again.');
+            })
+            .finally(() => {
+                const progressContainer = this.progressOverlay;
+                if (!redirected) {
+                    if (progressContainer) {
+                        progressContainer.style.display = 'none';
+                    }
+                    this.hideProgressIndicator();
+                    this.enableNavigation();
                 }
             });
-
-            console.log('Response status:', response.status);
-            
-            const responseText = await response.text();
-            console.log('Raw response:', responseText);
-            
-            let result;
-            try {
-                // Clean the response in case there's extra whitespace or BOM
-                const cleanedResponse = responseText.trim();
-                result = JSON.parse(cleanedResponse);
-            } catch (jsonError) {
-                console.error('JSON Parse Error:', jsonError);
-                console.error('Response that failed to parse:', responseText);
-                this.hideProgressIndicator();
-                this.enableNavigation();
-                this.showError('Server returned an invalid response. Please try again.');
-                return;
-            }
-
-            console.log('Parsed result:', result);
-
-            // Check for WordPress error response
-            if (!result || typeof result !== 'object') {
-                throw new Error('Invalid response format');
-            }
-
-            // Handle success/error from WordPress
-            if (result.success === false) {
-                const errorMessage = result.data || 'An error occurred while generating your business case.';
-                this.hideProgressIndicator();
-                this.enableNavigation();
-                this.showError(errorMessage);
-                return;
-            }
-
-            // Check for narrative error
-            const data = result.data || {};
-            const narrativeError = data?.narrative?.error;
-            if (narrativeError) {
-                this.hideProgressIndicator();
-                this.enableNavigation();
-                this.showError(narrativeError);
-                return;
-            }
-
-            // Success - display results
-            this.completeProgress();
-            setTimeout(() => {
-                this.displayResults(result.data);
-                this.showSuccess(result.data.download_url);
-                
-                // Hide the form
-                if (this.form) {
-                    this.form.style.display = 'none';
-                }
-                
-                // Close the modal
-                const modal = document.getElementById('rtbcbModalOverlay');
-                if (modal) {
-                    setTimeout(() => {
-                        modal.classList.remove('active');
-                        document.body.style.overflow = '';
-                    }, 1000);
-                }
-                
-                this.trackAnalytics('business_case_generated', {
-                    category: result.data.recommendation?.recommended,
-                    roi_base: result.data.scenarios?.base?.total_annual_benefit
-                });
-            }, 500);
-
-        } catch (error) {
-            console.error('Submission Error:', error);
-            this.showError('A network error occurred. Please check your connection and try again.');
-        } finally {
-            this.hideProgressIndicator();
-            this.enableNavigation();
-        }
     }
 
     showProgressIndicator() {


### PR DESCRIPTION
## Summary
- refactor handleSubmit to use fetch promise chain instead of async/await
- hide progress overlay in finally after ensuring no redirect

## Testing
- `node tests/handle-submit-error.test.js`
- `php tests/json-output-lint.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7d4950a0c8331b0ed71af6e5d6b4a