### PR TITLE
Surface LLM generation errors and display in wizard

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -698,11 +698,12 @@ class BusinessCaseBuilder {
         // Show error in modal
         const modalBody = this.form.closest('.rtbcb-modal-body');
         if (modalBody) {
+            const safeMessage = this.escapeHTML(message);
             const errorHTML = `
                 <div class="rtbcb-error-container" style="padding: 40px; text-align: center;">
                     <div class="rtbcb-error-icon" style="font-size: 48px; color: #ef4444; margin-bottom: 20px;">⚠️</div>
                     <h3 style="color: #ef4444; margin-bottom: 16px;">Unable to Generate Business Case</h3>
-                    <p style="color: #4b5563; margin-bottom: 24px;">${message}</p>
+                    <p style="color: #4b5563; margin-bottom: 24px;">${safeMessage}</p>
                     <button type="button" class="rtbcb-action-btn rtbcb-btn-primary" onclick="location.reload()">
                         Try Again
                     </button>
@@ -710,6 +711,12 @@ class BusinessCaseBuilder {
             `;
             modalBody.innerHTML = errorHTML;
         }
+    }
+
+    escapeHTML(str) {
+        const div = document.createElement('div');
+        div.textContent = str == null ? '' : String(str);
+        return div.innerHTML;
     }
 
     formatNumber(num) {

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -691,7 +691,18 @@ class Real_Treasury_BCB {
 
                     rtbcb_log_memory_usage( 'after_llm_generation' );
 
-                    if ( is_wp_error( $comprehensive_analysis ) || isset( $comprehensive_analysis['error'] ) ) {
+                    if ( is_wp_error( $comprehensive_analysis ) ) {
+                        $error_message   = $comprehensive_analysis->get_error_message();
+                        error_log( 'RTBCB: LLM generation error - ' . $error_message );
+                        $response_message = __( 'Failed to generate business case analysis.', 'rtbcb' );
+                        if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+                            $response_message = $error_message;
+                        }
+                        wp_send_json_error( [ 'message' => $response_message ], 500 );
+                    }
+
+                    if ( isset( $comprehensive_analysis['error'] ) ) {
+                        error_log( 'RTBCB: LLM generation error - ' . $comprehensive_analysis['error'] );
                         wp_send_json_error(
                             [ 'message' => __( 'Failed to generate business case analysis.', 'rtbcb' ) ],
                             500


### PR DESCRIPTION
## Summary
- Inspect `WP_Error` from LLM generation, logging and returning detailed messages in non-production environments
- Escape and show server-sent error messages in the wizard UI

## Testing
- `./tests/run-tests.sh` *(fails: Call to undefined function add_filter in scenario-selection.test.php)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ffef039483318b7516514b12b33f