### PR TITLE
Remove redundant ROI settings

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -2031,8 +2031,15 @@
         saveDashboardSettings(e) {
             e.preventDefault();
             const $form = $('#rtbcb-dashboard-settings-form');
-            let data = $form.serialize();
-            data += '&action=rtbcb_save_dashboard_settings';
+            const data = {
+                action: 'rtbcb_save_dashboard_settings',
+                nonce: $form.find('[name="nonce"]').val(),
+                rtbcb_openai_api_key: $('#rtbcb_openai_api_key').val(),
+                rtbcb_mini_model: $('#rtbcb_mini_model').val(),
+                rtbcb_premium_model: $('#rtbcb_premium_model').val(),
+                rtbcb_advanced_model: $('#rtbcb_advanced_model').val(),
+                rtbcb_embedding_model: $('#rtbcb_embedding_model').val()
+            };
             const $button = $form.find('button[type="submit"]').prop('disabled', true);
 
             $.post(rtbcbDashboard.ajaxurl, data).done((response) => {

--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -33,8 +33,6 @@ $mini_model     = $available_models['mini'];
 $premium_model  = $available_models['premium'];
 $advanced_model = $available_models['advanced'];
 $embedding_model = get_option( 'rtbcb_embedding_model', rtbcb_get_default_model( 'embedding' ) );
-$labor_cost      = get_option( 'rtbcb_labor_cost_per_hour', '' );
-$bank_fee        = get_option( 'rtbcb_bank_fee_baseline', '' );
 
 $chat_models = [
     'gpt-5'             => 'gpt-5',
@@ -1238,22 +1236,6 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                                     <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $embedding_model, $value ); ?>><?php echo esc_html( $label ); ?></option>
                                 <?php endforeach; ?>
                             </select>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row">
-                            <label for="rtbcb_labor_cost_per_hour"><?php esc_html_e( 'Labor Cost Per Hour', 'rtbcb' ); ?></label>
-                        </th>
-                        <td>
-                            <input type="number" step="0.01" id="rtbcb_labor_cost_per_hour" name="rtbcb_labor_cost_per_hour" value="<?php echo esc_attr( $labor_cost ); ?>" class="regular-text" />
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row">
-                            <label for="rtbcb_bank_fee_baseline"><?php esc_html_e( 'Bank Fee Baseline', 'rtbcb' ); ?></label>
-                        </th>
-                        <td>
-                            <input type="number" step="0.01" id="rtbcb_bank_fee_baseline" name="rtbcb_bank_fee_baseline" value="<?php echo esc_attr( $bank_fee ); ?>" class="regular-text" />
                         </td>
                     </tr>
                 </table>

--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -1579,8 +1579,6 @@ function rtbcb_save_dashboard_settings() {
         'rtbcb_premium_model'       => 'sanitize_text_field',
         'rtbcb_advanced_model'      => 'sanitize_text_field',
         'rtbcb_embedding_model'     => 'sanitize_text_field',
-        'rtbcb_labor_cost_per_hour' => 'floatval',
-        'rtbcb_bank_fee_baseline'   => 'floatval',
     ];
 
     foreach ( $fields as $option => $sanitize ) {


### PR DESCRIPTION
## Summary
- drop labor cost and bank fee fields from unified test dashboard
- stop saving removed ROI options in AJAX handler
- streamline settings save JS to only send active fields

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68ab7e58273c8331be29ede507ef3c42