### PR TITLE
Allow underscores in OpenAI API key validation

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -38,8 +38,9 @@ function rtbcb_clear_current_company() {
 function rtbcb_is_valid_openai_api_key( $api_key ) {
     $api_key = sanitize_text_field( $api_key );
     // OpenAI API keys can have `sk-` or `sk-proj-` prefixes with variable-length
-    // alphanumeric strings. See https://platform.openai.com/docs/guides/authentication
-    return (bool) preg_match( '/^sk-(?:proj-)?[a-zA-Z0-9]{32,}$/', $api_key );
+    // alphanumeric strings and underscores. See
+    // https://platform.openai.com/docs/guides/authentication
+    return (bool) preg_match( '/^sk-(?:proj-)?[A-Za-z0-9_]{32,}$/', $api_key );
 }
 
 /**

--- a/tests/openai-api-key-validation.test.php
+++ b/tests/openai-api-key-validation.test.php
@@ -1,0 +1,45 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+    function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+        // No-op for tests.
+    }
+}
+
+require_once __DIR__ . '/../inc/helpers.php';
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $text ) {
+        $text = is_scalar( $text ) ? (string) $text : '';
+        $text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
+        return trim( $text );
+    }
+}
+
+$valid_keys = [
+    'sk-' . str_repeat( 'a', 31 ) . '_',
+    'sk-proj-' . str_repeat( 'b', 15 ) . '_' . str_repeat( 'b', 16 ),
+];
+
+foreach ( $valid_keys as $key ) {
+    if ( ! rtbcb_is_valid_openai_api_key( $key ) ) {
+        echo "Valid key rejected: {$key}\n";
+        exit( 1 );
+    }
+}
+
+$invalid_keys = [
+    'sk-' . str_repeat( 'a', 31 ) . '-',
+];
+
+foreach ( $invalid_keys as $key ) {
+    if ( rtbcb_is_valid_openai_api_key( $key ) ) {
+        echo "Invalid key accepted: {$key}\n";
+        exit( 1 );
+    }
+}
+
+echo "openai-api-key-validation.test.php passed\n";

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -32,36 +32,40 @@ php tests/scenario-selection.test.php
 echo "6. Running parse comprehensive response test..."
 php tests/parse-comprehensive-response.test.php
 
+# OpenAI API key validation test
+echo "7. Running OpenAI API key validation test..."
+php tests/openai-api-key-validation.test.php
+
 # Mini model dynamic test
-echo "7. Running mini model dynamic test..."
+echo "8. Running mini model dynamic test..."
 php tests/mini-model-dynamic.test.php
 
 # API tester GPT-5 mini test
-echo "8. Running API tester GPT-5 mini test..."
+echo "9. Running API tester GPT-5 mini test..."
 php tests/api-tester-gpt5-mini.test.php
 
 # Live GPT-5 response test
-echo "9. Running live GPT-5 response test..."
+echo "10. Running live GPT-5 response test..."
 php tests/gpt5-responses-live.test.php
 
 # Reasoning-first output parsing test
-echo "10. Running reasoning-first output test..."
+echo "11. Running reasoning-first output test..."
 php tests/reasoning-first-output.test.php
 
 # OpenAI error handling test
-echo "10. Running OpenAI error handling test..."
+echo "12. Running OpenAI error handling test..."
 php tests/openai-error-handling.test.php
 
 # AJAX error handling test (PHPUnit)
-echo "11. Running AJAX error handling test..."
+echo "13. Running AJAX error handling test..."
 phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
 
 # Admin AJAX report generation tests
-echo "12. Running admin AJAX report generation tests..."
+echo "14. Running admin AJAX report generation tests..."
 phpunit tests/RTBCB_AdminAjaxReportTest.php
 
 # JavaScript tests
-echo "13. Running JavaScript tests..."
+echo "15. Running JavaScript tests..."
 node tests/handle-submit-error.test.js
 node tests/render-results-no-narrative.test.js
 node tests/handle-submit-success.test.js
@@ -70,10 +74,10 @@ node tests/temperature-model.test.js
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then
-    echo "14. Running WordPress coding standards check..."
+    echo "16. Running WordPress coding standards check..."
     phpcs --standard=WordPress --ignore=vendor .
 else
-    echo "14. Skipping WordPress coding standards (phpcs not installed)"
+    echo "16. Skipping WordPress coding standards (phpcs not installed)"
 fi
 
 echo "================================================"


### PR DESCRIPTION
## Summary
- allow underscores in OpenAI API key regex
- add unit test for API key validation and run it via test script

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found; OpenAI-dependent tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68ac677ec1e483318354088dad128b0b