### PR TITLE
Allow underscores in OpenAI API key validation

### DIFF
--- a/inc/class-rtbcb-api-tester.php
+++ b/inc/class-rtbcb-api-tester.php
@@ -33,7 +33,7 @@ class RTBCB_API_Tester {
             return [
                 'success' => false,
                 'message' => __( 'Invalid API key format', 'rtbcb' ),
-                'details' => __( 'API key must start with "sk-" and may contain letters, numbers, hyphens, and colons.', 'rtbcb' ),
+                'details' => __( 'API key must start with "sk-" and may contain letters, numbers, hyphens, colons, and underscores.', 'rtbcb' ),
             ];
         }
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -87,13 +87,13 @@ function rtbcb_is_business_email( $email ) {
  * Validate OpenAI API key format.
  *
  * Accepts standard and project-scoped keys which start with "sk-" and may
- * include letters, numbers, hyphens, and colons.
+ * include letters, numbers, hyphens, colons, and underscores.
  *
  * @param string $api_key API key.
  * @return bool Whether the format is valid.
  */
 function rtbcb_is_valid_openai_api_key( $api_key ) {
-    return is_string( $api_key ) && preg_match( '/^sk-[a-zA-Z0-9:-]{48,}$/', $api_key );
+    return is_string( $api_key ) && preg_match( '/^sk-[A-Za-z0-9:_-]{48,}$/', $api_key );
 }
 
 /**


### PR DESCRIPTION
## Summary
- expand OpenAI API key validation to allow underscores
- update validation error message to mention underscores

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a8ec28afc08331bcc0f469b63a3b06