### PR TITLE
Use circuit breaker warning message in dashboard tests

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -86,6 +86,7 @@ class RTBCB_Admin {
                         'generateOverview' => __( 'Generate Overview', 'rtbcb' ),
                         'complete'         => __( 'Complete!', 'rtbcb' ),
                         'error'            => __( 'Error occurred', 'rtbcb' ),
+                        'tooManyFailures'  => __( 'Too many recent failures. Please wait before retrying.', 'rtbcb' ),
                         'confirm_clear'    => __( 'Are you sure you want to clear all results?', 'rtbcb' ),
                         'running'          => __( 'Running...', 'rtbcb' ),
                         'retrieving'       => __( 'Retrieving...', 'rtbcb' ),

--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -837,7 +837,7 @@
         // Start the generation process
         startGeneration(companyName, model, showDebug) {
             if (!circuitBreaker.canExecute()) {
-                this.showNotification(rtbcbDashboard.strings.error, 'error');
+                this.showNotification(rtbcbDashboard.strings.tooManyFailures, 'warning');
                 return;
             }
 
@@ -1396,7 +1396,7 @@
         runRagQuery() {
             if (this.ragRequest) return;
             if (!circuitBreaker.canExecute()) {
-                this.showNotification(rtbcbDashboard.strings.error, 'error');
+                this.showNotification(rtbcbDashboard.strings.tooManyFailures, 'warning');
                 return;
             }
 
@@ -1774,7 +1774,7 @@
             // Check circuit breaker
             if (!circuitBreaker.canExecute()) {
                 console.error('[API Health] Circuit breaker open. Failures:', circuitBreaker.failures);
-                this.showNotification('Too many recent failures. Please wait before retrying.', 'warning');
+                this.showNotification(rtbcbDashboard.strings.tooManyFailures, 'warning');
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Localize "Too many recent failures. Please wait before retrying." and expose it to the dashboard scripts
- Show circuit breaker warning instead of generic error in generation and RAG queries
- Reuse the same warning for API health check

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit missing; OpenAI-dependent tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68aca4b98aec8331b2e6d32d4fd3b4d5