### PR TITLE
Ensure modal overlay stays within viewport

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -45,6 +45,7 @@
     left: 0 !important;
     width: 100vw !important;
     height: 100vh !important;
+    overflow: hidden !important;
     z-index: 999999 !important;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
     display: flex !important;
@@ -1099,6 +1100,7 @@
     left: 0;
     width: 100vw;
     height: 100vh;
+    overflow: hidden;
     background: linear-gradient(135deg, rgba(0, 0, 0, 0.4), rgba(40, 19, 69, 0.6));
     backdrop-filter: blur(20px) saturate(120%);
     -webkit-backdrop-filter: blur(20px) saturate(120%);
@@ -1129,8 +1131,8 @@
     width: 100%;
     max-width: 900px;
     margin: 0 auto;
-    max-height: none;
-    overflow: visible;
+    max-height: 100%;
+    overflow-y: auto;
     transform: scale(0.9) translateY(30px);
     transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     position: relative;


### PR DESCRIPTION
## Summary
- Prevent modal overlay from exceeding viewport height by hiding overflow in both overlay rules
- Allow modal content to scroll within the viewport with `overflow-y: auto` and bounded height

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68a8f0efd6a8833198634c399f2e38c5