### PR TITLE
Surface server detail in overview test errors

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -824,6 +824,11 @@
             } else if (xhr && xhr.responseJSON) {
                 errorMessage = xhr.responseJSON.data?.message || errorMessage;
                 debugInfo = xhr.responseJSON.data?.debug || {};
+
+                const detail = xhr.responseJSON.data?.detail;
+                if (detail) {
+                    debugInfo.detail = detail;
+                }
             } else if (error) {
                 errorMessage = error;
             }

--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -673,11 +673,11 @@ function rtbcb_ajax_test_llm_model() {
 function rtbcb_ajax_test_company_overview_enhanced() {
     // Verify nonce and permissions
     if ( ! check_ajax_referer( 'rtbcb_unified_test_dashboard', 'nonce', false ) ) {
-        rtbcb_send_json_error( 'security_check_failed', __( 'Security check failed.', 'rtbcb' ), 403 );
+        rtbcb_send_json_error( 'security_check_failed', __( 'Security check failed.', 'rtbcb' ), 403, 'Invalid or missing nonce.' );
     }
 
     if ( ! current_user_can( 'manage_options' ) ) {
-        rtbcb_send_json_error( 'insufficient_permissions', __( 'Insufficient permissions.', 'rtbcb' ), 403 );
+        rtbcb_send_json_error( 'insufficient_permissions', __( 'Insufficient permissions.', 'rtbcb' ), 403, 'User lacks manage_options capability.' );
     }
 
     // Get input parameters
@@ -688,7 +688,7 @@ function rtbcb_ajax_test_company_overview_enhanced() {
 
     // Validate required fields
     if ( empty( $company_name ) ) {
-        rtbcb_send_json_error( 'company_name_required', __( 'Company name is required.', 'rtbcb' ) );
+        rtbcb_send_json_error( 'company_name_required', __( 'Company name is required.', 'rtbcb' ), 400, 'Missing company_name parameter.' );
     }
 
     // Set timeout and memory limits for comprehensive analysis
@@ -704,7 +704,11 @@ function rtbcb_ajax_test_company_overview_enhanced() {
         $overview_result = rtbcb_test_generate_company_overview( $company_name, $model_key );
 
         if ( is_wp_error( $overview_result ) ) {
-            rtbcb_send_json_error( $overview_result->get_error_code(), $overview_result->get_error_message(), 500, $overview_result->get_error_data() );
+            $detail = $overview_result->get_error_data();
+            if ( empty( $detail ) ) {
+                $detail = $overview_result->get_error_message();
+            }
+            rtbcb_send_json_error( $overview_result->get_error_code(), $overview_result->get_error_message(), 500, $detail );
         }
 
         // Calculate metrics


### PR DESCRIPTION
## Summary
- Display server-provided `detail` info in the dashboard's error debug panel
- Return richer `detail` messages from the enhanced company overview AJAX handler for security, permission, validation, and internal errors

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `./tests/run-tests.sh` *(missing phpunit, OPENAI_API_KEY; some tests skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68ac9cf417c483319b04dd62a8762ab5