### PR TITLE
Gracefully handle missing WordPress test suite and surface API test errors

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -771,7 +771,7 @@ if (typeof jQuery !== 'undefined') {
                         error: error
                     });
                     this.setButtonState('[data-action="api-health-ping"]', 'error');
-                    $('#rtbcb-api-health-notice').text('API tests failed');
+                    $('#rtbcb-api-health-notice').text(error.message || 'API tests failed');
                 })
                 .finally(() => {
                     this.isGenerating = false;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,20 +5,26 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-// Composer autoloader must be loaded before WP_PHPUNIT__DIR will be available
+// Composer autoloader must be loaded before any tests run.
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
-// Give access to tests_add_filter() function.
-require_once getenv( 'WP_PHPUNIT_DIR' ) . '/includes/functions.php';
+// Only attempt to load the WordPress test suite if the path is provided.
+$wp_phpunit_dir = getenv( 'WP_PHPUNIT_DIR' );
 
-/**
- * Manually load the plugin being tested.
- */
-function _manually_load_plugin() {
-    require dirname( __DIR__ ) . '/real-treasury-business-case-builder.php';
+if ( $wp_phpunit_dir && file_exists( $wp_phpunit_dir . '/includes/functions.php' ) ) {
+    // Give access to tests_add_filter() function.
+    require_once $wp_phpunit_dir . '/includes/functions.php';
+
+    /**
+     * Manually load the plugin being tested.
+     */
+    function rtbcb_manually_load_plugin() {
+        require dirname( __DIR__ ) . '/real-treasury-business-case-builder.php';
+    }
+
+    tests_add_filter( 'muplugins_loaded', 'rtbcb_manually_load_plugin' );
+
+    // Start up the WP testing environment.
+    require_once $wp_phpunit_dir . '/includes/bootstrap.php';
 }
 
-tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
-
-// Start up the WP testing environment.
-require getenv( 'WP_PHPUNIT_DIR' ) . '/includes/bootstrap.php';


### PR DESCRIPTION
## Summary
- Load WordPress test suite only when available to prevent failing API-related tests
- Display API health test error messages in the unified dashboard

## Testing
- `npm test` *(fails: Class "PHPUnit\TextUI\Command" not found)*
- `find . -name "*.php" -not -path "./vendor/*" -exec php -l {} \;`


------
https://chatgpt.com/codex/tasks/task_e_68aedb09c1d88331915a4a419b7bf62c