### PR TITLE
feat: add LLM integration testing module

### DIFF
--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -717,33 +717,55 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                     <div class="rtbcb-config-section">
                         <h4><?php esc_html_e('Test Configuration', 'rtbcb'); ?></h4>
 
-                        <div class="rtbcb-control-group">
-                            <label for="llm-test-prompt"><?php esc_html_e('Test Prompt:', 'rtbcb'); ?></label>
-                            <textarea id="llm-test-prompt" rows="4" placeholder="<?php esc_attr_e('Enter your test prompt...', 'rtbcb'); ?>"></textarea>
+                        <!-- Model Selection Controls -->
+                        <div class="rtbcb-model-matrix">
+                            <h4><?php esc_html_e('Model Comparison Matrix', 'rtbcb'); ?></h4>
+                            <div class="rtbcb-model-grid">
+                                <?php foreach ($available_models as $key => $model): ?>
+                                <label class="rtbcb-model-option">
+                                    <input type="checkbox" name="llm-models[]" value="<?php echo esc_attr($key); ?>" checked />
+                                    <span class="rtbcb-model-info">
+                                        <strong><?php echo esc_html(ucfirst($key)); ?></strong>
+                                        <small><?php echo esc_html($model); ?></small>
+                                        <span class="rtbcb-cost-estimate" data-model="<?php echo esc_attr($key); ?>">~$0.00</span>
+                                    </span>
+                                </label>
+                                <?php endforeach; ?>
+                            </div>
                         </div>
 
-                        <div class="rtbcb-control-group">
-                            <label><?php esc_html_e('Models to Test:', 'rtbcb'); ?></label>
-                            <div class="rtbcb-model-checkboxes">
-                                <?php foreach ($available_models as $key => $model): ?>
-                                    <label class="rtbcb-checkbox-label">
-                                        <input type="checkbox" name="test-models[]" value="<?php echo esc_attr($key); ?>" 
-                                               data-model-name="<?php echo esc_attr($model); ?>" checked>
-                                        <span><?php echo esc_html(ucfirst($key) . ' (' . $model . ')'); ?></span>
-                                    </label>
-                                <?php endforeach; ?>
+                        <!-- Prompt Engineering Section -->
+                        <div class="rtbcb-prompt-variants">
+                            <h4><?php esc_html_e('A/B Prompt Testing', 'rtbcb'); ?></h4>
+                            <div class="rtbcb-variant-container">
+                                <div class="rtbcb-variant-item" data-variant="A">
+                                    <label><?php esc_html_e('Prompt A:', 'rtbcb'); ?></label>
+                                    <textarea id="llm-prompt-a" rows="4" placeholder="<?php esc_attr_e('Enter first prompt variant...', 'rtbcb'); ?>"></textarea>
+                                    <div class="rtbcb-variant-controls">
+                                        <label><?php esc_html_e('Temperature:', 'rtbcb'); ?> <input type="range" min="0" max="2" step="0.1" value="0.3" /></label>
+                                        <span class="temperature-display">0.3</span>
+                                    </div>
+                                </div>
+                                <div class="rtbcb-variant-item" data-variant="B">
+                                    <label><?php esc_html_e('Prompt B (Optional):', 'rtbcb'); ?></label>
+                                    <textarea id="llm-prompt-b" rows="4" placeholder="<?php esc_attr_e('Enter second prompt variant...', 'rtbcb'); ?>"></textarea>
+                                    <div class="rtbcb-variant-controls">
+                                        <label><?php esc_html_e('Temperature:', 'rtbcb'); ?> <input type="range" min="0" max="2" step="0.1" value="0.7" /></label>
+                                        <span class="temperature-display">0.7</span>
+                                    </div>
+                                </div>
                             </div>
                         </div>
 
                         <div class="rtbcb-control-row">
                             <div class="rtbcb-control-group">
                                 <label for="llm-max-tokens"><?php esc_html_e('Max Tokens:', 'rtbcb'); ?></label>
-                                <input type="number" id="llm-max-tokens" min="100" max="4000" value="1000">
+                                <input type="number" id="llm-max-tokens" min="100" max="4000" value="1000" />
                             </div>
 
                             <div class="rtbcb-control-group">
                                 <label for="llm-temperature"><?php esc_html_e('Temperature:', 'rtbcb'); ?></label>
-                                <input type="range" id="llm-temperature" min="0" max="2" step="0.1" value="0.3">
+                                <input type="range" id="llm-temperature" min="0" max="2" step="0.1" value="0.3" />
                                 <span id="llm-temperature-value">0.3</span>
                             </div>
                         </div>

--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -29,139 +29,6 @@ function rtbcb_prepare_enhanced_result( $overview, $debug = [] ) {
 }
 
 /**
- * Execute LLM test matrix across multiple models.
- *
- * @param array $input_data Sanitized input data.
- * @return array
- * @throws Exception When API key not configured.
- */
-function rtbcb_execute_llm_test_matrix( $input_data ) {
-    $results = [];
-    $api_key = get_option( 'rtbcb_openai_api_key' );
-
-    if ( empty( $api_key ) ) {
-        throw new Exception( __( 'OpenAI API key not configured.', 'rtbcb' ) );
-    }
-
-    // Model pricing per 1K tokens (input)
-    $pricing = [
-        'mini'     => 0.00015, // GPT-4O Mini
-        'premium'  => 0.005,   // GPT-4O
-        'advanced' => 0.015,   // O1-Preview
-    ];
-
-    foreach ( $input_data['modelIds'] as $model_key ) {
-        $model_name = get_option( "rtbcb_{$model_key}_model", rtbcb_get_default_model( $model_key ) );
-
-        $start_time = microtime( true );
-
-        try {
-            $messages = [
-                [ 'role' => 'user', 'content' => $input_data['promptA'] ],
-            ];
-
-            $request_data = [
-                'model'      => $model_name,
-                'messages'   => $messages,
-                'max_tokens' => $input_data['maxTokens'],
-            ];
-
-            // Add temperature if model supports it
-            if ( rtbcb_model_supports_temperature( $model_name ) ) {
-                $request_data['temperature'] = $input_data['temperature'];
-            }
-
-            $response = wp_remote_post(
-                'https://api.openai.com/v1/chat/completions',
-                [
-                    'headers' => [
-                        'Authorization' => 'Bearer ' . $api_key,
-                        'Content-Type'  => 'application/json',
-                    ],
-                    'body'    => wp_json_encode( $request_data ),
-                    'timeout' => 60,
-                ]
-            );
-
-            $end_time      = microtime( true );
-            $response_time = round( ( $end_time - $start_time ) * 1000 ); // ms
-
-            if ( is_wp_error( $response ) ) {
-                $results[ $model_key ] = [
-                    'success'       => false,
-                    'error'         => $response->get_error_message(),
-                    'response_time' => $response_time,
-                    'model_key'     => $model_key,
-                    'model_name'    => $model_name,
-                ];
-                continue;
-            }
-
-            $response_code = wp_remote_retrieve_response_code( $response );
-            $response_body = wp_remote_retrieve_body( $response );
-
-            if ( 200 !== $response_code ) {
-                $results[ $model_key ] = [
-                    'success'       => false,
-                    'error'         => sprintf( __( 'API error %d: %s', 'rtbcb' ), $response_code, $response_body ),
-                    'response_time' => $response_time,
-                    'model_key'     => $model_key,
-                    'model_name'    => $model_name,
-                ];
-                continue;
-            }
-
-            $decoded = json_decode( $response_body, true );
-
-            if ( ! isset( $decoded['choices'][0]['message']['content'] ) ) {
-                $results[ $model_key ] = [
-                    'success'       => false,
-                    'error'         => __( 'Unexpected API response format', 'rtbcb' ),
-                    'response_time' => $response_time,
-                    'model_key'     => $model_key,
-                    'model_name'    => $model_name,
-                ];
-                continue;
-            }
-
-            $content       = $decoded['choices'][0]['message']['content'];
-            $tokens_used   = $decoded['usage']['total_tokens'] ?? 0;
-            $cost_estimate = ( $tokens_used / 1000 ) * ( $pricing[ $model_key ] ?? 0.005 );
-
-            // Calculate quality metrics
-            $quality_score = rtbcb_calculate_llm_response_quality( $content, $input_data['promptA'] );
-
-            $results[ $model_key ] = [
-                'success'         => true,
-                'content'         => $content,
-                'response_time'   => $response_time,
-                'tokens_used'     => $tokens_used,
-                'cost_estimate'   => round( $cost_estimate, 6 ),
-                'quality_score'   => $quality_score,
-                'model_key'       => $model_key,
-                'model_name'      => $model_name,
-                'word_count'      => str_word_count( wp_strip_all_tags( $content ) ),
-                'character_count' => strlen( $content ),
-            ];
-
-        } catch ( Exception $e ) {
-            $end_time      = microtime( true );
-            $response_time = round( ( $end_time - $start_time ) * 1000 );
-
-            $results[ $model_key ] = [
-                'success'       => false,
-                'error'         => $e->getMessage(),
-                'response_time' => $response_time,
-                'model_key'     => $model_key,
-                'model_name'    => $model_name,
-            ];
-        }
-    }
-
-    return $results;
-}
-
-/**
  * Calculate LLM response quality score.
  *
  * @param string $content Model response content.
@@ -782,6 +649,82 @@ function rtbcb_calculate_model_cost( $tokens_used, $model_key ) {
     $rate = $cost_per_1k[ $model_key ] ?? 0.005;
     return ( $tokens_used / 1000 ) * $rate;
 }
+
+/**
+ * Get human-readable model name from key.
+ *
+ * @param string $model_key Model key.
+ * @return string
+ */
+function rtbcb_get_model_display_name( $model_key ) {
+    $names = [
+        'mini'     => __( 'GPT-4O Mini', 'rtbcb' ),
+        'premium'  => __( 'GPT-4O', 'rtbcb' ),
+        'advanced' => __( 'O1-Preview', 'rtbcb' ),
+    ];
+
+    return $names[ $model_key ] ?? ucfirst( $model_key );
+}
+
+/**
+ * Find best performing result by quality score.
+ *
+ * @param array $results Test results.
+ * @return array
+ */
+function rtbcb_find_best_performing_result( $results ) {
+    if ( empty( $results ) ) {
+        return [];
+    }
+
+    usort(
+        $results,
+        function ( $a, $b ) {
+            return ( $b['quality_score'] ?? 0 ) <=> ( $a['quality_score'] ?? 0 );
+        }
+    );
+
+    $best = $results[0];
+
+    return [
+        'model_key' => $best['model_key'],
+        'score'     => $best['quality_score'],
+        'reason'    => 'highest_quality',
+    ];
+}
+
+/*
+Per-run result schema
+[
+    'model_key' => 'mini',
+    'model_name' => 'GPT-4O Mini',
+    'prompt' => 'A',
+    'response' => 'Generated response text...',
+    'latency' => 1250.5,
+    'tokens_used' => 150,
+    'cost_estimate' => 0.000225,
+    'quality_score' => 85,
+    'pass_fail_rules' => [
+        'contains_roi' => true,
+        'json_parseable' => false,
+        'length_adequate' => true,
+    ],
+]
+
+Aggregation summary schema
+[
+    'total_tests' => 4,
+    'total_time' => 5.2,
+    'avg_latency' => 1312.75,
+    'total_tokens' => 600,
+    'total_cost' => 0.0009,
+    'best_performer' => [
+        'model_key' => 'premium',
+        'score' => 92,
+        'reason' => 'highest_quality',
+    ],
+]
+*/
 
 /**
  * Assess response quality using various metrics.
@@ -1780,95 +1723,135 @@ function rtbcb_save_dashboard_settings() {
  */
 function rtbcb_ajax_run_llm_test() {
     if ( ! check_ajax_referer( 'rtbcb_llm_testing', 'nonce', false ) ) {
-        wp_send_json_error(
-            [
-                'code'      => 'security_failed',
-                'message'   => __( 'Security check failed.', 'rtbcb' ),
-                'detail'    => null,
-                'requestId' => uniqid( 'req_' ),
-            ],
-            403
-        );
+        wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ], 403 );
     }
 
     if ( ! current_user_can( 'manage_options' ) ) {
-        wp_send_json_error(
-            [
-                'code'      => 'insufficient_permissions',
-                'message'   => __( 'Insufficient permissions.', 'rtbcb' ),
-                'detail'    => null,
-                'requestId' => uniqid( 'req_' ),
-            ],
-            403
-        );
+        wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ], 403 );
     }
 
     $input_data = [
-        'modelIds'    => array_map( 'sanitize_text_field', wp_unslash( $_POST['modelIds'] ?? [] ) ),
-        'promptA'     => sanitize_textarea_field( wp_unslash( $_POST['promptA'] ?? '' ) ),
-        'promptB'     => sanitize_textarea_field( wp_unslash( $_POST['promptB'] ?? '' ) ),
-        'inputs'      => array_map( 'sanitize_text_field', wp_unslash( $_POST['inputs'] ?? [] ) ),
-        'runMode'     => sanitize_text_field( wp_unslash( $_POST['runMode'] ?? 'single' ) ),
-        'maxTokens'   => intval( wp_unslash( $_POST['maxTokens'] ?? 1000 ) ),
-        'temperature' => floatval( wp_unslash( $_POST['temperature'] ?? 0.3 ) ),
+        'modelIds'   => array_map( 'sanitize_text_field', wp_unslash( $_POST['modelIds'] ?? [] ) ),
+        'promptA'    => sanitize_textarea_field( wp_unslash( $_POST['promptA'] ?? '' ) ),
+        'promptB'    => sanitize_textarea_field( wp_unslash( $_POST['promptB'] ?? '' ) ),
+        'runMode'    => sanitize_text_field( wp_unslash( $_POST['runMode'] ?? 'single' ) ),
+        'maxTokens'  => intval( wp_unslash( $_POST['maxTokens'] ?? 1000 ) ),
+        'temperature'=> floatval( wp_unslash( $_POST['temperature'] ?? 0.3 ) ),
     ];
 
     if ( empty( $input_data['modelIds'] ) ) {
-        wp_send_json_error(
-            [
-                'code'      => 'missing_models',
-                'message'   => __( 'No models specified.', 'rtbcb' ),
-                'detail'    => null,
-                'requestId' => uniqid( 'req_' ),
-            ],
-            400
-        );
+        wp_send_json_error( [ 'message' => __( 'No models selected.', 'rtbcb' ) ], 400 );
     }
 
     if ( empty( $input_data['promptA'] ) ) {
-        wp_send_json_error(
-            [
-                'code'      => 'missing_prompt',
-                'message'   => __( 'Prompt is required.', 'rtbcb' ),
-                'detail'    => null,
-                'requestId' => uniqid( 'req_' ),
-            ],
-            400
-        );
+        wp_send_json_error( [ 'message' => __( 'Prompt A is required.', 'rtbcb' ) ], 400 );
     }
 
     try {
+        $results    = [];
         $start_time = microtime( true );
-        $results    = rtbcb_execute_llm_test_matrix( $input_data );
-        $end_time   = microtime( true );
 
-        $result = [
-            'results'  => $results,
-            'metadata' => [
-                'totalTime'   => round( ( $end_time - $start_time ), 2 ),
-                'modelsCount' => count( $input_data['modelIds'] ),
-            ],
+        foreach ( $input_data['modelIds'] as $model_key ) {
+            $model_start = microtime( true );
+
+            $result_a = rtbcb_test_single_model( $model_key, $input_data['promptA'], $input_data );
+            $model_end = microtime( true );
+
+            $results[] = [
+                'model_key'     => $model_key,
+                'model_name'    => rtbcb_get_model_display_name( $model_key ),
+                'prompt'        => 'A',
+                'response'      => $result_a['content'],
+                'latency'       => round( ( $model_end - $model_start ) * 1000, 2 ),
+                'tokens_used'   => $result_a['tokens_used'],
+                'cost_estimate' => rtbcb_calculate_model_cost( $result_a['tokens_used'], $model_key ),
+                'quality_score' => rtbcb_assess_response_quality( $result_a['content'] ),
+            ];
+
+            if ( ! empty( $input_data['promptB'] ) ) {
+                $model_start = microtime( true );
+                $result_b    = rtbcb_test_single_model( $model_key, $input_data['promptB'], $input_data );
+                $model_end   = microtime( true );
+
+                $results[] = [
+                    'model_key'     => $model_key,
+                    'model_name'    => rtbcb_get_model_display_name( $model_key ),
+                    'prompt'        => 'B',
+                    'response'      => $result_b['content'],
+                    'latency'       => round( ( $model_end - $model_start ) * 1000, 2 ),
+                    'tokens_used'   => $result_b['tokens_used'],
+                    'cost_estimate' => rtbcb_calculate_model_cost( $result_b['tokens_used'], $model_key ),
+                    'quality_score' => rtbcb_assess_response_quality( $result_b['content'] ),
+                ];
+            }
+        }
+
+        $total_time = round( ( microtime( true ) - $start_time ), 2 );
+
+        $summary = [
+            'total_tests' => count( $results ),
+            'total_time'  => $total_time,
+            'avg_latency' => array_sum( array_column( $results, 'latency' ) ) / max( count( $results ), 1 ),
+            'total_tokens'=> array_sum( array_column( $results, 'tokens_used' ) ),
+            'total_cost'  => array_sum( array_column( $results, 'cost_estimate' ) ),
+            'best_performer' => rtbcb_find_best_performing_result( $results ),
         ];
 
-        wp_send_json_success(
-            [
-                'data'      => $result,
-                'timestamp' => current_time( 'mysql' ),
-                'requestId' => uniqid( 'req_' ),
-            ]
-        );
+        wp_send_json_success( [
+            'results'   => $results,
+            'summary'   => $summary,
+            'timestamp' => current_time( 'mysql' ),
+        ] );
+
     } catch ( Exception $e ) {
         error_log( 'RTBCB LLM Test Error: ' . $e->getMessage() );
-        wp_send_json_error(
-            [
-                'code'      => 'execution_failed',
-                'message'   => __( 'LLM test execution failed.', 'rtbcb' ),
-                'detail'    => WP_DEBUG ? $e->getMessage() : null,
-                'requestId' => uniqid( 'req_' ),
-            ],
-            500
-        );
+        wp_send_json_error( [
+            'message' => __( 'LLM test execution failed.', 'rtbcb' ),
+            'detail'  => WP_DEBUG ? $e->getMessage() : null,
+        ], 500 );
     }
+}
+
+function rtbcb_test_single_model( $model_key, $prompt, $config ) {
+    $llm = new RTBCB_LLM();
+
+    $model_map = [
+        'mini'     => get_option( 'rtbcb_mini_model', 'gpt-4o-mini' ),
+        'premium'  => get_option( 'rtbcb_premium_model', 'gpt-4o' ),
+        'advanced' => get_option( 'rtbcb_advanced_model', 'o1-preview' ),
+    ];
+
+    $model_name = $model_map[ $model_key ] ?? 'gpt-4o-mini';
+
+    $response = wp_remote_post( 'https://api.openai.com/v1/chat/completions', [
+        'headers' => [
+            'Authorization' => 'Bearer ' . get_option( 'rtbcb_openai_api_key' ),
+            'Content-Type'  => 'application/json',
+        ],
+        'body'    => wp_json_encode( [
+            'model'      => $model_name,
+            'messages'   => [ [ 'role' => 'user', 'content' => $prompt ] ],
+            'max_tokens' => $config['maxTokens'],
+            'temperature'=> rtbcb_model_supports_temperature( $model_name ) ? $config['temperature'] : null,
+        ] ),
+        'timeout' => 60,
+    ] );
+
+    if ( is_wp_error( $response ) ) {
+        throw new Exception( $response->get_error_message() );
+    }
+
+    $body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+    if ( ! isset( $body['choices'][0]['message']['content'] ) ) {
+        throw new Exception( 'Invalid API response structure' );
+    }
+
+    return [
+        'content'     => $body['choices'][0]['message']['content'],
+        'tokens_used' => $body['usage']['total_tokens'] ?? 0,
+        'model_used'  => $body['model'] ?? $model_name,
+    ];
 }
 
 /**


### PR DESCRIPTION
## Summary
- add model comparison matrix and A/B prompt UI to the LLM tests dashboard
- implement AJAX handler to run prompts across multiple models and summarize metrics
- document result schemas and helper functions for model names and performance scoring

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `./tests/run-tests.sh >/tmp/unit-tests.log && tail -n 20 /tmp/unit-tests.log` *(fails: phpunit: command not found; API connection test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac572b195c83319d75aa59a4729587