### PR TITLE
Improve test dashboard tab accessibility

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -1135,3 +1135,63 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
     RTBCBAdmin.init();
   });
 })(jQuery);
+
+document.addEventListener('DOMContentLoaded', function () {
+    var tabWrapper = document.getElementById('rtbcb-test-tabs');
+    if (!tabWrapper) {
+        return;
+    }
+
+    var tabs = Array.prototype.slice.call(tabWrapper.querySelectorAll('[role="tab"]'));
+
+    function activateTab(tab) {
+        var i;
+        var panel;
+        for (i = 0; i < tabs.length; i++) {
+            tabs[i].classList.remove('nav-tab-active');
+            tabs[i].setAttribute('aria-selected', 'false');
+            panel = document.getElementById(tabs[i].getAttribute('aria-controls'));
+            if (panel) {
+                panel.style.display = 'none';
+            }
+        }
+        tab.classList.add('nav-tab-active');
+        tab.setAttribute('aria-selected', 'true');
+        panel = document.getElementById(tab.getAttribute('aria-controls'));
+        if (panel) {
+            panel.style.display = 'block';
+            panel.focus();
+        }
+    }
+
+    tabWrapper.addEventListener('click', function (e) {
+        if (e.target && e.target.getAttribute('role') === 'tab') {
+            e.preventDefault();
+            activateTab(e.target);
+        }
+    });
+
+    tabWrapper.addEventListener('keydown', function (e) {
+        var index = tabs.indexOf(document.activeElement);
+        if (index === -1) {
+            return;
+        }
+
+        var newIndex = null;
+        if (e.key === 'ArrowRight') {
+            newIndex = (index + 1) % tabs.length;
+        } else if (e.key === 'ArrowLeft') {
+            newIndex = (index - 1 + tabs.length) % tabs.length;
+        } else if (e.key === 'Home') {
+            newIndex = 0;
+        } else if (e.key === 'End') {
+            newIndex = tabs.length - 1;
+        }
+
+        if (newIndex !== null) {
+            e.preventDefault();
+            tabs[newIndex].focus();
+            activateTab(tabs[newIndex]);
+        }
+    });
+});

--- a/admin/partials/test-dashboard-nav-tabs.php
+++ b/admin/partials/test-dashboard-nav-tabs.php
@@ -9,14 +9,14 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 ?>
-<h2 class="nav-tab-wrapper" id="rtbcb-test-tabs">
-    <a href="#rtbcb-test-company-overview" class="nav-tab nav-tab-active"><?php esc_html_e( 'Company Overview', 'rtbcb' ); ?></a>
-    <a href="#rtbcb-test-treasury-tech-overview" class="nav-tab"><?php esc_html_e( 'Treasury Tech', 'rtbcb' ); ?></a>
-    <a href="#rtbcb-test-industry-overview" class="nav-tab"><?php esc_html_e( 'Industry', 'rtbcb' ); ?></a>
-    <a href="#rtbcb-test-real-treasury-overview" class="nav-tab"><?php esc_html_e( 'Real Treasury', 'rtbcb' ); ?></a>
-    <a href="#rtbcb-test-recommended-category" class="nav-tab"><?php esc_html_e( 'Recommended Category', 'rtbcb' ); ?></a>
-    <a href="#rtbcb-test-estimated-benefits" class="nav-tab"><?php esc_html_e( 'Estimated Benefits', 'rtbcb' ); ?></a>
-    <a href="#rtbcb-api-test" class="nav-tab"><?php esc_html_e( 'API Test', 'rtbcb' ); ?></a>
-    <a href="#rtbcb-report-preview" class="nav-tab"><?php esc_html_e( 'Report Preview', 'rtbcb' ); ?></a>
-    <a href="#rtbcb-report-test" class="nav-tab"><?php esc_html_e( 'Report Test', 'rtbcb' ); ?></a>
+<h2 class="nav-tab-wrapper" id="rtbcb-test-tabs" role="tablist">
+    <a id="rtbcb-tab-company-overview" href="#rtbcb-test-company-overview" class="nav-tab nav-tab-active" role="tab" aria-selected="true" aria-controls="rtbcb-test-company-overview" tabindex="0"><?php esc_html_e( 'Company Overview', 'rtbcb' ); ?></a>
+    <a id="rtbcb-tab-treasury-tech-overview" href="#rtbcb-test-treasury-tech-overview" class="nav-tab" role="tab" aria-selected="false" aria-controls="rtbcb-test-treasury-tech-overview" tabindex="-1"><?php esc_html_e( 'Treasury Tech', 'rtbcb' ); ?></a>
+    <a id="rtbcb-tab-industry-overview" href="#rtbcb-test-industry-overview" class="nav-tab" role="tab" aria-selected="false" aria-controls="rtbcb-test-industry-overview" tabindex="-1"><?php esc_html_e( 'Industry', 'rtbcb' ); ?></a>
+    <a id="rtbcb-tab-real-treasury-overview" href="#rtbcb-test-real-treasury-overview" class="nav-tab" role="tab" aria-selected="false" aria-controls="rtbcb-test-real-treasury-overview" tabindex="-1"><?php esc_html_e( 'Real Treasury', 'rtbcb' ); ?></a>
+    <a id="rtbcb-tab-recommended-category" href="#rtbcb-test-recommended-category" class="nav-tab" role="tab" aria-selected="false" aria-controls="rtbcb-test-recommended-category" tabindex="-1"><?php esc_html_e( 'Recommended Category', 'rtbcb' ); ?></a>
+    <a id="rtbcb-tab-estimated-benefits" href="#rtbcb-test-estimated-benefits" class="nav-tab" role="tab" aria-selected="false" aria-controls="rtbcb-test-estimated-benefits" tabindex="-1"><?php esc_html_e( 'Estimated Benefits', 'rtbcb' ); ?></a>
+    <a id="rtbcb-tab-api-test" href="#rtbcb-api-test" class="nav-tab" role="tab" aria-selected="false" aria-controls="rtbcb-api-test" tabindex="-1"><?php esc_html_e( 'API Test', 'rtbcb' ); ?></a>
+    <a id="rtbcb-tab-report-preview" href="#rtbcb-report-preview" class="nav-tab" role="tab" aria-selected="false" aria-controls="rtbcb-report-preview" tabindex="-1"><?php esc_html_e( 'Report Preview', 'rtbcb' ); ?></a>
+    <a id="rtbcb-tab-report-test" href="#rtbcb-report-test" class="nav-tab" role="tab" aria-selected="false" aria-controls="rtbcb-report-test" tabindex="-1"><?php esc_html_e( 'Report Test', 'rtbcb' ); ?></a>
 </h2>

--- a/admin/partials/test-dashboard-tab-panels.php
+++ b/admin/partials/test-dashboard-tab-panels.php
@@ -9,30 +9,30 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 ?>
-<div id="rtbcb-test-company-overview" class="rtbcb-tab-panel" style="display:block;">
+<div id="rtbcb-test-company-overview" class="rtbcb-tab-panel" role="tabpanel" aria-labelledby="rtbcb-tab-company-overview" tabindex="0" style="display:block;">
     <?php include RTBCB_DIR . 'admin/partials/test-company-overview.php'; ?>
 </div>
-<div id="rtbcb-test-treasury-tech-overview" class="rtbcb-tab-panel" style="display:none;">
+<div id="rtbcb-test-treasury-tech-overview" class="rtbcb-tab-panel" role="tabpanel" aria-labelledby="rtbcb-tab-treasury-tech-overview" tabindex="0" style="display:none;">
     <?php include RTBCB_DIR . 'admin/partials/test-treasury-tech-overview.php'; ?>
 </div>
-<div id="rtbcb-test-industry-overview" class="rtbcb-tab-panel" style="display:none;">
+<div id="rtbcb-test-industry-overview" class="rtbcb-tab-panel" role="tabpanel" aria-labelledby="rtbcb-tab-industry-overview" tabindex="0" style="display:none;">
     <?php include RTBCB_DIR . 'admin/partials/test-industry-overview.php'; ?>
 </div>
-<div id="rtbcb-test-real-treasury-overview" class="rtbcb-tab-panel" style="display:none;">
+<div id="rtbcb-test-real-treasury-overview" class="rtbcb-tab-panel" role="tabpanel" aria-labelledby="rtbcb-tab-real-treasury-overview" tabindex="0" style="display:none;">
     <?php include RTBCB_DIR . 'admin/partials/test-real-treasury-overview.php'; ?>
 </div>
-<div id="rtbcb-test-recommended-category" class="rtbcb-tab-panel" style="display:none;">
+<div id="rtbcb-test-recommended-category" class="rtbcb-tab-panel" role="tabpanel" aria-labelledby="rtbcb-tab-recommended-category" tabindex="0" style="display:none;">
     <?php include RTBCB_DIR . 'admin/partials/test-recommended-category.php'; ?>
 </div>
-<div id="rtbcb-test-estimated-benefits" class="rtbcb-tab-panel" style="display:none;">
+<div id="rtbcb-test-estimated-benefits" class="rtbcb-tab-panel" role="tabpanel" aria-labelledby="rtbcb-tab-estimated-benefits" tabindex="0" style="display:none;">
     <?php include RTBCB_DIR . 'admin/partials/test-estimated-benefits.php'; ?>
 </div>
-<div id="rtbcb-api-test" class="rtbcb-tab-panel" style="display:none;">
+<div id="rtbcb-api-test" class="rtbcb-tab-panel" role="tabpanel" aria-labelledby="rtbcb-tab-api-test" tabindex="0" style="display:none;">
     <?php include RTBCB_DIR . 'admin/partials/test-api.php'; ?>
 </div>
-<div id="rtbcb-report-preview" class="rtbcb-tab-panel" style="display:none;">
+<div id="rtbcb-report-preview" class="rtbcb-tab-panel" role="tabpanel" aria-labelledby="rtbcb-tab-report-preview" tabindex="0" style="display:none;">
     <?php include RTBCB_DIR . 'admin/partials/test-report-preview.php'; ?>
 </div>
-<div id="rtbcb-report-test" class="rtbcb-tab-panel" style="display:none;">
+<div id="rtbcb-report-test" class="rtbcb-tab-panel" role="tabpanel" aria-labelledby="rtbcb-tab-report-test" tabindex="0" style="display:none;">
     <?php include RTBCB_DIR . 'admin/partials/test-report.php'; ?>
 </div>

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -52,17 +52,4 @@ $company = rtbcb_get_current_company();
     <?php include RTBCB_DIR . 'admin/partials/test-dashboard-nav-tabs.php'; ?>
 
     <?php include RTBCB_DIR . 'admin/partials/test-dashboard-tab-panels.php'; ?>
-
-    <script>
-    jQuery(function($){
-        $('#rtbcb-test-tabs a').on('click', function(e){
-            e.preventDefault();
-            var target = $(this).attr('href');
-            $('#rtbcb-test-tabs a').removeClass('nav-tab-active');
-            $(this).addClass('nav-tab-active');
-            $('.rtbcb-tab-panel').hide();
-            $(target).show();
-        });
-    });
-    </script>
 </div>


### PR DESCRIPTION
## Summary
- add ARIA roles and attributes for test dashboard tabs and panels
- move tab logic into rtbcb-admin.js using modern DOM APIs and keyboard navigation
- remove inline jQuery tab script

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68af6a797c908331a5baaf25082ba79d