### PR TITLE
Add sample inputs helper and integrate with diagnostics

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -642,15 +642,7 @@ class RTBCB_Admin {
 
         // 10. Test Basic Functionality
         try {
-            $test_inputs = [
-                'company_size'           => '$50M-$500M',
-                'industry'               => 'manufacturing',
-                'hours_reconciliation'   => 5,
-                'hours_cash_positioning' => 3,
-                'num_banks'              => 3,
-                'ftes'                   => 1,
-                'pain_points'            => [ 'manual_processes' ],
-            ];
+            $test_inputs = rtbcb_get_sample_inputs();
 
             if ( class_exists( 'RTBCB_Calculator' ) ) {
                 $roi_result = RTBCB_Calculator::calculate_roi( $test_inputs );

--- a/inc/class-rtbcb-tests.php
+++ b/inc/class-rtbcb-tests.php
@@ -87,13 +87,7 @@ class RTBCB_Tests {
 
         $llm = new RTBCB_LLM();
 
-        $user_inputs = [
-            'company_name' => 'Acme Corp',
-            'company_size' => '$50M-$500M',
-            'industry'     => 'manufacturing',
-            'job_title'    => 'Treasury Manager',
-            'pain_points'  => [ 'manual_processes', 'bank_fees' ],
-        ];
+        $user_inputs = rtbcb_get_sample_inputs();
 
         $roi_data = [
             'base' => [

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -212,3 +212,29 @@ function rtbcb_get_memory_status() {
     ];
 }
 
+/**
+ * Retrieve sample user inputs for testing purposes.
+ *
+ * @return array Sample user inputs.
+ */
+function rtbcb_get_sample_inputs() {
+    $inputs = [
+        'company_name'          => 'Acme Corp',
+        'company_size'          => '$50M-$500M',
+        'industry'              => 'manufacturing',
+        'job_title'             => 'Treasury Manager',
+        'hours_reconciliation'  => 5,
+        'hours_cash_positioning'=> 3,
+        'num_banks'             => 3,
+        'ftes'                  => 1,
+        'pain_points'           => [ 'manual_processes', 'bank_fees' ],
+    ];
+
+    /**
+     * Filter sample inputs used for diagnostics and tests.
+     *
+     * @param array $inputs Default sample inputs.
+     */
+    return apply_filters( 'rtbcb_sample_inputs', $inputs );
+}
+


### PR DESCRIPTION
## Summary
- add `rtbcb_get_sample_inputs()` helper returning representative data and allow override via `rtbcb_sample_inputs` filter
- replace hard-coded sample arrays in diagnostics and integration tests

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a8eec9f0488331bff9ddc47deadaf1