### PR TITLE
Ensure server runs health tests for all API components

### DIFF
--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -1836,6 +1836,36 @@ function rtbcb_rag_rebuild_index() {
 }
 
 /**
+ * Retrieve the API components and their associated test callbacks.
+ *
+ * @return array[]
+ */
+function rtbcb_get_api_health_components() {
+    return [
+        'chat'      => [
+            'label' => __( 'OpenAI Chat API', 'rtbcb' ),
+            'test'  => [ 'RTBCB_API_Tester', 'test_connection' ],
+        ],
+        'embedding' => [
+            'label' => __( 'OpenAI Embedding API', 'rtbcb' ),
+            'test'  => [ 'RTBCB_API_Tester', 'test_embedding' ],
+        ],
+        'portal'    => [
+            'label' => __( 'Real Treasury Portal', 'rtbcb' ),
+            'test'  => [ 'RTBCB_API_Tester', 'test_portal' ],
+        ],
+        'roi'       => [
+            'label' => __( 'ROI Calculator', 'rtbcb' ),
+            'test'  => [ 'RTBCB_API_Tester', 'test_roi_calculator' ],
+        ],
+        'rag'       => [
+            'label' => __( 'RAG Index', 'rtbcb' ),
+            'test'  => [ 'RTBCB_API_Tester', 'test_rag_index' ],
+        ],
+    ];
+}
+
+/**
  * Run all API health tests and return aggregated results.
  *
  * @return void
@@ -1861,28 +1891,7 @@ function rtbcb_run_api_health_tests() {
 
     error_log( '[RTBCB] Security checks passed, running tests...' );
 
-    $components = [
-        'chat'      => [
-            'label' => __( 'OpenAI Chat API', 'rtbcb' ),
-            'test'  => [ 'RTBCB_API_Tester', 'test_connection' ],
-        ],
-        'embedding' => [
-            'label' => __( 'OpenAI Embedding API', 'rtbcb' ),
-            'test'  => [ 'RTBCB_API_Tester', 'test_embedding' ],
-        ],
-        'portal'    => [
-            'label' => __( 'Real Treasury Portal', 'rtbcb' ),
-            'test'  => [ 'RTBCB_API_Tester', 'test_portal' ],
-        ],
-        'roi'       => [
-            'label' => __( 'ROI Calculator', 'rtbcb' ),
-            'test'  => [ 'RTBCB_API_Tester', 'test_roi_calculator' ],
-        ],
-        'rag'       => [
-            'label' => __( 'RAG Index', 'rtbcb' ),
-            'test'  => [ 'RTBCB_API_Tester', 'test_rag_index' ],
-        ],
-    ];
+    $components = rtbcb_get_api_health_components();
 
     $results   = [];
     $timestamp = current_time( 'mysql' );
@@ -2035,23 +2044,16 @@ function rtbcb_run_single_api_test() {
         rtbcb_send_json_error( 'insufficient_permissions', __( 'Insufficient permissions.', 'rtbcb' ), 403 );
     }
 
-    $component = isset( $_POST['component'] ) ? sanitize_key( wp_unslash( $_POST['component'] ) ) : '';
-    $start     = microtime( true );
+    $component  = isset( $_POST['component'] ) ? sanitize_key( wp_unslash( $_POST['component'] ) ) : '';
+    $start      = microtime( true );
+    $components = rtbcb_get_api_health_components();
 
-    $map = [
-        'chat'      => [ __( 'OpenAI Chat API', 'rtbcb' ), [ 'RTBCB_API_Tester', 'test_connection' ] ],
-        'embedding' => [ __( 'OpenAI Embedding API', 'rtbcb' ), [ 'RTBCB_API_Tester', 'test_embedding' ] ],
-        'portal'    => [ __( 'Real Treasury Portal', 'rtbcb' ), [ 'RTBCB_API_Tester', 'test_portal' ] ],
-        'roi'       => [ __( 'ROI Calculator', 'rtbcb' ), [ 'RTBCB_API_Tester', 'test_roi_calculator' ] ],
-        'rag'       => [ __( 'RAG Index', 'rtbcb' ), [ 'RTBCB_API_Tester', 'test_rag_index' ] ],
-    ];
-
-    if ( ! isset( $map[ $component ] ) ) {
+    if ( ! isset( $components[ $component ] ) ) {
         rtbcb_send_json_error( 'invalid_component', __( 'Invalid component.', 'rtbcb' ) );
     }
 
-    $name = $map[ $component ][0];
-    $test = call_user_func( $map[ $component ][1] );
+    $name = $components[ $component ]['label'];
+    $test = call_user_func( $components[ $component ]['test'] );
 
     $end = microtime( true );
 


### PR DESCRIPTION
## Summary
- centralize API health component definitions in a shared helper
- update bulk and single API test handlers to use the full component list

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68aca0cc2e84833186f6841adcf19404