### PR TITLE
docs: correct resetTime comment

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -26,7 +26,7 @@
     const circuitBreaker = {
         failures: 0,
         threshold: 5, // Increased from 3
-        resetTime: 60000, // Reduced from 300000 (1 minute)
+        resetTime: 60000, // Reduced from 300000 ms (five minutes) to 60000 ms (one minute)
 
         canExecute() {
             return this.failures < this.threshold;


### PR DESCRIPTION
## Summary
- update resetTime comment to reflect 300000 ms (five minutes) to 60000 ms (one minute)

## Testing
- `./tests/run-tests.sh` *(fails: phpunit: command not found; skipped tests due to missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68aca4bafe0883319698dbf7b986395b