### PR TITLE
style: enhance pain point card contrast

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -163,7 +163,7 @@
     all: unset !important;
     display: block !important;
     background: #ffffff !important;
-    border: 2px solid #e2e8f0 !important;
+    border: 2px solid #cbd5e1 !important;
     border-radius: 12px !important;
     overflow: hidden !important;
     transition: all 0.2s ease !important;
@@ -1417,7 +1417,7 @@
 
 .rtbcb-pain-point-card {
     background: white;
-    border: 2px solid #e2e8f0;
+    border: 2px solid #cbd5e1;
     border-radius: 6px;
     overflow: hidden;
     transition: all 0.2s ease;
@@ -1470,6 +1470,14 @@
     font-size: 13px;
     color: var(--text-secondary);
     line-height: 1.3;
+}
+
+.rtbcb-pain-point-card.rtbcb-selected .rtbcb-pain-point-title {
+    color: var(--dark-text) !important;
+}
+
+.rtbcb-pain-point-card.rtbcb-selected .rtbcb-pain-point-description {
+    color: var(--gray-text) !important;
 }
 
 /* Navigation - Compact */


### PR DESCRIPTION
## Summary
- darken pain point titles and descriptions when a card is selected
- strengthen default pain point card border for clearer separation

## Testing
- `node --check public/js/rtbcb-wizard.js`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a8edef1eb08331a0ef7c88d76fe98f