### PR TITLE
Use strpos for API key prefix check

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -45,7 +45,7 @@ function rtbcb_is_valid_openai_api_key( $api_key ) {
         return false;
     }
 
-    if ( ! str_starts_with( $api_key, 'sk-' ) ) {
+    if ( 0 !== strpos( $api_key, 'sk-' ) ) {
         return false;
     }
 


### PR DESCRIPTION
## Summary
- Replace `str_starts_with()` usage with `strpos()` in API key validation for broader PHP compatibility.
- Confirm plugin header continues to require PHP 7.4.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer test` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acf0da26a88331beee4e02ce1b1bf4