### PR TITLE
Improve security and performance of AJAX dashboard

### DIFF
--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -27,20 +27,11 @@ function rtbcb_enqueue_dashboard_assets() {
         filemtime( RTBCB_DIR . 'admin/css/unified-test-dashboard.css' )
     );
 
-    // Enqueue Chart.js before our script
-    wp_enqueue_script(
-        'chart-js',
-        'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js',
-        [],
-        '3.9.1',
-        true
-    );
-
     // Enqueue main dashboard script
     wp_enqueue_script(
         'rtbcb-unified-dashboard',
         $js_file,
-        [ 'jquery', 'chart-js' ],
+        [ 'jquery' ],
         filemtime( RTBCB_DIR . 'admin/js/unified-test-dashboard.js' ),
         true
     );
@@ -75,9 +66,11 @@ function rtbcb_enqueue_dashboard_assets() {
                 'error'         => __( 'Error occurred', 'rtbcb' ),
                 'running'       => __( 'Running...', 'rtbcb' ),
                 'settingsSaved' => __( 'Settings saved successfully', 'rtbcb' ),
+                'serviceUnavailable' => __( 'Service temporarily unavailable. Please try again later.', 'rtbcb' ),
             ],
             'urls'    => [
-                'settings' => admin_url( 'admin.php?page=rtbcb-unified-tests#settings' ),
+                'settings'    => admin_url( 'admin.php?page=rtbcb-unified-tests#settings' ),
+                'chartJsUrl'  => esc_url( 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js' ),
             ],
         ]
     );

--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -39,7 +39,7 @@ class RTBCB_API_Tester {
                     'Authorization' => 'Bearer ' . $api_key,
                     'Content-Type'  => 'application/json',
                 ],
-                'timeout' => 10,
+                'timeout' => 60,
             ]
         );
 
@@ -232,7 +232,7 @@ add_action( 'wp_ajax_rtbcb_export_results', 'rtbcb_ajax_export_results' );
  */
 function rtbcb_ajax_test_llm_model() {
     // Verify nonce and permissions
-    if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_llm_testing' ) ) {
+    if ( ! check_ajax_referer( 'rtbcb_llm_testing', 'nonce', false ) ) {
         wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ], 403 );
     }
 
@@ -380,7 +380,7 @@ function rtbcb_ajax_test_llm_model() {
  */
 function rtbcb_ajax_test_company_overview_enhanced() {
     // Verify nonce and permissions
-    if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_unified_test_dashboard' ) ) {
+    if ( ! check_ajax_referer( 'rtbcb_unified_test_dashboard', 'nonce', false ) ) {
         wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ], 403 );
     }
 
@@ -488,7 +488,7 @@ function rtbcb_ajax_test_company_overview_enhanced() {
  */
 function rtbcb_ajax_calculate_roi_test() {
     // Verify nonce and permissions
-    if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_roi_calculator_test' ) ) {
+    if ( ! check_ajax_referer( 'rtbcb_roi_calculator_test', 'nonce', false ) ) {
         wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ], 403 );
     }
 
@@ -552,7 +552,7 @@ function rtbcb_ajax_calculate_roi_test() {
  */
 function rtbcb_ajax_evaluate_response_quality() {
     // Verify nonce and permissions
-    if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_llm_testing' ) ) {
+    if ( ! check_ajax_referer( 'rtbcb_llm_testing', 'nonce', false ) ) {
         wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ], 403 );
     }
 
@@ -609,7 +609,7 @@ function rtbcb_ajax_evaluate_response_quality() {
  */
 function rtbcb_ajax_optimize_prompt_tokens() {
     // Verify nonce and permissions
-    if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_llm_testing' ) ) {
+    if ( ! check_ajax_referer( 'rtbcb_llm_testing', 'nonce', false ) ) {
         wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ], 403 );
     }
 
@@ -1648,7 +1648,7 @@ function rtbcb_run_data_health_checks() {
             'https://api.openai.com/v1/models',
             [
                 'headers' => [ 'Authorization' => 'Bearer ' . $api_key ],
-                'timeout' => 10,
+                'timeout' => 60,
             ]
         );
 
@@ -2322,7 +2322,7 @@ function rtbcb_execute_openai_health_ping() {
             'headers' => [
                 'Authorization' => 'Bearer ' . $api_key,
             ],
-            'timeout' => 10,
+            'timeout' => 60,
         ]
     );
 


### PR DESCRIPTION
## Summary
- Harden AJAX handlers with `check_ajax_referer` and extended timeouts
- Add dashboard circuit breaker, debounce utilities, and lazy Chart.js loader
- Defer heavy UI work and batch table updates to improve performance

## Testing
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac59a8821c8331afdd3311f8beb570