### PR TITLE
Handle missing narrative in wizard results

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -471,7 +471,8 @@ class BusinessCaseBuilder {
     }
 
     renderResults(data) {
-        const { scenarios, recommendation, narrative, company_name } = data;
+        const { scenarios, recommendation, company_name } = data;
+        const narrative = data.narrative || {};
         const displayName = company_name || 'Your Company';
 
         return `
@@ -487,9 +488,9 @@ class BusinessCaseBuilder {
 
                 ${this.renderRecommendation(recommendation, displayName)}
                 ${this.renderROISummary(scenarios, displayName)}
-                ${this.renderNarrative(narrative, displayName)}
+                ${this.renderNarrative(narrative)}
                 ${this.renderRiskAssessmentSection()}
-                ${this.renderNextSteps(narrative.next_actions || [], displayName)}
+                ${this.renderNextSteps(narrative?.next_actions || [], displayName)}
                 ${this.renderActions(data)}
             </div>
         `;
@@ -575,12 +576,12 @@ class BusinessCaseBuilder {
         `;
     }
 
-    renderNarrative(narrative) {
+    renderNarrative(narrative = {}) {
         return `
             <div class="rtbcb-narrative-section">
                 <h3>Executive Summary</h3>
                 <div class="rtbcb-narrative-content">
-                    ${narrative.narrative || 'Treasury technology investment presents a compelling opportunity for operational efficiency.'}
+                    ${narrative?.narrative || 'Treasury technology investment presents a compelling opportunity for operational efficiency.'}
                 </div>
             </div>
         `;

--- a/tests/render-results-no-narrative.test.js
+++ b/tests/render-results-no-narrative.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+global.window = {};
+global.document = {
+    readyState: 'complete',
+    addEventListener: () => {},
+    getElementById: () => null
+};
+
+const code = fs.readFileSync('public/js/rtbcb-wizard.js', 'utf8');
+vm.runInThisContext(code);
+
+const builder = new BusinessCaseBuilder();
+
+const data = {
+    scenarios: {},
+    recommendation: {},
+    company_name: 'Test Co'
+};
+
+const html = builder.renderResults(data);
+assert.ok(html.includes('Treasury technology investment presents a compelling opportunity for operational efficiency.'));
+console.log('Render results without narrative test passed.');

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -11,9 +11,10 @@ find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
 echo "2. Running JSON output lint..."
 php tests/json-output-lint.php
 
-# JavaScript test
+# JavaScript tests
 echo "3. Running JavaScript tests..."
 node tests/handle-submit-error.test.js
+node tests/render-results-no-narrative.test.js
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then


### PR DESCRIPTION
## Summary
- Safely render executive summary when API response lacks a narrative
- Default narrative next steps to avoid runtime errors
- Add test ensuring fallback summary appears without narrative

## Testing
- `tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a88e22aa748331b46d9850217b7f0b