### PR TITLE
Allow underscores in OpenAI API key validation

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -273,7 +273,7 @@ function rtbcb_is_business_email( $email ) {
  * @return bool Whether the format is valid.
  */
 function rtbcb_is_valid_openai_api_key( $api_key ) {
-    return preg_match( '/^sk-[A-Za-z0-9:_-]{48,}$/', $api_key );
+    return preg_match( '/^sk-[A-Za-z0-9_:-]{48,}$/', $api_key );
 }
 
 /**

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -273,7 +273,7 @@ function rtbcb_is_business_email( $email ) {
  * @return bool Whether the format is valid.
  */
 function rtbcb_is_valid_openai_api_key( $api_key ) {
-    return preg_match( '/^sk-[A-Za-z0-9]{48,}$/', $api_key );
+    return preg_match( '/^sk-[A-Za-z0-9:_-]{48,}$/', $api_key );
 }
 
 /**

--- a/tests/openai-api-key-validation.test.php
+++ b/tests/openai-api-key-validation.test.php
@@ -1,0 +1,37 @@
+<?php
+
+define( 'ABSPATH', __DIR__ . '/../' );
+
+if ( ! function_exists( 'add_filter' ) ) {
+    function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+        // No-op for testing.
+    }
+}
+
+require_once __DIR__ . '/../inc/helpers.php';
+
+$valid_keys = [
+    'sk-' . str_repeat( 'A', 20 ) . '_' . str_repeat( 'B', 27 ),
+    'sk-' . str_repeat( 'A', 20 ) . ':' . str_repeat( 'B', 27 ),
+];
+
+foreach ( $valid_keys as $key ) {
+    if ( ! rtbcb_is_valid_openai_api_key( $key ) ) {
+        echo "Valid key failed: {$key}\n";
+        exit( 1 );
+    }
+}
+
+$invalid_keys = [
+    'sk-' . str_repeat( 'A', 47 ),
+    'sk-' . str_repeat( 'A', 20 ) . '+' . str_repeat( 'B', 27 ),
+];
+
+foreach ( $invalid_keys as $key ) {
+    if ( rtbcb_is_valid_openai_api_key( $key ) ) {
+        echo "Invalid key passed: {$key}\n";
+        exit( 1 );
+    }
+}
+
+echo "openai-api-key-validation.test.php passed\n";

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -39,16 +39,20 @@ php tests/api-tester-gpt5-mini.test.php
 echo "9. Running reasoning-first output test..."
 php tests/reasoning-first-output.test.php
 
+# OpenAI API key validation test
+echo "10. Running OpenAI API key validation test..."
+php tests/openai-api-key-validation.test.php
+
 # AJAX error handling test (PHPUnit)
-echo "10. Running AJAX error handling test..."
+echo "11. Running AJAX error handling test..."
 phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
 
 # Admin AJAX report generation tests
-echo "11. Running admin AJAX report generation tests..."
+echo "12. Running admin AJAX report generation tests..."
 phpunit tests/RTBCB_AdminAjaxReportTest.php
 
 # JavaScript tests
-echo "12. Running JavaScript tests..."
+echo "13. Running JavaScript tests..."
 node tests/handle-submit-error.test.js
 node tests/render-results-no-narrative.test.js
 node tests/handle-submit-success.test.js
@@ -57,10 +61,10 @@ node tests/temperature-model.test.js
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then
-    echo "13. Running WordPress coding standards check..."
+    echo "14. Running WordPress coding standards check..."
     phpcs --standard=WordPress --ignore=vendor .
 else
-    echo "13. Skipping WordPress coding standards (phpcs not installed)"
+    echo "14. Skipping WordPress coding standards (phpcs not installed)"
 fi
 
 echo "================================================"


### PR DESCRIPTION
## Summary
- permit underscores, colons, and hyphens in OpenAI API keys via updated regex
- add regression test validating underscore and colon usage in API keys
- run new API key validation test in test suite

## Testing
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af408c2af88331be5da93574e392e6