### PR TITLE
Add localization guard for unified test dashboard

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -6,9 +6,14 @@
 (function($) {
     'use strict';
 
-    console.log('Test dashboard script loaded');
-    console.log('AJAX URL:', typeof rtbcbDashboard !== 'undefined' ? rtbcbDashboard.ajaxurl : ( typeof ajaxurl !== 'undefined' ? ajaxurl : 'undefined' ) );
-    console.log('Nonce:', typeof rtbcbDashboard !== 'undefined' && rtbcbDashboard.nonces ? rtbcbDashboard.nonces.apiHealth : 'undefined');
+    if ( typeof rtbcbDashboard === 'undefined' ) {
+        console.error( 'rtbcbDashboard is not defined' );
+        return;
+    }
+
+    console.log( 'Test dashboard script loaded' );
+    console.log( 'AJAX URL:', rtbcbDashboard.ajaxurl );
+    console.log( 'Nonce:', rtbcbDashboard.nonces ? rtbcbDashboard.nonces.apiHealth : 'undefined' );
 
     const debounce = (func, delay) => {
         let timeoutId;


### PR DESCRIPTION
## Summary
- Avoid runtime errors in unified test dashboard if `rtbcbDashboard` localization is missing
- Confirm unified test page localizes dashboard data with AJAX URL, nonces, and strings

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- ⚠️ `wp --version` (WordPress CLI not installed; unable to load plugin admin page)


------
https://chatgpt.com/codex/tasks/task_e_68ac86e5199083319ce8635b49fc1c3b