### PR TITLE
Ensure nonce validation for sample report generation

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -369,8 +369,9 @@
             button.disabled = true;
             try {
                 const formData = new FormData();
+                const nonceField = document.getElementById('nonce');
                 formData.append('action', 'rtbcb_generate_sample_report');
-                formData.append('nonce', rtbcbAdmin.nonce);
+                formData.append('nonce', nonceField ? nonceField.value : '');
                 const response = await fetch(rtbcbAdmin.ajax_url, { method: 'POST', body: formData });
                 if (!response.ok) {
                     throw new Error(`Server responded ${response.status}`);

--- a/admin/report-test-page.php
+++ b/admin/report-test-page.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div class="wrap rtbcb-admin-page">
     <h1><?php esc_html_e( 'Report Test', 'rtbcb' ); ?></h1>
     <p>
+        <?php wp_nonce_field( 'rtbcb_generate_report_preview', 'nonce' ); ?>
         <button type="button" id="rtbcb-generate-sample-report" class="button button-primary">
             <?php esc_html_e( 'Generate Sample Report', 'rtbcb' ); ?>
         </button>


### PR DESCRIPTION
## Summary
- Add nonce field to the sample report test page
- Pass nonce from DOM when generating sample report via AJAX

## Testing
- `bash tests/run-tests.sh`
- `php /tmp/check_ajax_nonce.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8fa66f2948331a8854ab5e5c37153