### PR TITLE
Use wp_add_inline_script for report preview sample data

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -72,6 +72,19 @@ class RTBCB_Admin {
                 'error'              => __( 'An error occurred. Please try again.', 'rtbcb' ),
             ],
         ] );
+
+        $rtbcb_sample_forms = rtbcb_get_sample_report_forms();
+        $rtbcb_sample_data  = [];
+
+        foreach ( $rtbcb_sample_forms as $key => $scenario ) {
+            $rtbcb_sample_data[ $key ] = $scenario['data'];
+        }
+
+        wp_add_inline_script(
+            'rtbcb-admin',
+            'rtbcbAdmin.sampleForms = ' . wp_json_encode( $rtbcb_sample_data ) . ';',
+            'after'
+        );
     }
 
     /**

--- a/admin/report-preview-page.php
+++ b/admin/report-preview-page.php
@@ -52,14 +52,3 @@ $sample_context     = $first_scenario['data'];
     </div>
 </div>
 
-<?php
-$rtbcb_sample_data = [];
-foreach ( $rtbcb_sample_forms as $key => $scenario ) {
-    $rtbcb_sample_data[ $key ] = $scenario['data'];
-}
-?>
-<script type="text/javascript">
-    window.rtbcbAdmin = window.rtbcbAdmin || {};
-    rtbcbAdmin.sampleForms = <?php echo wp_json_encode( $rtbcb_sample_data ); ?>;
-</script>
-


### PR DESCRIPTION
## Summary
- Remove inline script from report preview page
- Append sample forms data using `wp_add_inline_script` in admin asset enqueue

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `node <<'NODE'
const rtbcbAdmin = { sampleForms: { scenarioA: {foo:'bar'} } };
console.log('sampleForms', rtbcbAdmin.sampleForms);
const textarea = { value:'' };
const select = { value: 'scenarioA', addEventListener: (event, handler) => { select['on'+event] = handler; } };
const button = { addEventListener: (event, handler) => { button['on'+event] = handler; } };
const document = {
  getElementById: id => {
    if (id === 'rtbcb-sample-select') return select;
    if (id === 'rtbcb-sample-context') return textarea;
    if (id === 'rtbcb-load-sample') return button;
  }
};

function bindReportPreview() {
  const select = document.getElementById('rtbcb-sample-select');
  if (select) {
    const injectSample = () => {
      const key = select.value;
      const target = document.getElementById('rtbcb-sample-context');
      if (key && target && rtbcbAdmin.sampleForms && rtbcbAdmin.sampleForms[key]) {
        target.value = JSON.stringify(rtbcbAdmin.sampleForms[key], null, 2);
      }
    };
    select.addEventListener('change', injectSample);
    document.getElementById('rtbcb-load-sample')?.addEventListener('click', injectSample);
  }
}

bindReportPreview();
button.onclick();
console.log('textarea', textarea.value);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a9004210088331bf2a43f3cf2b950e