### PR TITLE
Ensure modal colors override theme styles

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -48,6 +48,7 @@
     overflow: hidden !important;
     z-index: 999999 !important;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
+    color: var(--text-primary) !important;
     display: flex !important;
     align-items: center !important;
     justify-content: center !important;
@@ -1158,7 +1159,7 @@
 /* Modal Header - Glassmorphic enhancement */
 .rtbcb-modal-header {
     background: linear-gradient(135deg, rgba(114, 22, 244, 0.1), rgba(143, 71, 246, 0.15));
-    color: var(--text-primary);
+    color: var(--text-primary) !important;
     padding: 32px 40px 20px 40px;
     position: relative;
     text-align: center;
@@ -1171,7 +1172,7 @@
     font-weight: 700;
     margin: 0 0 8px 0;
     line-height: 1.2;
-    color: var(--text-primary);
+    color: var(--text-primary) !important;
 }
 
 .rtbcb-modal-subtitle {
@@ -1332,7 +1333,7 @@
 .rtbcb-step-header h3 {
     font-size: 18px;
     margin: 0 0 6px 0;
-    color: var(--text-primary);
+    color: var(--text-primary) !important;
     font-weight: 600;
 }
 


### PR DESCRIPTION
## Summary
- Preserve base modal overlay color by explicitly setting `color: var(--text-primary) !important` on the reset block.
- Force modal header, title, and step headers to honor the light text tone across themes using `!important`.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68a8f29e7bdc833183b0e1f3e8990c5c