### PR TITLE
Load assets only when shortcode or plugin pages

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -476,13 +476,24 @@ class RTBCB_Plugin {
      * @return bool
      */
     private function should_load_assets() {
-        // Always load on admin pages for this plugin
-        if ( is_admin() && isset( $_GET['page'] ) && strpos( $_GET['page'], 'rtbcb' ) !== false ) {
+        if ( is_admin() ) {
+            if ( isset( $_GET['page'] ) ) {
+                $page = sanitize_key( wp_unslash( $_GET['page'] ) );
+
+                if ( strpos( $page, 'rtbcb' ) !== false ) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        $post = get_post();
+        if ( $post instanceof WP_Post && has_shortcode( $post->post_content, 'rt_business_case_builder' ) ) {
             return true;
         }
 
-        // Load on any page - let WordPress handle caching
-        return true;
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Only enqueue assets on plugin admin pages or when `rt_business_case_builder` shortcode is present
- Sanitize `$_GET['page']` before comparing and return false by default

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `npm test` *(fails: Failed opening required '/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68acf0db57748331a9e8faa29e21bee4