### PR TITLE
Add progress updates for admin overview generation

### DIFF
--- a/admin/js/company-overview.js
+++ b/admin/js/company-overview.js
@@ -9,6 +9,8 @@
         function sendRequest(companyName) {
             console.log('Starting simple company overview request');
 
+            let progress;
+
             $.ajax({
                 url: ajaxurl,
                 method: 'POST',
@@ -20,6 +22,11 @@
                 },
                 beforeSend: function() {
                     generateBtn.prop('disabled', true).text( __( 'Testing Connection...', 'rtbcb' ) );
+                    progress = rtbcbTestUtils.startProgress(resultsDiv, [
+                        __( 'Generating overview...', 'rtbcb' ),
+                        __( 'Model is analyzing data...', 'rtbcb' ),
+                        __( 'Finalizing response...', 'rtbcb' )
+                    ]);
                 },
                 success: function(response) {
                     console.log('AJAX Success:', response);
@@ -42,6 +49,7 @@
                     showError(message);
                 },
                 complete: function() {
+                    rtbcbTestUtils.stopProgress(progress);
                     generateBtn.prop('disabled', false).text( __( 'Generate Overview', 'rtbcb' ) );
                 }
             });

--- a/admin/js/real-treasury-overview.js
+++ b/admin/js/real-treasury-overview.js
@@ -46,7 +46,11 @@
 
             const start = performance.now();
             const original = rtbcbTestUtils.showLoading(generateBtn, 'Generating...');
-            resultsDiv.html('<p>Generating overview...</p>');
+            const progress = rtbcbTestUtils.startProgress(resultsDiv, [
+                'Generating overview...',
+                'Model is analyzing data...',
+                'Finalizing response...'
+            ]);
 
             $.ajax({
                 url: url,
@@ -97,6 +101,7 @@
                     });
                 },
                 complete: function() {
+                    rtbcbTestUtils.stopProgress(progress);
                     rtbcbTestUtils.hideLoading(generateBtn, original);
                 }
             });

--- a/admin/js/rtbcb-test-utils.js
+++ b/admin/js/rtbcb-test-utils.js
@@ -43,6 +43,27 @@
             container.html(notice);
             return notice;
         },
+        startProgress(container, messages, interval) {
+            let index = 0;
+            if (!Array.isArray(messages) || messages.length === 0) {
+                return 0;
+            }
+            container.html('<p>' + messages[0] + '</p>');
+            const timer = setInterval(function() {
+                index++;
+                if (index < messages.length) {
+                    container.append('<p>' + messages[index] + '</p>');
+                } else {
+                    clearInterval(timer);
+                }
+            }, interval || 4000);
+            return timer;
+        },
+        stopProgress(timer) {
+            if (timer) {
+                clearInterval(timer);
+            }
+        },
         copyToClipboard(text) {
             if (navigator.clipboard && navigator.clipboard.writeText) {
                 return navigator.clipboard.writeText(text);

--- a/admin/js/treasury-tech-overview.js
+++ b/admin/js/treasury-tech-overview.js
@@ -21,7 +21,11 @@
 
             const start = performance.now();
             const original = rtbcbTestUtils.showLoading(generateBtn, 'Generating...');
-            resultsDiv.html('<p>Generating overview...</p>');
+            const progress = rtbcbTestUtils.startProgress(resultsDiv, [
+                'Generating overview...',
+                'Model is analyzing data...',
+                'Finalizing response...'
+            ]);
 
             $.ajax({
                 url: ajaxurl,
@@ -72,6 +76,7 @@
                     });
                 },
                 complete: function() {
+                    rtbcbTestUtils.stopProgress(progress);
                     rtbcbTestUtils.hideLoading(generateBtn, original);
                 }
             });


### PR DESCRIPTION
## Summary
- add progress utility to show sequential status messages
- show model progress on admin test overview pages

## Testing
- `tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ab412adf588331959b7ecf11519a7e