### PR TITLE
Fix dashboard event handlers and add debugging logs

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -6,6 +6,10 @@
 (function($) {
     'use strict';
 
+    console.log('Test dashboard script loaded');
+    console.log('AJAX URL:', typeof rtbcbDashboard !== 'undefined' ? rtbcbDashboard.ajaxurl : ( typeof ajaxurl !== 'undefined' ? ajaxurl : 'undefined' ) );
+    console.log('Nonce:', typeof rtbcbDashboard !== 'undefined' && rtbcbDashboard.nonces ? rtbcbDashboard.nonces.apiHealth : 'undefined');
+
     const debounce = (func, delay) => {
         let timeoutId;
         return (...args) => {
@@ -132,34 +136,58 @@
         // Bind all event handlers using delegated pattern
         bindEvents() {
             // Use delegated handlers for dynamic content
-            $(document).off('.rtbcb').on('click.rtbcb', '[data-action="run-company-overview"]', (e) => {
+            $(document).off('.rtbcb').on('click.rtbcb', '[data-action="run-company-overview"]', function(e) {
                 e.preventDefault();
-                this.generateCompanyOverview();
+                try {
+                    Dashboard.generateCompanyOverview();
+                } catch (err) {
+                    console.error('Error generating company overview:', err);
+                }
             });
 
-            $(document).on('click.rtbcb', '[data-action="run-llm-test"]', (e) => {
+            $(document).on('click.rtbcb', '[data-action="run-llm-test"]', function(e) {
                 e.preventDefault();
-                this.runModelComparison();
+                try {
+                    Dashboard.runModelComparison();
+                } catch (err) {
+                    console.error('Error running LLM test:', err);
+                }
             });
 
-            $(document).on('click.rtbcb', '[data-action="run-rag-test"]', (e) => {
+            $(document).on('click.rtbcb', '[data-action="run-rag-test"]', function(e) {
                 e.preventDefault();
-                this.runRagQuery();
+                try {
+                    Dashboard.runRagQuery();
+                } catch (err) {
+                    console.error('Error running RAG test:', err);
+                }
             });
 
-            $(document).on('click.rtbcb', '[data-action="api-health-ping"]', (e) => {
+            $(document).on('click.rtbcb', '[data-action="api-health-ping"]', function(e) {
                 e.preventDefault();
-                this.runAllApiTests();
+                try {
+                    Dashboard.runAllApiTests();
+                } catch (err) {
+                    console.error('Error running API health tests:', err);
+                }
             });
 
-            $(document).on('click.rtbcb', '.rtbcb-retest', (e) => {
+            $(document).on('click.rtbcb', '.rtbcb-retest', function(e) {
                 e.preventDefault();
-                this.runSingleApiTest($(e.currentTarget).data('component'));
+                try {
+                    Dashboard.runSingleApiTest($(e.currentTarget).data('component'));
+                } catch (err) {
+                    console.error('Error running single API test:', err);
+                }
             });
 
-            $(document).on('click.rtbcb', '[data-action="export-results"]', (e) => {
+            $(document).on('click.rtbcb', '[data-action="export-results"]', function(e) {
                 e.preventDefault();
-                this.exportResults();
+                try {
+                    Dashboard.exportResults();
+                } catch (err) {
+                    console.error('Error exporting results:', err);
+                }
             });
 
             $(document).on('submit.rtbcb', '#rtbcb-dashboard-settings-form', this.saveDashboardSettings.bind(this));
@@ -1698,7 +1726,7 @@
     // });
 
     // Initialize when DOM is ready
-    $(document).ready(() => {
+    $(document).ready(function() {
         Dashboard.init();
     });
 

--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -1771,7 +1771,8 @@ function rtbcb_rag_rebuild_index() {
  * @return void
  */
 function rtbcb_run_api_health_tests() {
-    error_log( 'rtbcb_run_api_health_tests action: ' . print_r( $_POST, true ) );
+    error_log( 'AJAX handler called: rtbcb_run_api_health_tests' );
+    error_log( 'Request data: ' . print_r( $_POST, true ) );
 
     if ( ! check_ajax_referer( 'rtbcb_api_health_tests', 'nonce', false ) ) {
         rtbcb_send_json_error( 'security_check_failed', __( 'Security check failed.', 'rtbcb' ), 403 );
@@ -1925,6 +1926,8 @@ function rtbcb_run_data_health_checks() {
  * @return void
  */
 function rtbcb_run_single_api_test() {
+    error_log( 'AJAX handler called: rtbcb_run_single_api_test' );
+    error_log( 'Request data: ' . print_r( $_POST, true ) );
     if ( ! check_ajax_referer( 'rtbcb_api_health_tests', 'nonce', false ) ) {
         rtbcb_send_json_error( 'security_check_failed', __( 'Security check failed.', 'rtbcb' ), 403 );
     }
@@ -2072,6 +2075,8 @@ function rtbcb_save_dashboard_settings() {
  * @return void
  */
 function rtbcb_ajax_run_llm_test() {
+    error_log( 'AJAX handler called: rtbcb_ajax_run_llm_test' );
+    error_log( 'Request data: ' . print_r( $_POST, true ) );
     if ( ! check_ajax_referer( 'rtbcb_llm_testing', 'nonce', false ) ) {
         rtbcb_send_json_error( 'security_check_failed', __( 'Security check failed.', 'rtbcb' ), 403 );
     }
@@ -2300,6 +2305,8 @@ class RTBCB_Mock_Vector_DB implements RTBCB_Vector_DB {
  * @return void
  */
 function rtbcb_ajax_run_rag_test() {
+    error_log( 'AJAX handler called: rtbcb_ajax_run_rag_test' );
+    error_log( 'Request data: ' . print_r( $_POST, true ) );
     // Security and permission checks.
     if ( ! check_ajax_referer( 'rtbcb_rag_testing', 'nonce', false ) ) {
         rtbcb_send_json_error( 'security_check_failed', __( 'Security check failed.', 'rtbcb' ), 403 );
@@ -2500,7 +2507,8 @@ function rtbcb_audit_context_window( $context_chunks ) {
  * @return void
  */
 function rtbcb_ajax_api_health_ping() {
-    error_log( 'rtbcb_ajax_api_health_ping action: ' . print_r( $_POST, true ) );
+    error_log( 'AJAX handler called: rtbcb_ajax_api_health_ping' );
+    error_log( 'Request data: ' . print_r( $_POST, true ) );
 
     if ( ! check_ajax_referer( 'rtbcb_api_health_tests', 'nonce', false ) ) {
         rtbcb_send_json_error( 'security_failed', __( 'Security check failed.', 'rtbcb' ), 403, '', [ 'requestId' => uniqid( 'req_' ) ] );


### PR DESCRIPTION
## Summary
- replace arrow functions in Unified Test Dashboard events with regular functions to preserve context
- add client-side console logging and try/catch blocks for clearer errors
- log AJAX request details server-side for key test endpoints

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68ac7d7ce35c833186d41b05df894321