### PR TITLE
Centralize sample scenario data for report preview

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -309,8 +309,8 @@
                 const injectSample = () => {
                     const key = select.value;
                     const target = document.getElementById('rtbcb-sample-context');
-                    if (key && target && window.rtbcbSampleForms && rtbcbSampleForms[key]) {
-                        target.value = JSON.stringify(rtbcbSampleForms[key], null, 2);
+                    if (key && target && rtbcbAdmin.sampleForms && rtbcbAdmin.sampleForms[key]) {
+                        target.value = JSON.stringify(rtbcbAdmin.sampleForms[key], null, 2);
                     }
                 };
                 select.addEventListener('change', injectSample);
@@ -332,7 +332,7 @@
                 formData.append('nonce', rtbcbAdmin.nonce);
                 if (sampleKey) {
                     formData.append('action', 'rtbcb_generate_sample_report');
-                    formData.append('sample_key', sampleKey);
+                    formData.append('scenario_key', sampleKey);
                 } else {
                     formData.append('action', 'rtbcb_generate_report_preview');
                 }

--- a/admin/report-preview-page.php
+++ b/admin/report-preview-page.php
@@ -9,30 +9,9 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-$rtbcb_sample_forms = [
-    'enterprise_manufacturer' => [
-        'label' => __( 'Enterprise Manufacturer', 'rtbcb' ),
-        'data'  => [
-            'company_name'  => 'Acme Manufacturing',
-            'company_size'  => '1000-5000',
-            'industry'      => 'Manufacturing',
-            'location'      => 'USA',
-            'analysis_date' => current_time( 'Y-m-d' ),
-        ],
-    ],
-    'tech_startup'           => [
-        'label' => __( 'Tech Startup', 'rtbcb' ),
-        'data'  => [
-            'company_name'  => 'Innovatech',
-            'company_size'  => '1-50',
-            'industry'      => 'Technology',
-            'location'      => 'UK',
-            'analysis_date' => current_time( 'Y-m-d' ),
-        ],
-    ],
-];
-
-$sample_context = $rtbcb_sample_forms['enterprise_manufacturer']['data'];
+$rtbcb_sample_forms = rtbcb_get_sample_report_forms();
+$first_scenario     = reset( $rtbcb_sample_forms );
+$sample_context     = $first_scenario['data'];
 ?>
 <div class="wrap rtbcb-admin-page">
     <h1><?php esc_html_e( 'Report Preview', 'rtbcb' ); ?></h1>
@@ -80,6 +59,7 @@ foreach ( $rtbcb_sample_forms as $key => $scenario ) {
 }
 ?>
 <script type="text/javascript">
-    const rtbcbSampleForms = <?php echo wp_json_encode( $rtbcb_sample_data ); ?>;
+    window.rtbcbAdmin = window.rtbcbAdmin || {};
+    rtbcbAdmin.sampleForms = <?php echo wp_json_encode( $rtbcb_sample_data ); ?>;
 </script>
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -238,3 +238,50 @@ function rtbcb_get_sample_inputs() {
     return apply_filters( 'rtbcb_sample_inputs', $inputs );
 }
 
+/**
+ * Retrieve predefined sample report scenarios.
+ *
+ * @return array Map of scenario keys to labels and input data.
+ */
+function rtbcb_get_sample_report_forms() {
+    return [
+        'enterprise_manufacturer' => [
+            'label' => __( 'Enterprise Manufacturer', 'rtbcb' ),
+            'data'  => [
+                'company_name'  => 'Acme Manufacturing',
+                'company_size'  => '1000-5000',
+                'industry'      => 'Manufacturing',
+                'location'      => 'USA',
+                'analysis_date' => current_time( 'Y-m-d' ),
+            ],
+        ],
+        'tech_startup'           => [
+            'label' => __( 'Tech Startup', 'rtbcb' ),
+            'data'  => [
+                'company_name'  => 'Innovatech',
+                'company_size'  => '1-50',
+                'industry'      => 'Technology',
+                'location'      => 'UK',
+                'analysis_date' => current_time( 'Y-m-d' ),
+            ],
+        ],
+    ];
+}
+
+/**
+ * Map scenario keys to sample report inputs.
+ *
+ * @param array  $inputs       Default inputs.
+ * @param string $scenario_key Scenario identifier.
+ * @return array Filtered inputs.
+ */
+function rtbcb_map_sample_report_inputs( $inputs, $scenario_key ) {
+    $forms = rtbcb_get_sample_report_forms();
+    if ( $scenario_key && isset( $forms[ $scenario_key ] ) ) {
+        return $forms[ $scenario_key ]['data'];
+    }
+
+    return $inputs;
+}
+add_filter( 'rtbcb_sample_report_inputs', 'rtbcb_map_sample_report_inputs', 10, 2 );
+


### PR DESCRIPTION
## Summary
- Add `rtbcb_get_sample_report_forms` and filter to map scenario keys to sample inputs
- Load sample scenarios in report preview page from centralized mapping and expose to JS
- Use server-provided sample data in admin JS and send selected `scenario_key`

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8fa6833708331b9ed2774216297ee