### PR TITLE
fix: improve button state reset

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -1108,8 +1108,8 @@
                 this.resetButtonState($button, defaultText);
             });
 
-            // Also reset any other interactive elements
-            $('[data-action]').each((index, element) => {
+            // Also reset any other interactive elements (excluding buttons already handled above)
+            $('[data-action]:not(button)').each((index, element) => {
                 const $element = $(element);
                 $element.removeData('rtbcb-interacted');
                 $element.removeData('rtbcb-interacted-time');

--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -1093,7 +1093,7 @@
                    .html(this.escapeHtml(text));
         },
 
-        // Force reset all buttons (emergency cleanup) - FIXED VERSION
+        // Force reset all buttons (emergency cleanup)
         resetAllButtonStates() {
             console.log('Resetting all button states...');
 

--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -1093,15 +1093,33 @@
                    .html(this.escapeHtml(text));
         },
 
-        // Force reset all buttons (emergency cleanup)
+        // Force reset all buttons (emergency cleanup) - FIXED VERSION
         resetAllButtonStates() {
             console.log('Resetting all button states...');
+
             $('button[data-action]').each((index, element) => {
                 const $button = $(element);
+
+                // Clear all interaction tracking data
+                $button.removeData('rtbcb-interacted');
+                $button.removeData('rtbcb-interacted-time');
+
                 const defaultText = $button.data('default-text') || $button.text().trim();
                 this.resetButtonState($button, defaultText);
             });
+
+            // Also reset any other interactive elements
+            $('[data-action]').each((index, element) => {
+                const $element = $(element);
+                $element.removeData('rtbcb-interacted');
+                $element.removeData('rtbcb-interacted-time');
+            });
+
             this.isGenerating = false;
+
+            // Force remove any stuck loading states
+            $('.rtbcb-loading').removeClass('rtbcb-loading');
+            $('.rtbcb-touch-active').removeClass('rtbcb-touch-active');
         },
 
         // Progress management


### PR DESCRIPTION
## Summary
- enhance `resetAllButtonStates` to clear tracking data and stuck states for all interactive elements

## Testing
- ⚠️ `npm run lint:js` (ESLint config not found)
- ✅ `npm run test:js`
- ⚠️ `npm test` (phpunit not found)


------
https://chatgpt.com/codex/tasks/task_e_68ae3b25ad148331ac2736dee4fff7a2