### PR TITLE
Add AJAX listeners for connectivity tests

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -42,7 +42,7 @@ class RTBCB_Admin {
         add_action( 'wp_ajax_rtbcb_get_company_data', [ $this, 'ajax_get_company_data' ] );
         add_action( 'wp_ajax_rtbcb_test_estimated_benefits', [ $this, 'ajax_test_estimated_benefits' ] );
         add_action( 'wp_ajax_rtbcb_save_test_results', [ $this, 'save_test_results' ] );
-        add_action( 'wp_ajax_rtbcb_set_company_name', [ $this, 'ajax_set_company_name' ] );
+        add_action( 'wp_ajax_rtbcb_set_test_company', [ $this, 'ajax_set_test_company' ] );
         add_action( 'wp_ajax_rtbcb_test_generate_complete_report', [ $this, 'ajax_test_generate_complete_report' ] );
         add_action( 'wp_ajax_rtbcb_test_complete_report', [ $this, 'ajax_test_generate_complete_report' ] );
         add_action( 'wp_ajax_rtbcb_test_calculate_roi', [ $this, 'ajax_test_calculate_roi' ] );
@@ -935,8 +935,8 @@ class RTBCB_Admin {
      *
      * @return void
      */
-    public function ajax_set_company_name() {
-        check_ajax_referer( 'rtbcb_set_company', 'nonce' );
+    public function ajax_set_test_company() {
+        check_ajax_referer( 'rtbcb_set_test_company', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
             wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );


### PR DESCRIPTION
## Summary
- Add server-side action to save test company with nonce validation
- Wire up dashboard buttons to run AJAX tests for API, portal, and RAG index with success/error notices
- Reset previous test results when company name is saved

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6096dfc08331922e1f87290fa980