### PR TITLE
Improve overlay text contrast

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -19,7 +19,7 @@
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
     font-size: 16px !important;
     line-height: 1.5 !important;
-    color: #1f2937 !important;
+    color: var(--text-primary) !important;
 }
 
 .rtbcb-modal-overlay h1,
@@ -644,7 +644,7 @@
 
 .rtbcb-benefit-label {
     font-weight: 600;
-    color: #1f2937;
+    color: var(--text-primary);
 }
 
 .rtbcb-benefit-amount {
@@ -804,7 +804,7 @@
     display: block;
     margin-bottom: 8px;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--text-primary);
     font-size: 15px;
 }
 
@@ -847,7 +847,7 @@
     gap: 8px;
     margin-bottom: 0;
     font-weight: 500;
-    color: #1f2937;
+    color: var(--text-primary);
     cursor: pointer;
 }
 
@@ -1172,7 +1172,7 @@
 .rtbcb-modal-subtitle {
     font-size: 16px;
     margin: 0;
-    color: #4b5563;
+    color: var(--text-secondary);
     line-height: 1.5;
     font-weight: 500;
 }
@@ -1183,7 +1183,7 @@
     right: 20px;
     background: rgba(75, 85, 99, 0.1);
     border: none;
-    color: #4b5563;
+    color: var(--text-primary);
     width: 36px;
     height: 36px;
     border-radius: 50%;
@@ -1327,13 +1327,13 @@
 .rtbcb-step-header h3 {
     font-size: 18px;
     margin: 0 0 6px 0;
-    color: #1f2937;
+    color: var(--text-primary);
     font-weight: 600;
 }
 
 .rtbcb-step-header p {
     margin: 0;
-    color: #4b5563;
+    color: var(--text-secondary);
     font-size: 15px;
     line-height: 1.5;
 }
@@ -1353,7 +1353,7 @@
     display: block;
     margin-bottom: 8px;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--text-primary);
     font-size: 15px;
 }
 
@@ -1403,7 +1403,7 @@
 
 .rtbcb-field-help {
     font-size: 14px;
-    color: #4b5563;
+    color: var(--text-secondary);
     margin-top: 4px;
     line-height: 1.4;
 }
@@ -1462,14 +1462,14 @@
 .rtbcb-pain-point-title {
     font-size: 14px;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--text-primary);
     margin-bottom: 4px;
     line-height: 1.2;
 }
 
 .rtbcb-pain-point-description {
     font-size: 13px;
-    color: #4b5563;
+    color: var(--text-secondary);
     line-height: 1.3;
 }
 
@@ -1690,7 +1690,7 @@
 .rtbcb-consent-text {
     font-size: 15px;
     line-height: 1.6;
-    color: #1f2937;
+    color: var(--text-primary);
 }
 
 .rtbcb-consent-text a {
@@ -1728,7 +1728,7 @@
     align-items: flex-start;
     gap: 8px;
     font-size: 14px;
-    color: #1f2937;
+    color: var(--text-primary);
     line-height: 1.4;
 }
 
@@ -1868,8 +1868,8 @@
 /* Update color variables for better contrast */
 :root {
     /* Improved text colors for better readability */
-    --text-primary: #1f2937;        /* Dark gray for primary text */
-    --text-secondary: #4b5563;      /* Medium gray for secondary text */
+    --text-primary: #f3f4f6;        /* Light gray for primary text */
+    --text-secondary: #e5e7eb;      /* Lighter gray for secondary text */
     --text-muted: #6b7280;          /* Only for least important text */
     --text-light: #9ca3af;          /* Only for disabled states */
 


### PR DESCRIPTION
## Summary
- lighten `--text-primary` and `--text-secondary` to improve contrast on dark overlay
- switch label and description selectors to use the new light text variables

## Testing
- `./tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8e90211508331ae32befa5d84a7b0