### PR TITLE
Allow project-scoped OpenAI keys and share validation

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -606,7 +606,7 @@ class RTBCB_Admin {
         $api_key = get_option( 'rtbcb_openai_api_key' );
         $diagnostics['openai_api'] = [
             'configured'   => ! empty( $api_key ),
-            'valid_format' => ! empty( $api_key ) && preg_match( '/^sk-[a-zA-Z0-9]{48,}$/', $api_key ),
+            'valid_format' => ! empty( $api_key ) && rtbcb_is_valid_openai_api_key( $api_key ),
             'status'       => ! empty( $api_key ) ? 'CONFIGURED' : 'NOT_CONFIGURED',
         ];
 

--- a/inc/class-rtbcb-api-tester.php
+++ b/inc/class-rtbcb-api-tester.php
@@ -29,11 +29,11 @@ class RTBCB_API_Tester {
             ];
         }
 
-        if ( ! preg_match( '/^sk-[a-zA-Z0-9]{48,}$/', $api_key ) ) {
+        if ( ! rtbcb_is_valid_openai_api_key( $api_key ) ) {
             return [
                 'success' => false,
                 'message' => __( 'Invalid API key format', 'rtbcb' ),
-                'details' => __( 'API key should start with "sk-" followed by alphanumeric characters.', 'rtbcb' ),
+                'details' => __( 'API key must start with "sk-" and may contain letters, numbers, hyphens, and colons.', 'rtbcb' ),
             ];
         }
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -84,6 +84,19 @@ function rtbcb_is_business_email( $email ) {
 }
 
 /**
+ * Validate OpenAI API key format.
+ *
+ * Accepts standard and project-scoped keys which start with "sk-" and may
+ * include letters, numbers, hyphens, and colons.
+ *
+ * @param string $api_key API key.
+ * @return bool Whether the format is valid.
+ */
+function rtbcb_is_valid_openai_api_key( $api_key ) {
+    return is_string( $api_key ) && preg_match( '/^sk-[a-zA-Z0-9:-]{48,}$/', $api_key );
+}
+
+/**
  * Get client information for analytics
  *
  * @return array Client data


### PR DESCRIPTION
## Summary
- accept project-scoped OpenAI API keys with hyphens and colons
- centralize API key validation in new helper
- sync admin diagnostics with shared validator

## Testing
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8dc3afd5883318163e0374d49a047