### PR TITLE
Remove dark-mode override for public text colors

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -1874,13 +1874,13 @@
 
 /* READABILITY IMPROVEMENTS FOR TREASURY BUSINESS CASE BUILDER */
 
-/* 1. IMPROVE TEXT CONTRAST - Replace light grays with darker, more readable colors */
+/* 1. IMPROVE TEXT CONTRAST - Use light tones for dark backgrounds */
 
 /* Update color variables for better contrast */
 :root {
     /* Improved text colors for better readability */
-    --text-primary: #1f2937;        /* Dark slate for primary text */
-    --text-secondary: #4b5563;      /* Darker gray for secondary text */
+    --text-primary: #f3f4f6;        /* Light tone for primary text */
+    --text-secondary: #e5e7eb;      /* Lighter gray for secondary text */
     --text-muted: #6b7280;          /* Only for least important text */
     --text-light: #9ca3af;          /* Only for disabled states */
 
@@ -1888,13 +1888,6 @@
     --font-base: 1rem;              /* 16px */
     --font-sm: 0.9rem;              /* 14.4px (never smaller) */
     --font-xs: 0.875rem;            /* 14px (minimum readable size) */
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --text-primary: #f3f4f6;
-        --text-secondary: #e5e7eb;
-    }
 }
 
 /* 2. IMPROVE MODAL TEXT READABILITY */


### PR DESCRIPTION
## Summary
- Set `--text-primary` and `--text-secondary` to light tones for consistent appearance
- Remove dark-mode variable overrides to keep light colors across themes

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8f0eb92f48331ab3e8af4043de2aa