### PR TITLE
Add ROI calculator module styles

### DIFF
--- a/admin/css/unified-test-dashboard.css
+++ b/admin/css/unified-test-dashboard.css
@@ -587,3 +587,673 @@
     background: #f8d7da;
     border: 1px solid #721c24;
 }
+
+/* ROI Calculator Module Styles - Add to unified-test-dashboard.css */
+
+/* ROI Scenarios */
+.rtbcb-roi-scenarios {
+    margin-bottom: 32px;
+}
+
+.rtbcb-roi-scenarios h3 {
+    margin: 0 0 16px 0;
+    color: #1d2327;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.rtbcb-scenario-tabs {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 24px;
+    border-bottom: 1px solid #e1e1e1;
+    padding-bottom: 16px;
+}
+
+.rtbcb-scenario-tab {
+    padding: 8px 16px;
+    background: #f6f7f7;
+    border: 1px solid #c3c4c7;
+    border-radius: 4px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #646970;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.rtbcb-scenario-tab:hover {
+    background: #f0f0f1;
+    color: #2271b1;
+    border-color: #2271b1;
+}
+
+.rtbcb-scenario-tab.active {
+    background: #2271b1;
+    color: white;
+    border-color: #2271b1;
+}
+
+/* ROI Input Grid */
+.rtbcb-roi-input-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 32px;
+    margin-bottom: 32px;
+}
+
+.rtbcb-input-section {
+    background: #f8f9fa;
+    padding: 24px;
+    border-radius: 8px;
+    border: 1px solid #e1e1e1;
+}
+
+.rtbcb-input-section h4 {
+    margin: 0 0 20px 0;
+    color: #1d2327;
+    font-size: 16px;
+    font-weight: 600;
+    padding-bottom: 8px;
+    border-bottom: 2px solid #2271b1;
+}
+
+.rtbcb-input-helper {
+    display: inline-block;
+    margin-left: 8px;
+    font-size: 12px;
+    color: #646970;
+    font-weight: 500;
+}
+
+/* ROI Results */
+.rtbcb-roi-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+    margin-bottom: 32px;
+}
+
+.rtbcb-roi-card {
+    background: white;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    border-left: 4px solid #e1e1e1;
+    position: relative;
+    transition: all 0.3s ease;
+}
+
+.rtbcb-roi-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+}
+
+.rtbcb-roi-conservative {
+    border-left-color: #ffc107;
+    background: linear-gradient(135deg, #fff9e6, white);
+}
+
+.rtbcb-roi-realistic {
+    border-left-color: #28a745;
+    background: linear-gradient(135deg, #e6f7e6, white);
+}
+
+.rtbcb-roi-optimistic {
+    border-left-color: #007bff;
+    background: linear-gradient(135deg, #e6f3ff, white);
+}
+
+.rtbcb-roi-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.rtbcb-roi-card-header h4 {
+    margin: 0;
+    color: #1d2327;
+    font-size: 18px;
+    font-weight: 600;
+}
+
+.rtbcb-roi-confidence {
+    font-size: 12px;
+    color: #646970;
+    background: #f6f7f7;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-weight: 500;
+}
+
+.rtbcb-roi-value {
+    margin-bottom: 16px;
+}
+
+.rtbcb-roi-percentage {
+    display: block;
+    font-size: 36px;
+    font-weight: 700;
+    color: #1d2327;
+    line-height: 1;
+    margin-bottom: 4px;
+}
+
+.rtbcb-roi-amount {
+    display: block;
+    font-size: 16px;
+    color: #646970;
+    font-weight: 500;
+}
+
+.rtbcb-roi-payback {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: #646970;
+    font-size: 14px;
+}
+
+.rtbcb-roi-payback strong {
+    color: #1d2327;
+    font-size: 16px;
+}
+
+/* ROI State Colors */
+.rtbcb-roi-card.roi-excellent {
+    border-left-color: #28a745;
+    background: linear-gradient(135deg, #e6f7e6, white);
+}
+
+.rtbcb-roi-card.roi-excellent .rtbcb-roi-percentage {
+    color: #28a745;
+}
+
+.rtbcb-roi-card.roi-good {
+    border-left-color: #17a2b8;
+    background: linear-gradient(135deg, #e6f7fb, white);
+}
+
+.rtbcb-roi-card.roi-good .rtbcb-roi-percentage {
+    color: #17a2b8;
+}
+
+.rtbcb-roi-card.roi-fair {
+    border-left-color: #ffc107;
+    background: linear-gradient(135deg, #fff9e6, white);
+}
+
+.rtbcb-roi-card.roi-fair .rtbcb-roi-percentage {
+    color: #e0a800;
+}
+
+.rtbcb-roi-card.roi-poor {
+    border-left-color: #dc3545;
+    background: linear-gradient(135deg, #ffeaea, white);
+}
+
+.rtbcb-roi-card.roi-poor .rtbcb-roi-percentage {
+    color: #dc3545;
+}
+
+/* ROI Charts */
+.rtbcb-roi-charts {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 32px;
+    margin-bottom: 32px;
+}
+
+.rtbcb-chart-container {
+    background: white;
+    padding: 24px;
+    border-radius: 8px;
+    border: 1px solid #e1e1e1;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.rtbcb-chart-container h4 {
+    margin: 0 0 20px 0;
+    color: #1d2327;
+    font-size: 16px;
+    font-weight: 600;
+    text-align: center;
+}
+
+.rtbcb-chart-full {
+    grid-column: 1 / -1;
+}
+
+/* ROI Breakdown */
+.rtbcb-roi-breakdown {
+    background: #f8f9fa;
+    padding: 24px;
+    border-radius: 8px;
+    border: 1px solid #e1e1e1;
+    margin-top: 20px;
+}
+
+.rtbcb-roi-breakdown h4 {
+    margin: 0 0 24px 0;
+    color: #1d2327;
+    font-size: 18px;
+    font-weight: 600;
+    text-align: center;
+    padding-bottom: 12px;
+    border-bottom: 1px solid #e1e1e1;
+}
+
+.rtbcb-breakdown-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 32px;
+}
+
+.rtbcb-breakdown-full {
+    grid-column: 1 / -1;
+}
+
+.rtbcb-breakdown-section {
+    background: white;
+    padding: 20px;
+    border-radius: 6px;
+    border: 1px solid #e1e1e1;
+}
+
+.rtbcb-breakdown-section h5 {
+    margin: 0 0 16px 0;
+    color: #1d2327;
+    font-size: 16px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-size: 14px;
+}
+
+.rtbcb-breakdown-items {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.rtbcb-breakdown-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 0;
+    border-bottom: 1px solid #f0f0f1;
+}
+
+.rtbcb-breakdown-item:last-child {
+    border-bottom: none;
+}
+
+.rtbcb-breakdown-item.total {
+    border-top: 2px solid #e1e1e1;
+    margin-top: 8px;
+    padding-top: 16px;
+    font-weight: 600;
+    font-size: 16px;
+}
+
+.rtbcb-breakdown-item .label {
+    color: #646970;
+    font-size: 14px;
+}
+
+.rtbcb-breakdown-item .value {
+    color: #1d2327;
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.rtbcb-breakdown-item.total .label,
+.rtbcb-breakdown-item.total .value {
+    color: #1d2327;
+    font-size: 16px;
+}
+
+/* Assumptions */
+.rtbcb-assumptions-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.rtbcb-assumption-item {
+    background: white;
+    padding: 12px;
+    border-radius: 4px;
+    border-left: 3px solid #2271b1;
+    font-size: 14px;
+    color: #646970;
+    line-height: 1.4;
+}
+
+.rtbcb-assumption-item:before {
+    content: "\2022";
+    color: #2271b1;
+    margin-right: 8px;
+    font-weight: bold;
+}
+
+/* Sensitivity Analysis */
+.rtbcb-sensitivity-charts {
+    margin-bottom: 32px;
+}
+
+.rtbcb-sensitivity-table {
+    background: white;
+    padding: 24px;
+    border-radius: 8px;
+    border: 1px solid #e1e1e1;
+}
+
+.rtbcb-sensitivity-table h4 {
+    margin: 0 0 20px 0;
+    color: #1d2327;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.rtbcb-sensitivity-table table {
+    font-size: 14px;
+}
+
+.rtbcb-sensitivity-table th {
+    background: #f6f7f7;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.rtbcb-sensitivity-table td {
+    text-align: center;
+}
+
+.sensitivity-high {
+    color: #dc3545;
+    font-weight: 600;
+}
+
+.sensitivity-medium {
+    color: #ffc107;
+    font-weight: 600;
+}
+
+.sensitivity-low {
+    color: #28a745;
+    font-weight: 600;
+}
+
+/* Scenario Comparison */
+.rtbcb-scenario-comparison-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 32px;
+    margin-bottom: 32px;
+}
+
+.rtbcb-scenario-summary {
+    background: white;
+    padding: 24px;
+    border-radius: 8px;
+    border: 1px solid #e1e1e1;
+}
+
+.rtbcb-scenario-summary h4 {
+    margin: 0 0 20px 0;
+    color: #1d2327;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.rtbcb-scenario-summary table {
+    font-size: 14px;
+}
+
+.rtbcb-scenario-summary th {
+    background: #f6f7f7;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+/* ROI State Indicators */
+.roi-excellent {
+    color: #28a745 !important;
+    font-weight: 600;
+}
+
+.roi-good {
+    color: #17a2b8 !important;
+    font-weight: 600;
+}
+
+.roi-fair {
+    color: #ffc107 !important;
+    font-weight: 600;
+}
+
+.roi-poor {
+    color: #dc3545 !important;
+    font-weight: 600;
+}
+
+/* Recommendation States */
+.recommendation-excellent {
+    color: #28a745;
+    font-weight: 600;
+    padding: 4px 8px;
+    background: #e6f7e6;
+    border-radius: 4px;
+    font-size: 12px;
+}
+
+.recommendation-good {
+    color: #17a2b8;
+    font-weight: 600;
+    padding: 4px 8px;
+    background: #e6f7fb;
+    border-radius: 4px;
+    font-size: 12px;
+}
+
+.recommendation-fair {
+    color: #e0a800;
+    font-weight: 600;
+    padding: 4px 8px;
+    background: #fff9e6;
+    border-radius: 4px;
+    font-size: 12px;
+}
+
+.recommendation-poor {
+    color: #dc3545;
+    font-weight: 600;
+    padding: 4px 8px;
+    background: #ffeaea;
+    border-radius: 4px;
+    font-size: 12px;
+}
+
+/* Loading States */
+.rtbcb-roi-loading {
+    text-align: center;
+    padding: 60px 20px;
+    color: #646970;
+}
+
+.rtbcb-roi-loading .dashicons {
+    font-size: 48px;
+    margin-bottom: 16px;
+    opacity: 0.6;
+    animation: rtbcb-spin 2s linear infinite;
+}
+
+@keyframes rtbcb-spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* Empty States */
+.rtbcb-roi-empty {
+    text-align: center;
+    padding: 60px 20px;
+    color: #9ca3af;
+    background: #f9fafb;
+    border-radius: 8px;
+    border: 1px dashed #e1e1e1;
+}
+
+.rtbcb-roi-empty .dashicons {
+    font-size: 48px;
+    margin-bottom: 16px;
+    opacity: 0.5;
+}
+
+.rtbcb-roi-empty p {
+    margin: 0;
+    font-size: 16px;
+    font-style: italic;
+}
+
+/* Responsive Design */
+@media (max-width: 1200px) {
+    .rtbcb-roi-input-grid {
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 24px;
+    }
+
+    .rtbcb-roi-charts {
+        grid-template-columns: 1fr;
+        gap: 24px;
+    }
+
+    .rtbcb-scenario-comparison-grid {
+        grid-template-columns: 1fr;
+        gap: 24px;
+    }
+
+    .rtbcb-breakdown-grid {
+        grid-template-columns: 1fr;
+        gap: 24px;
+    }
+}
+
+@media (max-width: 768px) {
+    .rtbcb-scenario-tabs {
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .rtbcb-scenario-tab {
+        text-align: center;
+    }
+
+    .rtbcb-roi-summary-grid {
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
+
+    .rtbcb-roi-input-grid {
+        grid-template-columns: 1fr;
+        gap: 20px;
+    }
+
+    .rtbcb-input-section {
+        padding: 20px;
+    }
+
+    .rtbcb-roi-card {
+        padding: 20px;
+    }
+
+    .rtbcb-chart-container {
+        padding: 20px;
+    }
+
+    .rtbcb-roi-percentage {
+        font-size: 28px;
+    }
+
+    .rtbcb-breakdown-item {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+    }
+
+    .rtbcb-breakdown-item .value {
+        align-self: flex-end;
+    }
+}
+
+@media (max-width: 480px) {
+    .rtbcb-roi-card-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+
+    .rtbcb-roi-payback {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+    }
+
+    .rtbcb-sensitivity-table,
+    .rtbcb-scenario-summary {
+        overflow-x: auto;
+    }
+
+    .rtbcb-sensitivity-table table,
+    .rtbcb-scenario-summary table {
+        min-width: 600px;
+    }
+}
+
+/* Animation Enhancements */
+.rtbcb-roi-card {
+    animation: rtbcb-slideInUp 0.5s ease-out;
+}
+
+@keyframes rtbcb-slideInUp {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Focus States for Accessibility */
+.rtbcb-scenario-tab:focus {
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
+}
+
+.rtbcb-roi-input-grid input:focus,
+.rtbcb-roi-input-grid select:focus {
+    border-color: #2271b1;
+    box-shadow: 0 0 0 1px #2271b1;
+}
+
+/* Print Styles */
+@media print {
+    .rtbcb-roi-charts canvas {
+        max-height: 300px;
+    }
+
+    .rtbcb-action-buttons,
+    .rtbcb-results-actions {
+        display: none;
+    }
+
+    .rtbcb-roi-card {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #e1e1e1;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add comprehensive ROI calculator module styles with scenario tabs, ROI cards, breakdowns, and responsiveness

## Testing
- `./tests/run-tests.sh` *(phpunit: command not found; API connection test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab52f47bc08331a19c00ac04220a9a