### PR TITLE
Enhance test dashboard partials with summaries and cards

### DIFF
--- a/admin/js/company-overview.js
+++ b/admin/js/company-overview.js
@@ -4,6 +4,8 @@
     $(function() {
         const generateBtn = $('#rtbcb-generate-company-overview');
         const resultsDiv = $('#rtbcb-company-overview-results');
+        const card = $('#rtbcb-company-overview-card');
+        const metaDiv = $('#rtbcb-company-overview-meta');
 
         function sendRequest(companyName) {
             console.log('Starting simple company overview request');
@@ -39,8 +41,7 @@
         }
 
         function displaySimpleResults(data) {
-            let html = '<div class="simple-results">';
-            html += '<h3>Connection Test Results</h3>';
+            let html = '';
             html += '<p><strong>Status:</strong> ' + data.status + '</p>';
             html += '<p><strong>Message:</strong> ' + data.message + '</p>';
 
@@ -55,15 +56,30 @@
                     });
                     html += '</ul>';
                 }
+
+                if (data.simple_analysis.references) {
+                    metaDiv.html('<p><strong>Sources:</strong> ' + data.simple_analysis.references.join(', ') + '</p>');
+                }
             }
 
-            html += '</div>';
             resultsDiv.html(html);
+            card.show();
         }
 
         function showError(message) {
             resultsDiv.html('<div class="error-message" style="color: red; padding: 10px; border: 1px solid red;">' + message + '</div>');
         }
+
+        $('#rtbcb-regenerate-company-overview').on('click', function() {
+            generateBtn.trigger('click');
+        });
+
+        $('#rtbcb-copy-company-overview').on('click', function() {
+            var text = resultsDiv.text();
+            if (navigator.clipboard) {
+                navigator.clipboard.writeText(text);
+            }
+        });
 
         generateBtn.on('click', function(e) {
             e.preventDefault();

--- a/admin/js/real-treasury-overview.js
+++ b/admin/js/real-treasury-overview.js
@@ -5,6 +5,7 @@
         const generateBtn = $('#rtbcb-generate-real-treasury-overview');
         const clearBtn = $('#rtbcb-clear-real-treasury-overview');
         const resultsDiv = $('#rtbcb-real-treasury-overview-results');
+        const card = $('#rtbcb-real-treasury-overview-card');
         const includePortal = $('#rtbcb-include-portal');
         const categoriesSelect = $('#rtbcb-vendor-categories');
         const overrideCategories = $('#rtbcb-override-categories');
@@ -46,6 +47,7 @@
 
             const start = performance.now();
             const original = rtbcbTestUtils.showLoading(generateBtn, 'Generating...');
+            card.show();
             resultsDiv.html('<p>Generating overview...</p>');
 
             $.ajax({
@@ -66,25 +68,12 @@
                             elapsed_time: data.elapsed,
                             generated_at: data.generated
                         });
-                        const actions = $('<p />');
-                        const regen = $('<button type="button" class="button" />').text('Regenerate');
-                        const copy = $('<button type="button" class="button" />').text('Copy');
-                        const clear = $('<button type="button" class="button" />').text('Clear');
-                        regen.on('click', function() {
+                        $('#rtbcb-regenerate-real-treasury-overview').on('click', function(){
                             generateBtn.trigger('click');
                         });
-                        copy.on('click', function() {
-                            rtbcbTestUtils.copyToClipboard(text).then(function(){
-                                alert('Copied to clipboard');
-                            }).catch(function(err){
-                                alert('Copy failed: ' + err.message);
-                            });
+                        $('#rtbcb-copy-real-treasury-overview').on('click', function(){
+                            rtbcbTestUtils.copyToClipboard(text);
                         });
-                        clear.on('click', function() {
-                            clearBtn.trigger('click');
-                        });
-                        actions.append(regen).append(' ').append(copy).append(' ').append(clear);
-                        resultsDiv.find('.notice').append(actions);
                     } else {
                         rtbcbTestUtils.renderError(resultsDiv, response.data.message || 'Failed to generate overview', function(){
                             generateBtn.trigger('click');
@@ -107,6 +96,7 @@
             overrideCategories.prop('checked', false);
             categoriesSelect.val([]).hide();
             resultsDiv.html('');
+            card.hide();
         });
     });
 })(jQuery);

--- a/admin/js/recommended-category.js
+++ b/admin/js/recommended-category.js
@@ -4,6 +4,7 @@
     $(document).ready(function() {
         const $generateBtn = $('#rtbcb-generate-category-recommendation');
         const $resultsDiv = $('#rtbcb-category-recommendation-results');
+        const $card = $('#rtbcb-category-recommendation-card');
 
         function sendRequest() {
             const data = {
@@ -13,6 +14,7 @@
             };
 
             const original = rtbcbTestUtils.showLoading($generateBtn, 'Generating...');
+            $card.show();
             $resultsDiv.html('<p>Generating recommendation...</p>');
 
             $.ajax({
@@ -47,6 +49,12 @@
                             html += '<p><strong>Success Factors:</strong> ' + $('<div/>').text(rec.success_factors).html() + '</p>';
                         }
                         $resultsDiv.html(html);
+                        $('#rtbcb-regenerate-category-recommendation').on('click', function(){
+                            $generateBtn.trigger('click');
+                        });
+                        $('#rtbcb-copy-category-recommendation').on('click', function(){
+                            rtbcbTestUtils.copyToClipboard($resultsDiv.text());
+                        });
                     } else {
                         const message = (response.data && response.data.message) ? response.data.message : 'Failed to generate recommendation.';
                         rtbcbTestUtils.renderError($resultsDiv, message, sendRequest);

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -845,6 +845,7 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
                   if (iframe) {
                     iframe.srcdoc = data.data.html || data.data.report_html;
                   }
+                  document.getElementById('rtbcb-report-preview-card').style.display = 'block';
                   document.getElementById('rtbcb-download-pdf').style.display = 'inline-block';
                 } else {
                   var message = data.data && data.data.message ? data.data.message : rtbcbAdmin.strings.error;

--- a/admin/js/treasury-tech-overview.js
+++ b/admin/js/treasury-tech-overview.js
@@ -5,6 +5,7 @@
         const generateBtn = $('#rtbcb-generate-treasury-tech-overview');
         const clearBtn = $('#rtbcb-clear-treasury-tech-overview');
         const resultsDiv = $('#rtbcb-treasury-tech-overview-results');
+        const card = $('#rtbcb-treasury-tech-overview-card');
 
         generateBtn.on('click', function() {
             const focusAreas = [];
@@ -21,6 +22,7 @@
 
             const start = performance.now();
             const original = rtbcbTestUtils.showLoading(generateBtn, 'Generating...');
+            card.show();
             resultsDiv.html('<p>Generating overview...</p>');
 
             $.ajax({
@@ -41,25 +43,13 @@
                             elapsed_time: data.elapsed,
                             generated_at: data.generated
                         });
-                        const actions = $('<p />');
-                        const regen = $('<button type="button" class="button" />').text('Regenerate');
-                        const copy = $('<button type="button" class="button" />').text('Copy');
-                        const clear = $('<button type="button" class="button" />').text('Clear');
-                        regen.on('click', function() {
+                        $('#rtbcb-regenerate-treasury-tech-overview').on('click', function(){
                             generateBtn.trigger('click');
                         });
-                        copy.on('click', function() {
-                            rtbcbTestUtils.copyToClipboard(text).then(function(){
-                                alert('Copied to clipboard');
-                            }).catch(function(err){
-                                alert('Copy failed: ' + err.message);
-                            });
+                        $('#rtbcb-copy-treasury-tech-overview').on('click', function(){
+                            rtbcbTestUtils.copyToClipboard(text);
                         });
-                        clear.on('click', function() {
-                            clearBtn.trigger('click');
-                        });
-                        actions.append(regen).append(' ').append(copy).append(' ').append(clear);
-                        resultsDiv.find('.notice').append(actions);
+                        card.show();
                     } else {
                         rtbcbTestUtils.renderError(resultsDiv, response.data.message || 'Failed to generate overview', function(){
                             generateBtn.trigger('click');

--- a/admin/partials/test-api.php
+++ b/admin/partials/test-api.php
@@ -10,8 +10,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <h2><?php esc_html_e( 'OpenAI API Test', 'rtbcb' ); ?></h2>
-<div id="rtbcb-test-results" style="margin: 20px 0;">
-    <p><?php esc_html_e( 'Click the button below to test your OpenAI API connection:', 'rtbcb' ); ?></p>
+<p class="description"><?php esc_html_e( 'Verify that your API credentials and network connection are working properly.', 'rtbcb' ); ?></p>
+<?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-api-test', $test_results ?? [] ); ?>
+<?php if ( $rtbcb_last ) : ?>
+    <div class="notice notice-info" role="status">
+        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+        <p class="submit">
+            <button type="button" class="button" onclick="document.getElementById('rtbcb-api-test-card').scrollIntoView();">
+                <?php esc_html_e( 'View Details', 'rtbcb' ); ?>
+            </button>
+        </p>
+    </div>
+<?php endif; ?>
+<div id="rtbcb-api-test-card" class="rtbcb-result-card">
+    <details>
+        <summary><?php esc_html_e( 'Test Output', 'rtbcb' ); ?></summary>
+        <div id="rtbcb-test-results" style="margin: 20px 0;">
+            <p><?php esc_html_e( 'Click the button below to test your OpenAI API connection:', 'rtbcb' ); ?></p>
+        </div>
+    </details>
 </div>
 <button type="button" id="rtbcb-test-api-btn" class="button button-primary">
     <?php esc_html_e( 'Test API Connection', 'rtbcb' ); ?>

--- a/admin/partials/test-company-overview.php
+++ b/admin/partials/test-company-overview.php
@@ -10,6 +10,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <h2><?php esc_html_e( 'Test Company Overview', 'rtbcb' ); ?></h2>
+<p class="description"><?php esc_html_e( 'Generate a concise company profile using your configured AI model.', 'rtbcb' ); ?></p>
+<?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-company-overview', $test_results ?? [] ); ?>
+<?php if ( $rtbcb_last ) : ?>
+    <div class="notice notice-info" role="status">
+        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+        <p class="submit">
+            <button type="button" class="button" id="rtbcb-rerun-company-overview" data-section="rtbcb-test-company-overview">
+                <?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>
+            </button>
+        </p>
+    </div>
+<?php endif; ?>
 <div class="card">
     <h3 class="title"><?php esc_html_e( 'Generate Company Overview', 'rtbcb' ); ?></h3>
     <p><?php esc_html_e( 'Enter a company name to generate an AI-powered overview using the configured LLM.', 'rtbcb' ); ?></p>
@@ -30,33 +44,34 @@ if ( ! defined( 'ABSPATH' ) ) {
         <button type="button" id="rtbcb-generate-company-overview" class="button button-primary">
             <?php esc_html_e( 'Generate Overview', 'rtbcb' ); ?>
         </button>
-        <button type="button" id="rtbcb-regenerate-company-overview" class="button" style="display:none;">
-            <?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>
-        </button>
-        <button type="button" id="rtbcb-copy-company-overview" class="button" style="display:none;">
-            <?php esc_html_e( 'Copy to Clipboard', 'rtbcb' ); ?>
-        </button>
         <button type="button" id="rtbcb-clear-company-overview" class="button">
             <?php esc_html_e( 'Clear', 'rtbcb' ); ?>
         </button>
     </p>
 </div>
-<div id="rtbcb-company-overview-results"></div>
-<div id="rtbcb-company-overview-meta"></div>
+<div id="rtbcb-company-overview-card" class="rtbcb-result-card" style="display:none;">
+    <details>
+        <summary><?php esc_html_e( 'Generated Overview', 'rtbcb' ); ?></summary>
+        <div id="rtbcb-company-overview-results"></div>
+        <div id="rtbcb-company-overview-meta" class="rtbcb-meta"></div>
+        <p class="rtbcb-actions">
+            <button type="button" id="rtbcb-regenerate-company-overview" class="button">
+                <?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>
+            </button>
+            <button type="button" id="rtbcb-copy-company-overview" class="button">
+                <?php esc_html_e( 'Copy to Clipboard', 'rtbcb' ); ?>
+            </button>
+        </p>
+    </details>
+</div>
 <style>
-#rtbcb-company-overview-results {
+#rtbcb-company-overview-card details {
     margin-top: 20px;
 }
-
-#rtbcb-company-overview-results .notice {
-    margin: 5px 0;
-}
-
 #rtbcb-company-overview-results div[style*="background"] {
     white-space: pre-wrap;
     line-height: 1.6;
 }
-
 #rtbcb-company-overview-meta {
     margin-top: 10px;
 }
@@ -65,4 +80,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php if ( ! isset( $GLOBALS['ajaxurl'] ) || empty( $GLOBALS['ajaxurl'] ) ) : ?>
 var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
 <?php endif; ?>
+document.getElementById( 'rtbcb-rerun-company-overview' )?.addEventListener( 'click', function() {
+    document.getElementById( 'rtbcb-generate-company-overview' ).click();
+});
 </script>

--- a/admin/partials/test-estimated-benefits.php
+++ b/admin/partials/test-estimated-benefits.php
@@ -28,6 +28,20 @@ $recommended_category = get_option( 'rtbcb_last_recommended_category', '' );
 $categories           = RTBCB_Category_Recommender::get_all_categories();
 ?>
 <h2><?php esc_html_e( 'Test Estimated Benefits', 'rtbcb' ); ?></h2>
+<p class="description"><?php esc_html_e( 'Estimate potential savings and efficiency gains based on company metrics.', 'rtbcb' ); ?></p>
+<?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-estimated-benefits', $test_results ?? [] ); ?>
+<?php if ( $rtbcb_last ) : ?>
+    <div class="notice notice-info" role="status">
+        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+        <p class="submit">
+            <button type="button" class="button" id="rtbcb-rerun-benefits" data-section="rtbcb-test-estimated-benefits">
+                <?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>
+            </button>
+        </p>
+    </div>
+<?php endif; ?>
 <form id="rtbcb-benefits-estimate-form">
     <table class="form-table">
         <tr>
@@ -74,4 +88,14 @@ $categories           = RTBCB_Category_Recommender::get_all_categories();
         </button>
     </p>
 </form>
-<div id="rtbcb-benefits-estimate-results"></div>
+<div id="rtbcb-benefits-estimate-card" class="rtbcb-result-card">
+    <details>
+        <summary><?php esc_html_e( 'Estimated Benefits', 'rtbcb' ); ?></summary>
+        <div id="rtbcb-benefits-estimate-results"></div>
+    </details>
+</div>
+<script>
+document.getElementById( 'rtbcb-rerun-benefits' )?.addEventListener( 'click', function() {
+    jQuery( '#rtbcb-benefits-estimate-form' ).trigger( 'submit' );
+});
+</script>

--- a/admin/partials/test-industry-overview.php
+++ b/admin/partials/test-industry-overview.php
@@ -29,6 +29,20 @@ $company_sum  = isset( $company['summary'] ) ? sanitize_textarea_field( $company
 $company_ind  = isset( $company['industry'] ) ? sanitize_text_field( $company['industry'] ) : '';
 ?>
 <h2><?php esc_html_e( 'Test Industry Overview', 'rtbcb' ); ?></h2>
+<p class="description"><?php esc_html_e( 'Generate insights about the company\'s industry to inform later recommendations.', 'rtbcb' ); ?></p>
+<?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-industry-overview', $test_results ?? [] ); ?>
+<?php if ( $rtbcb_last ) : ?>
+    <div class="notice notice-info" role="status">
+        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+        <p class="submit">
+            <button type="button" class="button" id="rtbcb-rerun-industry-overview" data-section="rtbcb-test-industry-overview">
+                <?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>
+            </button>
+        </p>
+    </div>
+<?php endif; ?>
 <?php if ( ! empty( $company_name ) ) : ?>
     <h3><?php echo esc_html( $company_name ); ?></h3>
     <?php if ( ! empty( $company_sum ) ) : ?>
@@ -53,4 +67,14 @@ $company_ind  = isset( $company['industry'] ) ? sanitize_text_field( $company['i
         <button type="button" id="rtbcb-clear-results" class="button"><?php esc_html_e( 'Clear Results', 'rtbcb' ); ?></button>
     </p>
 </form>
-<div id="rtbcb-industry-overview-results"></div>
+<div id="rtbcb-industry-overview-card" class="rtbcb-result-card">
+    <details>
+        <summary><?php esc_html_e( 'Generated Overview', 'rtbcb' ); ?></summary>
+        <div id="rtbcb-industry-overview-results"></div>
+    </details>
+</div>
+<script>
+document.getElementById( 'rtbcb-rerun-industry-overview' )?.addEventListener( 'click', function() {
+    jQuery( '#rtbcb-industry-overview-form' ).trigger( 'submit' );
+});
+</script>

--- a/admin/partials/test-real-treasury-overview.php
+++ b/admin/partials/test-real-treasury-overview.php
@@ -24,6 +24,20 @@ if ( empty( $company ) ) {
 }
 ?>
 <h2><?php esc_html_e( 'Test Real Treasury Overview Generation', 'rtbcb' ); ?></h2>
+<p class="description"><?php esc_html_e( 'Create a tailored treasury overview based on company data and selected options.', 'rtbcb' ); ?></p>
+<?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-real-treasury-overview', $test_results ?? [] ); ?>
+<?php if ( $rtbcb_last ) : ?>
+    <div class="notice notice-info" role="status">
+        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+        <p class="submit">
+            <button type="button" class="button" id="rtbcb-rerun-real-treasury" data-section="rtbcb-test-real-treasury-overview">
+                <?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>
+            </button>
+        </p>
+    </div>
+<?php endif; ?>
 <div class="card">
     <h3 class="title"><?php esc_html_e( 'Generate Real Treasury Overview', 'rtbcb' ); ?></h3>
     <p><?php esc_html_e( 'Configure options and generate an overview.', 'rtbcb' ); ?></p>
@@ -76,14 +90,21 @@ if ( empty( $company ) ) {
             <?php esc_html_e( 'Clear Results', 'rtbcb' ); ?>
         </button>
     </p>
+    </div>
+<div id="rtbcb-real-treasury-overview-card" class="rtbcb-result-card" style="display:none;">
+    <details>
+        <summary><?php esc_html_e( 'Generated Overview', 'rtbcb' ); ?></summary>
+        <div id="rtbcb-real-treasury-overview-results"></div>
+        <div id="rtbcb-real-treasury-overview-meta" class="rtbcb-meta"></div>
+        <p class="rtbcb-actions">
+            <button type="button" id="rtbcb-regenerate-real-treasury-overview" class="button"><?php esc_html_e( 'Regenerate', 'rtbcb' ); ?></button>
+            <button type="button" id="rtbcb-copy-real-treasury-overview" class="button"><?php esc_html_e( 'Copy', 'rtbcb' ); ?></button>
+        </p>
+    </details>
 </div>
-<div id="rtbcb-real-treasury-overview-results"></div>
 <style>
-#rtbcb-real-treasury-overview-results {
+#rtbcb-real-treasury-overview-card details {
     margin-top: 20px;
-}
-#rtbcb-real-treasury-overview-results .notice {
-    margin: 5px 0;
 }
 #rtbcb-real-treasury-overview-results div[style*="background"] {
     white-space: pre-wrap;
@@ -94,4 +115,7 @@ if ( empty( $company ) ) {
 <?php if ( ! isset( $GLOBALS['ajaxurl'] ) || empty( $GLOBALS['ajaxurl'] ) ) : ?>
 var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
 <?php endif; ?>
+document.getElementById( 'rtbcb-rerun-real-treasury' )?.addEventListener( 'click', function() {
+    document.getElementById( 'rtbcb-generate-real-treasury-overview' ).click();
+});
 </script>

--- a/admin/partials/test-recommended-category.php
+++ b/admin/partials/test-recommended-category.php
@@ -28,6 +28,20 @@ $industry_insights   = get_option( 'rtbcb_industry_insights', '' );
 $treasury_challenges = get_option( 'rtbcb_treasury_challenges', '' );
 ?>
 <h2><?php esc_html_e( 'Test Category Recommendation Generation', 'rtbcb' ); ?></h2>
+<p class="description"><?php esc_html_e( 'Receive an AI-suggested treasury technology category based on gathered data.', 'rtbcb' ); ?></p>
+<?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-recommended-category', $test_results ?? [] ); ?>
+<?php if ( $rtbcb_last ) : ?>
+    <div class="notice notice-info" role="status">
+        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+        <p class="submit">
+            <button type="button" class="button" id="rtbcb-rerun-category" data-section="rtbcb-test-recommended-category">
+                <?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>
+            </button>
+        </p>
+    </div>
+<?php endif; ?>
 <form id="rtbcb-category-recommendation-form">
     <table class="form-table">
         <tr>
@@ -61,4 +75,18 @@ $treasury_challenges = get_option( 'rtbcb_treasury_challenges', '' );
         <button type="button" id="rtbcb-generate-category-recommendation" class="button button-primary"><?php esc_html_e( 'Generate Recommendation', 'rtbcb' ); ?></button>
     </p>
 </form>
-<div id="rtbcb-category-recommendation-results"></div>
+<div id="rtbcb-category-recommendation-card" class="rtbcb-result-card" style="display:none;">
+    <details>
+        <summary><?php esc_html_e( 'Recommendation', 'rtbcb' ); ?></summary>
+        <div id="rtbcb-category-recommendation-results"></div>
+        <p class="rtbcb-actions">
+            <button type="button" id="rtbcb-regenerate-category-recommendation" class="button"><?php esc_html_e( 'Regenerate', 'rtbcb' ); ?></button>
+            <button type="button" id="rtbcb-copy-category-recommendation" class="button"><?php esc_html_e( 'Copy', 'rtbcb' ); ?></button>
+        </p>
+    </details>
+</div>
+<script>
+document.getElementById( 'rtbcb-rerun-category' )?.addEventListener( 'click', function() {
+    document.getElementById( 'rtbcb-generate-category-recommendation' ).click();
+});
+</script>

--- a/admin/partials/test-report-preview.php
+++ b/admin/partials/test-report-preview.php
@@ -24,6 +24,20 @@ if ( empty( $company ) ) {
 }
 ?>
 <h2><?php esc_html_e( 'Report Preview', 'rtbcb' ); ?></h2>
+<p class="description"><?php esc_html_e( 'Preview the generated business case report before finalizing.', 'rtbcb' ); ?></p>
+<?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-report-preview', $test_results ?? [] ); ?>
+<?php if ( $rtbcb_last ) : ?>
+    <div class="notice notice-info" role="status">
+        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+        <p class="submit">
+            <button type="button" class="button" id="rtbcb-rerun-report-preview" data-section="rtbcb-report-preview">
+                <?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>
+            </button>
+        </p>
+    </div>
+<?php endif; ?>
 <form id="rtbcb-report-preview-form" method="post" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>">
     <input type="hidden" name="action" value="rtbcb_generate_report_preview" />
     <p>
@@ -58,6 +72,16 @@ if ( empty( $company ) ) {
         </button>
     </p>
 </form>
-<div id="rtbcb-report-preview">
-    <iframe id="rtbcb-report-iframe"></iframe>
+<div id="rtbcb-report-preview-card" class="rtbcb-result-card" style="display:none;">
+    <details>
+        <summary><?php esc_html_e( 'Preview', 'rtbcb' ); ?></summary>
+        <div id="rtbcb-report-preview">
+            <iframe id="rtbcb-report-iframe"></iframe>
+        </div>
+    </details>
 </div>
+<script>
+document.getElementById( 'rtbcb-rerun-report-preview' )?.addEventListener( 'click', function() {
+    document.getElementById( 'rtbcb-generate-report' ).click();
+});
+</script>

--- a/admin/partials/test-report.php
+++ b/admin/partials/test-report.php
@@ -20,6 +20,20 @@ if ( empty( $company ) ) {
 }
 ?>
 <h2><?php esc_html_e( 'Report Test', 'rtbcb' ); ?></h2>
+<p class="description"><?php esc_html_e( 'Generate a full business case report to test end-to-end content creation.', 'rtbcb' ); ?></p>
+<?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-report-test', $test_results ?? [] ); ?>
+<?php if ( $rtbcb_last ) : ?>
+    <div class="notice notice-info" role="status">
+        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+        <p class="submit">
+            <button type="button" class="button" id="rtbcb-rerun-report-test" data-section="rtbcb-report-test">
+                <?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>
+            </button>
+        </p>
+    </div>
+<?php endif; ?>
 <?php wp_nonce_field( 'rtbcb_test_generate_complete_report', 'rtbcb_complete_report_nonce' ); ?>
 <table class="form-table">
     <tr>
@@ -110,3 +124,8 @@ if ( empty( $company ) ) {
     </div>
 </div>
 <div id="rtbcb-report-preview" style="display:none;"></div>
+<script>
+document.getElementById( 'rtbcb-rerun-report-test' )?.addEventListener( 'click', function() {
+    document.getElementById( 'rtbcb-generate-report' ).click();
+});
+</script>

--- a/admin/partials/test-treasury-tech-overview.php
+++ b/admin/partials/test-treasury-tech-overview.php
@@ -47,6 +47,20 @@ if ( empty( $suggested_focus_areas ) && ! empty( $company_size ) ) {
 }
 ?>
 <h2><?php esc_html_e( 'Test Treasury Technology Overview', 'rtbcb' ); ?></h2>
+<p class="description"><?php esc_html_e( 'Assess the treasury technology landscape and highlight key focus areas.', 'rtbcb' ); ?></p>
+<?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-treasury-tech-overview', $test_results ?? [] ); ?>
+<?php if ( $rtbcb_last ) : ?>
+    <div class="notice notice-info" role="status">
+        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+        <p class="submit">
+            <button type="button" class="button" id="rtbcb-rerun-treasury-tech" data-section="rtbcb-test-treasury-tech-overview">
+                <?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>
+            </button>
+        </p>
+    </div>
+<?php endif; ?>
 <?php if ( $company_name || $company_size || $company_complexity ) : ?>
     <p><?php printf( esc_html__( 'Company: %1$s | Size: %2$s | Complexity: %3$s', 'rtbcb' ), esc_html( $company_name ), esc_html( $company_size ), esc_html( $company_complexity ) ); ?></p>
 <?php endif; ?>
@@ -87,14 +101,21 @@ if ( empty( $suggested_focus_areas ) && ! empty( $company_size ) ) {
             <?php esc_html_e( 'Clear', 'rtbcb' ); ?>
         </button>
     </p>
+    </div>
+<div id="rtbcb-treasury-tech-overview-card" class="rtbcb-result-card" style="display:none;">
+    <details>
+        <summary><?php esc_html_e( 'Generated Overview', 'rtbcb' ); ?></summary>
+        <div id="rtbcb-treasury-tech-overview-results"></div>
+        <div id="rtbcb-treasury-tech-overview-meta" class="rtbcb-meta"></div>
+        <p class="rtbcb-actions">
+            <button type="button" id="rtbcb-regenerate-treasury-tech-overview" class="button"><?php esc_html_e( 'Regenerate', 'rtbcb' ); ?></button>
+            <button type="button" id="rtbcb-copy-treasury-tech-overview" class="button"><?php esc_html_e( 'Copy', 'rtbcb' ); ?></button>
+        </p>
+    </details>
 </div>
-<div id="rtbcb-treasury-tech-overview-results"></div>
 <style>
-#rtbcb-treasury-tech-overview-results {
+#rtbcb-treasury-tech-overview-card details {
     margin-top: 20px;
-}
-#rtbcb-treasury-tech-overview-results .notice {
-    margin: 5px 0;
 }
 #rtbcb-treasury-tech-overview-results div[style*="background"] {
     white-space: pre-wrap;
@@ -105,4 +126,7 @@ if ( empty( $suggested_focus_areas ) && ! empty( $company_size ) ) {
 <?php if ( ! isset( $GLOBALS['ajaxurl'] ) || empty( $GLOBALS['ajaxurl'] ) ) : ?>
 var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
 <?php endif; ?>
+document.getElementById( 'rtbcb-rerun-treasury-tech' )?.addEventListener( 'click', function() {
+    document.getElementById( 'rtbcb-generate-treasury-tech-overview' ).click();
+});
 </script>

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -137,6 +137,31 @@ function rtbcb_require_completed_steps( $current_section ) {
 }
 
 /**
+ * Retrieve the most recent test result for a section.
+ *
+ * @param string     $section_id   Section identifier.
+ * @param array|null $test_results Optional preloaded test results.
+ * @return array|null Matching result or null when none found.
+ */
+function rtbcb_get_last_test_result( $section_id, $test_results = null ) {
+    if ( null === $test_results ) {
+        $test_results = get_option( 'rtbcb_test_results', [] );
+    }
+
+    if ( ! is_array( $test_results ) ) {
+        return null;
+    }
+
+    foreach ( $test_results as $result ) {
+        if ( isset( $result['section'] ) && $result['section'] === $section_id ) {
+            return $result;
+        }
+    }
+
+    return null;
+}
+
+/**
  * Render a button to start a new company analysis.
  *
  * The button clears existing company data and navigates to the Company


### PR DESCRIPTION
## Summary
- add helper to fetch latest test results by section
- show last test status and intro descriptions on each admin test tab
- display generated outputs in collapsible cards with copy/regenerate actions

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68af5d66595c8331abd9b5910db0d5f3