### PR TITLE
Use primary text color for chart titles

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -1595,7 +1595,7 @@
 .rtbcb-chart-title {
     font-weight: 600;
     margin-bottom: 20px;
-    color: var(--dark-text);
+    color: var(--text-primary);
 }
 
 .rtbcb-benefit-bars {


### PR DESCRIPTION
## Summary
- use `var(--text-primary)` for `.rtbcb-chart-title` so chart headings match primary text color

## Testing
- `./tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8eb32b3948331b71665ad98dfab5a