### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -736,7 +736,7 @@
                     setTimeout(() => $button.removeClass('rtbcb-error').html(defaultText), 5000);
                     break;
                 default:
-                    $button.prop('disabled', false).html(text || defaultText);
+                    $button.prop('disabled', false).html(text ? text : this.escapeHtml(defaultText));
                     break;
             }
         },


### PR DESCRIPTION
Potential fix for [https://github.com/RealTreasury/business-case-builder/security/code-scanning/8](https://github.com/RealTreasury/business-case-builder/security/code-scanning/8)

To fix the issue, ensure any text from the DOM (specifically `defaultText` from `$button.text()`) is escaped for HTML meta-characters before being passed to `.html()`. The code already includes an `escapeHtml` utility function at lines 707–711, which can be utilized. Update the default branch of the `switch` statement in `setButtonState` at line 739 so that **if `text` is not provided, the fallback (`defaultText`) is escaped with `escapeHtml()`** before being passed to `.html()`. 

Edit only the relevant lines: in the `setButtonState` method, on the default case, change:

```js
$button.prop('disabled', false).html(text || defaultText);
```

to

```js
$button.prop('disabled', false).html(text ? text : this.escapeHtml(defaultText));
```

This ensures that the original DOM text is properly escaped before being interpreted as HTML. If `text` is supplied, use it as-is (it is already used with `.html()` in other branches, and it could be subject to the same concern—if supplied by the caller, it should likewise be escaped unless the caller guarantees its safety).

Optionally, for full security, you may also wish to escape `text` in all paths unless you know it is always safe HTML—but the minimum fix, per the described issue, is for `defaultText`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
