### PR TITLE
Use text-primary color for alternative name and step headings

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -687,7 +687,7 @@
 
 .rtbcb-alternative-name {
     font-weight: 600;
-    color: var(--dark-text);
+    color: var(--text-primary);
     margin-bottom: 8px;
 }
 
@@ -787,7 +787,7 @@
 
 .rtbcb-step-content h5 {
     margin: 0 0 8px 0;
-    color: var(--dark-text);
+    color: var(--text-primary);
     font-weight: 600;
 }
 


### PR DESCRIPTION
## Summary
- Switch alternative name and step heading color variables to `--text-primary`

## Testing
- `./tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8eb31582c8331a41744b064359efb