### PR TITLE
Clean up admin dashboard scripts

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -51,6 +51,11 @@ class RTBCB_Admin {
             RTBCB_VERSION
         );
         if ( false !== strpos( $hook, RTBCB_UNIFIED_TESTS_SLUG ) || RTBCB_UNIFIED_TESTS_SLUG === $page ) {
+            wp_dequeue_script( 'rtbcb-dashboard' );
+            wp_deregister_script( 'rtbcb-dashboard' );
+            wp_dequeue_script( 'rtbcb-test-dashboard' );
+            wp_deregister_script( 'rtbcb-test-dashboard' );
+
             wp_enqueue_style(
                 'rtbcb-unified-dashboard',
                 RTBCB_URL . 'admin/css/unified-test-dashboard.css',


### PR DESCRIPTION
## Summary
- ensure unified tests only load the new dashboard script
- remove obsolete dashboard scripts to avoid conflicts

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `node` (jsdom) verify updateApiRow, updateApiSummary, showNotification
- `node` (jsdom) simulate API tests updating DOM


------
https://chatgpt.com/codex/tasks/task_e_68aca373f4fc8331a79c02ffc636a455