### PR TITLE
test: validate report HTML instead of PDF link

### DIFF
--- a/tests/handle-submit-success.test.js
+++ b/tests/handle-submit-success.test.js
@@ -22,7 +22,13 @@ global.ajaxObj = { ajax_url: '' };
 
 global.fetch = async () => ({
     ok: true,
-    json: async () => ({ success: true, data: { report_html: '<div>Report</div>' } }),
+    json: async () => ({
+        success: true,
+        data: {
+            report_html: '<div>Report</div>',
+            download_url: 'http://example.com/test.pdf'
+        }
+    }),
     text: async () => ''
 });
 
@@ -33,6 +39,7 @@ vm.runInThisContext(code);
 
 (async () => {
     await handleSubmit({ preventDefault() {}, target: {} });
-    assert.ok(reportContainer.innerHTML.includes('Report'));
+    assert.strictEqual(reportContainer.innerHTML, '<div>Report</div>');
+    assert.ok(!reportContainer.innerHTML.includes('test.pdf'));
     console.log('Success path test passed.');
 })();


### PR DESCRIPTION
## Summary
- Ensure front-end submission test ignores `download_url`
- Verify that `report_html` is rendered without creating a PDF link

## Testing
- `tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8a08101448331a113a934fb12eddd