### PR TITLE
Proxy OpenAI responses server-side

### DIFF
--- a/public/js/rtbcb-report.js
+++ b/public/js/rtbcb-report.js
@@ -302,13 +302,13 @@ async function generateProfessionalReport(businessContext) {
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         try {
-            const response = await fetch('https://api.openai.com/v1/responses', {
+            const formData = new FormData();
+            formData.append('action', 'rtbcb_openai_responses');
+            formData.append('body', JSON.stringify(requestBody));
+
+            const response = await fetch(rtbcbReport.ajax_url, {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${rtbcbReport.api_key}`
-                },
-                body: JSON.stringify(requestBody)
+                body: formData
             });
 
             if (!response.ok) {

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -97,6 +97,8 @@ class Real_Treasury_BCB {
         // AJAX handlers
         add_action( 'wp_ajax_rtbcb_generate_case', [ $this, 'ajax_generate_comprehensive_case_debug' ] );
         add_action( 'wp_ajax_nopriv_rtbcb_generate_case', [ $this, 'ajax_generate_comprehensive_case_debug' ] );
+        add_action( 'wp_ajax_rtbcb_openai_responses', 'rtbcb_proxy_openai_responses' );
+        add_action( 'wp_ajax_nopriv_rtbcb_openai_responses', 'rtbcb_proxy_openai_responses' );
 
         $this->init_hooks_debug();
     }
@@ -465,10 +467,10 @@ class Real_Treasury_BCB {
             'rtbcb-report',
             'rtbcbReport',
             [
-                'api_key'            => $api_key,
                 'report_model'       => $report_model,
                 'defaults'           => $config_localized,
                 'model_capabilities' => $model_capabilities,
+                'ajax_url'           => admin_url( 'admin-ajax.php' ),
             ]
         );
     }

--- a/tests/temperature-model.test.js
+++ b/tests/temperature-model.test.js
@@ -11,11 +11,16 @@ const { execSync } = require('child_process');
     const unsupportedModels = [...capabilities.temperature.unsupported, 'gpt-5-mini'];
     const supportedModels = ['gpt-4o', 'gpt-4.1-preview'];
 
+    global.FormData = class {
+        constructor() { this.store = {}; }
+        append(key, value) { this.store[key] = value; }
+    };
+
     for (const model of [...unsupportedModels, ...supportedModels]) {
         let capturedBody;
-        global.rtbcbReport = { report_model: model, api_key: 'test', model_capabilities: capabilities };
+        global.rtbcbReport = { report_model: model, model_capabilities: capabilities, ajax_url: 'https://example.com' };
         global.fetch = async (url, options) => {
-            capturedBody = JSON.parse(options.body);
+            capturedBody = JSON.parse(options.body.store.body);
             return { ok: true, json: async () => ({ output_text: '<html></html>' }) };
         };
         global.document = { getElementById: () => null };


### PR DESCRIPTION
## Summary
- Register new AJAX handlers to proxy OpenAI Responses API calls
- Strip API key from localized script and expose `ajax_url` instead
- Forward OpenAI requests server-side and update report generator to use the proxy

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af4091259483318f12ab76b18228cc