### PR TITLE
Handle dashboard settings form submission via AJAX

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -157,6 +157,8 @@
                 this.exportResults();
             });
 
+            $(document).on('submit.rtbcb', '#rtbcb-dashboard-settings-form', this.saveDashboardSettings.bind(this));
+
             // Tab navigation
             $('.rtbcb-test-tabs .nav-tab').on('click.rtbcb', this.handleTabClick.bind(this));
         },

--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -1072,7 +1072,7 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                 <h2><?php esc_html_e( 'Settings', 'rtbcb' ); ?></h2>
                 <p><?php esc_html_e( 'Configure plugin options.', 'rtbcb' ); ?></p>
             </div>
-            <form id="rtbcb-dashboard-settings-form">
+            <form id="rtbcb-dashboard-settings-form" method="post">
                 <?php wp_nonce_field( 'rtbcb_save_dashboard_settings', 'nonce' ); ?>
                 <table class="form-table" role="presentation">
                     <tr>


### PR DESCRIPTION
## Summary
- wire up dashboard settings form submission to reuse existing AJAX save handler
- set dashboard settings form to post to avoid full page refresh

## Testing
- `bash tests/run-tests.sh` *(phpunit: command not found; API-based tests skipped: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_68ac60e541dc833199dfcf8ff5a6177a