### PR TITLE
Fix localized admin object name

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -613,10 +613,14 @@ final class RTBCB_Business_Case_Builder {
             true
         );
         
-        wp_localize_script( 'rtbcb-admin', 'rtbcb_admin', array(
-            'ajax_url' => admin_url( 'admin-ajax.php' ),
-            'nonce' => wp_create_nonce( 'rtbcb_admin_action' )
-        ) );
+        wp_localize_script(
+            'rtbcb-admin',
+            'rtbcbAdmin',
+            array(
+                'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+                'nonce'   => wp_create_nonce( 'rtbcb_admin_action' ),
+            )
+        );
     }
     
     /**


### PR DESCRIPTION
## Summary
- Use `rtbcbAdmin` as the localized object for the admin script and expose camel-cased `ajaxUrl`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `npm test` *(fails: Cannot open file "/workspace/business-case-builder/tests/bootstrap.php")*

------
https://chatgpt.com/codex/tasks/task_e_68ade49582fc8331a744a3fd186d32f9