### PR TITLE
Handle invalid OpenAI key format

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -603,11 +603,12 @@ class RTBCB_Admin {
         }
 
         // 7. Check OpenAI API Configuration
-        $api_key = get_option( 'rtbcb_openai_api_key' );
+        $api_key      = get_option( 'rtbcb_openai_api_key' );
+        $valid_format = ! empty( $api_key ) && rtbcb_is_valid_openai_api_key( $api_key );
         $diagnostics['openai_api'] = [
             'configured'   => ! empty( $api_key ),
-            'valid_format' => ! empty( $api_key ) && rtbcb_is_valid_openai_api_key( $api_key ),
-            'status'       => ! empty( $api_key ) ? 'CONFIGURED' : 'NOT_CONFIGURED',
+            'valid_format' => $valid_format,
+            'status'       => ! empty( $api_key ) ? ( $valid_format ? 'CONFIGURED' : 'INVALID_FORMAT' ) : 'NOT_CONFIGURED',
         ];
 
         // 8. Check Memory Limit

--- a/admin/dashboard-page.php
+++ b/admin/dashboard-page.php
@@ -16,13 +16,24 @@ $roi_stats = $stats['average_roi'] ?? [];
 $leads = $recent_leads_data['leads'] ?? [];
 
 // System health checks
-$api_key_configured = ! empty( get_option( 'rtbcb_openai_api_key' ) );
+$api_key = get_option( 'rtbcb_openai_api_key' );
+$api_key_configured = ! empty( $api_key );
+$api_key_valid = $api_key_configured && rtbcb_is_valid_openai_api_key( $api_key );
 $portal_active = (bool) ( has_filter( 'rt_portal_get_vendors' ) || has_filter( 'rt_portal_get_vendor_notes' ) );
 $last_indexed = get_option( 'rtbcb_last_indexed', '' );
 
 // Quick stats
 $conversion_rate = $total_leads > 0 ? ( $recent_leads / $total_leads ) * 100 : 0;
 $avg_roi = intval( $roi_stats['avg_base'] ?? 0 );
+$api_key_status_class = $api_key_valid ? 'rtbcb-status-good' : 'rtbcb-status-warning';
+$api_key_status_icon  = $api_key_valid ? 'dashicons-yes-alt' : 'dashicons-warning';
+if ( ! $api_key_configured ) {
+    $api_key_status_text = __( 'Not configured', 'rtbcb' );
+} elseif ( ! $api_key_valid ) {
+    $api_key_status_text = __( 'Invalid key format', 'rtbcb' );
+} else {
+    $api_key_status_text = __( 'Configured', 'rtbcb' );
+}
 ?>
 
 <div class="wrap rtbcb-admin-page rtbcb-dashboard">
@@ -47,17 +58,17 @@ $avg_roi = intval( $roi_stats['avg_base'] ?? 0 );
     <div class="rtbcb-system-status">
         <h3><?php esc_html_e( 'System Status', 'rtbcb' ); ?></h3>
         <div class="rtbcb-status-grid">
-            <div class="rtbcb-status-item <?php echo $api_key_configured ? 'rtbcb-status-good' : 'rtbcb-status-warning'; ?>">
+            <div class="rtbcb-status-item <?php echo esc_attr( $api_key_status_class ); ?>">
                 <div class="rtbcb-status-icon">
-                    <span class="dashicons <?php echo $api_key_configured ? 'dashicons-yes-alt' : 'dashicons-warning'; ?>"></span>
+                    <span class="dashicons <?php echo esc_attr( $api_key_status_icon ); ?>"></span>
                 </div>
                 <div class="rtbcb-status-content">
                     <div class="rtbcb-status-label"><?php esc_html_e( 'OpenAI API', 'rtbcb' ); ?></div>
                     <div class="rtbcb-status-value">
-                        <?php echo $api_key_configured ? esc_html__( 'Configured', 'rtbcb' ) : esc_html__( 'Not configured', 'rtbcb' ); ?>
+                        <?php echo esc_html( $api_key_status_text ); ?>
                     </div>
                 </div>
-                <?php if ( ! $api_key_configured ) : ?>
+                <?php if ( ! $api_key_configured || ! $api_key_valid ) : ?>
                     <a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-settings' ) ); ?>" class="rtbcb-status-action">
                         <?php esc_html_e( 'Configure', 'rtbcb' ); ?>
                     </a>

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,9 @@ Add the `[rt_business_case_builder]` shortcode to a post or page.
 = Does the plugin generate PDF reports? =
 Yes. The plugin generates downloadable PDF reports for each business case.
 
+= Why does the dashboard say "Invalid key format" for my OpenAI API key? =
+This indicates the saved API key doesn't match the expected pattern. Verify the key starts with `sk-` and is copied completely.
+
 == Changelog ==
 = 2.1.0 =
 * Added PDF report generation capabilities.


### PR DESCRIPTION
## Summary
- mark OpenAI API key status as `INVALID_FORMAT` when a key is present but malformed
- surface invalid key format on the dashboard system status
- document the new status in the FAQ

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8dfae5cb08331b7ba2d024e539826