### PR TITLE
Improve dashboard settings save handling

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -495,17 +495,31 @@
             }
 
             this.makeRequest(requestData)
-                .then(response => {
-                    if (response.api_valid) {
-                        this.showNotification(rtbcbDashboard.strings?.validApiKeySaved || 'Valid API key saved', 'success');
-                    } else {
-                        this.showError(rtbcbDashboard.strings?.apiKeyValidationFailed || 'API key validation failed');
+                .then((response) => {
+                    if (response.reload) {
+                        window.location.reload();
+                        return;
                     }
-                    this.updateApiKeyStatus(!!response.api_valid);
+
+                    const isValid = !!response.api_valid;
+                    rtbcbDashboard.api_valid = isValid;
+                    this.updateApiKeyStatus(isValid);
+                    $('[data-action="run-company-overview"]').prop('disabled', !isValid);
+
+                    if (isValid) {
+                        this.showNotification(
+                            response.message || rtbcbDashboard.strings?.validApiKeySaved || 'Valid API key saved',
+                            'success'
+                        );
+                    } else {
+                        this.showError(
+                            response.message || rtbcbDashboard.strings?.apiKeyValidationFailed || 'API key validation failed'
+                        );
+                    }
                 })
-                .catch(error => {
+                .catch((error) => {
                     console.error('Settings save error:', error);
-                    this.showError(error.message || 'Failed to save settings');
+                    this.showError(error.message || rtbcbDashboard.strings?.settingsSaveFailed || 'Failed to save settings');
                 });
         },
 


### PR DESCRIPTION
## Summary
- Update dashboard settings save to reload on request or update UI state
- Toggle `Generate Overview` button based on returned API validity
- Display success/error feedback for API key save operations

## Testing
- `bash tests/run-tests.sh` *(fails: wp_remote_get undefined, phpunit missing)*

------
https://chatgpt.com/codex/tasks/task_e_68acd251b0348331aeb5aa0e95956fdf