### PR TITLE
Simplify API test page to only report success/failure

### DIFF
--- a/admin/api-test-page.php
+++ b/admin/api-test-page.php
@@ -39,42 +39,6 @@ if ( ! defined( 'ABSPATH' ) ) {
                     }
                     html += '</div>';
                     $results.html(html);
-
-                    var reportHtml = response.data.html || html;
-                    var $actions = $('<p></p>');
-                    var $viewLink = $('<a>', {
-                        href: '#',
-                        target: '_blank',
-                        class: 'button',
-                        text: '<?php echo esc_js( __( 'View Full Page', 'rtbcb' ) ); ?>'
-                    });
-                    var $downloadBtn = $('<button>', {
-                        type: 'button',
-                        class: 'button button-secondary',
-                        text: '<?php echo esc_js( __( 'Download HTML', 'rtbcb' ) ); ?>'
-                    });
-                    $actions.append($viewLink).append(' ').append($downloadBtn);
-                    $results.append($actions);
-
-                    $viewLink.on('click', function(e){
-                        e.preventDefault();
-                        var blob = new Blob([reportHtml], {type: 'text/html'});
-                        var url = URL.createObjectURL(blob);
-                        window.open(url, '_blank');
-                        setTimeout(function(){ URL.revokeObjectURL(url); }, 1000);
-                    });
-
-                    $downloadBtn.on('click', function(){
-                        var blob = new Blob([reportHtml], {type: 'text/html'});
-                        var url = URL.createObjectURL(blob);
-                        var a = document.createElement('a');
-                        a.href = url;
-                        a.download = 'rtbcb-test.html';
-                        document.body.appendChild(a);
-                        a.click();
-                        document.body.removeChild(a);
-                        URL.revokeObjectURL(url);
-                    });
                 } else {
                     var errorHtml = '<div class="notice notice-error"><p><strong>❌ ' + response.data.message + '</strong></p>' +
                         '<p>' + response.data.details + '</p>';


### PR DESCRIPTION
## Summary
- Remove view and download report actions from the API test admin page
- Ensure API test now only displays success or error messages

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a8f1ef937483318cf8def9941c7596