### PR TITLE
Wrap API test logging in debug check

### DIFF
--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -2025,8 +2025,10 @@ function rtbcb_run_data_health_checks() {
  * @return void
  */
 function rtbcb_run_single_api_test() {
-    error_log( 'AJAX handler called: rtbcb_run_single_api_test' );
-    error_log( 'Request data: ' . print_r( $_POST, true ) );
+    if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+        error_log( 'AJAX handler called: rtbcb_run_single_api_test' );
+        error_log( 'Request data: ' . print_r( $_POST, true ) );
+    }
     if ( ! check_ajax_referer( 'rtbcb_api_health_tests', 'nonce', false ) ) {
         rtbcb_send_json_error( 'security_check_failed', __( 'Security check failed.', 'rtbcb' ), 403 );
     }


### PR DESCRIPTION
## Summary
- Limit API test debug logs to environments with `WP_DEBUG` enabled

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `tests/run-tests.sh` *(fails: phpunit: command not found; missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68aca143d6bc8331b8741e4e20f779e4