### PR TITLE
Expose RAG index metrics in test dashboard

### DIFF
--- a/admin/partials/dashboard-connectivity.php
+++ b/admin/partials/dashboard-connectivity.php
@@ -15,18 +15,38 @@ $company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_d
 <div class="card">
     <h2 class="title"><?php esc_html_e( 'Connectivity Tests & Status', 'rtbcb' ); ?></h2>
     <table class="widefat striped">
+        <thead>
+            <tr>
+                <th><?php esc_html_e( 'Check', 'rtbcb' ); ?></th>
+                <th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
+                <th><?php esc_html_e( 'Indexed Items', 'rtbcb' ); ?></th>
+                <th><?php esc_html_e( 'Last Updated', 'rtbcb' ); ?></th>
+            </tr>
+        </thead>
         <tbody>
             <tr>
                 <th><?php esc_html_e( 'OpenAI API Key', 'rtbcb' ); ?></th>
                 <td><?php echo $openai_status ? esc_html__( 'Configured', 'rtbcb' ) : esc_html__( 'Missing', 'rtbcb' ); ?></td>
+                <td><?php esc_html_e( 'N/A', 'rtbcb' ); ?></td>
+                <td><?php esc_html_e( 'N/A', 'rtbcb' ); ?></td>
             </tr>
             <tr>
                 <th><?php esc_html_e( 'Portal Integration', 'rtbcb' ); ?></th>
                 <td><?php echo $portal_active ? esc_html__( 'Active', 'rtbcb' ) : esc_html__( 'Inactive', 'rtbcb' ); ?></td>
+                <td><?php esc_html_e( 'N/A', 'rtbcb' ); ?></td>
+                <td><?php esc_html_e( 'N/A', 'rtbcb' ); ?></td>
             </tr>
             <tr>
                 <th><?php esc_html_e( 'RAG Index', 'rtbcb' ); ?></th>
-                <td><?php echo $rag_health ? esc_html__( 'Healthy', 'rtbcb' ) : esc_html__( 'Needs attention', 'rtbcb' ); ?></td>
+                <td><?php echo $rag_is_healthy ? esc_html__( 'Healthy', 'rtbcb' ) : esc_html__( 'Needs attention', 'rtbcb' ); ?></td>
+                <td><?php echo isset( $rag_health['indexed_items'] ) ? esc_html( number_format_i18n( $rag_health['indexed_items'] ) ) : esc_html( '0' ); ?></td>
+                <td>
+                    <?php
+                    echo ! empty( $rag_health['last_updated'] )
+                        ? esc_html( mysql2date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $rag_health['last_updated'] ) )
+                        : esc_html__( 'Never', 'rtbcb' );
+                    ?>
+                </td>
             </tr>
         </tbody>
     </table>

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -44,7 +44,10 @@ $company = rtbcb_get_current_company();
         <p id="rtbcb-test-status"></p>
     </div>
 
-    <?php include RTBCB_DIR . 'admin/partials/dashboard-connectivity.php'; ?>
+    <?php
+    $rag_is_healthy = isset( $rag_health['status'] ) && 'healthy' === $rag_health['status'];
+    include RTBCB_DIR . 'admin/partials/dashboard-connectivity.php';
+    ?>
 
     <h2 class="nav-tab-wrapper" id="rtbcb-test-tabs">
         <a href="#rtbcb-test-company-overview" class="nav-tab nav-tab-active"><?php esc_html_e( 'Company Overview', 'rtbcb' ); ?></a>


### PR DESCRIPTION
## Summary
- Derive RAG health status from `check_rag_health()` and pass boolean to dashboard
- Expand connectivity table to show indexed item count and last update time

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68af62a4d29c8331a96e1e60dcc1b457