### PR TITLE
Rename AJAX localization object to rtbcbAjax

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -406,7 +406,7 @@ class BusinessCaseBuilder {
 
             console.log('RTBCB: Submitting form data:', Object.fromEntries(formData));
 
-            const response = await fetch(ajaxObj.ajax_url, {
+            const response = await fetch(rtbcbAjax.ajax_url, {
                 method: 'POST',
                 body: formData,
                 credentials: 'same-origin'

--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -112,7 +112,7 @@ function handleSubmit(e) {
 
     try {
         const xhr = new XMLHttpRequest();
-        xhr.open('POST', ajaxObj.ajax_url, false);
+        xhr.open('POST', rtbcbAjax.ajax_url, false);
         xhr.send(formData);
 
         if (xhr.status < 200 || xhr.status >= 300) {

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -397,35 +397,32 @@ class RTBCB_Plugin {
             true
         );
 
-        // CRITICAL FIX: Check if ajaxObj already exists to prevent override
-        if ( ! wp_script_is( 'rtbcb-script', 'done' ) ) {
-            wp_localize_script(
-                'rtbcb-script',
-                'ajaxObj',
-                [
-                    'ajax_url'    => admin_url( 'admin-ajax.php' ),
-                    'strings'     => [
-                        'error'                   => __( 'An error occurred. Please try again.', 'rtbcb' ),
-                        'generating'              => __( 'Generating your comprehensive business case...', 'rtbcb' ),
-                        'analyzing'               => __( 'Analyzing your treasury operations...', 'rtbcb' ),
-                        'financial_modeling'      => __( 'Building financial models...', 'rtbcb' ),
-                        'risk_assessment'         => __( 'Conducting risk assessment...', 'rtbcb' ),
-                        'industry_benchmarking'   => __( 'Performing industry benchmarking...', 'rtbcb' ),
-                        'implementation_planning' => __( 'Creating implementation roadmap...', 'rtbcb' ),
-                        'vendor_evaluation'       => __( 'Preparing vendor evaluation framework...', 'rtbcb' ),
-                        'finalizing_report'       => __( 'Finalizing professional report...', 'rtbcb' ),
-                        'invalid_email'           => __( 'Please enter a valid email address.', 'rtbcb' ),
-                        'required_field'          => __( 'This field is required.', 'rtbcb' ),
-                        'select_pain_points'      => __( 'Please select at least one pain point.', 'rtbcb' ),
-                    ],
-                    'settings'    => [
-                        'pdf_enabled'            => get_option( 'rtbcb_pdf_enabled', true ),
-                        'comprehensive_analysis' => get_option( 'rtbcb_comprehensive_analysis', true ),
-                        'professional_reports'   => get_option( 'rtbcb_professional_reports', true ),
-                    ],
-                ]
-            );
-        }
+        wp_localize_script(
+            'rtbcb-script',
+            'rtbcbAjax',
+            [
+                'ajax_url'    => admin_url( 'admin-ajax.php' ),
+                'strings'     => [
+                    'error'                   => __( 'An error occurred. Please try again.', 'rtbcb' ),
+                    'generating'              => __( 'Generating your comprehensive business case...', 'rtbcb' ),
+                    'analyzing'               => __( 'Analyzing your treasury operations...', 'rtbcb' ),
+                    'financial_modeling'      => __( 'Building financial models...', 'rtbcb' ),
+                    'risk_assessment'         => __( 'Conducting risk assessment...', 'rtbcb' ),
+                    'industry_benchmarking'   => __( 'Performing industry benchmarking...', 'rtbcb' ),
+                    'implementation_planning' => __( 'Creating implementation roadmap...', 'rtbcb' ),
+                    'vendor_evaluation'       => __( 'Preparing vendor evaluation framework...', 'rtbcb' ),
+                    'finalizing_report'       => __( 'Finalizing professional report...', 'rtbcb' ),
+                    'invalid_email'           => __( 'Please enter a valid email address.', 'rtbcb' ),
+                    'required_field'          => __( 'This field is required.', 'rtbcb' ),
+                    'select_pain_points'      => __( 'Please select at least one pain point.', 'rtbcb' ),
+                ],
+                'settings'    => [
+                    'pdf_enabled'            => get_option( 'rtbcb_pdf_enabled', true ),
+                    'comprehensive_analysis' => get_option( 'rtbcb_comprehensive_analysis', true ),
+                    'professional_reports'   => get_option( 'rtbcb_professional_reports', true ),
+                ],
+            ]
+        );
 
         wp_enqueue_script(
             'rtbcb-report',

--- a/tests/handle-server-error-display.test.js
+++ b/tests/handle-server-error-display.test.js
@@ -18,7 +18,7 @@ global.document = {
     }
 };
 
-global.ajaxObj = { ajax_url: '' };
+global.rtbcbAjax = { ajax_url: '' };
 
 global.DOMPurify = { sanitize: (html) => html };
 

--- a/tests/handle-submit-error.test.js
+++ b/tests/handle-submit-error.test.js
@@ -18,7 +18,7 @@ global.document = {
     }
 };
 
-global.ajaxObj = { ajax_url: '' };
+global.rtbcbAjax = { ajax_url: '' };
 
 global.DOMPurify = { sanitize: (html) => html };
 

--- a/tests/handle-submit-success.test.js
+++ b/tests/handle-submit-success.test.js
@@ -18,7 +18,7 @@ global.document = {
     }
 };
 
-global.ajaxObj = { ajax_url: '' };
+global.rtbcbAjax = { ajax_url: '' };
 
 global.DOMPurify = { sanitize: (html) => html };
 


### PR DESCRIPTION
## Summary
- Localize frontend script with new `rtbcbAjax` object and remove conditional guard
- Update wizard and frontend scripts to reference `rtbcbAjax`
- Adjust tests for renamed localization object

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `npm test` *(fails: phpunit: not found)*
- `npm run test:js`


------
https://chatgpt.com/codex/tasks/task_e_68acf0d9bb8083318f33ca2ece8f3226