### PR TITLE
Log nonce errors and enforce API health nonce

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -78,15 +78,19 @@
                 // Reset any stuck button states first
                 this.resetAllButtonStates();
                 
-                this.bindEvents();
-                this.initializeTabs();
-                this.setupValidation();
-                this.loadSavedState();
-                
-                // Initialize Chart.js if available
-                if (typeof Chart !== 'undefined') {
-                    this.setupCharts();
-                }
+            this.bindEvents();
+            this.initializeTabs();
+            this.setupValidation();
+            this.loadSavedState();
+
+            if (!rtbcbDashboard.nonces || !rtbcbDashboard.nonces.apiHealth) {
+                this.showNotification('Security token missing. Please refresh the page.', 'warning');
+            }
+
+            // Initialize Chart.js if available
+            if (typeof Chart !== 'undefined') {
+                this.setupCharts();
+            }
                 
                 // Add emergency reset handler (Ctrl/Cmd + R while on dashboard)
                 $(document).on('keydown.rtbcb-dashboard', (e) => {
@@ -582,7 +586,7 @@
 
             const requestData = {
                 action: 'rtbcb_run_api_health_tests',
-                nonce: rtbcbDashboard.nonces?.apiHealth || ''
+                nonce: rtbcbDashboard.nonces.apiHealth
             };
 
             this.makeRequest(requestData)

--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -586,7 +586,7 @@
 
             const requestData = {
                 action: 'rtbcb_run_api_health_tests',
-                nonce: rtbcbDashboard.nonces.apiHealth
+                nonce: rtbcbDashboard.nonces?.apiHealth
             };
 
             this.makeRequest(requestData)

--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -47,6 +47,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function rtbcb_send_json_error( $code, $message, $status = 400, $debug = '', $extra = [] ) {
+    if ( in_array( $code, [ 'security_check_failed', 'invalid_nonce', 'security_failed' ], true ) ) {
+        $user_id = get_current_user_id();
+        $request_data = wp_json_encode( array_map( 'sanitize_text_field', wp_unslash( $_REQUEST ) ) );
+        error_log( sprintf( 'RTBCB nonce failure [%s] for user %d: %s', $code, $user_id, $request_data ) );
+    }
+
     $data = array_merge(
         [
             'code'    => $code,

--- a/inc/enhanced-ajax-handlers.php
+++ b/inc/enhanced-ajax-handlers.php
@@ -49,7 +49,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 function rtbcb_send_json_error( $code, $message, $status = 400, $debug = '', $extra = [] ) {
     if ( in_array( $code, [ 'security_check_failed', 'invalid_nonce', 'security_failed' ], true ) ) {
         $user_id = get_current_user_id();
-        $request_data = wp_json_encode( array_map( 'sanitize_text_field', wp_unslash( $_REQUEST ) ) );
+        // Filter out sensitive fields before logging request data.
+        $sensitive_keys = [ 'password', 'pass', 'pwd', 'api_key', 'apikey', 'token', 'auth', 'authorization', 'secret' ];
+        $filtered_request = wp_unslash( $_REQUEST );
+        foreach ( $sensitive_keys as $sensitive_key ) {
+            if ( isset( $filtered_request[ $sensitive_key ] ) ) {
+                $filtered_request[ $sensitive_key ] = '[FILTERED]';
+            }
+        }
+        $request_data = wp_json_encode( array_map( 'sanitize_text_field', $filtered_request ) );
         error_log( sprintf( 'RTBCB nonce failure [%s] for user %d: %s', $code, $user_id, $request_data ) );
     }
 


### PR DESCRIPTION
## Summary
- Always send `apiHealth` nonce for API health tests and show refresh notice when missing
- Add detailed logging for failed nonce verification

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `npm test` *(fails: Class "PHPUnit\TextUI\Command" not found)*
- `npm run lint:js` *(fails: ESLint couldn't find config "@wordpress/eslint-plugin/recommended")*

------
https://chatgpt.com/codex/tasks/task_e_68ae342948c88331baaa8e2d2a61dda5