### PR TITLE
feat: show prompt and timing in company overview

### DIFF
--- a/admin/js/company-overview.js
+++ b/admin/js/company-overview.js
@@ -15,17 +15,27 @@
             $.ajax({
                 url: ajaxurl,
                 method: 'POST',
-                timeout: 180000, // Increase to 3 minutes
+                timeout: 180000,
                 data: {
                     action: 'rtbcb_company_overview_simple',
                     company_name: companyName,
-                    nonce: rtbcb_ajax.nonce
+                    nonce: rtbcb_ajax.nonce,
+                    include_prompt: true // Request to include prompt in response
                 },
                 beforeSend: function() {
                     generateBtn.prop('disabled', true).text( __( 'Connecting...', 'rtbcb' ) );
-                    progress = rtbcbTestUtils.startProgress(resultsDiv, [
+
+                    // Show initial progress with prompt preparation
+                    resultsDiv.html('<div class="rtbcb-progress-container">' +
+                        '<div class="rtbcb-progress-section">' +
+                        '<h4>' + __( 'Preparing Analysis Request', 'rtbcb' ) + '</h4>' +
+                        '<p>' + __( 'Building prompt for: ', 'rtbcb' ) + '<strong>' + companyName + '</strong></p>' +
+                        '</div></div>');
+
+                    progress = rtbcbTestUtils.startProgress(resultsDiv.find('.rtbcb-progress-container'), [
                         __( 'Connecting to AI service...', 'rtbcb' ),
-                        __( 'Analyzing company data...', 'rtbcb' ),
+                        __( 'Sending analysis request...', 'rtbcb' ),
+                        __( 'AI processing company data...', 'rtbcb' ),
                         __( 'Generating treasury insights...', 'rtbcb' ),
                         __( 'Compiling recommendations...', 'rtbcb' ),
                         __( 'Finalizing analysis...', 'rtbcb' )
@@ -36,7 +46,7 @@
                     console.log(`Request completed in ${duration}s:`, response);
 
                     if (response.success) {
-                        displaySimpleResults(response.data);
+                        displaySimpleResults(response.data, duration);
                     } else {
                         showError( __( 'Analysis failed: ', 'rtbcb' ) + ( response.data?.message || 'Unknown error' ) );
                     }
@@ -66,27 +76,85 @@
             });
         }
 
-        function displaySimpleResults(data) {
+        // Update displaySimpleResults to show the prompt and timing
+        function displaySimpleResults(data, duration) {
             let html = '<div class="simple-results">';
-            html += '<h3>' + __( 'Connection Test Results', 'rtbcb' ) + '</h3>';
-            html += '<p><strong>' + __( 'Status:', 'rtbcb' ) + '</strong> ' + data.status + '</p>';
-            html += '<p><strong>' + __( 'Message:', 'rtbcb' ) + '</strong> ' + data.message + '</p>';
 
+            // Header with timing
+            html += '<div class="results-header" style="background: #f0f0f1; padding: 15px; border-left: 4px solid #00a32a; margin-bottom: 20px;">';
+            html += '<h3 style="margin: 0 0 10px 0;">' + __( 'Company Analysis Results', 'rtbcb' ) + '</h3>';
+            html += '<p style="margin: 0;"><strong>' + __( 'Status:', 'rtbcb' ) + '</strong> ' + data.status + '</p>';
+            if (duration) {
+                html += '<p style="margin: 5px 0 0 0;"><strong>' + __( 'Processing Time:', 'rtbcb' ) + '</strong> ' + duration + 's</p>';
+            }
+            html += '</div>';
+
+            // Show the prompt that was sent (if available)
+            if (data.prompt_sent) {
+                html += '<div class="prompt-display" style="margin-bottom: 20px;">';
+                html += '<details style="border: 1px solid #ddd; border-radius: 4px; padding: 10px;">';
+                html += '<summary style="cursor: pointer; font-weight: bold; padding: 5px 0;">' +
+                    __( 'View AI Prompt Sent', 'rtbcb' ) + ' <small>(' + __( 'click to expand', 'rtbcb' ) + ')</small></summary>';
+                html += '<div style="margin-top: 10px; background: #f9f9f9; padding: 15px; border-radius: 4px; overflow-x: auto;">';
+                html += '<h4 style="margin-top: 0;">' + __( 'System Instructions:', 'rtbcb' ) + '</h4>';
+                html += '<pre style="white-space: pre-wrap; font-size: 12px; line-height: 1.4;">' +
+                    escapeHtml(data.prompt_sent.system || 'No system prompt') + '</pre>';
+                html += '<h4>' + __( 'User Prompt:', 'rtbcb' ) + '</h4>';
+                html += '<pre style="white-space: pre-wrap; font-size: 12px; line-height: 1.4;">' +
+                    escapeHtml(data.prompt_sent.user || 'No user prompt') + '</pre>';
+                html += '</div></details></div>';
+            }
+
+            // Analysis results
             if (data.simple_analysis) {
-                html += '<h4>' + __( 'Sample Analysis:', 'rtbcb' ) + '</h4>';
-                html += '<p>' + data.simple_analysis.analysis + '</p>';
+                html += '<div class="analysis-results">';
+                html += '<h4>' + __( 'Company Analysis:', 'rtbcb' ) + '</h4>';
+                html += '<div style="background: white; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-bottom: 15px;">';
+                html += '<p style="line-height: 1.6;">' + data.simple_analysis.analysis + '</p>';
+                html += '</div>';
 
-                if (data.simple_analysis.recommendations) {
-                    html += '<h4>' + __( 'Sample Recommendations:', 'rtbcb' ) + '</h4><ul>';
+                if (data.simple_analysis.recommendations && data.simple_analysis.recommendations.length > 0) {
+                    html += '<h4>' + __( 'Treasury Technology Recommendations:', 'rtbcb' ) + '</h4>';
+                    html += '<div style="background: white; padding: 15px; border: 1px solid #ddd; border-radius: 4px;">';
+                    html += '<ul style="margin: 0; padding-left: 20px;">';
                     data.simple_analysis.recommendations.forEach(function(rec) {
-                        html += '<li>' + rec + '</li>';
+                        html += '<li style="margin-bottom: 8px; line-height: 1.5;">' + rec + '</li>';
                     });
-                    html += '</ul>';
+                    html += '</ul></div>';
                 }
+
+                if (data.simple_analysis.references && data.simple_analysis.references.length > 0) {
+                    html += '<h4 style="margin-top: 20px;">' + __( 'References:', 'rtbcb' ) + '</h4>';
+                    html += '<div style="background: #f8f9fa; padding: 10px; border-radius: 4px;">';
+                    html += '<ul style="margin: 0; padding-left: 20px; font-size: 12px;">';
+                    data.simple_analysis.references.forEach(function(ref) {
+                        html += '<li style="margin-bottom: 5px;"><a href="' + ref + '" target="_blank">' + ref + '</a></li>';
+                    });
+                    html += '</ul></div>';
+                }
+                html += '</div>';
+            }
+
+            // Debug information
+            if (data.debug_info) {
+                html += '<div class="debug-info" style="margin-top: 20px;">';
+                html += '<details style="border: 1px solid #ccc; border-radius: 4px; padding: 10px; background: #f8f9fa;">';
+                html += '<summary style="cursor: pointer; font-weight: bold; color: #666;">' +
+                    __( 'Debug Information', 'rtbcb' ) + '</summary>';
+                html += '<pre style="font-size: 11px; margin-top: 10px; white-space: pre-wrap;">' +
+                    JSON.stringify(data.debug_info, null, 2) + '</pre>';
+                html += '</details></div>';
             }
 
             html += '</div>';
             resultsDiv.html(html);
+        }
+
+        // Helper function to escape HTML
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
         }
 
         // Add retry functionality


### PR DESCRIPTION
## Summary
- display progress for prompt preparation and AI request
- expose prompt and processing time in company overview results

## Testing
- `npm test` *(fails: Could not read package.json)*
- `tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ab4a6a911883318478b3fdab37b95d