### PR TITLE
Add API key debug endpoint and validation checks

### DIFF
--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -9,6 +9,7 @@ add_action( 'wp_ajax_rtbcb_run_llm_test', 'rtbcb_ajax_run_llm_test' );
 add_action( 'wp_ajax_rtbcb_run_rag_test', 'rtbcb_ajax_run_rag_test' );
 add_action( 'wp_ajax_rtbcb_api_health_ping', 'rtbcb_ajax_api_health_ping' );
 add_action( 'wp_ajax_rtbcb_export_results', 'rtbcb_ajax_export_results' );
+add_action( 'wp_ajax_rtbcb_debug_api_key', 'rtbcb_debug_api_key' );
 
 // Remove duplicate handlers and add debug logging.
 add_action(
@@ -60,6 +61,33 @@ function rtbcb_send_json_error( $code, $message, $status = 400, $detail = '', $e
     }
 
     wp_send_json_error( $data, $status );
+}
+
+/**
+ * Debug OpenAI API key configuration.
+ *
+ * Provides basic information about the stored API key for troubleshooting
+ * purposes. Requires manage_options capability.
+ *
+ * @return void
+ */
+function rtbcb_debug_api_key() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        wp_die( esc_html__( 'Unauthorized', 'rtbcb' ) );
+    }
+
+    $api_key    = sanitize_text_field( get_option( 'rtbcb_openai_api_key' ) );
+    $key_length = strlen( $api_key );
+    $key_preview = $key_length > 10 ? substr( $api_key, 0, 8 ) . '...' . substr( $api_key, -4 ) : 'too_short';
+
+    wp_send_json_success(
+        [
+            'configured'   => ! empty( $api_key ),
+            'length'       => $key_length,
+            'preview'      => $key_preview,
+            'valid_format' => rtbcb_is_valid_openai_api_key( $api_key ),
+        ]
+    );
 }
 
 /**

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -32,8 +32,8 @@ function rtbcb_clear_current_company() {
 /**
  * Validate OpenAI API key format.
  *
- * Provides a simple check that the key is non-empty and uses the `sk-` prefix.
- * The value is sanitized before validation.
+ * Ensures the key is non-empty, uses the `sk-` prefix and meets a minimum
+ * length requirement. The value is sanitized before validation.
  *
  * @param string $api_key API key to validate.
  * @return bool True if the key appears valid.
@@ -41,7 +41,19 @@ function rtbcb_clear_current_company() {
 function rtbcb_is_valid_openai_api_key( $api_key ) {
     $api_key = sanitize_text_field( $api_key );
 
-    return ( '' !== $api_key ) && ( 0 === strpos( $api_key, 'sk-' ) );
+    if ( empty( $api_key ) ) {
+        return false;
+    }
+
+    if ( ! str_starts_with( $api_key, 'sk-' ) ) {
+        return false;
+    }
+
+    if ( strlen( $api_key ) < 20 ) {
+        return false;
+    }
+
+    return true;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add AJAX handler to expose API key status for diagnostics
- enhance OpenAI API key validation with prefix and length checks

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `vendor/bin/phpunit 2>&1 | head -n 20` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8ee4b32c8331b5e6cae89a4598bd