### PR TITLE
Use data-action attributes for dashboard buttons

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -211,6 +211,60 @@
                 }
             });
 
+            $(document).on('click.rtbcb', '[data-action="clear-results"]', function(e) {
+                e.preventDefault();
+                try {
+                    Dashboard.clearResults();
+                } catch (err) {
+                    console.error('Error clearing results:', err);
+                }
+            });
+
+            $(document).on('click.rtbcb', '[data-action="export-results"]', function(e) {
+                e.preventDefault();
+                try {
+                    Dashboard.exportResults();
+                } catch (err) {
+                    console.error('Error exporting results:', err);
+                }
+            });
+
+            $(document).on('click.rtbcb', '[data-action="copy-results"]', function(e) {
+                e.preventDefault();
+                try {
+                    Dashboard.copyResults();
+                } catch (err) {
+                    console.error('Error copying results:', err);
+                }
+            });
+
+            $(document).on('click.rtbcb', '[data-action="regenerate-results"]', function(e) {
+                e.preventDefault();
+                try {
+                    Dashboard.regenerateResults();
+                } catch (err) {
+                    console.error('Error regenerating results:', err);
+                }
+            });
+
+            $(document).on('click.rtbcb', '[data-action="toggle-debug"]', function(e) {
+                e.preventDefault();
+                try {
+                    Dashboard.toggleDebugPanel();
+                } catch (err) {
+                    console.error('Error toggling debug panel:', err);
+                }
+            });
+
+            $(document).on('click.rtbcb', '[data-action="retry-request"]', function(e) {
+                e.preventDefault();
+                try {
+                    Dashboard.retryRequest();
+                } catch (err) {
+                    console.error('Error retrying request:', err);
+                }
+            });
+
             $(document).on('click.rtbcb', '[data-action="run-llm-test"]', function(e) {
                 e.preventDefault();
                 try {
@@ -229,7 +283,43 @@
                 }
             });
 
-            $(document).on('click.rtbcb', '#calculate-roi', function(e) {
+            $(document).on('click.rtbcb', '[data-action="rebuild-rag-index"]', function(e) {
+                e.preventDefault();
+                try {
+                    Dashboard.rebuildRagIndex();
+                } catch (err) {
+                    console.error('Error rebuilding RAG index:', err);
+                }
+            });
+
+            $(document).on('click.rtbcb', '[data-action="cancel-rag-test"]', function(e) {
+                e.preventDefault();
+                try {
+                    Dashboard.cancelRagQuery();
+                } catch (err) {
+                    console.error('Error cancelling RAG query:', err);
+                }
+            });
+
+            $(document).on('click.rtbcb', '[data-action="copy-rag-context"]', function(e) {
+                e.preventDefault();
+                try {
+                    Dashboard.copyRagContext();
+                } catch (err) {
+                    console.error('Error copying RAG context:', err);
+                }
+            });
+
+            $(document).on('click.rtbcb', '[data-action="export-rag-results"]', function(e) {
+                e.preventDefault();
+                try {
+                    Dashboard.exportRagResults();
+                } catch (err) {
+                    console.error('Error exporting RAG results:', err);
+                }
+            });
+
+            $(document).on('click.rtbcb', '[data-action="calculate-roi"]', function(e) {
                 e.preventDefault();
                 try {
                     Dashboard.calculateRoiTest();
@@ -250,7 +340,7 @@
                 }
             });
 
-            $(document).on('click.rtbcb', '#export-roi-results', function(e) {
+            $(document).on('click.rtbcb', '[data-action="export-roi-results"]', function(e) {
                 e.preventDefault();
                 try {
                     Dashboard.exportRoiResults();
@@ -268,7 +358,7 @@
                 }
             });
 
-            $(document).on('click.rtbcb', '.rtbcb-retest', function(e) {
+            $(document).on('click.rtbcb', '[data-action="api-health-retest"]', function(e) {
                 e.preventDefault();
                 try {
                     Dashboard.runSingleApiTest($(e.currentTarget).data('component'));
@@ -277,22 +367,25 @@
                 }
             });
 
-            $(document).on('click.rtbcb', '[data-action="export-results"]', function(e) {
+            $(document).on('click.rtbcb', '[data-action="run-data-health"]', function(e) {
                 e.preventDefault();
                 try {
-                    Dashboard.exportResults();
+                    Dashboard.runDataHealthChecks();
                 } catch (err) {
-                    console.error('Error exporting results:', err);
+                    console.error('Error running data health checks:', err);
                 }
             });
 
-            $(document).on('submit.rtbcb', '#rtbcb-dashboard-settings-form', this.saveDashboardSettings.bind(this));
+            $(document).on('click.rtbcb', '[data-action="generate-preview-report"]', function(e) {
+                e.preventDefault();
+                try {
+                    Dashboard.generatePreviewReport();
+                } catch (err) {
+                    console.error('Error generating preview report:', err);
+                }
+            });
 
-            // Tab navigation
-            $('.rtbcb-test-tabs .nav-tab').on('click.rtbcb', this.handleTabClick.bind(this));
-
-            // Toggle API key visibility
-            $(document).on('click.rtbcb', '#rtbcb-toggle-api-key', function() {
+            $(document).on('click.rtbcb', '[data-action="toggle-api-key"]', function() {
                 const $input = $('#rtbcb_openai_api_key');
                 const input = $input[0];
                 const currentValue = $input.val();
@@ -304,6 +397,11 @@
 
                 $(this).text(isPassword ? rtbcbDashboard.strings.hide : rtbcbDashboard.strings.show);
             });
+
+            $(document).on('submit.rtbcb', '#rtbcb-dashboard-settings-form', this.saveDashboardSettings.bind(this));
+
+            // Tab navigation
+            $('.rtbcb-test-tabs .nav-tab').on('click.rtbcb', this.handleTabClick.bind(this));
         },
 
         // Initialize tab system
@@ -525,7 +623,7 @@
             }
 
             this.isGenerating = true;
-            this.setButtonState('#run-llm-matrix-test', 'loading', 'Testing Models...');
+            this.setButtonState('[data-action="run-llm-test"]', 'loading', 'Testing Models...');
             this.hideContainers(['llm-test-results']);
 
             const requestData = {
@@ -539,17 +637,17 @@
             this.request('run_llm_test', requestData)
                 .then((data) => {
                     this.displayLLMResults(data);
-                    this.setButtonState('#run-llm-matrix-test', 'success', 'Tests Complete');
+                    this.setButtonState('[data-action="run-llm-test"]', 'success', 'Tests Complete');
                     this.showNotification(`LLM tests completed for ${selectedModels.length} models`, 'success');
                 })
                 .catch((error) => {
-                    this.setButtonState('#run-llm-matrix-test', 'error', 'Test Failed');
+                    this.setButtonState('[data-action="run-llm-test"]', 'error', 'Test Failed');
                     this.showNotification('LLM test failed: ' + error.message, 'error');
                 })
                 .finally(() => {
                     this.isGenerating = false;
                     setTimeout(() => {
-                        this.setButtonState('#run-llm-matrix-test', 'ready');
+                        this.setButtonState('[data-action="run-llm-test"]', 'ready');
                     }, 3000);
                 });
         },
@@ -573,7 +671,7 @@
             const selectedModels = $('input[name="test-models[]"]:checked').length;
 
             const isValid = prompt.length > 0 && selectedModels > 0;
-            $('#run-llm-matrix-test').prop('disabled', !isValid);
+            $('[data-action="run-llm-test"]').prop('disabled', !isValid);
         },
 
         displayLLMResults: function(data) {
@@ -599,7 +697,7 @@
 
                 // Store results for export
                 this.llmTestResults = data;
-                $('#export-llm-results').prop('disabled', false);
+                $('[data-action="export-results"][data-export-type="llm"]').prop('disabled', false);
 
                 // Show results container
                 $('#llm-test-results').show().addClass('rtbcb-fade-in');
@@ -855,7 +953,7 @@
 
             // Show container and enable actions
             resultsContainer.show().addClass('rtbcb-fade-in');
-            $('[data-action="export-results"], #copy-results, #regenerate-results').prop('disabled', false);
+            $('[data-action="export-results"], [data-action="copy-results"], [data-action="regenerate-results"]').prop('disabled', false);
 
             // Hide progress
             this.hideProgressContainer();
@@ -1052,7 +1150,7 @@
             this.hideContainers(['results', 'error', 'progress']);
             this.hideDebugPanel();
             $('#company-name-input').val('').focus();
-            $('[data-action="export-results"], #copy-results, #regenerate-results').prop('disabled', true);
+            $('[data-action="export-results"], [data-action="copy-results"], [data-action="regenerate-results"]').prop('disabled', true);
             this.showNotification('Results cleared', 'info');
         },
 
@@ -1276,7 +1374,7 @@
             });
 
             $('#rtbcb-rag-progress').text(rtbcbDashboard.strings.retrieving).show();
-            $('#rtbcb-rag-cancel').show();
+            $('[data-action="cancel-rag-test"]').show();
             this.validateRagQuery();
 
             this.ragRequest.done((res) => {
@@ -1296,7 +1394,7 @@
             }).always(() => {
                 this.ragRequest = null;
                 $('#rtbcb-rag-progress').hide();
-                $('#rtbcb-rag-cancel').hide();
+                $('[data-action="cancel-rag-test"]').hide();
                 this.validateRagQuery();
             });
         },
@@ -1337,7 +1435,7 @@
                 this.ragRequest.abort();
                 this.ragRequest = null;
                 $('#rtbcb-rag-progress').hide();
-                $('#rtbcb-rag-cancel').hide();
+                $('[data-action="cancel-rag-test"]').hide();
                 this.validateRagQuery();
                 this.showNotification('Retrieval cancelled', 'info');
             }
@@ -1370,10 +1468,10 @@
 
             if (this.ragResults.length) {
                 $('#rtbcb-rag-results').show();
-                $('#rtbcb-copy-rag-context, #rtbcb-export-rag-results').prop('disabled', false);
+                $('[data-action="copy-rag-context"], [data-action="export-rag-results"]').prop('disabled', false);
             } else {
                 $('#rtbcb-rag-results').hide();
-                $('#rtbcb-copy-rag-context, #rtbcb-export-rag-results').prop('disabled', true);
+                $('[data-action="copy-rag-context"], [data-action="export-rag-results"]').prop('disabled', true);
                 this.showNotification(rtbcbDashboard.strings.noResults, 'warning');
             }
 
@@ -1424,7 +1522,7 @@
         },
 
         rebuildRagIndex() {
-            const btn = $('#rtbcb-rag-rebuild').prop('disabled', true);
+            const btn = $('[data-action="rebuild-rag-index"]').prop('disabled', true);
             $('#rtbcb-rag-index-notice').text(rtbcbDashboard.strings.retrieving);
             $.post(rtbcbDashboard.ajaxurl, {
                 action: 'rtbcb_rag_rebuild_index',
@@ -1473,7 +1571,7 @@
         },
 
         calculateRoiTest() {
-            const button = $('#calculate-roi').prop('disabled', true);
+            const button = $('[data-action="calculate-roi"]').prop('disabled', true);
             const roiData = {};
             $('#roi-calculator').find('input, select').each(function() {
                 roiData[this.id] = $(this).val();
@@ -1570,7 +1668,7 @@
             };
 
             $('#roi-results-container').show();
-            $('#export-roi-results').prop('disabled', false);
+            $('[data-action="export-roi-results"]').prop('disabled', false);
         },
 
         exportRoiResults() {
@@ -1783,7 +1881,7 @@
 
         // Run data health checks
         runDataHealthChecks() {
-            const button = $('#rtbcb-run-data-health').prop('disabled', true);
+            const button = $('[data-action="run-data-health"]').prop('disabled', true);
             $('#rtbcb-data-health-results').html(`<tr><td colspan="3">${rtbcbDashboard.strings.running}</td></tr>`);
 
             $.post(rtbcbDashboard.ajaxurl, {
@@ -1818,7 +1916,7 @@
 
         // Generate report preview
         generatePreviewReport() {
-            const button = $('#rtbcb-generate-preview-report').prop('disabled', true);
+            const button = $('[data-action="generate-preview-report"]').prop('disabled', true);
 
             $.post(rtbcbDashboard.ajaxurl, {
                 action: 'rtbcb_generate_preview_report',

--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -181,14 +181,14 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                 </div>
 
                 <div class="rtbcb-action-buttons">
-                    <button type="button" id="generate-company-overview" class="button button-primary" <?php disabled( ! $api_valid ); ?>>
+                    <button type="button" class="button button-primary" data-action="run-company-overview" <?php disabled( ! $api_valid ); ?>>
                         <span class="dashicons dashicons-update"></span>
                         <?php esc_html_e( 'Generate Overview', 'rtbcb' ); ?>
                     </button>
-                    <button type="button" id="clear-results" class="button">
+                    <button type="button" class="button" data-action="clear-results">
                         <?php esc_html_e( 'Clear Results', 'rtbcb' ); ?>
                     </button>
-                    <button type="button" id="export-results" class="button" disabled>
+                    <button type="button" class="button" data-action="export-results" disabled>
                         <?php esc_html_e( 'Export Results', 'rtbcb' ); ?>
                     </button>
                 </div>
@@ -212,7 +212,7 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
             <div id="debug-panel" class="rtbcb-debug-panel" style="display: none;">
                 <div class="rtbcb-debug-header">
                     <h3><?php esc_html_e( 'Debug Information', 'rtbcb' ); ?></h3>
-                    <button type="button" id="toggle-debug" class="button button-small">
+                    <button type="button" class="button button-small" data-action="toggle-debug">
                         <?php esc_html_e( 'Toggle', 'rtbcb' ); ?>
                     </button>
                 </div>
@@ -254,11 +254,11 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                 <div class="rtbcb-results-header">
                     <h3><?php esc_html_e( 'Analysis Results', 'rtbcb' ); ?></h3>
                     <div class="rtbcb-results-actions">
-                        <button type="button" id="copy-results" class="button button-small">
+                        <button type="button" class="button button-small" data-action="copy-results">
                             <span class="dashicons dashicons-admin-page"></span>
                             <?php esc_html_e( 'Copy', 'rtbcb' ); ?>
                         </button>
-                        <button type="button" id="regenerate-results" class="button button-small">
+                        <button type="button" class="button button-small" data-action="regenerate-results">
                             <span class="dashicons dashicons-update"></span>
                             <?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>
                         </button>
@@ -272,7 +272,7 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
             <div id="error-container" class="rtbcb-error-container" style="display: none;">
                 <div class="rtbcb-error-header">
                     <h3><?php esc_html_e( 'Error Details', 'rtbcb' ); ?></h3>
-                    <button type="button" id="retry-request" class="button button-primary">
+                    <button type="button" class="button button-primary" data-action="retry-request">
                         <?php esc_html_e( 'Retry', 'rtbcb' ); ?>
                     </button>
                 </div>
@@ -432,19 +432,19 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                 </div>
 
                 <div class="rtbcb-action-buttons">
-                    <button type="button" id="calculate-roi" class="button button-primary">
+                    <button type="button" class="button button-primary" data-action="calculate-roi">
                         <span class="dashicons dashicons-calculator"></span>
                         <?php esc_html_e( 'Calculate ROI', 'rtbcb' ); ?>
                     </button>
-                    <button type="button" id="run-sensitivity-analysis" class="button">
+                    <button type="button" class="button" data-action="run-sensitivity-analysis">
                         <span class="dashicons dashicons-chart-line"></span>
                         <?php esc_html_e( 'Sensitivity Analysis', 'rtbcb' ); ?>
                     </button>
-                    <button type="button" id="compare-scenarios" class="button">
+                    <button type="button" class="button" data-action="compare-scenarios">
                         <span class="dashicons dashicons-slides"></span>
                         <?php esc_html_e( 'Compare Scenarios', 'rtbcb' ); ?>
                     </button>
-                    <button type="button" id="export-roi-results" class="button" disabled>
+                    <button type="button" class="button" data-action="export-roi-results" disabled>
                         <span class="dashicons dashicons-download"></span>
                         <?php esc_html_e( 'Export Results', 'rtbcb' ); ?>
                     </button>
@@ -456,11 +456,11 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                 <div class="rtbcb-results-header">
                     <h3><?php esc_html_e( 'ROI Calculation Results', 'rtbcb' ); ?></h3>
                     <div class="rtbcb-results-actions">
-                        <button type="button" id="toggle-roi-details" class="button button-small">
+                        <button type="button" class="button button-small" data-action="toggle-roi-details">
                             <span class="dashicons dashicons-visibility"></span>
                             <?php esc_html_e( 'Show Details', 'rtbcb' ); ?>
                         </button>
-                        <button type="button" id="copy-roi-summary" class="button button-small">
+                        <button type="button" class="button button-small" data-action="copy-roi-summary">
                             <span class="dashicons dashicons-admin-page"></span>
                             <?php esc_html_e( 'Copy Summary', 'rtbcb' ); ?>
                         </button>
@@ -722,14 +722,12 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                 </div>
 
                 <div class="rtbcb-action-buttons">
-                    <button type="button" id="run-llm-matrix-test" class="button button-primary" 
-                            data-action="run-llm-test" data-default-text="Run Model Matrix Test">
+                    <button type="button" class="button button-primary" data-action="run-llm-test" data-default-text="Run Model Matrix Test">
                         <span class="dashicons dashicons-networking"></span>
                         <?php esc_html_e('Run Model Matrix Test', 'rtbcb'); ?>
                     </button>
 
-                    <button type="button" id="export-llm-results" class="button" disabled
-                            data-action="export-results" data-export-type="llm">
+                    <button type="button" class="button" data-action="export-results" data-export-type="llm" disabled>
                         <span class="dashicons dashicons-download"></span>
                         <?php esc_html_e('Export Results', 'rtbcb'); ?>
                     </button>
@@ -797,7 +795,7 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                     </span>
                     <span id="rtbcb-rag-index-size"><?php printf( esc_html__( 'Entries: %d', 'rtbcb' ), intval( $index_size ) ); ?></span>
                 </div>
-                <button type="button" id="rtbcb-rag-rebuild" class="button"><?php esc_html_e( 'Rebuild Index', 'rtbcb' ); ?></button>
+                <button type="button" class="button" data-action="rebuild-rag-index"><?php esc_html_e( 'Rebuild Index', 'rtbcb' ); ?></button>
                 <div id="rtbcb-rag-index-notice" class="rtbcb-index-notice"></div>
             </div>
 
@@ -825,11 +823,11 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                     </label>
                 </div>
                 <div class="rtbcb-action-buttons">
-                    <button type="button" id="rtbcb-run-rag-query" class="button button-primary" disabled>
+                    <button type="button" class="button button-primary" data-action="run-rag-test" disabled>
                         <span class="dashicons dashicons-search"></span>
                         <?php esc_html_e( 'Run Retrieval', 'rtbcb' ); ?>
                     </button>
-                    <button type="button" id="rtbcb-rag-cancel" class="button" style="display: none;">
+                    <button type="button" class="button" data-action="cancel-rag-test" style="display: none;">
                         <?php esc_html_e( 'Cancel', 'rtbcb' ); ?>
                     </button>
                 </div>
@@ -850,8 +848,8 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                     <tbody></tbody>
                 </table>
                 <div class="rtbcb-action-buttons">
-                    <button type="button" id="rtbcb-copy-rag-context" class="button" disabled><?php esc_html_e( 'Copy Context', 'rtbcb' ); ?></button>
-                    <button type="button" id="rtbcb-export-rag-results" class="button" disabled><?php esc_html_e( 'Export Results', 'rtbcb' ); ?></button>
+                    <button type="button" class="button" data-action="copy-rag-context" disabled><?php esc_html_e( 'Copy Context', 'rtbcb' ); ?></button>
+                    <button type="button" class="button" data-action="export-rag-results" disabled><?php esc_html_e( 'Export Results', 'rtbcb' ); ?></button>
                 </div>
                 <details id="rtbcb-rag-debug" class="rtbcb-debug-panel">
                     <summary><?php esc_html_e( 'Debug Info', 'rtbcb' ); ?></summary>
@@ -888,7 +886,7 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                 <p><?php esc_html_e( 'Monitor API connectivity, rate limits, and error handling', 'rtbcb' ); ?></p>
             </div>
             <div class="rtbcb-api-controls">
-                <button type="button" id="rtbcb-run-all-api-tests" class="button button-primary" data-action="api-health-ping">
+                <button type="button" class="button button-primary" data-action="api-health-ping">
                     <span class="dashicons dashicons-update"></span>
                     <?php esc_html_e( 'Run All Tests', 'rtbcb' ); ?>
                 </button>
@@ -941,10 +939,10 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                                 <?php echo isset( $result['message'] ) ? esc_html( $result['message'] ) : esc_html__( 'Not tested', 'rtbcb' ); ?>
                             </td>
                             <td class="rtbcb-actions">
-                                <button type="button" class="button rtbcb-retest" data-component="<?php echo esc_attr( $key ); ?>">
+                                <button type="button" class="button" data-action="api-health-retest" data-component="<?php echo esc_attr( $key ); ?>">
                                     <?php esc_html_e( 'Retest', 'rtbcb' ); ?>
                                 </button>
-                                <button type="button" class="button rtbcb-view-details" data-component="<?php echo esc_attr( $key ); ?>">
+                                <button type="button" class="button" data-action="api-health-details" data-component="<?php echo esc_attr( $key ); ?>">
                                     <?php esc_html_e( 'Details', 'rtbcb' ); ?>
                                 </button>
                             </td>
@@ -976,7 +974,7 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                 </p>
             </div>
             <div class="rtbcb-data-health-controls">
-                <button type="button" id="rtbcb-run-data-health" class="button button-primary">
+                <button type="button" class="button button-primary" data-action="run-data-health">
                     <span class="dashicons dashicons-update"></span>
                     <?php esc_html_e( 'Run Checks', 'rtbcb' ); ?>
                 </button>
@@ -1006,7 +1004,7 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                 <p><?php esc_html_e( 'Generate a preview of the full report.', 'rtbcb' ); ?></p>
             </div>
             <div class="rtbcb-report-controls">
-                <button type="button" id="rtbcb-generate-preview-report" class="button button-primary">
+                <button type="button" class="button button-primary" data-action="generate-preview-report">
                     <span class="dashicons dashicons-media-document"></span>
                     <?php esc_html_e( 'Generate Report', 'rtbcb' ); ?>
                 </button>
@@ -1034,7 +1032,7 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                         </th>
                         <td>
                             <input type="password" id="rtbcb_openai_api_key" name="rtbcb_openai_api_key" value="<?php echo esc_attr( $api_key ); ?>" class="regular-text" autocomplete="off" />
-                            <button type="button" id="rtbcb-toggle-api-key" class="button button-secondary"><?php esc_html_e( 'Show', 'rtbcb' ); ?></button>
+                            <button type="button" class="button button-secondary" data-action="toggle-api-key"><?php esc_html_e( 'Show', 'rtbcb' ); ?></button>
                         </td>
                     </tr>
                     <tr>
@@ -1042,7 +1040,7 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                             <label><?php esc_html_e( 'Diagnostics', 'rtbcb' ); ?></label>
                         </th>
                         <td>
-                            <button type="button" class="button" id="rtbcb-run-tests" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rtbcb_nonce' ) ); ?>"><?php esc_html_e( 'Run Diagnostics', 'rtbcb' ); ?></button>
+                            <button type="button" class="button" data-action="run-diagnostics" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rtbcb_nonce' ) ); ?>"><?php esc_html_e( 'Run Diagnostics', 'rtbcb' ); ?></button>
                             <p class="description"><?php esc_html_e( 'Verify integration and system health.', 'rtbcb' ); ?></p>
                         </td>
                     </tr>


### PR DESCRIPTION
## Summary
- replace dashboard button IDs with `data-action` attributes (e.g., `run-company-overview`, `run-rag-test`)
- refactor unified-test-dashboard JS to bind events to new attributes and add handlers for missing actions

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `node <test script>`

------
https://chatgpt.com/codex/tasks/task_e_68ac9cefdcdc83319eb2ce1832fdb9f2