### PR TITLE
Render business case report HTML via template

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -138,7 +138,19 @@ class RTBCB_Router {
      * @return string Report HTML.
      */
     private function get_report_html( $business_case_data ) {
-        return '';
+        $template_path = RTBCB_DIR . 'templates/report-template.php';
+
+        if ( ! file_exists( $template_path ) ) {
+            return '';
+        }
+
+        $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
+
+        ob_start();
+        include $template_path;
+        $html = ob_get_clean();
+
+        return wp_kses_post( $html );
     }
 }
 

--- a/templates/report-template.php
+++ b/templates/report-template.php
@@ -1,7 +1,73 @@
 <?php
 /**
  * Template for generated business case report.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ *
+ * @var array $business_case_data Business case data from the LLM.
  */
 
-// Placeholder for report template content.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div class="rtbcb-report">
+    <h2><?php echo esc_html__( 'Business Case Report', 'rtbcb' ); ?></h2>
+    <?php if ( ! empty( $business_case_data['narrative'] ) ) : ?>
+        <p><?php echo esc_html( $business_case_data['narrative'] ); ?></p>
+    <?php endif; ?>
 
+    <?php if ( ! empty( $business_case_data['risks'] ) ) : ?>
+        <h3><?php echo esc_html__( 'Risks', 'rtbcb' ); ?></h3>
+        <ul>
+            <?php foreach ( (array) $business_case_data['risks'] as $risk ) : ?>
+                <li><?php echo esc_html( $risk ); ?></li>
+            <?php endforeach; ?>
+        </ul>
+    <?php endif; ?>
+
+    <?php if ( ! empty( $business_case_data['assumptions_explained'] ) ) : ?>
+        <h3><?php echo esc_html__( 'Assumptions', 'rtbcb' ); ?></h3>
+        <ul>
+            <?php foreach ( (array) $business_case_data['assumptions_explained'] as $assumption ) : ?>
+                <li><?php echo esc_html( $assumption ); ?></li>
+            <?php endforeach; ?>
+        </ul>
+    <?php endif; ?>
+
+    <?php if ( ! empty( $business_case_data['citations'] ) ) : ?>
+        <h3><?php echo esc_html__( 'Citations', 'rtbcb' ); ?></h3>
+        <ol>
+            <?php foreach ( (array) $business_case_data['citations'] as $citation ) : ?>
+                <li>
+                    <?php
+                    if ( is_array( $citation ) && ! empty( $citation['url'] ) ) {
+                        $url  = esc_url( $citation['url'] );
+                        $text = ! empty( $citation['text'] ) ? esc_html( $citation['text'] ) : $url;
+                        echo '<a href="' . $url . '">' . $text . '</a>';
+                    } else {
+                        echo esc_html( is_array( $citation ) ? wp_json_encode( $citation ) : $citation );
+                    }
+                    ?>
+                </li>
+            <?php endforeach; ?>
+        </ol>
+    <?php endif; ?>
+
+    <?php if ( ! empty( $business_case_data['next_actions'] ) ) : ?>
+        <h3><?php echo esc_html__( 'Next Actions', 'rtbcb' ); ?></h3>
+        <ul>
+            <?php foreach ( (array) $business_case_data['next_actions'] as $action ) : ?>
+                <li><?php echo esc_html( $action ); ?></li>
+            <?php endforeach; ?>
+        </ul>
+    <?php endif; ?>
+
+    <?php if ( isset( $business_case_data['confidence'] ) ) : ?>
+        <p><?php printf( esc_html__( 'Confidence: %s%%', 'rtbcb' ), esc_html( round( (float) $business_case_data['confidence'] * 100 ) ) ); ?></p>
+    <?php endif; ?>
+
+    <?php if ( ! empty( $business_case_data['recommended_category'] ) ) : ?>
+        <p><?php echo esc_html__( 'Recommended Category:', 'rtbcb' ) . ' ' . esc_html( $business_case_data['recommended_category'] ); ?></p>
+    <?php endif; ?>
+</div>

--- a/tests/handle-submit-success.test.js
+++ b/tests/handle-submit-success.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const progressContainer = { innerHTML: '', style: {} };
+const formContainer = { style: {} };
+const reportContainer = { innerHTML: '', style: {} };
+
+global.document = {
+    readyState: 'complete',
+    addEventListener: () => {},
+    getElementById: (id) => {
+        if (id === 'rtbcb-progress-container') return progressContainer;
+        if (id === 'rtbcb-form-container') return formContainer;
+        if (id === 'rtbcb-report-container') return reportContainer;
+        if (id === 'rtbcb-form') return {};
+        return null;
+    }
+};
+
+global.ajaxObj = { ajax_url: '', rtbcb_nonce: '' };
+
+global.fetch = async () => ({
+    ok: true,
+    json: async () => ({ success: true, data: { report_html: '<div>Report</div>' } }),
+    text: async () => ''
+});
+
+global.FormData = class { constructor() {} };
+
+const code = fs.readFileSync('public/js/rtbcb.js', 'utf8');
+vm.runInThisContext(code);
+
+(async () => {
+    await handleSubmit({ preventDefault() {}, target: {} });
+    assert.ok(reportContainer.innerHTML.includes('Report'));
+    console.log('Success path test passed.');
+})();

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -15,6 +15,7 @@ php tests/json-output-lint.php
 echo "3. Running JavaScript tests..."
 node tests/handle-submit-error.test.js
 node tests/render-results-no-narrative.test.js
+node tests/handle-submit-success.test.js
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then


### PR DESCRIPTION
## Summary
- render business case report via new template with escaped dynamic values
- load template through `RTBCB_Router::get_report_html()` using output buffering
- add JavaScript test to ensure AJAX success responses include the report HTML

## Testing
- `./tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8901595cc83319acbd1447266e7ce