### PR TITLE
Add report preview tab to unified dashboard

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -51,6 +51,12 @@
                 this.toggleApiDetails(comp);
             });
 
+            // Report preview controls
+            $('#rtbcb-report-preview-form').on('submit', (e) => {
+                e.preventDefault();
+                this.generateReportPreview();
+            });
+
             // Real-time input validation
             $('#company-name-input').on('input', this.validateInput.bind(this));
 
@@ -491,6 +497,34 @@
                 .catch(() => {
                     this.showNotification('Failed to copy to clipboard', 'error');
                 });
+        },
+
+        generateReportPreview() {
+            const nonce = $('#rtbcb_generate_preview_report_nonce').val();
+            const companyOverview = $('#results-content').html() || '';
+            const apiResults = this.apiResults || {};
+
+            $.ajax({
+                url: rtbcbDashboard.ajaxurl,
+                type: 'POST',
+                data: {
+                    action: 'rtbcb_generate_preview_report',
+                    nonce: nonce,
+                    company_overview: companyOverview,
+                    api_results: JSON.stringify(apiResults)
+                },
+                success: (response) => {
+                    if (response.success && response.data?.html) {
+                        $('#rtbcb-report-preview-frame').attr('srcdoc', response.data.html);
+                        this.showNotification('Report generated', 'success');
+                    } else {
+                        this.showNotification(response.data?.message || 'Failed to generate report', 'error');
+                    }
+                },
+                error: () => {
+                    this.showNotification('Failed to generate report', 'error');
+                }
+            });
         },
 
         // Utility methods

--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -72,6 +72,10 @@ $available_models = [
                 <span class="dashicons dashicons-cloud"></span>
                 <?php esc_html_e( 'API Health', 'rtbcb' ); ?>
             </a>
+            <a href="#report-preview" class="nav-tab" data-tab="report-preview">
+                <span class="dashicons dashicons-media-document"></span>
+                <?php esc_html_e( 'Report Preview', 'rtbcb' ); ?>
+            </a>
         </nav>
     </div>
 
@@ -988,6 +992,26 @@ $available_models = [
                     <?php endforeach; ?>
                 </tbody>
             </table>
+        </div>
+    </div>
+
+    <div id="report-preview" class="rtbcb-test-section" style="display: none;">
+        <div class="rtbcb-test-panel">
+            <div class="rtbcb-panel-header">
+                <h2><?php esc_html_e( 'Report Preview', 'rtbcb' ); ?></h2>
+                <p><?php esc_html_e( 'Generate a preview of the comprehensive report', 'rtbcb' ); ?></p>
+            </div>
+
+            <form id="rtbcb-report-preview-form">
+                <?php wp_nonce_field( 'rtbcb_generate_preview_report', 'rtbcb_generate_preview_report_nonce' ); ?>
+                <p>
+                    <button type="submit" id="rtbcb-generate-report-preview" class="button button-primary">
+                        <?php esc_html_e( 'Generate Report', 'rtbcb' ); ?>
+                    </button>
+                </p>
+            </form>
+
+            <iframe id="rtbcb-report-preview-frame" class="rtbcb-report-preview-frame" style="width: 100%; height: 600px; border: 1px solid #ddd;"></iframe>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add Report Preview tab with iframe and nonce-protected form
- generate preview HTML via new `rtbcb_generate_preview_report` AJAX action
- wire up dashboard JS to request preview and display it

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `tests/run-tests.sh` *(fails: phpunit: command not found; API connection test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab74ba633483319e7fac6df4fa82c8