### PR TITLE
feat: add report preview to unified dashboard

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -80,6 +80,7 @@ class RTBCB_Admin {
                         'dashboard' => wp_create_nonce( 'rtbcb_unified_test_dashboard' ),
                         'llm'       => wp_create_nonce( 'rtbcb_llm_testing' ),
                         'apiHealth' => wp_create_nonce( 'rtbcb_api_health_tests' ),
+                        'reportPreview' => wp_create_nonce( 'rtbcb_generate_preview_report' ),
                     ],
                     'strings' => [
                         'generating'     => __( 'Generating...', 'rtbcb' ),

--- a/admin/css/unified-test-dashboard.css
+++ b/admin/css/unified-test-dashboard.css
@@ -1979,6 +1979,17 @@
     }
 }
 
+/* Report Preview Module Styles */
+#rtbcb-report-preview-container {
+    margin-top: 20px;
+}
+
+#rtbcb-report-preview-frame {
+    width: 100%;
+    height: 600px;
+    border: 1px solid #ccd0d4;
+}
+
 /* Animation Enhancements */
 .rtbcb-model-summary-card,
 .rtbcb-variant-item,

--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -65,6 +65,9 @@
             $('#rtbcb-rag-cancel').on('click', this.cancelRagQuery.bind(this));
             $('#rtbcb-rag-use-context').on('change', (e) => { this.useRagContext = e.target.checked; });
 
+            // Report preview controls
+            $('#rtbcb-generate-preview-report').on('click', this.generatePreviewReport.bind(this));
+
             // Real-time input validation
             $('#company-name-input').on('input', this.validateInput.bind(this));
 
@@ -1960,6 +1963,26 @@
                 message = rtbcbDashboard.strings.errorsDetected.replace('%d', failures);
             }
             $('#rtbcb-api-health-notice').text(message);
+        },
+
+        // Generate report preview
+        generatePreviewReport() {
+            const button = $('#rtbcb-generate-preview-report').prop('disabled', true);
+
+            $.post(rtbcbDashboard.ajaxurl, {
+                action: 'rtbcb_generate_preview_report',
+                nonce: rtbcbDashboard.nonces.reportPreview
+            }).done((response) => {
+                if (response.success) {
+                    $('#rtbcb-report-preview-frame').attr('srcdoc', response.data.html || '');
+                } else {
+                    this.showNotification(response.data?.message || rtbcbDashboard.strings.error, 'error');
+                }
+            }).fail(() => {
+                this.showNotification(rtbcbDashboard.strings.error, 'error');
+            }).always(() => {
+                button.prop('disabled', false);
+            });
         },
 
         // Validation

--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -77,6 +77,10 @@ $index_size   = (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . $wpdb->prefix . 
                 <span class="dashicons dashicons-cloud"></span>
                 <?php esc_html_e( 'API Health', 'rtbcb' ); ?>
             </a>
+            <a href="#report-preview" class="nav-tab" data-tab="report-preview">
+                <span class="dashicons dashicons-media-document"></span>
+                <?php esc_html_e( 'Report Preview', 'rtbcb' ); ?>
+            </a>
         </nav>
     </div>
 
@@ -1065,6 +1069,25 @@ $index_size   = (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . $wpdb->prefix . 
                     <?php endforeach; ?>
                 </tbody>
             </table>
+        </div>
+    </div>
+
+    <!-- Report Preview Section -->
+    <div id="report-preview" class="rtbcb-test-section" style="display: none;">
+        <div class="rtbcb-test-panel">
+            <div class="rtbcb-panel-header">
+                <h2><?php esc_html_e( 'Report Preview', 'rtbcb' ); ?></h2>
+                <p><?php esc_html_e( 'Generate a preview of the full report.', 'rtbcb' ); ?></p>
+            </div>
+            <div class="rtbcb-report-controls">
+                <button type="button" id="rtbcb-generate-preview-report" class="button button-primary">
+                    <span class="dashicons dashicons-media-document"></span>
+                    <?php esc_html_e( 'Generate Report', 'rtbcb' ); ?>
+                </button>
+            </div>
+            <div id="rtbcb-report-preview-container">
+                <iframe id="rtbcb-report-preview-frame"></iframe>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add Report Preview tab with iframe and generate button
- wire up AJAX handler and nonce to return full report HTML
- style report preview container within dashboard

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found; API connection test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab76d13f1083318da91e70eb6f4bb5