### PR TITLE
Add filters for ROI multipliers and error cost map

### DIFF
--- a/inc/class-rtbcb-calculator.php
+++ b/inc/class-rtbcb-calculator.php
@@ -42,12 +42,30 @@ class RTBCB_Calculator {
      * @return array
      */
     private static function calculate_scenario( $inputs, $settings, $category, $scenario_type, $industry_mult ) {
-        $multipliers = [
-            'conservative' => 0.8,
-            'base'         => 1.0,
-            'optimistic'   => 1.2,
-        ];
-        $multiplier = $multipliers[ $scenario_type ];
+        /**
+         * Filters the scenario multipliers used to adjust ROI calculations.
+         *
+         * @param array  $multipliers   Associative array of scenario multipliers.
+         * @param array  $inputs        User provided inputs.
+         * @param array  $settings      Plugin settings.
+         * @param array  $category      Recommended category info.
+         * @param string $scenario_type Scenario type.
+         * @param float  $industry_mult Industry benchmark multiplier.
+         */
+        $multipliers = apply_filters(
+            'rtbcb_roi_multipliers',
+            [
+                'conservative' => 0.8,
+                'base'         => 1.0,
+                'optimistic'   => 1.2,
+            ],
+            $inputs,
+            $settings,
+            $category,
+            $scenario_type,
+            $industry_mult
+        );
+        $multiplier  = $multipliers[ $scenario_type ];
 
         $labor_savings   = self::calculate_labor_savings( $inputs, $settings, $multiplier );
         $fee_savings     = self::calculate_fee_savings( $inputs, $settings, $multiplier );
@@ -118,12 +136,26 @@ class RTBCB_Calculator {
      * @return float Annual error reduction benefit.
      */
     private static function calculate_error_reduction( $inputs, $settings, $multiplier ) {
-        $cost_map = [
-            '<$50M'       => 25000,
-            '$50M-$500M'  => 75000,
-            '$500M-$2B'   => 200000,
-            '>$2B'        => 500000,
-        ];
+        /**
+         * Filters the base error cost map used for calculating error reduction savings.
+         *
+         * @param array $cost_map   Map of company sizes to base error costs.
+         * @param array $inputs     User provided inputs.
+         * @param array $settings   Plugin settings.
+         * @param float $multiplier Scenario multiplier.
+         */
+        $cost_map = apply_filters(
+            'rtbcb_error_cost_map',
+            [
+                '<$50M'       => 25000,
+                '$50M-$500M'  => 75000,
+                '$500M-$2B'   => 200000,
+                '>$2B'        => 500000,
+            ],
+            $inputs,
+            $settings,
+            $multiplier
+        );
         $company_size = isset( $inputs['company_size'] ) ? $inputs['company_size'] : '';
         $base_cost    = isset( $cost_map[ $company_size ] ) ? $cost_map[ $company_size ] : 50000;
         $reduction    = 0.25 * $multiplier;

--- a/tests/filters-override.test.php
+++ b/tests/filters-override.test.php
@@ -1,0 +1,64 @@
+<?php
+require_once __DIR__ . '/../inc/class-rtbcb-calculator.php';
+
+if ( ! function_exists( 'add_filter' ) ) {
+    $GLOBALS['rtbcb_filters'] = [];
+
+    function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+        $GLOBALS['rtbcb_filters'][ $tag ] = $function_to_add;
+    }
+
+    function apply_filters( $tag, $value ) {
+        $args = func_get_args();
+        $tag  = array_shift( $args );
+        $value = array_shift( $args );
+
+        if ( isset( $GLOBALS['rtbcb_filters'][ $tag ] ) ) {
+            $value = call_user_func_array( $GLOBALS['rtbcb_filters'][ $tag ], array_merge( [ $value ], $args ) );
+        }
+
+        return $value;
+    }
+}
+
+$inputs = [
+    'hours_reconciliation' => 10,
+    'hours_cash_positioning' => 0,
+    'num_banks' => 1,
+    'company_size' => '$50M-$500M',
+];
+
+$settings = [
+    'labor_cost_per_hour' => 100,
+    'bank_fee_baseline' => 15000,
+];
+
+$category = [ 'roi_range' => [ 0, 1000000 ] ];
+$scenario = 'base';
+$industry_mult = 1.0;
+
+add_filter( 'rtbcb_roi_multipliers', function ( $multipliers, $inputs, $settings, $category, $scenario_type, $industry ) {
+    $multipliers['base'] = 2.0;
+    return $multipliers;
+}, 10, 6 );
+
+add_filter( 'rtbcb_error_cost_map', function ( $cost_map ) {
+    $cost_map['$50M-$500M'] = 1000000;
+    return $cost_map;
+}, 10, 4 );
+
+$method = new ReflectionMethod( RTBCB_Calculator::class, 'calculate_scenario' );
+$method->setAccessible( true );
+$result = $method->invoke( null, $inputs, $settings, $category, $scenario, $industry_mult );
+
+if ( abs( $result['assumptions']['efficiency_improvement'] - 0.60 ) > 0.0001 ) {
+    echo "Multiplier filter did not apply\n";
+    exit( 1 );
+}
+
+if ( 500000 !== (int) $result['error_reduction'] ) {
+    echo "Error cost map filter did not apply\n";
+    exit( 1 );
+}
+
+echo "filters-override.test.php passed\n";

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -15,18 +15,22 @@ php tests/json-output-lint.php
 echo "3. Running cosine similarity search test..."
 php tests/cosine-similarity-search.test.php
 
+# Filter override test
+echo "4. Running filter override test..."
+php tests/filters-override.test.php
+
 # JavaScript tests
-echo "4. Running JavaScript tests..."
+echo "5. Running JavaScript tests..."
 node tests/handle-submit-error.test.js
 node tests/render-results-no-narrative.test.js
 node tests/handle-submit-success.test.js
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then
-    echo "5. Running WordPress coding standards check..."
+    echo "6. Running WordPress coding standards check..."
     phpcs --standard=WordPress --ignore=vendor .
 else
-    echo "5. Skipping WordPress coding standards (phpcs not installed)"
+    echo "6. Skipping WordPress coding standards (phpcs not installed)"
 fi
 
 echo "================================================"


### PR DESCRIPTION
## Summary
- Allow ROI scenario multipliers to be customized via `rtbcb_roi_multipliers` filter.
- Allow error cost mapping to be customized via `rtbcb_error_cost_map` filter.
- Add test and test runner integration verifying filter overrides.

## Testing
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8eec8e538833189d9b7c9dc3377ad