### PR TITLE
Refactor RAG cosine search to limit database load

### DIFF
--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -33,6 +33,7 @@ class RTBCB_RAG {
             text_hash varchar(64) NOT NULL,
             embedding longtext NOT NULL,
             metadata longtext NOT NULL,
+            embedding_norm float NOT NULL,
             updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
             PRIMARY KEY (id),
             UNIQUE KEY hash_key (text_hash),
@@ -101,13 +102,14 @@ class RTBCB_RAG {
         $wpdb->replace(
             $table_name,
             [
-                'type'      => 'vendor',
-                'ref_id'    => isset( $vendor['id'] ) ? sanitize_text_field( $vendor['id'] ) : '',
-                'text_hash' => $text_hash,
-                'embedding' => maybe_serialize( $embedding ),
-                'metadata'  => maybe_serialize( $vendor ),
+                'type'          => 'vendor',
+                'ref_id'        => isset( $vendor['id'] ) ? sanitize_text_field( $vendor['id'] ) : '',
+                'text_hash'     => $text_hash,
+                'embedding'     => maybe_serialize( $embedding ),
+                'metadata'      => maybe_serialize( $vendor ),
+                'embedding_norm' => $this->calculate_embedding_norm( $embedding ),
             ],
-            [ '%s', '%s', '%s', '%s', '%s' ]
+            [ '%s', '%s', '%s', '%s', '%s', '%f' ]
         );
     }
 
@@ -129,13 +131,14 @@ class RTBCB_RAG {
         $wpdb->replace(
             $table_name,
             [
-                'type'      => 'note',
-                'ref_id'    => isset( $note['id'] ) ? sanitize_text_field( $note['id'] ) : '',
-                'text_hash' => $text_hash,
-                'embedding' => maybe_serialize( $embedding ),
-                'metadata'  => maybe_serialize( $note ),
+                'type'          => 'note',
+                'ref_id'        => isset( $note['id'] ) ? sanitize_text_field( $note['id'] ) : '',
+                'text_hash'     => $text_hash,
+                'embedding'     => maybe_serialize( $embedding ),
+                'metadata'      => maybe_serialize( $note ),
+                'embedding_norm' => $this->calculate_embedding_norm( $embedding ),
             ],
-            [ '%s', '%s', '%s', '%s', '%s' ]
+            [ '%s', '%s', '%s', '%s', '%s', '%f' ]
         );
     }
 
@@ -192,7 +195,17 @@ class RTBCB_RAG {
         global $wpdb;
         $table_name = $wpdb->prefix . 'rtbcb_rag_index';
 
-        $rows = $wpdb->get_results( "SELECT * FROM {$table_name}", ARRAY_A );
+        $query_norm = $this->calculate_embedding_norm( $query_embedding );
+        $limit      = max( $top_k * 10, $top_k );
+
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT type, ref_id, embedding, metadata FROM {$table_name} ORDER BY ABS( embedding_norm - %f ) ASC LIMIT %d",
+                $query_norm,
+                $limit
+            ),
+            ARRAY_A
+        );
 
         $scores = [];
         foreach ( $rows as $row ) {
@@ -200,7 +213,7 @@ class RTBCB_RAG {
             if ( ! is_array( $embedding ) ) {
                 continue;
             }
-            $score      = $this->cosine_similarity( $query_embedding, $embedding );
+            $score    = $this->cosine_similarity( $query_embedding, $embedding );
             $scores[] = [
                 'score'    => $score,
                 'type'     => $row['type'],
@@ -220,6 +233,21 @@ class RTBCB_RAG {
         );
 
         return array_slice( $scores, 0, $top_k );
+    }
+
+    /**
+     * Calculate the Euclidean norm of an embedding vector.
+     *
+     * @param array $embedding Embedding vector.
+     *
+     * @return float Vector norm.
+     */
+    private function calculate_embedding_norm( $embedding ) {
+        $norm = 0;
+        foreach ( $embedding as $value ) {
+            $norm += $value * $value;
+        }
+        return sqrt( $norm );
     }
 
     /**

--- a/tests/cosine-similarity-search.test.php
+++ b/tests/cosine-similarity-search.test.php
@@ -1,0 +1,63 @@
+<?php
+require_once __DIR__ . '/../inc/class-rtbcb-rag.php';
+
+if ( ! defined( 'ARRAY_A' ) ) {
+    define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+if ( ! function_exists( 'maybe_unserialize' ) ) {
+    function maybe_unserialize( $data ) {
+        return $data;
+    }
+}
+
+class WPDB_Stub {
+    public $prefix = '';
+    public $last_query = '';
+
+    public function prepare( $query, ...$args ) {
+        $this->last_query = vsprintf( $query, $args );
+        return $this->last_query;
+    }
+
+    public function get_results( $sql, $output ) {
+        $this->last_query = $sql;
+        return [
+            [ 'type' => 'vendor', 'ref_id' => '1', 'embedding' => [ 1, 0 ], 'metadata' => [] ],
+            [ 'type' => 'vendor', 'ref_id' => '2', 'embedding' => [ 0.8, 0.2 ], 'metadata' => [] ],
+            [ 'type' => 'vendor', 'ref_id' => '3', 'embedding' => [ 0, 1 ], 'metadata' => [] ],
+        ];
+    }
+}
+
+global $wpdb;
+$wpdb = new WPDB_Stub();
+
+class RTBCB_RAG_Test extends RTBCB_RAG {
+    public function __construct() {}
+    public function run_search( $query_embedding, $top_k ) {
+        $method = new ReflectionMethod( RTBCB_RAG::class, 'cosine_similarity_search' );
+        $method->setAccessible( true );
+        return $method->invoke( $this, $query_embedding, $top_k );
+    }
+}
+
+$rag     = new RTBCB_RAG_Test();
+$results = $rag->run_search( [ 1, 0 ], 2 );
+
+if ( 2 !== count( $results ) ) {
+    echo "Expected 2 results, got " . count( $results ) . "\n";
+    exit( 1 );
+}
+
+if ( $results[0]['score'] < $results[1]['score'] ) {
+    echo "Results are not sorted by score\n";
+    exit( 1 );
+}
+
+if ( false === stripos( $wpdb->last_query, 'limit' ) ) {
+    echo "LIMIT clause missing from query\n";
+    exit( 1 );
+}
+
+echo "cosine-similarity-search.test.php passed\n";

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -11,17 +11,21 @@ find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
 echo "2. Running JSON output lint..."
 php tests/json-output-lint.php
 
+# Cosine similarity search test
+echo "3. Running cosine similarity search test..."
+php tests/cosine-similarity-search.test.php
+
 # JavaScript tests
-echo "3. Running JavaScript tests..."
+echo "4. Running JavaScript tests..."
 node tests/handle-submit-error.test.js
 node tests/render-results-no-narrative.test.js
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then
-    echo "4. Running WordPress coding standards check..."
+    echo "5. Running WordPress coding standards check..."
     phpcs --standard=WordPress --ignore=vendor .
 else
-    echo "4. Skipping WordPress coding standards (phpcs not installed)"
+    echo "5. Skipping WordPress coding standards (phpcs not installed)"
 fi
 
 echo "================================================"


### PR DESCRIPTION
## Summary
- precompute and store embedding norms in the `rtbcb_rag_index` table
- use SQL `ORDER BY`/`LIMIT` with embedding norms to reduce rows fetched
- add unit test ensuring cosine search returns sorted, limited results

## Testing
- `./tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8901ae5408331894141735cfac7db