### PR TITLE
Add comprehensive report option to router

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -12,9 +12,11 @@ class RTBCB_Router {
     /**
      * Handle form submission and generate the business case.
      *
+     * @param string $report_type Optional report type (basic or comprehensive).
+     *
      * @return void
      */
-    public function handle_form_submission() {
+    public function handle_form_submission( $report_type = 'basic' ) {
         // Nonce verification.
         if ( ! isset( $_POST['rtbcb_nonce'] ) || ! wp_verify_nonce( $_POST['rtbcb_nonce'], 'rtbcb_form_action' ) ) {
             wp_send_json_error( [ 'message' => __( 'Nonce verification failed.', 'rtbcb' ) ], 403 );
@@ -33,6 +35,11 @@ class RTBCB_Router {
 
             $form_data = $validated_data;
 
+            // Determine report type from request if provided.
+            if ( isset( $_POST['report_type'] ) ) {
+                $report_type = sanitize_text_field( wp_unslash( $_POST['report_type'] ) );
+            }
+
             // Instantiate necessary classes.
             $llm = new RTBCB_LLM();
             $rag = new RTBCB_RAG();
@@ -43,19 +50,29 @@ class RTBCB_Router {
             // Generate context from RAG.
             $rag_context = $rag->get_context( $form_data['company_description'] );
 
-            // Route to the appropriate model.
-            $model = $this->route_model( $form_data, $rag_context );
-            if ( is_wp_error( $model ) ) {
-                throw new Exception( $model->get_error_message() );
-            }
+            if ( 'comprehensive' === $report_type ) {
+                // Generate comprehensive business case with LLM.
+                $business_case_data = $llm->generate_comprehensive_business_case( $form_data, $calculations, $rag_context );
+            } else {
+                // Route to the appropriate model.
+                $model = $this->route_model( $form_data, $rag_context );
+                if ( is_wp_error( $model ) ) {
+                    throw new Exception( $model->get_error_message() );
+                }
 
-            // Generate business case with LLM.
-            $business_case_data = $llm->generate_business_case( $form_data, $calculations, $rag_context, $model );
+                // Generate basic business case with LLM.
+                $business_case_data = $llm->generate_business_case( $form_data, $calculations, $rag_context, $model );
+            }
 
             // Check for LLM generation errors before proceeding.
             if ( is_wp_error( $business_case_data ) ) {
                 throw new Exception( $business_case_data->get_error_message() );
             }
+
+            // Generate report HTML based on type.
+            $report_html = 'comprehensive' === $report_type ?
+                $this->get_comprehensive_report_html( $business_case_data ) :
+                $this->get_report_html( $business_case_data );
 
             // Save the lead.
             $leads   = new RTBCB_Leads();
@@ -66,7 +83,7 @@ class RTBCB_Router {
                 [
                     'message'     => __( 'Business case generated successfully.', 'rtbcb' ),
                     'report_id'   => $lead_id,
-                    'report_html' => $this->get_report_html( $business_case_data ),
+                    'report_html' => $report_html,
                 ]
             );
         } catch ( Exception $e ) {
@@ -162,6 +179,29 @@ class RTBCB_Router {
 
         if ( ! file_exists( $template_path ) ) {
             return '';
+        }
+
+        $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
+
+        ob_start();
+        include $template_path;
+        $html = ob_get_clean();
+
+        return wp_kses_post( $html );
+    }
+
+    /**
+     * Generate comprehensive report HTML.
+     *
+     * @param array $business_case_data Business case data.
+     *
+     * @return string Report HTML.
+     */
+    private function get_comprehensive_report_html( $business_case_data ) {
+        $template_path = RTBCB_DIR . 'templates/comprehensive-report-template.php';
+
+        if ( ! file_exists( $template_path ) ) {
+            return $this->get_report_html( $business_case_data );
         }
 
         $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];


### PR DESCRIPTION
## Summary
- Allow `RTBCB_Router::handle_form_submission` to request basic or comprehensive reports and call the appropriate LLM method
- Provide `RTBCB_Router::get_comprehensive_report_html` for rendering the comprehensive template

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8f4a502148331907b82f12dab5f03