### PR TITLE
Allow variable-length OpenAI API keys

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -37,8 +37,9 @@ function rtbcb_clear_current_company() {
  */
 function rtbcb_is_valid_openai_api_key( $api_key ) {
     $api_key = sanitize_text_field( $api_key );
-    return (bool) preg_match( '/^sk-[a-zA-Z0-9]{48}$/', $api_key ) ||
-        (bool) preg_match( '/^sk-proj-[a-zA-Z0-9]{48}$/', $api_key );
+    // OpenAI API keys can have `sk-` or `sk-proj-` prefixes with variable-length
+    // alphanumeric strings. See https://platform.openai.com/docs/guides/authentication
+    return (bool) preg_match( '/^sk-(?:proj-)?[a-zA-Z0-9]{32,}$/', $api_key );
 }
 
 /**


### PR DESCRIPTION
## Summary
- relax OpenAI API key validation to accept variable-length `sk-` and `sk-proj-` formats

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68ac62f190308331bdbdfe0696376758