### PR TITLE
Fix settings form nonce and improve logging

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -1442,22 +1442,27 @@
             const $form = $('#rtbcb-dashboard-settings-form');
             const data = {
                 action: 'rtbcb_save_dashboard_settings',
-                nonce: $form.find('[name="nonce"]').val(),
+                nonce: rtbcbDashboard.nonces.saveSettings || $form.find('[name="nonce"]').val(),
                 rtbcb_openai_api_key: $('#rtbcb_openai_api_key').val(),
                 rtbcb_mini_model: $('#rtbcb_mini_model').val(),
                 rtbcb_premium_model: $('#rtbcb_premium_model').val(),
                 rtbcb_advanced_model: $('#rtbcb_advanced_model').val(),
                 rtbcb_embedding_model: $('#rtbcb_embedding_model').val()
             };
+
+            console.log('[RTBCB] Saving dashboard settings', data);
+
             const $button = $form.find('button[type="submit"]').prop('disabled', true);
 
             $.post(rtbcbDashboard.ajaxurl, data).done((response) => {
+                console.log('[RTBCB] Save settings response', response);
                 if (response.success) {
                     this.showNotification(rtbcbDashboard.strings.settingsSaved, 'success');
                 } else {
                     this.showNotification(response.data?.message || rtbcbDashboard.strings.error, 'error');
                 }
-            }).fail(() => {
+            }).fail((jqXHR, textStatus) => {
+                console.error('[RTBCB] Save settings AJAX error', textStatus);
                 this.showNotification(rtbcbDashboard.strings.error, 'error');
             }).always(() => {
                 $button.prop('disabled', false);

--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -51,6 +51,7 @@ function rtbcb_enqueue_dashboard_assets() {
             'reportPreview' => wp_create_nonce( 'rtbcb_generate_preview_report' ),
             'dataHealth'    => wp_create_nonce( 'rtbcb_data_health_checks' ),
             'ragTesting'    => wp_create_nonce( 'rtbcb_rag_testing' ),
+            'saveSettings'  => wp_create_nonce( 'rtbcb_save_dashboard_settings' ),
         ],
         'models'  => [
             'mini'     => get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) ),

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -37,9 +37,11 @@ function rtbcb_clear_current_company() {
  */
 function rtbcb_is_valid_openai_api_key( $api_key ) {
     $api_key = sanitize_text_field( $api_key );
-    // OpenAI API keys can have `sk-` or `sk-proj-` prefixes with variable-length
-    // alphanumeric strings. See https://platform.openai.com/docs/guides/authentication
-    return (bool) preg_match( '/^sk-(?:proj-)?[a-zA-Z0-9]{32,}$/', $api_key );
+    // OpenAI API keys use the `sk-` prefix and may contain hyphens or underscores
+    // with varying lengths. This provides a permissive check while still
+    // preventing obviously invalid values. See
+    // https://platform.openai.com/docs/guides/authentication
+    return (bool) preg_match( '/^sk-[A-Za-z0-9_-]{20,}$/', $api_key );
 }
 
 /**


### PR DESCRIPTION
## Summary
- include missing `saveSettings` nonce for unified dashboard
- send localized nonce and add debug logging when saving dashboard settings
- relax OpenAI API key regex and log AJAX handler details

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68ac6772b2748331bd093e92dd7481da