### PR TITLE
Add nonce support for new dashboard actions

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -75,7 +75,10 @@ class RTBCB_Admin {
                         'llm'       => wp_create_nonce( 'rtbcb_llm_testing' ),
                         'apiHealth' => wp_create_nonce( 'rtbcb_api_health_tests' ),
                         'reportPreview' => wp_create_nonce( 'rtbcb_generate_preview_report' ),
-                        'dataHealth' => wp_create_nonce( 'rtbcb_data_health_checks' ),
+                        'dataHealth'   => wp_create_nonce( 'rtbcb_data_health_checks' ),
+                        'ragTesting'   => wp_create_nonce( 'rtbcb_rag_testing' ),
+                        'saveSettings' => wp_create_nonce( 'rtbcb_save_dashboard_settings' ),
+                        'roiCalculator' => wp_create_nonce( 'rtbcb_roi_calculator_test' ),
                     ],
                     'strings' => [
                         'generating'     => __( 'Generating...', 'rtbcb' ),

--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -1645,7 +1645,11 @@
             'test_rag_query': 'dashboard',
             'run_rag_test': 'ragTesting',
             'run_api_health_tests': 'apiHealth',
-            'api_health_ping': 'apiHealth'
+            'api_health_ping': 'apiHealth',
+            'calculate_roi_test': 'roiCalculator',
+            'run_data_health_checks': 'dataHealth',
+            'generate_preview_report': 'reportPreview',
+            'save_dashboard_settings': 'saveSettings'
         };
         return actionNonceMap[action] || 'dashboard';
     };


### PR DESCRIPTION
## Summary
- Localize nonces for RAG testing, dashboard settings, and ROI calculator
- Map additional dashboard actions to their nonce keys
- Ensure AJAX requests include the proper nonce tokens

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68ac9768c0a48331880710a3c69c595a