### PR TITLE
Add API key debug utilities

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -80,6 +80,7 @@ class RTBCB_Admin {
                         'ragTesting'    => wp_create_nonce( 'rtbcb_rag_testing' ),
                         'saveSettings'  => wp_create_nonce( 'rtbcb_save_dashboard_settings' ),
                         'roiCalculator' => wp_create_nonce( 'rtbcb_roi_calculator_test' ),
+                        'debugApiKey'   => wp_create_nonce( 'rtbcb_debug_api_key' ),
                     ],
                     'strings' => [
                         'generating'       => __( 'Generating...', 'rtbcb' ),
@@ -104,6 +105,15 @@ class RTBCB_Admin {
                         'settingsSaved'    => __( 'Settings saved.', 'rtbcb' ),
                         'show'             => __( 'Show', 'rtbcb' ),
                         'hide'             => __( 'Hide', 'rtbcb' ),
+                        'debugApiKey'      => __( 'Debug API Key', 'rtbcb' ),
+                        'apiKeyDebug'      => __( 'API Key Debug', 'rtbcb' ),
+                        'configured'       => __( 'Configured', 'rtbcb' ),
+                        'length'           => __( 'Length', 'rtbcb' ),
+                        'preview'          => __( 'Preview', 'rtbcb' ),
+                        'validFormat'      => __( 'Valid format', 'rtbcb' ),
+                        'debugApiKeyFailed'=> __( 'API key debug failed.', 'rtbcb' ),
+                        'yes'              => __( 'Yes', 'rtbcb' ),
+                        'no'               => __( 'No', 'rtbcb' ),
                     ],
                     'models'  => [
                         'mini'     => get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) ),

--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -367,6 +367,15 @@
                 }
             });
 
+            $(document).on('click.rtbcb', '[data-action="debug-api-key"]', function(e) {
+                e.preventDefault();
+                try {
+                    Dashboard.debugApiKey();
+                } catch (err) {
+                    console.error('Error debugging API key:', err);
+                }
+            });
+
             $(document).on('click.rtbcb', '[data-action="run-data-health"]', function(e) {
                 e.preventDefault();
                 try {
@@ -1945,6 +1954,32 @@
                 message = rtbcbDashboard.strings.errorsDetected.replace('%d', failures);
             }
             $('#rtbcb-api-health-notice').text(message);
+        },
+
+        debugApiKey() {
+            if (!rtbcbDashboard.nonces || !rtbcbDashboard.nonces.debugApiKey) {
+                this.showNotification(rtbcbDashboard.strings.error, 'error');
+                return;
+            }
+
+            $.post(rtbcbDashboard.ajaxurl, {
+                action: 'rtbcb_debug_api_key',
+                nonce: rtbcbDashboard.nonces.debugApiKey
+            }).done((response) => {
+                if (response.success) {
+                    const data = response.data || {};
+                    const info = `${rtbcbDashboard.strings.configured}: ${data.configured ? rtbcbDashboard.strings.yes : rtbcbDashboard.strings.no}\n`
+                        + `${rtbcbDashboard.strings.length}: ${data.length}\n`
+                        + `${rtbcbDashboard.strings.preview}: ${data.preview}\n`
+                        + `${rtbcbDashboard.strings.validFormat}: ${data.valid_format ? rtbcbDashboard.strings.yes : rtbcbDashboard.strings.no}`;
+                    alert(`${rtbcbDashboard.strings.apiKeyDebug}\n\n${info}`);
+                } else {
+                    this.showNotification(rtbcbDashboard.strings.debugApiKeyFailed, 'error');
+                }
+            }).fail((jqXHR, textStatus, errorThrown) => {
+                const detail = errorThrown || textStatus;
+                this.showNotification(`${rtbcbDashboard.strings.debugApiKeyFailed}: ${detail}`, 'error');
+            });
         },
 
         // Run data health checks

--- a/admin/unified-test-dashboard-page.php
+++ b/admin/unified-test-dashboard-page.php
@@ -890,6 +890,9 @@ $last_index_display = $last_indexed ? $last_indexed : __( 'Never', 'rtbcb' );
                     <span class="dashicons dashicons-update"></span>
                     <?php esc_html_e( 'Run All Tests', 'rtbcb' ); ?>
                 </button>
+                <button type="button" class="button" data-action="debug-api-key">
+                    <?php esc_html_e( 'Debug API Key', 'rtbcb' ); ?>
+                </button>
                 <div id="rtbcb-api-health-notice" class="rtbcb-api-health-notice">
                     <?php
                     if ( $last_timestamp ) {

--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -76,6 +76,10 @@ function rtbcb_send_json_error( $code, $message, $status = 400, $debug = '', $ex
  * @return void
  */
 function rtbcb_debug_api_key() {
+    if ( ! check_ajax_referer( 'rtbcb_debug_api_key', 'nonce', false ) ) {
+        wp_die( esc_html__( 'Security check failed.', 'rtbcb' ) );
+    }
+
     if ( ! current_user_can( 'manage_options' ) ) {
         wp_die( esc_html__( 'Unauthorized', 'rtbcb' ) );
     }


### PR DESCRIPTION
## Summary
- add Debug API Key button to API Health tools
- localize and secure API key debug AJAX endpoint
- surface key info in dashboard via alert dialog

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68aca49f1b4c8331b4694ce73669414a