### PR TITLE
Improve wizard progress step contrast and responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,10 +222,12 @@ The plugin includes CSS custom properties for easy theming:
 ```css
 :root {
     --primary-purple: #7216f4;
+    --primary-purple-light: #a78bfa;
     --secondary-purple: #8f47f6;
     --light-purple: #c77dff;
     --dark-text: #281345;
     --gray-text: #4b5563;
+    --neutral-200: #e5e7eb;
     --success-green: #10b981;
 }
 ```

--- a/public/css/rtbcb-variables.css
+++ b/public/css/rtbcb-variables.css
@@ -41,10 +41,12 @@
     /* Legacy variable mapping for backward compatibility */
     --primary-purple: var(--primary-color);
     --secondary-purple: var(--secondary-color);
+    --primary-purple-light: #a78bfa;
     --light-purple: var(--accent-color);
     --dark-text: #281345;
     --gray-text: #4b5563;
     --high-contrast-text: #4a4a4a;
+    --neutral-200: #e5e7eb;
     --success-green: var(--success-color);
     --warning-orange: var(--warning-color);
     --error-red: var(--error-color);

--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -1269,12 +1269,12 @@
 }
 
 .rtbcb-progress-number {
-    width: 40px;
-    height: 40px;
+    width: 48px;
+    height: 48px;
     border-radius: 50%;
-    background: rgba(114, 22, 244, 0.1);
+    background: var(--neutral-200);
     border: 2px solid var(--primary-purple);
-    color: var(--primary-purple);
+    color: var(--primary-purple-light);
     position: relative;
     z-index: 1;
     display: flex;
@@ -1283,8 +1283,8 @@
     font-weight: 600;
     margin-bottom: 6px;
     transition: all 0.3s ease;
-    font-size: 16px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    font-size: 20px;
+    box-shadow: var(--shadow-sm);
 }
 
 .rtbcb-progress-step.active .rtbcb-progress-number {
@@ -1599,6 +1599,12 @@
 
     .rtbcb-progress-step {
         padding: 0 4px;
+    }
+
+    .rtbcb-progress-number {
+        width: 40px;
+        height: 40px;
+        font-size: 16px;
     }
 }
 


### PR DESCRIPTION
## Summary
- Enlarge wizard progress step circles and add neutral background with lighter purple text for better contrast
- Introduce `--primary-purple-light` and `--neutral-200` design tokens
- Document new design tokens in README

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fffb575c8331a6a66e255453cb6c