### PR TITLE
Proxy report generation through WordPress AJAX

### DIFF
--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -532,6 +532,8 @@ add_action( 'wp_ajax_rtbcb_rag_rebuild_index', 'rtbcb_rag_rebuild_index' );
 add_action( 'wp_ajax_rtbcb_generate_preview_report', 'rtbcb_generate_preview_report' );
 add_action( 'wp_ajax_rtbcb_save_dashboard_settings', 'rtbcb_save_dashboard_settings' );
 add_action( 'wp_ajax_rtbcb_export_dashboard_results', 'rtbcb_export_dashboard_results' );
+add_action( 'wp_ajax_rtbcb_generate_report', 'rtbcb_generate_report' );
+add_action( 'wp_ajax_nopriv_rtbcb_generate_report', 'rtbcb_generate_report' );
 
 /**
  * Test individual LLM model with given prompt.
@@ -2967,6 +2969,67 @@ function rtbcb_export_dashboard_results() {
         error_log( 'RTBCB Export Error: ' . $e->getMessage() );
         rtbcb_send_json_error( 'export_failed', __( 'Export generation failed.', 'rtbcb' ), 500, $e->getMessage() );
     }
+}
+
+/**
+ * Generate professional report via OpenAI using stored API key.
+ *
+ * @return void
+ */
+function rtbcb_generate_report() {
+    if ( ! check_ajax_referer( 'rtbcb_generate_report', 'nonce', false ) ) {
+        rtbcb_send_json_error( 'security_check_failed', __( 'Security check failed.', 'rtbcb' ), 403 );
+    }
+
+    if ( ! current_user_can( 'manage_options' ) ) {
+        rtbcb_send_json_error( 'insufficient_permissions', __( 'Insufficient permissions.', 'rtbcb' ), 403 );
+    }
+
+    $request_raw = wp_unslash( $_POST['request'] ?? '' );
+    if ( empty( $request_raw ) ) {
+        rtbcb_send_json_error( 'invalid_request', __( 'Invalid request.', 'rtbcb' ), 400 );
+    }
+
+    $request = json_decode( $request_raw, true );
+    if ( ! is_array( $request ) ) {
+        rtbcb_send_json_error( 'invalid_request', __( 'Invalid request.', 'rtbcb' ), 400 );
+    }
+
+    $api_key = sanitize_text_field( get_option( 'rtbcb_openai_api_key', '' ) );
+    if ( empty( $api_key ) ) {
+        rtbcb_send_json_error( 'api_key_not_configured', __( 'OpenAI API key not configured.', 'rtbcb' ), 500 );
+    }
+
+    $args = [
+        'timeout' => 60,
+        'headers' => [
+            'Content-Type'  => 'application/json',
+            'Authorization' => 'Bearer ' . $api_key,
+        ],
+        'body'    => wp_json_encode( $request ),
+    ];
+
+    $response = wp_remote_post( 'https://api.openai.com/v1/responses', $args );
+
+    if ( is_wp_error( $response ) ) {
+        rtbcb_send_json_error( 'http_request_failed', __( 'HTTP request failed.', 'rtbcb' ), 500, $response->get_error_message() );
+    }
+
+    $code    = wp_remote_retrieve_response_code( $response );
+    $body    = wp_remote_retrieve_body( $response );
+    $decoded = json_decode( $body, true );
+
+    if ( 200 !== $code || ! is_array( $decoded ) ) {
+        rtbcb_send_json_error( 'api_error', __( 'API request failed.', 'rtbcb' ), $code, $body );
+    }
+
+    if ( isset( $decoded['error'] ) ) {
+        $message = is_array( $decoded['error'] ) ? sanitize_text_field( $decoded['error']['message'] ?? '' ) : '';
+        rtbcb_send_json_error( 'api_error', $message ? $message : __( 'API request failed.', 'rtbcb' ), $code, $body );
+    }
+
+    $html = wp_kses_post( $decoded['output_text'] ?? '' );
+    wp_send_json_success( [ 'html' => $html ] );
 }
 
 /**

--- a/public/js/rtbcb-report.js
+++ b/public/js/rtbcb-report.js
@@ -297,10 +297,14 @@ function generateProfessionalReport(businessContext) {
     }
 
     const xhr = new XMLHttpRequest();
-    xhr.open('POST', 'https://api.openai.com/v1/responses', false);
-    xhr.setRequestHeader('Content-Type', 'application/json');
-    xhr.setRequestHeader('Authorization', `Bearer ${rtbcbReport.api_key}`);
-    xhr.send(JSON.stringify(requestBody));
+    xhr.open('POST', rtbcbReport.ajax_url, false);
+    xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+    const params = new URLSearchParams({
+        action: 'rtbcb_generate_report',
+        nonce: rtbcbReport.nonce,
+        request: JSON.stringify(requestBody)
+    });
+    xhr.send(params.toString());
 
     if (xhr.status < 200 || xhr.status >= 300) {
         throw new Error('HTTP ' + xhr.status);
@@ -308,12 +312,12 @@ function generateProfessionalReport(businessContext) {
 
     const data = JSON.parse(xhr.responseText);
 
-    if (data.error) {
-        const errorMessage = data.error.message || 'Responses API error';
+    if (!data.success) {
+        const errorMessage = (data.data && data.data.message) ? data.data.message : 'Server error';
         throw new Error(errorMessage);
     }
 
-    const htmlContent = data.output_text;
+    const htmlContent = data.data.html;
     const cleanedHTML = htmlContent
         .replace(/```html\n?/g, '')
         .replace(/```\n?/g, '')

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -435,7 +435,6 @@ class RTBCB_Plugin {
             true
         );
 
-        $api_key      = sanitize_text_field( get_option( 'rtbcb_openai_api_key', '' ) );
         $report_model = sanitize_text_field( get_option( 'rtbcb_advanced_model', rtbcb_get_default_model( 'advanced' ) ) );
 
         $config = rtbcb_get_gpt5_config( get_option( 'rtbcb_gpt5_config', [] ) );
@@ -462,9 +461,10 @@ class RTBCB_Plugin {
             'rtbcb-report',
             'rtbcbReport',
             [
-                'api_key'            => $api_key,
-                'report_model'       => $report_model,
-                'defaults'           => $config_localized,
+                'ajax_url'          => admin_url( 'admin-ajax.php' ),
+                'nonce'             => wp_create_nonce( 'rtbcb_generate_report' ),
+                'report_model'      => $report_model,
+                'defaults'          => $config_localized,
                 'model_capabilities' => $model_capabilities,
             ]
         );

--- a/tests/temperature-model.test.js
+++ b/tests/temperature-model.test.js
@@ -12,14 +12,15 @@ const supportedModels = ['gpt-4o', 'gpt-4.1-preview'];
 
 for (const model of [...unsupportedModels, ...supportedModels]) {
     let capturedBody;
-    global.rtbcbReport = { report_model: model, api_key: 'test', model_capabilities: capabilities };
+    global.rtbcbReport = { report_model: model, model_capabilities: capabilities, ajax_url: '/fake', nonce: 'nonce' };
     global.XMLHttpRequest = function () {
         this.open = function () {};
         this.setRequestHeader = function () {};
         this.send = function (body) {
-            capturedBody = JSON.parse(body);
+            const params = new URLSearchParams(body);
+            capturedBody = JSON.parse(params.get('request'));
             this.status = 200;
-            this.responseText = JSON.stringify({ output_text: '<html></html>' });
+            this.responseText = JSON.stringify({ success: true, data: { html: '<html></html>' } });
         };
     };
     global.document = { getElementById: () => null };


### PR DESCRIPTION
## Summary
- Add `rtbcb_generate_report` AJAX handler that proxies OpenAI requests using stored API key with nonce and capability checks
- Localize report script with AJAX URL/nonce and remove exposed API key
- Update report JavaScript and tests to call new WordPress endpoint

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `node tests/temperature-model.test.js`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca608aa4883318f3e66de7e5351bd