### PR TITLE
feat: refine progress indicator colors

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -421,7 +421,7 @@
 .rtbcb-progress-text {
     font-size: 18px;
     font-weight: 600;
-    color: var(--dark-text);
+    color: var(--text-primary);
     margin-bottom: 20px;
 }
 
@@ -1258,7 +1258,7 @@
     border-radius: 50%;
     background: rgba(255, 255, 255, 0.9);
     border: 2px solid #e2e8f0;
-    color: #4b5563;
+    color: var(--text-primary);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1284,7 +1284,7 @@
 
 .rtbcb-progress-label {
     font-size: 14px;
-    color: #4b5563;
+    color: var(--text-primary);
     font-weight: 600;
     text-align: center;
 }


### PR DESCRIPTION
## Summary
- use `var(--text-primary)` for progress text, numbers, and labels
- retain brand colors for active and completed progress states

## Testing
- `./tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8eb2ffbd88331be13d4b60c628241