### PR TITLE
Update stable tag for WordPress release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: realtreasury
 Tags: business, case, builder, roi, treasury
 Requires at least: 6.0
 Tested up to: 6.0
-Stable tag: 0.1.0
+Stable tag: 2.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- update stable tag in `readme.txt` to match release version `2.1.0`

## Testing
- `./tests/run-tests.sh`
- `npm run deploy` *(fails: Could not read package.json)*
- `wp plugin deploy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8896082d48331996e3dbfb80c841f