### PR TITLE
Ensure dashboard initialization waits for jQuery

### DIFF
--- a/admin/js/unified-test-dashboard.js
+++ b/admin/js/unified-test-dashboard.js
@@ -1580,6 +1580,17 @@ if (typeof jQuery !== 'undefined') {
     })(jQuery);
 }
 
+function waitForDashboardAndInit() {
+    if ( typeof jQuery === 'undefined' ) {
+        setTimeout( waitForDashboardAndInit, RETRY_DELAY );
+        return;
+    }
+
+    jQuery( function() {
+        check();
+    } );
+}
+
 // Start initialization: wait for rtbcbDashboard to be available, then initialize dashboard logic
 waitForDashboardAndInit();
 })();


### PR DESCRIPTION
## Summary
- Add waitForDashboardAndInit helper to defer check() until jQuery is loaded and DOM is ready
- Maintain dashboard initialization logic to ensure button events bind in order

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config "@wordpress/eslint-plugin/recommended")*
- `npm run test:js`


------
https://chatgpt.com/codex/tasks/task_e_68aefd1661e083319e23fc7a19880ae4