### PR TITLE
Refactor model settings to use dynamic options

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -105,9 +105,9 @@ class RTBCB_Admin {
                         'settingsSaved'  => __( 'Settings saved.', 'rtbcb' ),
                     ],
                     'models'  => [
-                        'mini'     => get_option( 'rtbcb_mini_model', 'gpt-4o-mini' ),
-                        'premium'  => get_option( 'rtbcb_premium_model', 'gpt-4o' ),
-                        'advanced' => get_option( 'rtbcb_advanced_model', 'o1-preview' ),
+                        'mini'     => get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) ),
+                        'premium'  => get_option( 'rtbcb_premium_model', rtbcb_get_default_model( 'premium' ) ),
+                        'advanced' => get_option( 'rtbcb_advanced_model', rtbcb_get_default_model( 'advanced' ) ),
                     ],
                     'apiHealth' => [
                         'lastResults' => get_option( 'rtbcb_last_api_test', [] ),

--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -23,9 +23,9 @@ $has_company_data = ! empty( $company_data );
 
 // Available models for testing
 $available_models = [
-    'mini'     => get_option( 'rtbcb_mini_model', 'gpt-4o-mini' ),
-    'premium'  => get_option( 'rtbcb_premium_model', 'gpt-4o' ),
-    'advanced' => get_option( 'rtbcb_advanced_model', 'o1-preview' ),
+    'mini'     => get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) ),
+    'premium'  => get_option( 'rtbcb_premium_model', rtbcb_get_default_model( 'premium' ) ),
+    'advanced' => get_option( 'rtbcb_advanced_model', rtbcb_get_default_model( 'advanced' ) ),
 ];
 
 // Settings values
@@ -34,21 +34,29 @@ $premium_model  = $available_models['premium'];
 $advanced_model = $available_models['advanced'];
 $embedding_model = get_option( 'rtbcb_embedding_model', rtbcb_get_default_model( 'embedding' ) );
 
-$chat_models = [
-    'gpt-5'             => 'gpt-5',
-    'gpt-5-mini'        => 'gpt-5-mini',
-    'gpt-5-nano'        => 'gpt-5-nano',
-    'gpt-5-chat-latest' => 'gpt-5-chat-latest',
-    'gpt-4o-mini'       => 'gpt-4o-mini',
-    'gpt-4o'            => 'gpt-4o',
-    'o1-mini'           => 'o1-mini',
-    'o1-preview'        => 'o1-preview',
-];
+$all_models = rtbcb_get_available_models();
+$chat_models = [];
+$embedding_models = [];
 
-$embedding_models = [
-    'text-embedding-3-small' => 'text-embedding-3-small',
-    'text-embedding-3-large' => 'text-embedding-3-large',
-];
+foreach ( $all_models as $model ) {
+    if ( false !== strpos( $model, 'embedding' ) ) {
+        $embedding_models[ $model ] = $model;
+    } else {
+        $chat_models[ $model ] = $model;
+    }
+}
+
+if ( empty( $chat_models ) ) {
+    $chat_models = [
+        $mini_model     => $mini_model,
+        $premium_model  => $premium_model,
+        $advanced_model => $advanced_model,
+    ];
+}
+
+if ( empty( $embedding_models ) ) {
+    $embedding_models = [ $embedding_model => $embedding_model ];
+}
 
 // RAG index information
 global $wpdb;
@@ -618,9 +626,9 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
 
     // Get available models for testing
     $available_models = [
-        'mini'     => get_option( 'rtbcb_mini_model', 'gpt-4o-mini' ),
-        'premium'  => get_option( 'rtbcb_premium_model', 'gpt-4o' ),
-        'advanced' => get_option( 'rtbcb_advanced_model', 'o1-preview' ),
+        'mini'     => get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) ),
+        'premium'  => get_option( 'rtbcb_premium_model', rtbcb_get_default_model( 'premium' ) ),
+        'advanced' => get_option( 'rtbcb_advanced_model', rtbcb_get_default_model( 'advanced' ) ),
     ];
 
     $model_capabilities = rtbcb_get_model_capabilities();

--- a/inc/class-rtbcb-api-tester.php
+++ b/inc/class-rtbcb-api-tester.php
@@ -72,7 +72,7 @@ class RTBCB_API_Tester {
             ];
         }
 
-        $model = get_option( 'rtbcb_embedding_model', 'text-embedding-3-small' );
+        $model = get_option( 'rtbcb_embedding_model', rtbcb_get_default_model( 'embedding' ) );
         $args  = [
             'headers' => [
                 'Authorization' => 'Bearer ' . $api_key,

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -1230,7 +1230,7 @@ Respond with the JSON structure only. No additional text.";
         }
 
         $endpoint          = 'https://api.openai.com/v1/responses';
-        $model_name        = sanitize_text_field( $model ?: 'gpt-5-mini' );
+        $model_name        = sanitize_text_field( $model ?: rtbcb_get_default_model( 'gpt5_mini' ) );
         $model_name        = rtbcb_normalize_model_name( $model_name );
         $max_output_tokens = max( 256, intval( $max_output_tokens ?? 4000 ) ); // Reduced for faster response
 

--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -181,7 +181,7 @@ class RTBCB_RAG {
      */
     private function get_embedding( $text ) {
         $api_key = get_option( 'rtbcb_openai_api_key' );
-        $model   = get_option( 'rtbcb_embedding_model', 'text-embedding-3-small' );
+        $model   = get_option( 'rtbcb_embedding_model', rtbcb_get_default_model( 'embedding' ) );
 
         if ( empty( $api_key ) ) {
             return [];

--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -79,9 +79,9 @@ function rtbcb_ajax_test_llm_model() {
 
     // Validate model key
     $available_models = [
-        'mini'     => get_option( 'rtbcb_mini_model', 'gpt-4o-mini' ),
-        'premium'  => get_option( 'rtbcb_premium_model', 'gpt-4o' ),
-        'advanced' => get_option( 'rtbcb_advanced_model', 'o1-preview' ),
+        'mini'     => get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) ),
+        'premium'  => get_option( 'rtbcb_premium_model', rtbcb_get_default_model( 'premium' ) ),
+        'advanced' => get_option( 'rtbcb_advanced_model', rtbcb_get_default_model( 'advanced' ) ),
     ];
 
     if ( ! isset( $available_models[ $model_key ] ) ) {

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -294,7 +294,7 @@ class RTBCB_Plugin {
         // Add new options introduced in 2.1.0
         if ( version_compare( $from_version, '2.1.0', '<' ) ) {
             $new_options = [
-                'rtbcb_advanced_model'        => 'gpt-5-mini',
+                'rtbcb_advanced_model'        => rtbcb_get_default_model( 'advanced' ),
                 'rtbcb_comprehensive_analysis' => true,
             ];
 
@@ -438,7 +438,7 @@ class RTBCB_Plugin {
         );
 
         $api_key      = sanitize_text_field( get_option( 'rtbcb_openai_api_key', '' ) );
-        $report_model = sanitize_text_field( get_option( 'rtbcb_advanced_model', 'gpt-5-mini' ) );
+        $report_model = sanitize_text_field( get_option( 'rtbcb_advanced_model', rtbcb_get_default_model( 'advanced' ) ) );
 
         $config = rtbcb_get_gpt5_config( get_option( 'rtbcb_gpt5_config', [] ) );
 


### PR DESCRIPTION
## Summary
- Add helper to fetch and cache available OpenAI models
- Replace hardcoded model defaults with `rtbcb_get_default_model()` throughout admin and AJAX handlers
- Populate settings dropdowns and localized data from dynamic option values

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `./tests/run-tests.sh` *(phpunit: command not found; API connection test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7ff342148331ae3b9ac809a0a972