### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,8 @@ jobs:
     needs: [php-quality, phpunit-tests, javascript-quality, wordpress-com-compatibility]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/RealTreasury/business-case-builder/security/code-scanning/15](https://github.com/RealTreasury/business-case-builder/security/code-scanning/15)

The best way to fix this problem is to explicitly declare a `permissions` block in the workflow, granting only the minimum required permissions. Since the `build-release` job only requires reading repository contents (to checkout code) and uploading artifacts (which does not require GITHUB_TOKEN permissions), read-only access to `contents` is sufficient.

This can be done in two ways:
1. At the root level—apply to all jobs without their own `permissions` block.  
2. At the job level—add a `permissions` block specifically for the `build-release` job.

The recommended minimal fix is:
- Add `permissions: contents: read` under the `build-release` job (starting at line 257).
- This change requires no additional imports, methods, or definitions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
