### PR TITLE
Remove unused polling and clean up localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A comprehensive WordPress plugin that helps treasury teams quantify the benefits
 - Multi-step form with progress indicators
 - Real-time form validation and error handling
 - Interactive pain point selection with visual cards
+- Immediate report rendering via a single AJAX request—no polling needed
 - Responsive design optimized for all devices
 
 **🔍 Improved ROI Calculations**

--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -17,24 +17,6 @@ function handleSubmissionError(errorMessage) {
 }
 
 /**
- * Polls the backend for a generated report.
- * @param {string} reportId - The report identifier.
- * @returns {Promise<object>} The result data.
- */
-async function pollForResult(reportId) {
-    const url = `${ajaxObj.ajax_url}?action=rtbcb_poll_result&report_id=${encodeURIComponent(reportId)}`;
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Server responded with status ${response.status}.`);
-    }
-    const result = await response.json();
-    if (!result.success) {
-        throw new Error(result.data.message || 'An unknown error occurred.');
-    }
-    return result.data;
-}
-
-/**
  * Handles the form submission by sending data to the backend.
  * @param {Event} e - The form submission event.
  */

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -384,7 +384,6 @@ class Real_Treasury_BCB {
             'ajaxObj',
             [
                 'ajax_url'    => admin_url( 'admin-ajax.php' ),
-                'rtbcb_nonce' => wp_create_nonce( 'rtbcb_generate' ),
                 'strings'     => [
                     'error'                   => __( 'An error occurred. Please try again.', 'rtbcb' ),
                     'generating'              => __( 'Generating your comprehensive business case...', 'rtbcb' ),

--- a/tests/handle-submit-error.test.js
+++ b/tests/handle-submit-error.test.js
@@ -18,7 +18,7 @@ global.document = {
     }
 };
 
-global.ajaxObj = { ajax_url: '', rtbcb_nonce: '' };
+global.ajaxObj = { ajax_url: '' };
 
 global.fetch = async () => ({
     ok: true,

--- a/tests/handle-submit-success.test.js
+++ b/tests/handle-submit-success.test.js
@@ -18,7 +18,7 @@ global.document = {
     }
 };
 
-global.ajaxObj = { ajax_url: '', rtbcb_nonce: '' };
+global.ajaxObj = { ajax_url: '' };
 
 global.fetch = async () => ({
     ok: true,


### PR DESCRIPTION
## Summary
- drop unused polling helper in rtbcb.js for direct form submission
- simplify script localization by removing unused nonce
- document immediate AJAX rendering with no polling

## Testing
- `tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a899dbcae48331aaacc9d088364499