### PR TITLE
Optimize OpenAI API call timeout

### DIFF
--- a/tests/gpt5-responses-api.test.php
+++ b/tests/gpt5-responses-api.test.php
@@ -36,7 +36,7 @@ class RTBCB_GPT5_Integration_Test extends WP_UnitTestCase {
         // Verify GPT-5 specific parameters
         $this->assertArrayHasKey( 'reasoning', $captured_body );
         $this->assertArrayHasKey( 'text', $captured_body );
-        $this->assertEquals( 'high', $captured_body['reasoning']['effort'] ); // Should be high for business case
+        $this->assertEquals( 'medium', $captured_body['reasoning']['effort'] ); // Reduced effort for faster responses
         
         remove_all_filters( 'pre_http_request' );
     }


### PR DESCRIPTION
## Summary
- Optimize OpenAI API request settings for faster company overview responses
- Reduce default reasoning effort and verbosity to medium
- Log response codes and shorten API timeout

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*
- `phpunit tests/gpt5-responses-api.test.php` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4936c17083318e66a8619f9e06a7