### PR TITLE
Document testing dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,15 @@ add_filter('rtbcb_category_scores', function($scores, $inputs) {
 
 ## 🧪 Testing and Quality Assurance
 
+### Testing Dashboard
+Use the unified testing dashboard to verify each report component. This
+dashboard replaces individual test pages from earlier versions. Navigate to
+**Real Treasury → Test Dashboard** in the WordPress admin to access it. The
+page is restricted to users with the `manage_options` capability. AJAX
+actions from the dashboard require nonces such as `rtbcb_test_company_overview`,
+`rtbcb_test_estimated_benefits`, and `rtbcb_test_dashboard` when saving
+results.
+
 ### Automated Tests
 The plugin includes integration tests for all major components. These can be run from the settings page via the **Run Diagnostics** button or programmatically:
 ```php

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -54,7 +54,7 @@ function rtbcb_model_supports_temperature( $model ) {
 }
 
 /**
- * Get dashboard sections and their completion state.
+ * Get testing dashboard sections and their completion state.
  *
  * The returned array is keyed by section ID and contains the section label,
  * related option key, dependencies, and whether the section has been
@@ -104,22 +104,22 @@ function rtbcb_get_dashboard_sections() {
 }
 
 /**
- * Ensure all previous steps are complete before rendering a page.
+ * Ensure required sections are complete before rendering a dashboard section.
  *
- * Outputs a warning linking to the starting page when prerequisites are
- * missing.
+ * Outputs a warning linking to the first incomplete section when prerequisites
+ * are missing.
  *
- * @param string $current_page Current page slug.
+ * @param string $current_section Current section ID.
  * @return bool True when allowed, false otherwise.
  */
-function rtbcb_require_completed_steps( $current_page ) {
+function rtbcb_require_completed_steps( $current_section ) {
     $sections = rtbcb_get_dashboard_sections();
 
-    if ( empty( $sections[ $current_page ]['requires'] ) ) {
+    if ( empty( $sections[ $current_section ]['requires'] ) ) {
         return true;
     }
 
-    foreach ( $sections[ $current_page ]['requires'] as $dependency ) {
+    foreach ( $sections[ $current_section ]['requires'] as $dependency ) {
         if ( empty( $sections[ $dependency ]['completed'] ) ) {
             $url = admin_url( 'admin.php?page=rtbcb-test-dashboard#' . $dependency );
             echo '<div class="notice notice-error"><p>' .
@@ -139,8 +139,8 @@ function rtbcb_require_completed_steps( $current_page ) {
 /**
  * Render a button to start a new company analysis.
  *
- * The button clears existing company data and redirects to the Company Overview
- * page so a new analysis can begin.
+ * The button clears existing company data and navigates to the Company
+ * Overview section of the testing dashboard so a new analysis can begin.
  *
  * @return void
  */

--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,13 @@ Use the `[rt_business_case_builder]` shortcode to embed the calculator on any pa
 2. Activate the plugin through the "Plugins" menu in WordPress.
 3. Navigate to **Real Treasury → Settings** to configure ROI defaults and API keys.
 
+== Testing Dashboard ==
+From the WordPress admin, go to **Real Treasury → Test Dashboard** to run
+section tests for company overview, recommended category, and more. The
+dashboard replaces the individual test pages from earlier versions. Access
+requires the `manage_options` capability and each test action uses a dedicated
+nonce such as `rtbcb_test_company_overview` to protect requests.
+
 == Frequently Asked Questions ==
 = How do I display the calculator? =
 Add the `[rt_business_case_builder]` shortcode to a post or page.


### PR DESCRIPTION
## Summary
- document unified testing dashboard in plugin docs
- update helper utilities to reference dashboard sections instead of individual pages

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af4e9164908331ba164200c488eaff