### PR TITLE
Ensure modal overlay centers content with padding

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -47,6 +47,10 @@
     height: 100vh !important;
     z-index: 999999 !important;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    padding: 20px !important;
 }
 
 /* Reset and isolate modal container */
@@ -62,8 +66,8 @@
     width: 100% !important;
     max-width: 900px !important;
     margin: 0 auto !important;
-    overflow: visible !important;
-    max-height: none !important;
+    overflow: auto !important;
+    max-height: 90vh !important;
     position: relative !important;
 }
 


### PR DESCRIPTION
## Summary
- convert overlay to flex layout with centered content and padding
- allow modal content to scroll and respect viewport height

## Testing
- `node test-centering.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8edf0d9908331a3ec62ecec341dac