### PR TITLE
Validate OpenAI API key before saving

### DIFF
--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -2052,12 +2052,19 @@ function rtbcb_save_dashboard_settings() {
         wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ], 403 );
     }
 
+    $openai_key = isset( $_POST['rtbcb_openai_api_key'] ) ? sanitize_text_field( wp_unslash( $_POST['rtbcb_openai_api_key'] ) ) : '';
+
+    if ( $openai_key && ! rtbcb_is_valid_openai_api_key( $openai_key ) ) {
+        wp_send_json_error( [ 'message' => __( 'Invalid OpenAI API key format.', 'rtbcb' ) ] );
+    }
+
+    update_option( 'rtbcb_openai_api_key', $openai_key );
+
     $fields = [
-        'rtbcb_openai_api_key'      => 'sanitize_text_field',
-        'rtbcb_mini_model'          => 'sanitize_text_field',
-        'rtbcb_premium_model'       => 'sanitize_text_field',
-        'rtbcb_advanced_model'      => 'sanitize_text_field',
-        'rtbcb_embedding_model'     => 'sanitize_text_field',
+        'rtbcb_mini_model'      => 'sanitize_text_field',
+        'rtbcb_premium_model'   => 'sanitize_text_field',
+        'rtbcb_advanced_model'  => 'sanitize_text_field',
+        'rtbcb_embedding_model' => 'sanitize_text_field',
     ];
 
     foreach ( $fields as $option => $sanitize ) {


### PR DESCRIPTION
## Summary
- validate OpenAI API key before saving dashboard settings
- respond with an error when the key format is invalid

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68ac62f299788331a02e600cd24be004