### PR TITLE
Use preview nonce for report AJAX

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -63,6 +63,7 @@ class RTBCB_Admin {
         wp_localize_script( 'rtbcb-admin', 'rtbcbAdmin', [
             'ajax_url'          => admin_url( 'admin-ajax.php' ),
             'nonce'             => wp_create_nonce( 'rtbcb_nonce' ),
+            'report_preview_nonce' => wp_create_nonce( 'rtbcb_generate_report_preview' ),
             'diagnostics_nonce' => wp_create_nonce( 'rtbcb_diagnostics' ),
             'strings'           => [
                 'confirm_delete'     => __( 'Are you sure you want to delete this lead?', 'rtbcb' ),

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -329,7 +329,6 @@
                 const formData = new FormData(form);
                 const select = document.getElementById('rtbcb-sample-select');
                 const sampleKey = select ? select.value : '';
-                formData.append('nonce', rtbcbAdmin.nonce);
                 if (sampleKey) {
                     formData.append('action', 'rtbcb_generate_sample_report');
                     formData.append('sample_key', sampleKey);
@@ -370,7 +369,7 @@
             try {
                 const formData = new FormData();
                 formData.append('action', 'rtbcb_generate_sample_report');
-                formData.append('nonce', rtbcbAdmin.nonce);
+                formData.append('nonce', rtbcbAdmin.report_preview_nonce);
                 const response = await fetch(rtbcbAdmin.ajax_url, { method: 'POST', body: formData });
                 if (!response.ok) {
                     throw new Error(`Server responded ${response.status}`);


### PR DESCRIPTION
## Summary
- Remove redundant nonce append when generating report previews
- Localize dedicated preview nonce for sample and preview report requests

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l | tail -n 5`
- `tests/run-tests.sh | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a8fa643fa883318e1a04fe6a3142dd