### PR TITLE
Add diagnostics test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ add_filter('rtbcb_pdf_data', function($data) {
 ## 🧪 Testing and Quality Assurance
 
 ### Automated Tests
-The plugin includes integration tests for all major components:
+The plugin includes integration tests for all major components. These can be run from the settings page via the **Run Diagnostics** button or programmatically:
 ```php
 // Run integration tests
 $results = RTBCB_Tests::run_integration_tests();

--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -27,6 +27,7 @@ class RTBCB_Admin {
         add_action( 'wp_ajax_rtbcb_export_leads', [ $this, 'export_leads_csv' ] );
         add_action( 'wp_ajax_rtbcb_delete_lead', [ $this, 'delete_lead' ] );
         add_action( 'wp_ajax_rtbcb_bulk_action_leads', [ $this, 'bulk_action_leads' ] );
+        add_action( 'wp_ajax_rtbcb_run_tests', [ $this, 'run_integration_tests' ] );
     }
 
     /**
@@ -371,6 +372,23 @@ class RTBCB_Admin {
         $rag->rebuild_index();
 
         wp_send_json_success( [ 'message' => __( 'RAG index rebuilt successfully.', 'rtbcb' ) ] );
+    }
+
+    /**
+     * Run integration diagnostics.
+     *
+     * @return void
+     */
+    public function run_integration_tests() {
+        check_ajax_referer( 'rtbcb_nonce', 'nonce' );
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
+        }
+
+        $results = RTBCB_Tests::run_integration_tests();
+
+        wp_send_json_success( $results );
     }
 
     /**

--- a/admin/data-health-page.php
+++ b/admin/data-health-page.php
@@ -23,6 +23,7 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
         <strong><?php echo esc_html__( 'Last RAG Index:', 'rtbcb' ); ?></strong>
         <?php echo esc_html( $last_index_display ); ?>
     </p>
+    <p><?php echo esc_html__( 'Need more details? Run diagnostics from the settings page.', 'rtbcb' ); ?></p>
 </div>
 
 

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -6,6 +6,7 @@
             this.bindDashboardActions();
             this.bindExportButtons();
             this.initLeadsManager();
+            this.bindDiagnosticsButton();
         },
 
         bindDashboardActions() {
@@ -16,6 +17,10 @@
 
         bindExportButtons() {
             $('#rtbcb-export-leads').on('click', this.exportLeads);
+        },
+
+        bindDiagnosticsButton() {
+            $('#rtbcb-run-tests').on('click', this.runDiagnostics);
         },
 
         async testApiConnection(e) {
@@ -110,6 +115,39 @@
                 alert(rtbcbAdmin.strings.error);
             }
             label.text(original);
+            button.prop('disabled', false);
+        },
+
+        async runDiagnostics(e) {
+            e.preventDefault();
+            const button = $(this);
+            button.prop('disabled', true);
+
+            try {
+                const formData = new FormData();
+                formData.append('action', 'rtbcb_run_tests');
+                formData.append('nonce', $(this).data('nonce') || rtbcbAdmin.nonce);
+
+                const response = await fetch(rtbcbAdmin.ajax_url, {
+                    method: 'POST',
+                    body: formData
+                });
+                const data = await response.json();
+                if (data.success) {
+                    let message = '';
+                    for (const [key, result] of Object.entries(data.data)) {
+                        message += `${key}: ${result.passed ? 'PASS' : 'FAIL'} - ${result.message}\n`;
+                    }
+                    alert(message);
+                    console.log('Diagnostics results:', data.data);
+                } else {
+                    alert(data.data?.message || rtbcbAdmin.strings.error);
+                }
+            } catch (err) {
+                console.error('Diagnostics error:', err);
+                alert(rtbcbAdmin.strings.error);
+            }
+
             button.prop('disabled', false);
         },
 

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -49,6 +49,15 @@ $embedding_models = [
             </tr>
             <tr>
                 <th scope="row">
+                    <label><?php echo esc_html__( 'Diagnostics', 'rtbcb' ); ?></label>
+                </th>
+                <td>
+                    <button type="button" class="button" id="rtbcb-run-tests" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rtbcb_nonce' ) ); ?>"><?php echo esc_html__( 'Run Diagnostics', 'rtbcb' ); ?></button>
+                    <p class="description"><?php echo esc_html__( 'Verify integration and system health.', 'rtbcb' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
                     <label for="rtbcb_mini_model"><?php echo esc_html__( 'Mini Model', 'rtbcb' ); ?></label>
                 </th>
                 <td>


### PR DESCRIPTION
## Summary
- add `rtbcb_run_tests` AJAX handler and `run_integration_tests` method
- expose "Run Diagnostics" button in settings and data health page note
- send AJAX request in admin JS and show pass/fail results
- document diagnostics feature in README

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a893cded248331a32a30559cee7994