### PR TITLE
Use company_name key for company overview test

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -326,7 +326,7 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
       var start = performance.now();
       var formData = new FormData();
       formData.append('action', 'rtbcb_test_company_overview');
-      formData.append('company', company);
+      formData.append('company_name', company);
       formData.append('nonce', nonce);
       fetch(rtbcbAdmin.ajax_url, {
         method: 'POST',


### PR DESCRIPTION
## Summary
- send `company_name` instead of `company` in company overview test request

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68af68767cc08331a97b75eec8ce5796