### PR TITLE
Ensure progress steps display above progress line

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -93,7 +93,7 @@
     right: 10% !important;
     height: 2px !important;
     background: #e2e8f0 !important;
-    z-index: 1 !important;
+    z-index: 0 !important;
 }
 
 /* Step content fixes */
@@ -1239,7 +1239,7 @@
     right: 0;
     height: 2px;
     background: rgba(226, 232, 240, 0.6);
-    z-index: 1;
+    z-index: 0;
 }
 
 .rtbcb-progress-step {


### PR DESCRIPTION
## Summary
- Lower progress line pseudo-element z-index so the line sits behind markers.
- Confirm progress step elements maintain higher z-index for visible numbers and checkmarks.

## Testing
- `./tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8edefd20c833189a2fc947d31a2c9