### PR TITLE
Use static ROI calculator in router

### DIFF
--- a/inc/class-rtbcb-calculator.php
+++ b/inc/class-rtbcb-calculator.php
@@ -7,6 +7,8 @@
 
 /**
  * Class RTBCB_Calculator.
+ *
+ * Provides static ROI calculation helpers.
  */
 class RTBCB_Calculator {
     /**

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -34,12 +34,11 @@ class RTBCB_Router {
             $form_data = $validated_data;
 
             // Instantiate necessary classes.
-            $calculator = new RTBCB_Calculator();
-            $llm        = new RTBCB_LLM();
-            $rag        = new RTBCB_RAG();
+            $llm = new RTBCB_LLM();
+            $rag = new RTBCB_RAG();
 
             // Perform calculations.
-            $calculations = $calculator->calculate( $form_data );
+            $calculations = RTBCB_Calculator::calculate_roi( $form_data );
 
             // Generate context from RAG.
             $rag_context = $rag->get_context( $form_data['company_description'] );

--- a/inc/class-rtbcb-tests.php
+++ b/inc/class-rtbcb-tests.php
@@ -47,7 +47,7 @@ class RTBCB_Tests {
     }
 
     /**
-     * Ensure ROI calculator is available.
+     * Ensure ROI calculator static method is available.
      *
      * @return array Test result.
      */
@@ -61,7 +61,7 @@ class RTBCB_Tests {
 
         return [
             'passed'  => true,
-            'message' => __( 'ROI calculator is available.', 'rtbcb' ),
+            'message' => __( 'ROI calculator static method available.', 'rtbcb' ),
         ];
     }
 


### PR DESCRIPTION
## Summary
- call `RTBCB_Calculator::calculate_roi()` statically from router
- document ROI calculator as static utility and adjust integration tests

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8900da3248331bafb7d205b025991