### PR TITLE
Handle invalid OpenAI API key format

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Add the shortcode to any page or post:
 ## 🎛️ Admin Dashboard Features
 
 ### Main Dashboard
-- **System Status**: OpenAI API, Portal Integration, RAG Index health
+- **System Status**: OpenAI API (configuration and key format), Portal Integration, RAG Index health
 - **Key Metrics**: Total leads, recent activity, average ROI
 - **Recent Leads**: Latest form submissions with quick actions
 - **Quick Actions**: Test API, export data, rebuild index

--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -603,17 +603,23 @@ class RTBCB_Admin {
         }
 
         // 7. Check OpenAI API Configuration
-        $api_key        = get_option( 'rtbcb_openai_api_key' );
-        $configured     = ! empty( $api_key );
-        $valid_format   = $configured && rtbcb_is_valid_openai_api_key( $api_key );
-        $api_test       = RTBCB_API_Tester::test_connection();
+        $api_key      = get_option( 'rtbcb_openai_api_key' );
+        $configured   = ! empty( $api_key );
+        $valid_format = $configured ? rtbcb_is_valid_openai_api_key( $api_key ) : false;
+        $api_test     = RTBCB_API_Tester::test_connection();
+
+        $status = $api_test['success'] ? 'OK' : 'FAIL';
+        if ( $configured && ! $valid_format ) {
+            $status = 'INVALID_FORMAT';
+        }
+
         $diagnostics['openai_api'] = [
             'configured'   => $configured,
             'valid_format' => $valid_format,
             'success'      => $api_test['success'],
             'message'      => $api_test['message'],
             'details'      => $api_test['details'] ?? '',
-            'status'       => $api_test['success'] ? 'OK' : 'FAIL',
+            'status'       => $status,
         ];
 
         // 8. Check Memory Limit

--- a/admin/dashboard-page.php
+++ b/admin/dashboard-page.php
@@ -16,9 +16,11 @@ $roi_stats = $stats['average_roi'] ?? [];
 $leads = $recent_leads_data['leads'] ?? [];
 
 // System health checks
-$api_key_configured = ! empty( get_option( 'rtbcb_openai_api_key' ) );
+$api_key       = get_option( 'rtbcb_openai_api_key' );
+$api_key_configured = ! empty( $api_key );
+$api_key_valid = $api_key_configured && rtbcb_is_valid_openai_api_key( $api_key );
 $portal_active = (bool) ( has_filter( 'rt_portal_get_vendors' ) || has_filter( 'rt_portal_get_vendor_notes' ) );
-$last_indexed = get_option( 'rtbcb_last_indexed', '' );
+$last_indexed  = get_option( 'rtbcb_last_indexed', '' );
 
 // Quick stats
 $conversion_rate = $total_leads > 0 ? ( $recent_leads / $total_leads ) * 100 : 0;
@@ -47,17 +49,25 @@ $avg_roi = intval( $roi_stats['avg_base'] ?? 0 );
     <div class="rtbcb-system-status">
         <h3><?php esc_html_e( 'System Status', 'rtbcb' ); ?></h3>
         <div class="rtbcb-status-grid">
-            <div class="rtbcb-status-item <?php echo $api_key_configured ? 'rtbcb-status-good' : 'rtbcb-status-warning'; ?>">
+            <div class="rtbcb-status-item <?php echo $api_key_valid ? 'rtbcb-status-good' : 'rtbcb-status-warning'; ?>">
                 <div class="rtbcb-status-icon">
-                    <span class="dashicons <?php echo $api_key_configured ? 'dashicons-yes-alt' : 'dashicons-warning'; ?>"></span>
+                    <span class="dashicons <?php echo $api_key_valid ? 'dashicons-yes-alt' : 'dashicons-warning'; ?>"></span>
                 </div>
                 <div class="rtbcb-status-content">
                     <div class="rtbcb-status-label"><?php esc_html_e( 'OpenAI API', 'rtbcb' ); ?></div>
                     <div class="rtbcb-status-value">
-                        <?php echo $api_key_configured ? esc_html__( 'Configured', 'rtbcb' ) : esc_html__( 'Not configured', 'rtbcb' ); ?>
+                        <?php
+                        if ( ! $api_key_configured ) {
+                            esc_html_e( 'Not configured', 'rtbcb' );
+                        } elseif ( ! $api_key_valid ) {
+                            esc_html_e( 'Invalid key format', 'rtbcb' );
+                        } else {
+                            esc_html_e( 'Configured', 'rtbcb' );
+                        }
+                        ?>
                     </div>
                 </div>
-                <?php if ( ! $api_key_configured ) : ?>
+                <?php if ( ! $api_key_valid ) : ?>
                     <a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-settings' ) ); ?>" class="rtbcb-status-action">
                         <?php esc_html_e( 'Configure', 'rtbcb' ); ?>
                     </a>

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ A WordPress plugin that calculates the ROI of treasury technology, builds a narr
 == Description ==
 Real Treasury Business Case Builder helps treasury teams quantify the benefits of modern treasury tools. The plugin provides an ROI calculator, generates narrative summaries with large language models, integrates with the Real Treasury portal for vendor research, and exports comprehensive PDF reports.
 
-Use the `[rt_business_case_builder]` shortcode to embed the calculator on any page. Admin pages allow you to configure default assumptions, set OpenAI API keys, review captured leads, and monitor data health.
+Use the `[rt_business_case_builder]` shortcode to embed the calculator on any page. Admin pages allow you to configure default assumptions, set OpenAI API keys with format validation, review captured leads, and monitor data health.
 
 == Installation ==
 1. Upload `real-treasury-business-case-builder` to the `/wp-content/plugins/` directory.


### PR DESCRIPTION
## Summary
- Mark OpenAI diagnostics as `INVALID_FORMAT` when a key is present but fails validation
- Display "Invalid key format" in dashboard system status for misconfigured keys
- Document API key format validation in README and plugin readme

## Testing
- `tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8e0d99814833194c3bd131a440865