### PR TITLE
Update default shortcode title

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -448,7 +448,7 @@ class Real_Treasury_BCB {
         // Parse attributes
         $atts = shortcode_atts( [
             'style'    => 'default',
-            'title'    => __( 'Treasury Technology Business Case Builder', 'rtbcb' ),
+            'title'    => __( 'Treasury Tech Business Case Builder', 'rtbcb' ),
             'subtitle' => __( 'Generate a data-driven business case for your treasury technology investment.', 'rtbcb' ),
         ], $atts, 'rt_business_case_builder' );
 


### PR DESCRIPTION
## Summary
- shorten default shortcode title to "Treasury Tech Business Case Builder"

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `php -r 'function __($t,$d){return $t;} function esc_html($t){return $t;} function esc_html_e($t,$d){echo $t;} function wp_nonce_field(){} class RTBCB_Category_Recommender{public static function get_all_categories(){return [];}} include "templates/business-case-form.php";' | grep -n "modal-title" -n`

------
https://chatgpt.com/codex/tasks/task_e_68a8f76e10e88331ae06a15bae757b2b