### PR TITLE
Unify admin nonce usage for AJAX requests

### DIFF
--- a/admin/classes/Admin.php
+++ b/admin/classes/Admin.php
@@ -553,7 +553,7 @@ class RTBCB_Admin {
                     'page' => 'rtbcb-leads',
                     'action' => 'export',
                     'lead_ids' => implode( ',', $lead_ids ),
-                    'nonce' => wp_create_nonce( 'rtbcb_export_leads' ),
+                    'nonce' => wp_create_nonce( 'rtbcb_admin_nonce' ),
                 ], admin_url( 'admin.php' ) ) );
                 exit;
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -618,7 +618,7 @@ final class RTBCB_Business_Case_Builder {
             'rtbcbAdmin',
             array(
                 'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-                'nonce'   => wp_create_nonce( 'rtbcb_admin_action' ),
+                'nonce'   => wp_create_nonce( 'rtbcb_admin_nonce' ),
             )
         );
     }


### PR DESCRIPTION
## Summary
- Use a single `rtbcb_admin_nonce` action for admin nonce generation
- Align bulk export redirect with unified nonce

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `npm test` *(fails: Cannot open file "/workspace/business-case-builder/tests/bootstrap.php".)*

------
https://chatgpt.com/codex/tasks/task_e_68ade5b156f08331a9bb790e76272b94