### PR TITLE
Sanitize dashboard message handling

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -771,10 +771,11 @@
             const errorContent = $('#error-content');
             const errorDebug = $('#error-debug');
 
-            errorContent.html(`<strong>Error:</strong> ${message}`);
+            const safeMessage = $('<div/>').text(message).html();
+            errorContent.html(`<strong>Error:</strong> ${safeMessage}`);
 
             if (Object.keys(debugInfo).length > 0) {
-                errorDebug.html(JSON.stringify(debugInfo, null, 2)).show();
+                errorDebug.text(JSON.stringify(debugInfo, null, 2)).show();
             } else {
                 errorDebug.hide();
             }
@@ -1065,11 +1066,15 @@
         },
 
         showNotification(message, type = 'info') {
+            const allowedTypes = ['success', 'error', 'warning', 'info'];
+            const safeType = allowedTypes.includes(type) ? type : 'info';
+            const safeMessage = $('<div/>').text(message).html();
+
             // Create notification element
             const notification = $(`
-                <div class="rtbcb-notification rtbcb-${type}">
-                    <span class="dashicons dashicons-${this.getNotificationIcon(type)}"></span>
-                    <span class="message">${message}</span>
+                <div class="rtbcb-notification rtbcb-${safeType}">
+                    <span class="dashicons dashicons-${this.getNotificationIcon(safeType)}"></span>
+                    <span class="message">${safeMessage}</span>
                     <button class="dismiss">&times;</button>
                 </div>
             `);
@@ -1476,7 +1481,7 @@
             row.find('.rtbcb-last-tested').text(result.last_tested || '');
             row.find('.rtbcb-response-time').text(result.response_time ? `${result.response_time} ms` : '');
             const msg = result.message || '';
-            row.find('.rtbcb-message').html(msg);
+            row.find('.rtbcb-message').text(msg);
             $(`#rtbcb-details-${component} pre`).text(JSON.stringify(result.details || {}, null, 2));
         },
 
@@ -1524,7 +1529,8 @@
             }).fail((jqXHR, textStatus, errorThrown) => {
                 const detail = jqXHR?.responseJSON?.data?.detail || errorThrown || textStatus;
                 const msg = `${rtbcbDashboard.strings.error}: ${detail}`;
-                $('#rtbcb-data-health-results').html(`<tr><td colspan="3">${msg}</td></tr>`);
+                const safeMsg = $('<div/>').text(msg).html();
+                $('#rtbcb-data-health-results').html(`<tr><td colspan="3">${safeMsg}</td></tr>`);
                 this.showNotification(msg, 'error');
                 console.error('[Data Health] Request error:', textStatus, errorThrown, jqXHR?.responseText);
             }).always(() => {


### PR DESCRIPTION
## Summary
- Escape error content and debug details when displaying failures
- Restrict notification types and escape message text before rendering alerts
- Prevent API health and data health messages from injecting HTML

## Testing
- `bash tests/run-tests.sh` *(phpunit: command not found; OpenAI-dependent tests skipped; JS tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8a8077a88331b1b4ddebc6a94fdb