### PR TITLE
Refactor dashboard test results and add quick actions

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -113,6 +113,8 @@ class RTBCB_Admin {
                 'generating'          => __( 'Generating...', 'rtbcb' ),
                 'copied'              => __( 'Copied to clipboard.', 'rtbcb' ),
                 'retry'               => __( 'Retry', 'rtbcb' ),
+                'view'                => __( 'View', 'rtbcb' ),
+                'rerun'               => __( 'Re-run', 'rtbcb' ),
             ],
         ] );
 
@@ -360,7 +362,15 @@ class RTBCB_Admin {
             ];
         }
 
-        update_option( 'rtbcb_test_results', $sanitized );
+        $existing    = get_option( 'rtbcb_test_results', [] );
+        $existing    = is_array( $existing ) ? $existing : [];
+        $combined    = array_merge( $sanitized, $existing );
+        $max_results = 10;
+        if ( count( $combined ) > $max_results ) {
+            $combined = array_slice( $combined, 0, $max_results );
+        }
+
+        update_option( 'rtbcb_test_results', $combined );
 
         wp_send_json_success();
     }

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -486,6 +486,14 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
       var status = $('#rtbcb-test-status');
       var tableBody = $('#rtbcb-test-results-summary tbody');
       var originalText = button.text();
+      var sectionMap = {
+        'Company Overview': 'rtbcb-test-company-overview',
+        'Treasury Tech Overview': 'rtbcb-test-treasury-tech-overview',
+        'Industry Overview': 'rtbcb-test-industry-overview',
+        'Real Treasury Overview': 'rtbcb-test-real-treasury-overview',
+        'Recommended Category': 'rtbcb-test-recommended-category',
+        'Estimated Benefits': 'rtbcb-test-estimated-benefits'
+      };
       var runTests = _async(function () {
         var tests = [{
           action: 'rtbcb_test_company_overview',
@@ -533,7 +541,9 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
           }, _empty), function () {
             tableBody.empty();
             results.forEach(function (item) {
-              var row = '<tr><td>' + item.section + '</td><td>' + item.status + '</td><td>' + item.message + '</td><td>' + new Date().toLocaleString() + '</td></tr>';
+              var sectionId = sectionMap[item.section] || '';
+              var actions = sectionId ? '<a href="#' + sectionId + '" class="rtbcb-jump-tab">' + rtbcbAdmin.strings.view + '</a> | <a href="#" class="rtbcb-rerun-test" data-section="' + sectionId + '">' + rtbcbAdmin.strings.rerun + '</a>' : '';
+              var row = '<tr><td>' + item.section + '</td><td>' + item.status + '</td><td>' + item.message + '</td><td>' + new Date().toLocaleString() + '</td><td>' + actions + '</td></tr>';
               tableBody.append(row);
             });
             status.text('');

--- a/admin/partials/dashboard-connectivity.php
+++ b/admin/partials/dashboard-connectivity.php
@@ -42,6 +42,8 @@ $company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_d
         <?php wp_nonce_field( 'rtbcb_set_company', 'rtbcb_set_company_nonce' ); ?>
     </p>
     <p id="rtbcb-connectivity-status"></p>
+
+    <?php include RTBCB_DIR . 'admin/partials/dashboard-test-results.php'; ?>
 </div>
 <script>
 (function($){

--- a/admin/partials/dashboard-test-results.php
+++ b/admin/partials/dashboard-test-results.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Dashboard recent test results.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$max_results  = 10;
+$recent_results = [];
+if ( ! empty( $test_results ) && is_array( $test_results ) ) {
+    $recent_results = array_slice( $test_results, 0, $max_results );
+}
+
+$sections     = rtbcb_get_dashboard_sections();
+?>
+
+<h2 class="title"><?php esc_html_e( 'Recent Test Results', 'rtbcb' ); ?></h2>
+<table class="widefat striped" id="rtbcb-test-results-summary">
+    <thead>
+        <tr>
+            <th><?php esc_html_e( 'Section', 'rtbcb' ); ?></th>
+            <th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
+            <th><?php esc_html_e( 'Message', 'rtbcb' ); ?></th>
+            <th><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
+            <th><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php if ( ! empty( $recent_results ) ) : ?>
+        <?php foreach ( $recent_results as $result ) : ?>
+            <?php
+            $section_id    = isset( $result['section'] ) ? sanitize_text_field( $result['section'] ) : '';
+            $section_label = isset( $sections[ $section_id ]['label'] ) ? $sections[ $section_id ]['label'] : $section_id;
+            ?>
+            <tr>
+                <td><?php echo esc_html( $section_label ); ?></td>
+                <td><?php echo esc_html( $result['status'] ); ?></td>
+                <td><?php echo esc_html( $result['message'] ); ?></td>
+                <td><?php echo esc_html( $result['timestamp'] ); ?></td>
+                <td>
+                    <?php if ( $section_id ) : ?>
+                        <a href="#<?php echo esc_attr( $section_id ); ?>" class="rtbcb-jump-tab"><?php esc_html_e( 'View', 'rtbcb' ); ?></a>
+                        |
+                        <a href="#" class="rtbcb-rerun-test" data-section="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Re-run', 'rtbcb' ); ?></a>
+                    <?php endif; ?>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+    <?php else : ?>
+        <tr>
+            <td colspan="5"><?php esc_html_e( 'No test results found.', 'rtbcb' ); ?></td>
+        </tr>
+    <?php endif; ?>
+    </tbody>
+</table>
+<script>
+(function($){
+    $('#rtbcb-test-results-summary').on('click', '.rtbcb-jump-tab', function(e){
+        e.preventDefault();
+        var target = $(this).attr('href');
+        $('#rtbcb-test-tabs a[href="' + target + '"]').trigger('click');
+    });
+    $('#rtbcb-test-results-summary').on('click', '.rtbcb-rerun-test', function(e){
+        e.preventDefault();
+        var section = $(this).data('section');
+        $('#rtbcb-test-tabs a[href="#' + section + '"]').trigger('click');
+        $('#' + section).find('form').first().trigger('submit');
+    });
+})(jQuery);
+</script>

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -86,36 +86,6 @@ $company = rtbcb_get_current_company();
         <?php include RTBCB_DIR . 'admin/partials/test-report.php'; ?>
     </div>
 
-    <div class="card">
-        <h2 class="title"><?php esc_html_e( 'Recent Test Results', 'rtbcb' ); ?></h2>
-        <table class="widefat striped" id="rtbcb-test-results-summary">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e( 'Section', 'rtbcb' ); ?></th>
-                    <th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
-                    <th><?php esc_html_e( 'Message', 'rtbcb' ); ?></th>
-                    <th><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-            <?php if ( ! empty( $test_results ) ) : ?>
-                <?php foreach ( $test_results as $result ) : ?>
-                    <tr>
-                        <td><?php echo esc_html( $result['section'] ); ?></td>
-                        <td><?php echo esc_html( $result['status'] ); ?></td>
-                        <td><?php echo esc_html( $result['message'] ); ?></td>
-                        <td><?php echo esc_html( $result['timestamp'] ); ?></td>
-                    </tr>
-                <?php endforeach; ?>
-            <?php else : ?>
-                <tr>
-                    <td colspan="4"><?php esc_html_e( 'No test results found.', 'rtbcb' ); ?></td>
-                </tr>
-            <?php endif; ?>
-            </tbody>
-        </table>
-    </div>
-
     <script>
     jQuery(function($){
         $('#rtbcb-test-tabs a').on('click', function(e){


### PR DESCRIPTION
## Summary
- move test results into a reusable partial and include it with connectivity tests
- display only the latest 10 entries with View/Re-run links
- persist and localize recent results for dashboard actions

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68af55807e2c8331b0e58100b50f623c