### PR TITLE
Add configurable circuit breaker settings to unified test dashboard

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -117,6 +117,10 @@ class RTBCB_Admin {
                     'apiHealth' => [
                         'lastResults' => get_option( 'rtbcb_last_api_test', [] ),
                     ],
+                    'circuitBreaker' => [
+                        'threshold' => (int) get_option( 'rtbcb_cb_threshold', 5 ),
+                        'resetTime' => (int) get_option( 'rtbcb_cb_reset_time', 60000 ),
+                    ],
                     'urls'     => [
                         'settings' => admin_url( 'admin.php?page=' . RTBCB_UNIFIED_TESTS_SLUG . '#settings' ),
                     ],
@@ -284,6 +288,8 @@ class RTBCB_Admin {
             'rtbcb_premium_model'   => 'sanitize_text_field',
             'rtbcb_advanced_model'  => 'sanitize_text_field',
             'rtbcb_embedding_model' => 'sanitize_text_field',
+            'rtbcb_cb_threshold'    => 'absint',
+            'rtbcb_cb_reset_time'   => 'absint',
         ];
 
         foreach ( $fields as $option => $sanitize ) {

--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -25,8 +25,8 @@
 
     const circuitBreaker = {
         failures: 0,
-        threshold: 5, // Increased from 3
-        resetTime: 60000, // Reduced from 300000 (1 minute)
+        threshold: parseInt(rtbcbDashboard.circuitBreaker.threshold, 10) || 5,
+        resetTime: parseInt(rtbcbDashboard.circuitBreaker.resetTime, 10) || 60000,
 
         canExecute() {
             return this.failures < this.threshold;

--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -33,6 +33,8 @@ $mini_model     = $available_models['mini'];
 $premium_model  = $available_models['premium'];
 $advanced_model = $available_models['advanced'];
 $embedding_model = get_option( 'rtbcb_embedding_model', rtbcb_get_default_model( 'embedding' ) );
+$cb_threshold = (int) get_option( 'rtbcb_cb_threshold', 5 );
+$cb_reset_time = (int) get_option( 'rtbcb_cb_reset_time', 60000 );
 
 $all_models = rtbcb_get_available_models();
 $chat_models = [];
@@ -1090,6 +1092,24 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                                     <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $embedding_model, $value ); ?>><?php echo esc_html( $label ); ?></option>
                                 <?php endforeach; ?>
                             </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="rtbcb_cb_threshold"><?php esc_html_e( 'Circuit Breaker Threshold', 'rtbcb' ); ?></label>
+                        </th>
+                        <td>
+                            <input type="number" id="rtbcb_cb_threshold" name="rtbcb_cb_threshold" value="<?php echo esc_attr( $cb_threshold ); ?>" class="small-text" min="1" />
+                            <p class="description"><?php esc_html_e( 'Number of consecutive failures before the circuit opens.', 'rtbcb' ); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="rtbcb_cb_reset_time"><?php esc_html_e( 'Circuit Breaker Reset Time (ms)', 'rtbcb' ); ?></label>
+                        </th>
+                        <td>
+                            <input type="number" id="rtbcb_cb_reset_time" name="rtbcb_cb_reset_time" value="<?php echo esc_attr( $cb_reset_time ); ?>" class="small-text" min="0" step="1000" />
+                            <p class="description"><?php esc_html_e( 'Time before the circuit resets after opening.', 'rtbcb' ); ?></p>
                         </td>
                     </tr>
                 </table>

--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -2133,6 +2133,8 @@ function rtbcb_save_dashboard_settings() {
         'rtbcb_premium_model'   => 'sanitize_text_field',
         'rtbcb_advanced_model'  => 'sanitize_text_field',
         'rtbcb_embedding_model' => 'sanitize_text_field',
+        'rtbcb_cb_threshold'    => 'absint',
+        'rtbcb_cb_reset_time'   => 'absint',
     ];
 
     foreach ( $fields as $option => $sanitize ) {


### PR DESCRIPTION
## Summary
- Allow admins to set circuit breaker threshold and reset time in unified test dashboard settings
- Store new settings as WordPress options and expose them to JS via `wp_localize_script`
- Initialize dashboard circuit breaker with localized values instead of fixed literals

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68aca4bc0b0c8331afaefae3149b43c0