### PR TITLE
Add GPT-5 model options and defaults

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -18,10 +18,14 @@ $bank_fee        = get_option( 'rtbcb_bank_fee_baseline', '' );
 $pdf_enabled     = (bool) get_option( 'rtbcb_pdf_enabled', true );
 
 $chat_models = [
-    'gpt-4o-mini' => 'gpt-4o-mini',
-    'gpt-4o'      => 'gpt-4o',
-    'o1-mini'     => 'o1-mini',
-    'o1-preview'  => 'o1-preview',
+    'gpt-5'            => 'gpt-5',
+    'gpt-5-mini'       => 'gpt-5-mini',
+    'gpt-5-nano'       => 'gpt-5-nano',
+    'gpt-5-chat-latest'=> 'gpt-5-chat-latest',
+    'gpt-4o-mini'      => 'gpt-4o-mini',
+    'gpt-4o'           => 'gpt-4o',
+    'o1-mini'          => 'o1-mini',
+    'o1-preview'       => 'o1-preview',
 ];
 
 $embedding_models = [

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -36,9 +36,9 @@ class RTBCB_LLM {
     public function __construct() {
         $this->api_key = get_option( 'rtbcb_openai_api_key' );
         $this->models  = [
-            'mini'      => get_option( 'rtbcb_mini_model', 'gpt-4o-mini' ),
-            'premium'   => get_option( 'rtbcb_premium_model', 'gpt-4o' ),
-            'advanced'  => get_option( 'rtbcb_advanced_model', 'o1-preview' ),
+            'mini'      => get_option( 'rtbcb_mini_model', 'gpt-5-mini' ),
+            'premium'   => get_option( 'rtbcb_premium_model', 'gpt-5' ),
+            'advanced'  => get_option( 'rtbcb_advanced_model', 'gpt-5-chat-latest' ),
             'embedding' => get_option( 'rtbcb_embedding_model', 'text-embedding-3-small' ),
         ];
     }

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -97,12 +97,14 @@ class RTBCB_Router {
         $complexity = $this->calculate_complexity( $inputs, $chunks );
         $category   = RTBCB_Category_Recommender::recommend_category( $inputs )['recommended'];
 
-        $model = get_option( 'rtbcb_mini_model', 'gpt-4o-mini' );
+        $model = get_option( 'rtbcb_mini_model', 'gpt-5-mini' );
 
-        if ( $complexity > 0.6 || 'trms' === $category ) {
-            $model = get_option( 'rtbcb_premium_model', 'gpt-4o' );
+        if ( $complexity > 0.8 ) {
+            $model = get_option( 'rtbcb_advanced_model', 'gpt-5-chat-latest' );
+        } elseif ( $complexity > 0.6 || 'trms' === $category ) {
+            $model = get_option( 'rtbcb_premium_model', 'gpt-5' );
         } elseif ( 'tms_lite' === $category && $complexity > 0.4 ) {
-            $model = get_option( 'rtbcb_premium_model', 'gpt-4o' );
+            $model = get_option( 'rtbcb_premium_model', 'gpt-5' );
         }
 
         return $model;

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -280,7 +280,7 @@ class Real_Treasury_BCB {
         // Add new options introduced in 2.1.0
         if ( version_compare( $from_version, '2.1.0', '<' ) ) {
             $new_options = [
-                'rtbcb_advanced_model'        => 'o1-preview',
+                'rtbcb_advanced_model'        => 'gpt-5-chat-latest',
                 'rtbcb_comprehensive_analysis' => true,
                 'rtbcb_professional_reports'   => true,
             ];
@@ -326,9 +326,9 @@ class Real_Treasury_BCB {
      */
     private function set_default_options() {
         $defaults = [
-            'rtbcb_mini_model'         => 'gpt-4o-mini',
-            'rtbcb_premium_model'      => 'gpt-4o',
-            'rtbcb_advanced_model'     => 'o1-preview',
+            'rtbcb_mini_model'         => 'gpt-5-mini',
+            'rtbcb_premium_model'      => 'gpt-5',
+            'rtbcb_advanced_model'     => 'gpt-5-chat-latest',
             'rtbcb_embedding_model'    => 'text-embedding-3-small',
             'rtbcb_labor_cost_per_hour'=> 100,
             'rtbcb_bank_fee_baseline'  => 15000,


### PR DESCRIPTION
## Summary
- expose new GPT-5 model variants in settings page dropdowns
- default mini, premium, and advanced models now use GPT-5 equivalents
- router selects GPT-5 advanced model for high-complexity requests

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a88ed303e0833198e7411f2de15000