### PR TITLE
Preserve focus areas during company data sanitization

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -202,11 +202,18 @@ function rtbcb_sanitize_form_data( $data ) {
     }
     
     // Text fields
-    $text_fields = [ 'company_size', 'industry' ];
+    $text_fields = [ 'company_size', 'industry', 'name', 'size', 'complexity' ];
     foreach ( $text_fields as $field ) {
         if ( isset( $data[ $field ] ) ) {
             $sanitized[ $field ] = sanitize_text_field( $data[ $field ] );
         }
+    }
+
+    // Focus areas array
+    if ( isset( $data['focus_areas'] ) && is_array( $data['focus_areas'] ) ) {
+        $sanitized['focus_areas'] = array_filter(
+            array_map( 'sanitize_text_field', $data['focus_areas'] )
+        );
     }
     
     // Numeric fields


### PR DESCRIPTION
## Summary
- keep `name`, `size`, `complexity`, and `focus_areas` when sanitizing form data
- ensure treasury tech overview generation receives selected focus areas

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `./tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1851f4208331b9550aedb163e90d