### PR TITLE
Require API key before running API health tests

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -104,6 +104,7 @@ class RTBCB_Admin {
                         'settingsSaved'    => __( 'Settings saved.', 'rtbcb' ),
                         'show'             => __( 'Show', 'rtbcb' ),
                         'hide'             => __( 'Hide', 'rtbcb' ),
+                        'apiKeyRequired'   => __( 'Please save a valid OpenAI API key in the Settings tab before running tests.', 'rtbcb' ),
                     ],
                     'models'  => [
                         'mini'     => get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) ),

--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -1778,6 +1778,15 @@
                 return;
             }
 
+            const apiKey = $('#rtbcb_openai_api_key').val();
+            if (!apiKey) {
+                console.warn('[API Health] OpenAI API key missing');
+                const msg = rtbcbDashboard.strings.apiKeyRequired;
+                $('#rtbcb-api-health-notice').text(msg);
+                this.showNotification(msg, 'warning');
+                return;
+            }
+
             const $button = $('[data-action="api-health-ping"]').prop('disabled', true);
             $('#rtbcb-api-health-notice').text('Running comprehensive API health tests...');
 
@@ -1855,6 +1864,15 @@
                 this.showNotification(rtbcbDashboard.strings.error, 'error');
                 return;
             }
+            const apiKey = $('#rtbcb_openai_api_key').val();
+            if (!apiKey) {
+                console.warn('[API Health] OpenAI API key missing');
+                const msg = rtbcbDashboard.strings.apiKeyRequired;
+                $('#rtbcb-api-health-notice').text(msg);
+                this.showNotification(msg, 'warning');
+                return;
+            }
+
             const button = $(`.rtbcb-retest[data-component="${component}"]`).prop('disabled', true);
             $.ajax({
                 url: rtbcbDashboard.ajaxurl,

--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -87,6 +87,9 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
         <?php
     endif;
     ?>
+    <?php if ( ! $api_valid ) : ?>
+        <div class="notice notice-warning"><p><?php esc_html_e( 'Please enter and save a valid OpenAI API key in the Settings tab to run tests.', 'rtbcb' ); ?></p></div>
+    <?php endif; ?>
     <div class="rtbcb-dashboard-header">
         <h1><?php esc_html_e( 'Unified Test Dashboard', 'rtbcb' ); ?></h1>
         <p class="rtbcb-dashboard-subtitle">


### PR DESCRIPTION
## Summary
- prevent API health tests from running without a saved OpenAI API key
- show admin banner prompting to save a valid key
- add translatable string for API key warning

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68aca49e3bf083318693377db1f65d51