### PR TITLE
Fix API Health test button selector

### DIFF
--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -959,7 +959,7 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                 <p><?php esc_html_e( 'Monitor API connectivity, rate limits, and error handling', 'rtbcb' ); ?></p>
             </div>
             <div class="rtbcb-api-controls">
-                <button type="button" id="rtbcb-run-all-api-tests" class="button button-primary">
+                <button type="button" id="rtbcb-run-all-api-tests" class="button button-primary" data-action="api-health-ping">
                     <span class="dashicons dashicons-update"></span>
                     <?php esc_html_e( 'Run All Tests', 'rtbcb' ); ?>
                 </button>


### PR DESCRIPTION
## Summary
- add data-action attribute so API health tests button matches JS selector

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit missing, OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_68ac74e1d98483319fbbcc168c1dde8b