### PR TITLE
Add tests for AJAX error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 wp-config.php
+.phpunit.result.cache

--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
@@ -1,0 +1,132 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if ( ! class_exists( 'WP_Error' ) ) {
+    class WP_Error {
+        private $message;
+        public function __construct( $code = '', $message = '' ) {
+            $this->message = $message;
+        }
+        public function get_error_message() {
+            return $this->message;
+        }
+    }
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+    function is_wp_error( $thing ) {
+        return $thing instanceof WP_Error;
+    }
+}
+
+if ( ! function_exists( 'wp_verify_nonce' ) ) {
+    function wp_verify_nonce( $nonce, $action ) {
+        return true;
+    }
+}
+
+if ( ! function_exists( 'sanitize_email' ) ) {
+    function sanitize_email( $email ) {
+        return $email;
+    }
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $text ) {
+        return $text;
+    }
+}
+
+if ( ! function_exists( 'is_email' ) ) {
+    function is_email( $email ) {
+        return filter_var( $email, FILTER_VALIDATE_EMAIL );
+    }
+}
+
+if ( ! function_exists( 'wp_get_environment_type' ) ) {
+    function wp_get_environment_type() {
+        return 'production';
+    }
+}
+
+if ( ! function_exists( '__' ) ) {
+    function __( $text, $domain = null ) {
+        return $text;
+    }
+}
+
+if ( ! function_exists( 'rtbcb_increase_memory_limit' ) ) {
+    function rtbcb_increase_memory_limit() {}
+}
+
+if ( ! function_exists( 'rtbcb_log_memory_usage' ) ) {
+    function rtbcb_log_memory_usage( $stage ) {}
+}
+
+if ( ! class_exists( 'RTBCB_LLM' ) ) {
+    class RTBCB_LLM {
+        public function generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context ) {
+            return new WP_Error( 'llm_error', 'LLM failed' );
+        }
+    }
+}
+
+if ( ! class_exists( 'RTBCB_JSON_Error' ) ) {
+    class RTBCB_JSON_Error extends Exception {
+        public $data;
+        public $status;
+        public function __construct( $data, $status ) {
+            parent::__construct();
+            $this->data   = $data;
+            $this->status = $status;
+        }
+    }
+}
+
+if ( ! function_exists( 'wp_send_json_error' ) ) {
+    function wp_send_json_error( $data = null, $status_code = null ) {
+        throw new RTBCB_JSON_Error(
+            [
+                'success' => false,
+                'data'    => $data,
+            ],
+            $status_code
+        );
+    }
+}
+
+if ( ! class_exists( 'Real_Treasury_BCB' ) ) {
+    class Real_Treasury_BCB {
+        public function ajax_generate_comprehensive_case() {
+            $llm = new RTBCB_LLM();
+            $comprehensive_analysis = $llm->generate_comprehensive_business_case( [], [], [] );
+            if ( is_wp_error( $comprehensive_analysis ) ) {
+                $error_message    = $comprehensive_analysis->get_error_message();
+                $response_message = __( 'Failed to generate business case analysis.', 'rtbcb' );
+                if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+                    $response_message = $error_message;
+                }
+                wp_send_json_error( [ 'message' => $response_message ], 500 );
+            }
+        }
+    }
+}
+
+final class RTBCB_AjaxGenerateComprehensiveCaseErrorTest extends TestCase {
+    public function test_ajax_returns_error_json_when_llm_fails() {
+        $plugin = new Real_Treasury_BCB();
+        try {
+            $plugin->ajax_generate_comprehensive_case();
+            $this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
+        } catch ( RTBCB_JSON_Error $e ) {
+            $this->assertSame( 500, $e->status );
+            $this->assertSame(
+                [
+                    'success' => false,
+                    'data'    => [ 'message' => 'Failed to generate business case analysis.' ],
+                ],
+                $e->data
+            );
+        }
+    }
+}

--- a/tests/handle-server-error-display.test.js
+++ b/tests/handle-server-error-display.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const progressContainer = { innerHTML: '', style: {} };
+const formContainer = { style: {} };
+const reportContainer = { innerHTML: '', style: {} };
+
+global.document = {
+    readyState: 'complete',
+    addEventListener: () => {},
+    getElementById: (id) => {
+        if (id === 'rtbcb-progress-container') return progressContainer;
+        if (id === 'rtbcb-form-container') return formContainer;
+        if (id === 'rtbcb-report-container') return reportContainer;
+        if (id === 'rtbcb-form') return {};
+        return null;
+    }
+};
+
+global.ajaxObj = { ajax_url: '' };
+
+global.fetch = async () => ({
+    ok: false,
+    status: 500,
+    text: async () => JSON.stringify({ success: false, data: { message: 'Server exploded' } })
+});
+
+global.FormData = class { constructor() {} };
+
+const code = fs.readFileSync('public/js/rtbcb.js', 'utf8');
+vm.runInThisContext(code);
+
+(async () => {
+    await handleSubmit({ preventDefault() {}, target: {} });
+    assert.ok(progressContainer.innerHTML.includes('Server exploded'));
+    console.log('Server error display test passed.');
+})();

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -27,18 +27,23 @@ php tests/scenario-selection.test.php
 echo "6. Running parse comprehensive response test..."
 php tests/parse-comprehensive-response.test.php
 
+# AJAX error handling test (PHPUnit)
+echo "7. Running AJAX error handling test..."
+phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
+
 # JavaScript tests
-echo "7. Running JavaScript tests..."
+echo "8. Running JavaScript tests..."
 node tests/handle-submit-error.test.js
 node tests/render-results-no-narrative.test.js
 node tests/handle-submit-success.test.js
+node tests/handle-server-error-display.test.js
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then
-    echo "8. Running WordPress coding standards check..."
+    echo "9. Running WordPress coding standards check..."
     phpcs --standard=WordPress --ignore=vendor .
 else
-    echo "8. Skipping WordPress coding standards (phpcs not installed)"
+    echo "9. Skipping WordPress coding standards (phpcs not installed)"
 fi
 
 echo "================================================"


### PR DESCRIPTION
## Summary
- add PHPUnit test that mocks the LLM and asserts AJAX error response
- add JavaScript test to surface server errors in the frontend
- update test runner to execute new checks

## Testing
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a901f5c7948331ad94632f1ed8ec02