### PR TITLE
Fix sample report generation JS and asset loading

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -41,7 +41,8 @@ class RTBCB_Admin {
      * @return void
      */
     public function enqueue_admin_assets( $hook ) {
-        if ( strpos( $hook, 'rtbcb' ) === false ) {
+        $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+        if ( strpos( $hook, 'rtbcb' ) === false && strpos( $page, 'rtbcb' ) === false ) {
             return;
         }
 

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -369,8 +369,9 @@
             try {
                 const formData = new FormData();
                 const nonceField = document.getElementById('nonce');
+                const nonce = nonceField ? nonceField.value : (rtbcbAdmin?.report_preview_nonce || '');
                 formData.append('action', 'rtbcb_generate_sample_report');
-                formData.append('nonce', nonceField ? nonceField.value : '');
+                formData.append('nonce', nonce);
                 const response = await fetch(rtbcbAdmin.ajax_url, { method: 'POST', body: formData });
                 if (!response.ok) {
                     throw new Error(`Server responded ${response.status}`);


### PR DESCRIPTION
## Summary
- Ensure admin assets load on Report Test page by also checking `$_GET['page']`
- Use localized nonce fallback when generating sample reports so AJAX requests always include valid nonce

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a900af429c8331ae13ac3230a7355b