### PR TITLE
refactor: remove remaining async functions

### DIFF
--- a/admin/analytics-page.php
+++ b/admin/analytics-page.php
@@ -287,7 +287,7 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeAnalyticsCharts();
 });
 
-async function initializeAnalyticsCharts() {
+function initializeAnalyticsCharts() {
     const fallbackMessage = '<?php echo esc_js( __( 'Chart unavailable', 'rtbcb' ) ); ?>';
     const showFallback = (id) => {
         const canvas = document.getElementById(id);

--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -64,7 +64,7 @@ function handleSubmissionError(errorMessage) {
  * Handles the form submission by sending data to the backend.
  * @param {Event} e - The form submission event.
  */
-async function handleSubmit(e) {
+function handleSubmit(e) {
     e.preventDefault();
     const form = e.target;
     const formData = new FormData(form);
@@ -72,61 +72,64 @@ async function handleSubmit(e) {
     const formContainer = document.getElementById('rtbcb-form-container');
 
     // Show progress indicator
-    if (formContainer) formContainer.style.display = 'none';
-    if (progressContainer) progressContainer.style.display = 'block';
-
-    try {
-        const response = await fetch(ajaxObj.ajax_url, {
-            method: 'POST',
-            body: formData,
-        });
-
-        // Check for server-side errors
-        if (!response.ok) {
-            const errorText = await response.text();
-            let errorMessage = `Server responded with status ${response.status}.`;
-            try {
-                const errorJson = JSON.parse(errorText);
-                errorMessage = errorJson.data.message || errorMessage;
-            } catch (jsonError) {
-                console.error('Could not parse error response as JSON.', jsonError);
-                errorMessage = errorText || errorMessage;
-            }
-            throw new Error(errorMessage);
-        }
-
-        const result = await response.json();
-
-        // Application-specific errors
-        if (!result.success) {
-            throw new Error(result.data.message || 'An unknown error occurred.');
-        }
-
-        // On success, display the report
-        const reportContainer = document.getElementById('rtbcb-report-container');
-        if (progressContainer) progressContainer.style.display = 'none';
-        if (reportContainer) {
-            // Sanitize server-provided HTML before injecting to prevent XSS.
-            // Only allow expected markup needed for business case output.
-            const allowedTags = [
-                'a', 'p', 'br', 'strong', 'em', 'ul', 'ol', 'li',
-                'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'span',
-                'table', 'thead', 'tbody', 'tr', 'th', 'td'
-            ];
-            const allowedAttr = { a: [ 'href', 'title', 'target', 'rel' ], '*': [ 'style' ] };
-            const sanitized = typeof DOMPurify !== 'undefined'
-                ? DOMPurify.sanitize(
-                    result.data.report_html,
-                    { ALLOWED_TAGS: allowedTags, ALLOWED_ATTR: allowedAttr }
-                )
-                : result.data.report_html;
-            reportContainer.innerHTML = sanitized;
-            reportContainer.style.display = 'block';
-        }
-
-    } catch (error) {
-        handleSubmissionError(error.message);
+    if (formContainer) {
+        formContainer.style.display = 'none';
     }
+    if (progressContainer) {
+        progressContainer.style.display = 'block';
+    }
+
+    return fetch(ajaxObj.ajax_url, {
+        method: 'POST',
+        body: formData,
+    })
+        .then(function(response) {
+            if (!response.ok) {
+                return response.text().then(function(errorText) {
+                    let errorMessage = `Server responded with status ${response.status}.`;
+                    try {
+                        const errorJson = JSON.parse(errorText);
+                        errorMessage = errorJson.data.message || errorMessage;
+                    } catch (jsonError) {
+                        console.error('Could not parse error response as JSON.', jsonError);
+                        errorMessage = errorText || errorMessage;
+                    }
+                    throw new Error(errorMessage);
+                });
+            }
+            return response.json();
+        })
+        .then(function(result) {
+            if (!result.success) {
+                throw new Error(result.data.message || 'An unknown error occurred.');
+            }
+
+            const reportContainer = document.getElementById('rtbcb-report-container');
+            if (progressContainer) {
+                progressContainer.style.display = 'none';
+            }
+            if (reportContainer) {
+                // Sanitize server-provided HTML before injecting to prevent XSS.
+                // Only allow expected markup needed for business case output.
+                const allowedTags = [
+                    'a', 'p', 'br', 'strong', 'em', 'ul', 'ol', 'li',
+                    'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'span',
+                    'table', 'thead', 'tbody', 'tr', 'th', 'td'
+                ];
+                const allowedAttr = { a: [ 'href', 'title', 'target', 'rel' ], '*': [ 'style' ] };
+                const sanitized = typeof DOMPurify !== 'undefined'
+                    ? DOMPurify.sanitize(
+                        result.data.report_html,
+                        { ALLOWED_TAGS: allowedTags, ALLOWED_ATTR: allowedAttr }
+                    )
+                    : result.data.report_html;
+                reportContainer.innerHTML = sanitized;
+                reportContainer.style.display = 'block';
+            }
+        })
+        .catch(function(error) {
+            handleSubmissionError(error.message);
+        });
 }
 
 // Ensure the form submission is handled by our new function


### PR DESCRIPTION
## Summary
- replace wizard submit handler async usage with promise chain
- rewrite report generation to use Promise-based retries and display logic
- return fetch promise from form submission handler for proper chaining

## Testing
- `node --check public/js/rtbcb-wizard.js`
- `node --check public/js/rtbcb-report.js`
- `node --check public/js/rtbcb.js`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `node tests/handle-submit-success.test.js`
- `node tests/handle-submit-error.test.js`
- `node tests/handle-server-error-display.test.js`
- `node tests/render-results-no-narrative.test.js`
- `node tests/temperature-model.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab053e5eb48331bcddf6c8d1f44737