### PR TITLE
Add comprehensive LLM response parser with tests

### DIFF
--- a/tests/parse-comprehensive-response.test.php
+++ b/tests/parse-comprehensive-response.test.php
@@ -1,0 +1,138 @@
+<?php
+require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
+
+if ( ! class_exists( 'WP_Error' ) ) {
+    class WP_Error {
+        public $errors = [];
+        public function __construct( $code = '', $message = '' ) {
+            $this->errors[ $code ] = [ $message ];
+        }
+    }
+}
+
+if ( ! function_exists( '__' ) ) {
+    function __( $text, $domain = null ) {
+        return $text;
+    }
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+    function is_wp_error( $thing ) {
+        return $thing instanceof WP_Error;
+    }
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+    function get_option( $name, $default = '' ) {
+        return $default;
+    }
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $text ) {
+        $text = is_scalar( $text ) ? (string) $text : '';
+        $text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
+        return trim( $text );
+    }
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
+    function wp_remote_retrieve_body( $response ) {
+        return $response['body'] ?? '';
+    }
+}
+
+$llm    = new RTBCB_LLM();
+$method = new ReflectionMethod( RTBCB_LLM::class, 'parse_comprehensive_response' );
+$method->setAccessible( true );
+
+$valid_json = [
+    'executive_summary' => [
+        'strategic_positioning'   => 'pos',
+        'business_case_strength'  => 'Strong',
+        'key_value_drivers'       => [ 'driver' ],
+        'executive_recommendation'=> 'rec',
+        'confidence_level'        => 0.9,
+    ],
+    'operational_analysis' => [
+        'current_state_assessment' => [
+            'efficiency_rating'    => 'Good',
+            'benchmark_comparison' => 'peer',
+            'capacity_utilization' => 'high',
+        ],
+        'process_inefficiencies'  => [],
+        'automation_opportunities'=> [],
+    ],
+    'industry_insights' => [
+        'sector_trends'          => 'trend',
+        'competitive_benchmarks' => 'bench',
+        'regulatory_considerations' => 'reg',
+    ],
+    'technology_recommendations' => [
+        'primary_solution' => [
+            'category'     => 'cat',
+            'rationale'    => 'why',
+            'key_features' => [ 'feature' ],
+        ],
+        'implementation_approach' => [
+            'phase_1'        => 'p1',
+            'phase_2'        => 'p2',
+            'success_metrics'=> [ 'metric' ],
+        ],
+    ],
+    'financial_analysis' => [
+        'investment_breakdown' => [
+            'software_licensing'      => 'cost',
+            'implementation_services' => 'cost',
+            'training_change_management' => 'cost',
+        ],
+        'payback_analysis' => [
+            'payback_months' => 12,
+            'roi_3_year'     => 50,
+            'npv_analysis'   => 'npv',
+        ],
+    ],
+    'risk_mitigation' => [
+        'implementation_risks' => [ 'risk' ],
+        'mitigation_strategies' => [
+            'risk_1_mitigation' => 'mit1',
+            'risk_2_mitigation' => 'mit2',
+        ],
+    ],
+    'next_steps' => [ 'step' ],
+];
+
+$response = [
+    'body' => json_encode( [
+        'choices' => [
+            [ 'message' => [ 'content' => json_encode( $valid_json ) ] ],
+        ],
+    ] ),
+];
+
+$result = $method->invoke( $llm, $response );
+
+if ( is_wp_error( $result ) ) {
+    echo "Valid response produced WP_Error\n";
+    exit( 1 );
+}
+
+$required = [ 'executive_summary', 'operational_analysis', 'industry_insights', 'technology_recommendations', 'financial_analysis', 'risk_mitigation', 'next_steps' ];
+
+foreach ( $required as $key ) {
+    if ( ! isset( $result[ $key ] ) ) {
+        echo "Missing expected key: {$key}\n";
+        exit( 1 );
+    }
+}
+
+$bad_response = [ 'body' => 'not json' ];
+$bad_result   = $method->invoke( $llm, $bad_response );
+
+if ( ! is_wp_error( $bad_result ) ) {
+    echo "Invalid response did not return WP_Error\n";
+    exit( 1 );
+}
+
+echo "parse-comprehensive-response.test.php passed\n";
+

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -23,18 +23,22 @@ php tests/filters-override.test.php
 echo "5. Running scenario selection test..."
 php tests/scenario-selection.test.php
 
+# Parse comprehensive response test
+echo "6. Running parse comprehensive response test..."
+php tests/parse-comprehensive-response.test.php
+
 # JavaScript tests
-echo "6. Running JavaScript tests..."
+echo "7. Running JavaScript tests..."
 node tests/handle-submit-error.test.js
 node tests/render-results-no-narrative.test.js
 node tests/handle-submit-success.test.js
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then
-    echo "7. Running WordPress coding standards check..."
+    echo "8. Running WordPress coding standards check..."
     phpcs --standard=WordPress --ignore=vendor .
 else
-    echo "7. Skipping WordPress coding standards (phpcs not installed)"
+    echo "8. Skipping WordPress coding standards (phpcs not installed)"
 fi
 
 echo "================================================"

--- a/tests/scenario-selection.test.php
+++ b/tests/scenario-selection.test.php
@@ -1,7 +1,4 @@
 <?php
-define( 'ABSPATH', __DIR__ );
-require_once __DIR__ . '/../inc/helpers.php';
-
 if ( ! function_exists( 'add_filter' ) ) {
     $GLOBALS['rtbcb_filters'] = [];
     function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
@@ -17,6 +14,9 @@ if ( ! function_exists( 'add_filter' ) ) {
         return $value;
     }
 }
+
+define( 'ABSPATH', __DIR__ );
+require_once __DIR__ . '/../inc/helpers.php';
 
 $received = '';
 add_filter( 'rtbcb_sample_report_inputs', function ( $inputs, $scenario_key ) use ( &$received ) {


### PR DESCRIPTION
## Summary
- add `parse_comprehensive_response()` to decode and validate OpenAI responses
- test comprehensive response parsing and hook into test runner
- fix scenario selection test stubs

## Testing
- `./tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8ffeed7448331923092eea02c7add