### PR TITLE
Use dedicated nonce for report preview

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -64,6 +64,7 @@ class RTBCB_Admin {
             'ajax_url'          => admin_url( 'admin-ajax.php' ),
             'nonce'             => wp_create_nonce( 'rtbcb_nonce' ),
             'diagnostics_nonce' => wp_create_nonce( 'rtbcb_diagnostics' ),
+            'report_preview_nonce' => wp_create_nonce( 'rtbcb_generate_report_preview' ),
             'strings'           => [
                 'confirm_delete'     => __( 'Are you sure you want to delete this lead?', 'rtbcb' ),
                 'confirm_bulk_delete'=> __( 'Are you sure you want to delete the selected leads?', 'rtbcb' ),

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -329,7 +329,6 @@
                 const formData = new FormData(form);
                 const select = document.getElementById('rtbcb-sample-select');
                 const sampleKey = select ? select.value : '';
-                formData.append('nonce', rtbcbAdmin.nonce);
                 if (sampleKey) {
                     formData.append('action', 'rtbcb_generate_sample_report');
                     formData.append('scenario_key', sampleKey);


### PR DESCRIPTION
## Summary
- Drop manual nonce injection in report preview requests
- Localize a dedicated `rtbcb_generate_report_preview` nonce for JS
- Rely on hidden form field so preview AJAX is validated server-side

## Testing
- `./tests/run-tests.sh` *(fails: Call to undefined function add_filter())*

------
https://chatgpt.com/codex/tasks/task_e_68a8fca1cb308331b35281d1e5642040