### PR TITLE
fix: ensure progress numbers overlay tracker line

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -1275,6 +1275,8 @@
     background: rgba(255, 255, 255, 0.9);
     border: 2px solid #e2e8f0;
     color: var(--text-primary);
+    position: relative;
+    z-index: 1;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Summary
- keep progress step numbers visible above tracker line by adding relative positioning and z-index

## Testing
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8f770b5c88331879ba06d04372654