### PR TITLE
Handle missing router in LLM model selection

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -88,9 +88,14 @@ class RTBCB_LLM {
      * @return string Model name.
      */
     private function select_model( $inputs, $chunks ) {
-        // TODO: Implement model routing logic via RTBCB_Router class
-        $router = new RTBCB_Router();
-        return $router->route_model( $inputs, $chunks );
+        if ( class_exists( 'RTBCB_Router' ) ) {
+            $router = new RTBCB_Router();
+            return $router->route_model( $inputs, $chunks );
+        }
+
+        error_log( 'RTBCB: Router class missing. Using default model.' );
+
+        return isset( $this->models['mini'] ) ? $this->models['mini'] : 'gpt-4o-mini';
     }
 
     /**


### PR DESCRIPTION
## Summary
- Gracefully handle missing `RTBCB_Router` when selecting a model for the LLM by logging a warning and falling back to the default model.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a896f99a388331b1d590728c3f51e2