### PR TITLE
refactor: remove async keywords causing syntax errors

### DIFF
--- a/admin/analytics-page.php
+++ b/admin/analytics-page.php
@@ -287,7 +287,7 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeAnalyticsCharts();
 });
 
-async function initializeAnalyticsCharts() {
+function initializeAnalyticsCharts() {
     const fallbackMessage = '<?php echo esc_js( __( 'Chart unavailable', 'rtbcb' ) ); ?>';
     const showFallback = (id) => {
         const canvas = document.getElementById(id);


### PR DESCRIPTION
## Summary
- remove async keyword from analytics chart initializer to avoid unsupported syntax
- replace async/await in frontend submit handler with Promise-based workflow

## Testing
- `node --check public/js/rtbcb.js`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68ab053e5eb48331bcddf6c8d1f44737