### PR TITLE
Add report preview admin page with AJAX preview

### DIFF
--- a/admin/css/rtbcb-admin.css
+++ b/admin/css/rtbcb-admin.css
@@ -14,6 +14,16 @@
     pointer-events: none;
 }
 
+#rtbcb-report-preview {
+    margin-top: 20px;
+}
+
+#rtbcb-report-iframe {
+    width: 100%;
+    height: 600px;
+    border: 1px solid #ccd0d4;
+}
+
 @media (max-width: 782px) {
     .rtbcb-admin-page .rtbcb-admin-header,
     .rtbcb-admin-page .rtbcb-dashboard {

--- a/admin/report-preview-page.php
+++ b/admin/report-preview-page.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Report preview admin page.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$sample_context = [
+    'company_name'  => 'Sample Company',
+    'analysis_date' => current_time( 'Y-m-d' ),
+];
+?>
+<div class="wrap rtbcb-admin-page">
+    <h1><?php esc_html_e( 'Report Preview', 'rtbcb' ); ?></h1>
+    <form id="rtbcb-report-preview-form">
+        <p>
+            <label for="rtbcb-sample-context">
+                <?php esc_html_e( 'Business Context (JSON)', 'rtbcb' ); ?>
+            </label>
+            <textarea id="rtbcb-sample-context" name="context" rows="8" class="large-text"><?php echo esc_textarea( wp_json_encode( $sample_context, JSON_PRETTY_PRINT ) ); ?></textarea>
+        </p>
+        <p>
+            <label for="rtbcb-template-override">
+                <?php esc_html_e( 'Template Override (optional PHP/HTML)', 'rtbcb' ); ?>
+            </label>
+            <textarea id="rtbcb-template-override" name="template" rows="8" class="large-text"></textarea>
+        </p>
+        <?php wp_nonce_field( 'rtbcb_generate_report_preview', 'nonce' ); ?>
+        <p>
+            <button type="submit" class="button button-primary" id="rtbcb-generate-report">
+                <?php esc_html_e( 'Generate Report', 'rtbcb' ); ?>
+            </button>
+            <button type="button" class="button" id="rtbcb-download-pdf" style="display:none;">
+                <?php esc_html_e( 'Download PDF', 'rtbcb' ); ?>
+            </button>
+        </p>
+    </form>
+    <div id="rtbcb-report-preview">
+        <iframe id="rtbcb-report-iframe"></iframe>
+    </div>
+</div>
+


### PR DESCRIPTION
## Summary
- add Report Preview admin page to experiment with business context and templates
- implement AJAX report generator and submenu entry
- add JS and CSS to preview reports inline and enable PDF download

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8f1f0fba08331a55e2ab942d60ee5