### PR TITLE
Improve WP_Error handling and expose messages

### DIFF
--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -26,22 +26,10 @@ function handleSubmissionError(errorMessage) {
             heading.textContent = 'Generation Failed';
 
             const message = document.createElement('p');
-            message.textContent = "We're sorry, but we couldn't generate your business case. Please try again later.";
-
-            const details = document.createElement('p');
-            details.style.fontSize = '0.9em';
-            details.style.color = '#6c757d';
-            details.style.marginTop = '15px';
-
-            const strong = document.createElement('strong');
-            strong.textContent = 'Error Details:';
-
-            details.appendChild(strong);
-            details.appendChild(document.createTextNode(' ' + errorMessage));
+            message.textContent = errorMessage;
 
             errorContent.appendChild(heading);
             errorContent.appendChild(message);
-            errorContent.appendChild(details);
 
             if (typeof progressContainer.appendChild === 'function') {
                 progressContainer.appendChild(errorContent);
@@ -51,10 +39,7 @@ function handleSubmissionError(errorMessage) {
         } else {
             progressContainer.innerHTML = '<div class="rtbcb-error-content">' +
                 '<h3 style="color: #dc3545;">Generation Failed</h3>' +
-                "<p>We're sorry, but we couldn't generate your business case. Please try again later.</p>" +
-                '<p style="font-size: 0.9em; color: #6c757d; margin-top: 15px;"><strong>Error Details:</strong> ' +
-                escapeHtml(errorMessage) +
-                '</p>' +
+                '<p>' + escapeHtml(errorMessage) + '</p>' +
                 '</div>';
         }
     }

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -891,10 +891,22 @@ class RTBCB_Plugin {
 
                     if ( is_wp_error( $comprehensive_analysis ) ) {
                         $error_message = $comprehensive_analysis->get_error_message();
-                        rtbcb_log_api_debug( 'LLM generation failed', $error_message );
                         $error_code    = method_exists( $comprehensive_analysis, 'get_error_code' ) ? $comprehensive_analysis->get_error_code() : '';
+                        $error_data    = method_exists( $comprehensive_analysis, 'get_error_data' ) ? $comprehensive_analysis->get_error_data() : null;
+                        rtbcb_log_error(
+                            'LLM generation failed',
+                            [
+                                'code'   => $error_code,
+                                'message' => $error_message,
+                                'data'   => $error_data,
+                                'errors' => isset( $comprehensive_analysis->errors ) ? $comprehensive_analysis->errors : [],
+                            ]
+                        );
                         if ( 'no_api_key' === $error_code ) {
-                            wp_send_json_error( [ 'message' => $error_message ], 500 );
+                            wp_send_json_error(
+                                [ 'message' => __( 'OpenAI API key not configured.', 'rtbcb' ) ],
+                                400
+                            );
                         }
                         $response_message = __( 'Failed to generate business case analysis.', 'rtbcb' );
                         if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {


### PR DESCRIPTION
## Summary
- Log detailed `WP_Error` information during LLM generation and surface message in non-production environments
- Return 400 status with clear message when OpenAI API key is missing
- Show backend error messages on submission failure

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac9309baa88331858669c8a96e1322