### PR TITLE
Align API health test components with dashboard

### DIFF
--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -1861,28 +1861,7 @@ function rtbcb_run_api_health_tests() {
 
     error_log( '[RTBCB] Security checks passed, running tests...' );
 
-    $components = [
-        'chat'      => [
-            'label' => __( 'OpenAI Chat API', 'rtbcb' ),
-            'test'  => [ 'RTBCB_API_Tester', 'test_connection' ],
-        ],
-        'embedding' => [
-            'label' => __( 'OpenAI Embedding API', 'rtbcb' ),
-            'test'  => [ 'RTBCB_API_Tester', 'test_embedding' ],
-        ],
-        'portal'    => [
-            'label' => __( 'Real Treasury Portal', 'rtbcb' ),
-            'test'  => [ 'RTBCB_API_Tester', 'test_portal' ],
-        ],
-        'roi'       => [
-            'label' => __( 'ROI Calculator', 'rtbcb' ),
-            'test'  => [ 'RTBCB_API_Tester', 'test_roi_calculator' ],
-        ],
-        'rag'       => [
-            'label' => __( 'RAG Index', 'rtbcb' ),
-            'test'  => [ 'RTBCB_API_Tester', 'test_rag_index' ],
-        ],
-    ];
+    $components = rtbcb_get_api_health_components();
 
     $results   = [];
     $timestamp = current_time( 'mysql' );
@@ -2035,20 +2014,14 @@ function rtbcb_run_single_api_test() {
 
     $component = isset( $_POST['component'] ) ? sanitize_key( wp_unslash( $_POST['component'] ) ) : '';
 
-    $tests = [
-        'chat'      => [ __( 'OpenAI Chat API', 'rtbcb' ), [ 'RTBCB_API_Tester', 'test_connection' ] ],
-        'embedding' => [ __( 'OpenAI Embedding API', 'rtbcb' ), [ 'RTBCB_API_Tester', 'test_embedding' ] ],
-        'portal'    => [ __( 'Real Treasury Portal', 'rtbcb' ), [ 'RTBCB_API_Tester', 'test_portal' ] ],
-        'roi'       => [ __( 'ROI Calculator', 'rtbcb' ), [ 'RTBCB_API_Tester', 'test_roi_calculator' ] ],
-        'rag'       => [ __( 'RAG Index', 'rtbcb' ), [ 'RTBCB_API_Tester', 'test_rag_index' ] ],
-    ];
+    $components = rtbcb_get_api_health_components();
 
-    if ( empty( $component ) || ! isset( $tests[ $component ] ) ) {
+    if ( empty( $component ) || ! isset( $components[ $component ] ) ) {
         rtbcb_send_json_error( 'invalid_component', __( 'Invalid component.', 'rtbcb' ) );
     }
 
-    $label    = sanitize_text_field( $tests[ $component ][0] );
-    $callback = $tests[ $component ][1];
+    $label    = sanitize_text_field( $components[ $component ]['label'] );
+    $callback = $components[ $component ]['test'];
 
     $start_time = microtime( true );
     $test       = call_user_func( $callback );

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -152,6 +152,36 @@ function rtbcb_get_available_models() {
     return $models;
 }
 
+/**
+ * Retrieve API health test components.
+ *
+ * @return array Map of component identifiers to labels and callbacks.
+ */
+function rtbcb_get_api_health_components() {
+    return [
+        'chat'      => [
+            'label' => __( 'OpenAI Chat API', 'rtbcb' ),
+            'test'  => [ 'RTBCB_API_Tester', 'test_connection' ],
+        ],
+        'embedding' => [
+            'label' => __( 'OpenAI Embedding API', 'rtbcb' ),
+            'test'  => [ 'RTBCB_API_Tester', 'test_embedding' ],
+        ],
+        'portal'    => [
+            'label' => __( 'Real Treasury Portal', 'rtbcb' ),
+            'test'  => [ 'RTBCB_API_Tester', 'test_portal' ],
+        ],
+        'roi'       => [
+            'label' => __( 'ROI Calculator', 'rtbcb' ),
+            'test'  => [ 'RTBCB_API_Tester', 'test_roi_calculator' ],
+        ],
+        'rag'       => [
+            'label' => __( 'RAG Index', 'rtbcb' ),
+            'test'  => [ 'RTBCB_API_Tester', 'test_rag_index' ],
+        ],
+    ];
+}
+
 function rtbcb_check_database_health() {
     global $wpdb;
 


### PR DESCRIPTION
## Summary
- centralize API health component definitions in `rtbcb_get_api_health_components`
- reuse shared component map in bulk and single API health test handlers

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found; missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68aca261fbfc833184fd619169544a99