### PR TITLE
Wrap AJAX handler logging in WP_DEBUG check

### DIFF
--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -15,14 +15,18 @@ add_action( 'wp_ajax_rtbcb_debug_api_key', 'rtbcb_debug_api_key' );
 add_action(
     'init',
     function () {
-        error_log( '[RTBCB] Registering AJAX handlers' );
+        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            error_log( '[RTBCB] Registering AJAX handlers' );
+        }
 
         // API Health handlers.
         add_action( 'wp_ajax_rtbcb_run_api_health_tests', 'rtbcb_run_api_health_tests' );
         add_action( 'wp_ajax_rtbcb_run_single_api_test', 'rtbcb_run_single_api_test' );
 
         // Verify handlers are registered.
-        error_log( '[RTBCB] API health handlers registered' );
+        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            error_log( '[RTBCB] API health handlers registered' );
+        }
     }
 );
 


### PR DESCRIPTION
## Summary
- guard AJAX handler registration logs with `WP_DEBUG` so logs only appear in debug environments

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68aca1fede5483318eb30b302f47e734