### PR TITLE
Add diagnostic helpers for unified test dashboard

### DIFF
--- a/admin/css/unified-test-dashboard.css
+++ b/admin/css/unified-test-dashboard.css
@@ -1257,6 +1257,17 @@
     }
 }
 
+/* Temporary diagnostic styles */
+.rtbcb-debug-outline * {
+    outline: 1px solid red !important;
+}
+
+.rtbcb-debug-z-index {
+    position: relative !important;
+    z-index: 999999 !important;
+    pointer-events: auto !important;
+}
+
 /* LLM Integration Testing Module Styles - Add to unified-test-dashboard.css */
 
 /* LLM Test Mode Navigation */
@@ -2031,5 +2042,16 @@
     .rtbcb-comparison-charts canvas {
         max-height: 300px;
     }
+}
+
+/* Temporary diagnostic styles */
+.rtbcb-debug-outline * {
+    outline: 1px solid red !important;
+}
+
+.rtbcb-debug-z-index {
+    position: relative !important;
+    z-index: 999999 !important;
+    pointer-events: auto !important;
 }
 

--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -2088,5 +2088,46 @@
     // Expose Dashboard object for debugging
     window.RTBCBDashboard = Dashboard;
 
+    // Add this debug helper
+    window.DashboardDiag = {
+        assertNonce: function(action) {
+            const nonces = rtbcbDashboard?.nonces || {};
+            console.log(`[DIAG] Nonce check for ${action}:`, nonces[action] ? 'FOUND' : 'MISSING');
+            return !!nonces[action];
+        },
+
+        assertTabVisibility: function() {
+            const activeTab = $('.rtbcb-test-section.active');
+            console.log('[DIAG] Active tab:', activeTab.attr('id'), 'Visible:', activeTab.is(':visible'));
+            return activeTab.length > 0 && activeTab.is(':visible');
+        },
+
+        countHandlers: function(selector) {
+            const events = $._data($(selector)[0], 'events') || {};
+            const count = Object.keys(events).length;
+            console.log(`[DIAG] Event handlers on ${selector}:`, count, events);
+            return count;
+        },
+
+        checkOverlays: function() {
+            const overlays = $('.rtbcb-loading, .rtbcb-overlay, .rtbcb-modal').filter(':visible');
+            console.log('[DIAG] Visible overlays:', overlays.length);
+            overlays.each(function() {
+                const zIndex = $(this).css('z-index');
+                const pointerEvents = $(this).css('pointer-events');
+                console.log(`[DIAG] Overlay ${this.className}: z-index=${zIndex}, pointer-events=${pointerEvents}`);
+            });
+            return overlays.length;
+        }
+    };
+
+    // Bind diagnostic to button clicks
+    $(document).on('click', '[data-action]', function(e) {
+        const action = $(this).data('action');
+        console.log(`[DIAG] Button click: ${action}, disabled=${$(this).prop('disabled')}, preventDefault called`);
+        window.DashboardDiag.assertNonce(action.replace('run-', '').replace('-test', ''));
+        window.DashboardDiag.checkOverlays();
+    });
+
 })(jQuery);
 

--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -1,4 +1,16 @@
 <?php
+// Temporary AJAX flow tracing
+add_action( 'wp_ajax_rtbcb_test_company_overview_enhanced', function() {
+    error_log( '[DIAG] AJAX Handler Entry: rtbcb_test_company_overview_enhanced' );
+    error_log( '[DIAG] POST data keys: ' . implode( ', ', array_keys( $_POST ) ) );
+    error_log( '[DIAG] Current user can manage_options: ' . ( current_user_can( 'manage_options' ) ? 'YES' : 'NO' ) );
+    // Continue to actual handler...
+}, 5 );
+
+add_action( 'wp_ajax_rtbcb_run_llm_test', function() {
+    error_log( '[DIAG] AJAX Handler Entry: rtbcb_run_llm_test - Handler ' . ( has_action( 'wp_ajax_rtbcb_run_llm_test' ) ? 'EXISTS' : 'MISSING' ) );
+}, 5 );
+
 /**
  * Enhanced AJAX helper functions.
  *


### PR DESCRIPTION
## Summary
- add DashboardDiag helper and click instrumentation to trace unified test dashboard flows
- log AJAX entry points for enhanced company overview and LLM tests
- introduce diagnostic CSS classes to visualize overlay layering

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68ab87591fe08331b3392e4d47b03a13