### PR TITLE
Improve wizard modal styling and initialization

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -1,7 +1,315 @@
 /* Enhanced Styles for Real Treasury Business Case Builder plugin */
 @import url("rtbcb-variables.css");
 
+/* Theme conflict prevention */
+.rtbcb-modal-overlay * {
+    margin: 0 !important;
+    padding: 0 !important;
+    box-sizing: border-box !important;
+}
 
+.rtbcb-modal-overlay *:not(input):not(select):not(textarea):not(button) {
+    background: transparent !important;
+    border: none !important;
+    outline: none !important;
+}
+
+/* Prevent theme typography overrides */
+.rtbcb-modal-overlay {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
+    font-size: 16px !important;
+    line-height: 1.5 !important;
+    color: #374151 !important;
+}
+
+.rtbcb-modal-overlay h1,
+.rtbcb-modal-overlay h2,
+.rtbcb-modal-overlay h3,
+.rtbcb-modal-overlay h4 {
+    font-family: inherit !important;
+    font-weight: 600 !important;
+    line-height: 1.2 !important;
+    margin: 0 0 12px 0 !important;
+}
+
+/* Add at the top of rtbcb.css - Higher specificity wrapper */
+.rtbcb-modal-overlay,
+.rtbcb-modal-overlay * {
+    box-sizing: border-box !important;
+}
+
+.rtbcb-modal-overlay {
+    all: initial;
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 100vw !important;
+    height: 100vh !important;
+    z-index: 999999 !important;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
+}
+
+/* Reset and isolate modal container */
+.rtbcb-modal-container {
+    all: unset;
+    display: block !important;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(248, 248, 248, 0.98) 50%, rgba(255, 255, 255, 0.95)) !important;
+    backdrop-filter: blur(25px) saturate(140%) !important;
+    -webkit-backdrop-filter: blur(25px) saturate(140%) !important;
+    border: 2px solid rgba(199, 125, 255, 0.3) !important;
+    border-radius: 20px !important;
+    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.25), 0 8px 32px rgba(114, 22, 244, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.8) !important;
+    width: 100% !important;
+    max-width: 900px !important;
+    margin: 0 auto !important;
+    max-height: 90vh !important;
+    overflow-y: auto !important;
+    position: relative !important;
+}
+
+/* Progress indicator fixes */
+.rtbcb-wizard-progress {
+    background: linear-gradient(135deg, rgba(248, 249, 255, 0.8), rgba(243, 244, 255, 0.9)) !important;
+    padding: 20px 40px !important;
+    margin: 0 !important;
+    border-bottom: 1px solid rgba(114, 22, 244, 0.1) !important;
+    position: relative !important;
+}
+
+.rtbcb-progress-steps {
+    display: flex !important;
+    justify-content: space-between !important;
+    align-items: center !important;
+    max-width: 600px !important;
+    margin: 0 auto !important;
+    position: relative !important;
+}
+
+.rtbcb-progress-steps::before {
+    content: '' !important;
+    position: absolute !important;
+    top: 18px !important;
+    left: 10% !important;
+    right: 10% !important;
+    height: 2px !important;
+    background: #e2e8f0 !important;
+    z-index: 1 !important;
+}
+
+/* Step content fixes */
+.rtbcb-wizard-step {
+    display: none !important;
+    padding: 32px 40px !important;
+    min-height: 400px !important;
+}
+
+.rtbcb-wizard-step.active {
+    display: block !important;
+}
+
+.rtbcb-step-content {
+    max-width: 600px !important;
+    margin: 0 auto !important;
+}
+
+/* Form field styling fixes */
+.rtbcb-form input[type="text"],
+.rtbcb-form input[type="email"],
+.rtbcb-form input[type="number"],
+.rtbcb-form select {
+    all: unset !important;
+    display: block !important;
+    width: 100% !important;
+    padding: 12px 16px !important;
+    border: 2px solid #e2e8f0 !important;
+    border-radius: 8px !important;
+    font-size: 16px !important;
+    font-family: inherit !important;
+    background: #ffffff !important;
+    color: #374151 !important;
+    transition: all 0.2s ease !important;
+    box-sizing: border-box !important;
+    appearance: none !important;
+    -webkit-appearance: none !important;
+    -moz-appearance: none !important;
+}
+
+/* Select dropdown arrow */
+.rtbcb-form select {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236b7280' d='M10.293 3.293L6 7.586 1.707 3.293A1 1 0 00.293 4.707l5 5a1 1 0 001.414 0l5-5a1 1 0 10-1.414-1.414z'/%3E%3C/svg%3E") !important;
+    background-repeat: no-repeat !important;
+    background-position: right 12px center !important;
+    background-size: 16px !important;
+    padding-right: 40px !important;
+}
+
+.rtbcb-form input:focus,
+.rtbcb-form select:focus {
+    border-color: #7216f4 !important;
+    outline: none !important;
+    box-shadow: 0 0 0 3px rgba(114, 22, 244, 0.1) !important;
+    z-index: 10 !important;
+}
+
+/* Pain Points Grid Layout Fix */
+.rtbcb-pain-points-grid {
+    display: grid !important;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)) !important;
+    gap: 16px !important;
+    margin: 24px 0 !important;
+}
+
+.rtbcb-pain-point-card {
+    all: unset !important;
+    display: block !important;
+    background: #ffffff !important;
+    border: 2px solid #e2e8f0 !important;
+    border-radius: 12px !important;
+    overflow: hidden !important;
+    transition: all 0.2s ease !important;
+    cursor: pointer !important;
+    position: relative !important;
+}
+
+.rtbcb-pain-point-card:hover {
+    border-color: #c77dff !important;
+    box-shadow: 0 4px 12px rgba(114, 22, 244, 0.1) !important;
+    transform: translateY(-2px) !important;
+}
+
+.rtbcb-pain-point-card.rtbcb-selected {
+    border-color: #7216f4 !important;
+    background: linear-gradient(135deg, #f8f9ff, #ffffff) !important;
+    box-shadow: 0 4px 20px rgba(114, 22, 244, 0.2) !important;
+}
+
+.rtbcb-pain-point-label {
+    all: unset !important;
+    display: block !important;
+    padding: 20px !important;
+    cursor: pointer !important;
+    width: 100% !important;
+    height: 100% !important;
+}
+
+.rtbcb-pain-point-label input[type="checkbox"] {
+    position: absolute !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+    width: 0 !important;
+    height: 0 !important;
+}
+
+/* Navigation Buttons Fix */
+.rtbcb-wizard-navigation {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    padding: 20px 40px !important;
+    border-top: 1px solid #e2e8f0 !important;
+    background: #f9fafb !important;
+    border-radius: 0 0 20px 20px !important;
+}
+
+.rtbcb-nav-btn {
+    all: unset !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 8px !important;
+    padding: 12px 24px !important;
+    border-radius: 8px !important;
+    font-size: 14px !important;
+    font-weight: 600 !important;
+    border: none !important;
+    cursor: pointer !important;
+    transition: all 0.2s ease !important;
+    background: #7216f4 !important;
+    color: #ffffff !important;
+    text-decoration: none !important;
+    min-width: 120px !important;
+}
+
+.rtbcb-nav-btn:hover:not(:disabled) {
+    transform: translateY(-1px) !important;
+    box-shadow: 0 4px 12px rgba(114, 22, 244, 0.3) !important;
+}
+
+.rtbcb-nav-btn:disabled {
+    background: #d1d5db !important;
+    color: #9ca3af !important;
+    cursor: not-allowed !important;
+    transform: none !important;
+    box-shadow: none !important;
+}
+
+/* Mobile Responsive Fixes */
+@media (max-width: 768px) {
+    .rtbcb-modal-overlay {
+        padding: 10px !important;
+    }
+
+    .rtbcb-modal-container {
+        max-width: 95vw !important;
+        max-height: 95vh !important;
+    }
+
+    .rtbcb-wizard-progress {
+        padding: 16px 20px !important;
+    }
+
+    .rtbcb-wizard-step {
+        padding: 20px !important;
+        min-height: 300px !important;
+    }
+
+    .rtbcb-wizard-navigation {
+        padding: 16px 20px !important;
+        flex-direction: column !important;
+        gap: 12px !important;
+    }
+
+    .rtbcb-nav-btn {
+        width: 100% !important;
+        min-width: auto !important;
+    }
+
+    .rtbcb-pain-points-grid {
+        grid-template-columns: 1fr !important;
+    }
+
+    .rtbcb-progress-steps {
+        justify-content: space-around !important;
+        gap: 8px !important;
+    }
+
+    .rtbcb-progress-label {
+        font-size: 10px !important;
+    }
+}
+
+/* Loading states and animations */
+@keyframes rtbcb-fadeIn {
+    from { opacity: 0; transform: scale(0.95); }
+    to { opacity: 1; transform: scale(1); }
+}
+
+.rtbcb-modal-overlay.active .rtbcb-modal-container {
+    animation: rtbcb-fadeIn 0.3s ease-out !important;
+}
+
+.rtbcb-wizard-step {
+    transition: opacity 0.3s ease, transform 0.3s ease !important;
+}
+
+.rtbcb-wizard-step:not(.active) {
+    opacity: 0 !important;
+    pointer-events: none !important;
+}
+
+.rtbcb-modal-overlay:focus-within {
+    outline: none !important;
+}
 
 /* Base Container Styles */
 .rtbcb-container {

--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -2,6 +2,44 @@
  * Business Case Builder Wizard Controller
  * Handles multi-step form navigation, validation, and submission
  */
+
+// Ensure modal functions are available immediately
+window.openBusinessCaseModal = function() {
+    const overlay = document.getElementById('rtbcbModalOverlay');
+    if (overlay) {
+        overlay.classList.add('active');
+        document.body.style.overflow = 'hidden';
+
+        // Force re-initialization
+        setTimeout(() => {
+            if (window.businessCaseBuilder) {
+                window.businessCaseBuilder.reinitialize();
+            } else {
+                window.businessCaseBuilder = new BusinessCaseBuilder();
+            }
+        }, 100);
+    }
+};
+
+window.closeBusinessCaseModal = function() {
+    const overlay = document.getElementById('rtbcbModalOverlay');
+    if (overlay) {
+        overlay.classList.remove('active');
+        document.body.style.overflow = '';
+    }
+};
+
+// Initialize on DOM ready with error handling
+document.addEventListener('DOMContentLoaded', function() {
+    try {
+        if (document.getElementById('rtbcbForm')) {
+            window.businessCaseBuilder = new BusinessCaseBuilder();
+        }
+    } catch (error) {
+        console.error('BusinessCaseBuilder initialization failed:', error);
+    }
+});
+
 class BusinessCaseBuilder {
     constructor() {
         this.currentStep = 1;
@@ -581,38 +619,3 @@ class BusinessCaseBuilder {
         this.updateProgressIndicator();
     }
 }
-
-// Initialize on DOM ready
-document.addEventListener('DOMContentLoaded', function() {
-    // Auto-initialize if form exists
-    if (document.getElementById('rtbcbForm')) {
-        window.businessCaseBuilder = new BusinessCaseBuilder();
-    }
-});
-
-// Make sure modal functions are globally available
-window.openBusinessCaseModal = function() {
-    const overlay = document.getElementById('rtbcbModalOverlay');
-    if (overlay) {
-        overlay.classList.add('active');
-        document.body.style.overflow = 'hidden';
-        
-        // Initialize or reinitialize the builder
-        setTimeout(() => {
-            if (!window.businessCaseBuilder) {
-                window.businessCaseBuilder = new BusinessCaseBuilder();
-            } else {
-                window.businessCaseBuilder.reinitialize();
-            }
-        }, 100);
-    }
-};
-
-window.closeBusinessCaseModal = function() {
-    const overlay = document.getElementById('rtbcbModalOverlay');
-    if (overlay) {
-        overlay.classList.remove('active');
-        document.body.style.overflow = '';
-    }
-};
-


### PR DESCRIPTION
## Summary
- isolate wizard modal from theme styles with a comprehensive reset and container tweaks
- refine wizard layout, field styles, pain point grid, and navigation for responsive usability
- add global modal helpers and guarded DOM-ready initialization in the wizard script

## Testing
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a86b48965883318bb7dc03074df586