### PR TITLE
Enable overview generation after saving settings

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -64,12 +64,14 @@
         startTime: null,
         currentRequest: null,
         charts: {},
+        apiKeyValid: false,
 
         // Initialize dashboard
         init() {
             console.log('Dashboard initializing...');
-            
+
             try {
+                this.apiKeyValid = $('#rtbcb_openai_api_key').val().trim().length > 0;
                 this.bindEvents();
                 this.initializeTabs();
                 this.setupValidation();
@@ -496,10 +498,14 @@
 
             this.makeRequest(requestData)
                 .then(response => {
-                    this.showNotification('Settings saved successfully', 'success');
+                    this.showNotification(response?.message || 'Settings saved successfully', 'success');
+                    this.apiKeyValid = $('#rtbcb_openai_api_key').val().trim().length > 0;
+                    this.validateCompanyInput();
                 })
                 .catch(error => {
                     console.error('Settings save error:', error);
+                    this.apiKeyValid = false;
+                    $('[data-action="run-company-overview"]').prop('disabled', true);
                     this.showError(error.message || 'Failed to save settings');
                 });
         },
@@ -520,8 +526,8 @@
         // Validation methods
         validateCompanyInput() {
             const companyName = $('#company-name-input').val().trim();
-            const isValid = companyName.length >= 2;
-            
+            const isValid = companyName.length >= 2 && this.apiKeyValid;
+
             $('[data-action="run-company-overview"]').prop('disabled', !isValid || this.isGenerating);
             
             if (companyName.length > 0 && companyName.length < 2) {

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -67,6 +67,7 @@ node tests/render-results-no-narrative.test.js
 node tests/handle-submit-success.test.js
 node tests/handle-server-error-display.test.js
 node tests/temperature-model.test.js
+node tests/save-settings-enable-button.test.js
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then

--- a/tests/save-settings-enable-button.test.js
+++ b/tests/save-settings-enable-button.test.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Simple DOM element stubs
+const button = { disabled: true };
+const apiInput = { value: '' };
+const companyInput = { value: '' };
+
+function jQueryStub(selector) {
+    if (selector === document) {
+        return { ready: () => {}, on: () => {}, off: () => {} };
+    }
+    if (selector === '#rtbcb_openai_api_key') {
+        return { val: () => apiInput.value };
+    }
+    if (selector === '#company-name-input') {
+        return {
+            val: () => companyInput.value,
+            addClass: () => {},
+            removeClass: () => {}
+        };
+    }
+    if (selector === '[data-action="run-company-overview"]') {
+        return {
+            prop: (name, value) => {
+                if (typeof value !== 'undefined') {
+                    button[name] = value;
+                }
+                return button[name];
+            }
+        };
+    }
+    return {};
+}
+
+global.$ = jQueryStub;
+global.jQuery = jQueryStub;
+global.window = {};
+global.document = { getElementById: () => ({}) };
+global.rtbcbDashboard = { ajaxurl: '', nonces: { saveSettings: 'nonce' } };
+
+global.FormData = function () {
+    this._data = {
+        nonce: 'nonce',
+        rtbcb_openai_api_key: apiInput.value
+    };
+    this.get = (name) => this._data[name];
+    this.entries = () => Object.entries(this._data);
+};
+
+const code = fs.readFileSync('admin/js/unified-test-dashboard.js', 'utf8');
+vm.runInThisContext(code);
+
+const RTBCBDashboard = window.RTBCBDashboard;
+RTBCBDashboard.showNotification = () => {};
+RTBCBDashboard.showError = () => {};
+RTBCBDashboard.isGenerating = false;
+
+// Prepare form values
+companyInput.value = 'Acme Corp';
+apiInput.value = 'sk-valid-key';
+
+// Synchronous makeRequest stub
+RTBCBDashboard.makeRequest = () => ({
+    then: (cb) => {
+        cb({ message: 'Settings saved' });
+        return { catch: () => {} };
+    }
+});
+
+button.disabled = true;
+RTBCBDashboard.saveSettings();
+assert.strictEqual(button.disabled, false);
+console.log('saveSettings enables button test passed.');


### PR DESCRIPTION
## Summary
- track OpenAI API key validity on the dashboard
- enable "Generate Overview" immediately after successfully saving a valid API key
- add test for settings save enabling overview button

## Testing
- `tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68acd08c6d74833184acebf02d6dfa50