### PR TITLE
Fix API key visibility toggle

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -165,8 +165,14 @@
             // Toggle API key visibility
             $(document).on('click.rtbcb', '#rtbcb-toggle-api-key', function() {
                 const $input = $('#rtbcb_openai_api_key');
-                const isPassword = $input.attr('type') === 'password';
-                $input.attr('type', isPassword ? 'text' : 'password');
+                const input = $input[0];
+                const currentValue = $input.val();
+                const isPassword = input.type === 'password';
+
+                // Toggle using DOM property to ensure value persists
+                input.type = isPassword ? 'text' : 'password';
+                $input.val(currentValue);
+
                 $(this).text(isPassword ? rtbcbDashboard.strings.hide : rtbcbDashboard.strings.show);
             });
         },


### PR DESCRIPTION
## Summary
- Ensure API key visibility toggle switches input `type` via DOM property so value persists
- Keep toggle button text in sync with `Show` and `Hide` labels

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE'\nconst input = { type: 'password', value: 'secret' };\nconst currentValue = input.value;\nconst isPassword = input.type === 'password';\ninput.type = isPassword ? 'text' : 'password';\ninput.value = currentValue;\nconsole.log('type:', input.type, 'value:', input.value);\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_68ac6f28c1ec8331b8cdcb6b41019fd9