### PR TITLE
Add LLM test tab with evaluation and prompt optimization

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -76,12 +76,20 @@ class RTBCB_Admin {
                 'rtbcbDashboard',
                 [
                     'ajaxurl' => admin_url( 'admin-ajax.php' ),
-                    'nonce'   => wp_create_nonce( 'rtbcb_unified_test_dashboard' ),
+                    'nonces'  => [
+                        'dashboard' => wp_create_nonce( 'rtbcb_unified_test_dashboard' ),
+                        'llm'       => wp_create_nonce( 'rtbcb_llm_testing' ),
+                    ],
                     'strings' => [
-                        'generating'   => __( 'Generating...', 'rtbcb' ),
-                        'complete'     => __( 'Complete!', 'rtbcb' ),
-                        'error'        => __( 'Error occurred', 'rtbcb' ),
-                        'confirm_clear'=> __( 'Are you sure you want to clear all results?', 'rtbcb' ),
+                        'generating'    => __( 'Generating...', 'rtbcb' ),
+                        'complete'      => __( 'Complete!', 'rtbcb' ),
+                        'error'         => __( 'Error occurred', 'rtbcb' ),
+                        'confirm_clear' => __( 'Are you sure you want to clear all results?', 'rtbcb' ),
+                    ],
+                    'models'  => [
+                        'mini'     => get_option( 'rtbcb_mini_model', 'gpt-4o-mini' ),
+                        'premium'  => get_option( 'rtbcb_premium_model', 'gpt-4o' ),
+                        'advanced' => get_option( 'rtbcb_advanced_model', 'o1-preview' ),
                     ],
                 ]
             );

--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -60,9 +60,9 @@ $available_models = [
                 <span class="dashicons dashicons-calculator"></span>
                 <?php esc_html_e( 'ROI Calculator', 'rtbcb' ); ?>
             </a>
-            <a href="#llm-integration" class="nav-tab" data-tab="llm-integration">
+            <a href="#llm-tests" class="nav-tab" data-tab="llm-tests">
                 <span class="dashicons dashicons-admin-network"></span>
-                <?php esc_html_e( 'LLM Integration', 'rtbcb' ); ?>
+                <?php esc_html_e( 'LLM Tests', 'rtbcb' ); ?>
             </a>
             <a href="#rag-system" class="nav-tab" data-tab="rag-system">
                 <span class="dashicons dashicons-search"></span>
@@ -573,7 +573,7 @@ $available_models = [
     <?php wp_nonce_field( 'rtbcb_roi_calculator_test', 'rtbcb_roi_calculator_nonce' ); ?>
 
     <?php
-    // LLM Integration Test Section - Replace the placeholder in unified-test-dashboard-page.php
+    // LLM Tests Section
 
     // Get available models for testing
     $available_models = [
@@ -585,8 +585,8 @@ $available_models = [
     $model_capabilities = rtbcb_get_model_capabilities();
     ?>
 
-    <!-- LLM Integration Test Section -->
-    <div id="llm-integration" class="rtbcb-test-section" style="display: none;">
+    <!-- LLM Tests Section -->
+    <div id="llm-tests" class="rtbcb-test-section" style="display: none;">
         <div class="rtbcb-test-panel">
             <div class="rtbcb-panel-header">
                 <h2><?php esc_html_e( 'LLM Integration Testing', 'rtbcb' ); ?></h2>
@@ -817,6 +817,11 @@ $available_models = [
                             <h5><?php esc_html_e( 'Response Input', 'rtbcb' ); ?></h5>
                             <textarea id="response-to-evaluate" rows="10" placeholder="<?php esc_attr_e( 'Paste response to evaluate...', 'rtbcb' ); ?>"></textarea>
 
+                            <div class="rtbcb-control-group">
+                                <label for="reference-response"><?php esc_html_e( 'Reference Text (optional):', 'rtbcb' ); ?></label>
+                                <textarea id="reference-response" rows="6" placeholder="<?php esc_attr_e( 'Enter reference text to compare...', 'rtbcb' ); ?>"></textarea>
+                            </div>
+
                             <div class="rtbcb-evaluation-actions">
                                 <button type="button" id="evaluate-response" class="button button-primary">
                                     <?php esc_html_e( 'Evaluate Response', 'rtbcb' ); ?>
@@ -876,9 +881,6 @@ $available_models = [
         </div>
     </div>
 
-    <!-- Hidden nonce for LLM testing AJAX requests -->
-    <?php wp_nonce_field( 'rtbcb_llm_testing', 'rtbcb_llm_testing_nonce' ); ?>
-
     <!-- RAG System Test Section (Placeholder) -->
     <div id="rag-system" class="rtbcb-test-section" style="display: none;">
         <div class="rtbcb-test-panel">
@@ -906,6 +908,3 @@ $available_models = [
     </div>
 </div>
 
-<!-- Hidden elements for nonce and AJAX -->
-<?php wp_nonce_field( 'rtbcb_unified_test_dashboard', 'rtbcb_unified_test_nonce' ); ?>
-<input type="hidden" id="ajaxurl" value="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" />

--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -280,6 +280,8 @@ function rtbcb_ajax_test_company_overview_enhanced() {
             'debug'        => $debug_info,
         ];
 
+        error_log( sprintf( 'RTBCB: Company Overview Test - %s (%d words, %ss)', $company_name, $word_count, $elapsed_time ) );
+
         wp_send_json_success( $response_data );
     } catch ( Exception $e ) {
         error_log( 'RTBCB Enhanced Company Overview Error: ' . $e->getMessage() );
@@ -538,6 +540,8 @@ function rtbcb_ajax_evaluate_response_quality() {
             'recommendations'   => rtbcb_generate_improvement_recommendations( $quality_metrics ),
         ];
 
+        error_log( sprintf( 'RTBCB: Response Evaluation - Score: %d', intval( $quality_metrics['overall_score'] ) ) );
+
         wp_send_json_success( $response_data );
     } catch ( Exception $e ) {
         error_log( 'RTBCB Response Quality Evaluation Error: ' . $e->getMessage() );
@@ -586,14 +590,22 @@ function rtbcb_ajax_optimize_prompt_tokens() {
         $optimized_analysis = rtbcb_analyze_prompt_tokens( $optimized_prompt );
 
         $response_data = [
-            'original_analysis'    => $analysis,
-            'optimized_analysis'   => $optimized_analysis,
-            'optimized_prompt'     => $optimized_prompt,
+            'original_analysis'     => $analysis,
+            'optimized_analysis'    => $optimized_analysis,
+            'optimized_prompt'      => wp_kses_post( $optimized_prompt ),
             'optimizations_applied' => $optimizations,
-            'token_savings'        => $analysis['estimated_tokens'] - $optimized_analysis['estimated_tokens'],
-            'cost_savings'         => rtbcb_calculate_token_cost_savings( $analysis, $optimized_analysis ),
+            'token_savings'         => $analysis['estimated_tokens'] - $optimized_analysis['estimated_tokens'],
+            'cost_savings'          => rtbcb_calculate_token_cost_savings( $analysis, $optimized_analysis ),
             'efficiency_improvement' => round( ( ( $analysis['estimated_tokens'] - $optimized_analysis['estimated_tokens'] ) / $analysis['estimated_tokens'] ) * 100, 2 ),
         ];
+
+        error_log(
+            sprintf(
+                'RTBCB: Prompt Optimization - %d -> %d tokens',
+                intval( $analysis['estimated_tokens'] ),
+                intval( $optimized_analysis['estimated_tokens'] )
+            )
+        );
 
         wp_send_json_success( $response_data );
     } catch ( Exception $e ) {


### PR DESCRIPTION
## Summary
- Rename dashboard tab to **LLM Tests** and add reference text field for response evaluation.
- Localize dashboard script with AJAX URLs, nonces and model names; hook up evaluation and optimization AJAX requests.
- Log company overview, response evaluation and prompt optimization events on the server.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `./tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6d4496a483319490eb1f5569abc3