### PR TITLE
Ensure dashboard waits for localized globals

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -13,7 +13,7 @@
                 attempts++;
                 setTimeout( check, RETRY_DELAY );
             } else {
-                console.error( 'rtbcbDashboard is not defined' );
+                console.error(`Failed to initialize dashboard after ${attempts} attempts (max ${MAX_RETRIES}): rtbcbDashboard is not defined`);
             }
             return;
         }

--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -1383,6 +1383,7 @@
     })(jQuery);
 }
 
-check();
+// Start initialization: wait for rtbcbDashboard to be available, then initialize dashboard logic
+waitForDashboardAndInit();
 })();
 

--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -2,30 +2,40 @@
  * Fixed Unified Test Dashboard JavaScript
  * Handles all dashboard functionality with improved error handling and state management
  */
-(function($) {
-    'use strict';
+(function ensureDashboard() {
+    const MAX_RETRIES = 5;
+    const RETRY_DELAY = 50;
+    let attempts = 0;
 
-    // Early validation
-    if (typeof rtbcbDashboard === 'undefined') {
-        console.error('rtbcbDashboard is not defined');
-        return;
-    }
+    function check() {
+        if ( typeof rtbcbDashboard === 'undefined' ) {
+            if ( attempts < MAX_RETRIES ) {
+                attempts++;
+                setTimeout( check, RETRY_DELAY );
+            } else {
+                console.error( 'rtbcbDashboard is not defined' );
+            }
+            return;
+        }
 
-    if (typeof jQuery === 'undefined') {
-        console.error('jQuery is not available');
-        return;
-    }
+        (function($) {
+        'use strict';
 
-    console.log('Test dashboard script loaded');
+        if (typeof jQuery === 'undefined') {
+            console.error('jQuery is not available');
+            return;
+        }
 
-    // Utility functions
-    const debounce = (func, delay) => {
-        let timeoutId;
-        return (...args) => {
-            clearTimeout(timeoutId);
-            timeoutId = setTimeout(() => func.apply(this, args), delay);
+        console.log('Test dashboard script loaded');
+
+        // Utility functions
+        const debounce = (func, delay) => {
+            let timeoutId;
+            return (...args) => {
+                clearTimeout(timeoutId);
+                timeoutId = setTimeout(() => func.apply(this, args), delay);
+            };
         };
-    };
 
     // Circuit breaker for API failures
     const circuitBreaker = {
@@ -1370,5 +1380,9 @@
     // Expose for debugging
     window.RTBCBDashboard = Dashboard;
 
-})(jQuery);
+    })(jQuery);
+}
+
+check();
+})();
 


### PR DESCRIPTION
## Summary
- Add retry guard in `unified-test-dashboard.js` so dashboard waits for `rtbcbDashboard` to exist before running
- Confirm `wp_localize_script` executes before the unified dashboard script is enqueued

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find `@wordpress/eslint-plugin/recommended`)*
- `npm test` *(fails: PHPUnit\TextUI\Command not found)*
- `php -l admin/class-rtbcb-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae3418d8bc8331ac970420eb9f79ae