### PR TITLE
Add sample report test page and AJAX handler

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -8,6 +8,7 @@
             this.initLeadsManager();
             this.bindDiagnosticsButton();
             this.bindReportPreview();
+            this.bindSampleReport();
         },
 
         bindDashboardActions() {
@@ -324,6 +325,40 @@
                     const iframe = document.getElementById('rtbcb-report-iframe');
                     if (iframe) { iframe.srcdoc = data.data.html; }
                     document.getElementById('rtbcb-download-pdf').style.display = 'inline-block';
+                } else {
+                    alert(data.data?.message || rtbcbAdmin.strings.error);
+                }
+            } catch(err) {
+                alert(`${rtbcbAdmin.strings.error} ${err.message}`);
+            }
+            button.textContent = original;
+            button.disabled = false;
+        },
+
+        bindSampleReport() {
+            const button = document.getElementById('rtbcb-generate-sample-report');
+            if (!button) { return; }
+            button.addEventListener('click', this.generateSampleReport.bind(this));
+        },
+
+        async generateSampleReport(e) {
+            e.preventDefault();
+            const button = e.currentTarget;
+            const original = button.textContent;
+            button.textContent = rtbcbAdmin.strings.processing;
+            button.disabled = true;
+            try {
+                const formData = new FormData();
+                formData.append('action', 'rtbcb_generate_sample_report');
+                formData.append('nonce', rtbcbAdmin.nonce);
+                const response = await fetch(rtbcbAdmin.ajax_url, { method: 'POST', body: formData });
+                if (!response.ok) {
+                    throw new Error(`Server responded ${response.status}`);
+                }
+                const data = await response.json();
+                if (data.success) {
+                    const iframe = document.getElementById('rtbcb-sample-report-frame');
+                    if (iframe) { iframe.srcdoc = data.data.report_html; }
                 } else {
                     alert(data.data?.message || rtbcbAdmin.strings.error);
                 }

--- a/admin/report-test-page.php
+++ b/admin/report-test-page.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Sample report test page.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div class="wrap rtbcb-admin-page">
+    <h1><?php esc_html_e( 'Report Test', 'rtbcb' ); ?></h1>
+    <p>
+        <button type="button" id="rtbcb-generate-sample-report" class="button button-primary">
+            <?php esc_html_e( 'Generate Sample Report', 'rtbcb' ); ?>
+        </button>
+    </p>
+    <div id="rtbcb-sample-report-container">
+        <iframe id="rtbcb-sample-report-frame"></iframe>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add admin Report Test page with button and iframe for sample reports
- wire up submenu and AJAX handler to generate sample report via router
- extend admin JS to request and display sample report

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a8f4a3cd288331bc3fef75c435d98d