### PR TITLE
Ensure unified dashboard script is sole dashboard asset

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -58,6 +58,10 @@ class RTBCB_Admin {
                 RTBCB_VERSION
             );
 
+            // Remove any legacy dashboard scripts to prevent conflicts.
+            wp_dequeue_script( 'rtbcb-dashboard' );
+            wp_deregister_script( 'rtbcb-dashboard' );
+
             wp_register_script(
                 'rtbcb-unified-dashboard',
                 RTBCB_URL . 'admin/js/unified-test-dashboard.js',


### PR DESCRIPTION
## Summary
- Deregister any legacy `rtbcb-dashboard` scripts before loading unified dashboard assets
- Continue registering and enqueuing the unified test dashboard JS when viewing the Unified Tests admin page

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68aca47f4ce483318fee500daf045beb