### PR TITLE
Refactor admin test assets

### DIFF
--- a/admin/css/rtbcb-admin.css
+++ b/admin/css/rtbcb-admin.css
@@ -74,3 +74,57 @@
         margin-bottom: 0;
     }
 }
+
+/* Test API styles */
+#rtbcb-test-results {
+    margin: 20px 0;
+}
+
+#rtbcb-test-results .notice {
+    padding: 15px;
+    margin: 15px 0;
+}
+
+#rtbcb-test-results .notice-success {
+    border-left: 4px solid #00a32a;
+    background: #f0f8ff;
+}
+
+#rtbcb-test-results .notice-error {
+    border-left: 4px solid #d63638;
+    background: #fff8f8;
+}
+
+/* Company Overview test styles */
+#rtbcb-company-overview-card details {
+    margin-top: 20px;
+}
+
+#rtbcb-company-overview-results div[style*="background"] {
+    white-space: pre-wrap;
+    line-height: 1.6;
+}
+
+#rtbcb-company-overview-meta {
+    margin-top: 10px;
+}
+
+/* Real Treasury Overview test styles */
+#rtbcb-real-treasury-overview-card details {
+    margin-top: 20px;
+}
+
+#rtbcb-real-treasury-overview-results div[style*="background"] {
+    white-space: pre-wrap;
+    line-height: 1.6;
+}
+
+/* Treasury Tech Overview test styles */
+#rtbcb-treasury-tech-overview-card details {
+    margin-top: 20px;
+}
+
+#rtbcb-treasury-tech-overview-results div[style*="background"] {
+    white-space: pre-wrap;
+    line-height: 1.6;
+}

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -1195,3 +1195,194 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     });
 });
+
+function rtbcb_set_ajaxurl() {
+    if (typeof ajaxurl === 'undefined' && window.rtbcbAdmin && rtbcbAdmin.ajax_url) {
+        window.ajaxurl = rtbcbAdmin.ajax_url;
+    }
+}
+
+function rtbcb_bind_regenerate(triggerId, targetId, eventType) {
+    var trigger = document.getElementById(triggerId);
+    var target = document.getElementById(targetId);
+    if (!trigger || !target) {
+        return;
+    }
+    trigger.addEventListener('click', function () {
+        if (eventType === 'submit') {
+            if (typeof jQuery !== 'undefined') {
+                jQuery(target).trigger('submit');
+            } else {
+                target.dispatchEvent(new Event('submit'));
+            }
+        } else {
+            target.click();
+        }
+    });
+}
+
+function rtbcb_init_api_test() {
+    if (typeof jQuery === 'undefined') {
+        return;
+    }
+    var $ = jQuery;
+    var $btn = $('#rtbcb-test-api-btn');
+    if (!$btn.length) {
+        return;
+    }
+    $btn.on('click', function () {
+        var nonce = $btn.data('nonce');
+        var testing = $btn.data('testing');
+        var testingMsg = $btn.data('testing-msg');
+        var success = $btn.data('success');
+        var available = $btn.data('available');
+        var http = $btn.data('http');
+        var fail = $btn.data('fail');
+        var ajaxFail = $btn.data('ajax-fail');
+        var label = $btn.data('label');
+        var $results = $('#rtbcb-test-results');
+        $btn.prop('disabled', true).text(testing);
+        $results.html('<p>' + testingMsg + '</p>');
+        $.post(ajaxurl, {
+            action: 'rtbcb_test_api',
+            nonce: nonce
+        }).done(function (response) {
+            if (response.success) {
+                var html = '<div class="notice notice-success"><p><strong>' + success + '</strong></p>' + '<p>' + response.data.details + '</p>';
+                if (response.data.models_available) {
+                    html += '<p><strong>' + available + '</strong> ' + response.data.models_available.join(', ') + '</p>';
+                }
+                html += '</div>';
+                $results.html(html);
+            } else {
+                var errorHtml = '<div class="notice notice-error"><p><strong>❌ ' + response.data.message + '</strong></p>' + '<p>' + response.data.details + '</p>';
+                if (response.data.http_code) {
+                    errorHtml += '<p>' + http + ' ' + response.data.http_code + '</p>';
+                }
+                errorHtml += '</div>';
+                $results.html(errorHtml);
+            }
+        }).fail(function () {
+            $results.html('<div class="notice notice-error"><p><strong>❌ ' + fail + '</strong></p><p>' + ajaxFail + '</p></div>');
+        }).always(function () {
+            $btn.prop('disabled', false).text(label);
+        });
+    });
+}
+
+function rtbcb_init_connectivity_tests() {
+    if (typeof jQuery === 'undefined') {
+        return;
+    }
+    var $ = jQuery;
+    var $status = $('#rtbcb-connectivity-status');
+    if (!$status.length) {
+        return;
+    }
+    function renderStatus(message, success) {
+        var cls = success ? 'notice notice-success' : 'notice notice-error';
+        $status.html('<div class="' + cls + '"><p>' + message + '</p></div>');
+    }
+    $('#rtbcb-test-openai').on('click', function () {
+        var $btn = $(this);
+        var original = $btn.text();
+        var data = $btn.data();
+        $btn.prop('disabled', true).text(rtbcbAdmin.strings.testing);
+        $.post(ajaxurl, {
+            action: 'rtbcb_test_api',
+            nonce: data.nonce
+        }).done(function (response) {
+            if (response.success) {
+                renderStatus(response.data.message || data.success, true);
+            } else {
+                renderStatus(response.data.message || data.failure, false);
+            }
+        }).fail(function () {
+            renderStatus(data.requestFailed, false);
+        }).always(function () {
+            $btn.prop('disabled', false).text(original);
+        });
+    });
+    $('#rtbcb-test-portal').on('click', function () {
+        var $btn = $(this);
+        var original = $btn.text();
+        var data = $btn.data();
+        $btn.prop('disabled', true).text(rtbcbAdmin.strings.testing);
+        $.post(ajaxurl, {
+            action: 'rtbcb_test_portal',
+            nonce: data.nonce
+        }).done(function (response) {
+            if (response.success) {
+                var msg = response.data && response.data.vendor_count !== undefined ? data.vendorLabel + ' ' + response.data.vendor_count : (response.data.message || data.success);
+                renderStatus(msg, true);
+            } else {
+                var failMsg = response.data && response.data.message ? response.data.message : data.failure;
+                renderStatus(failMsg, false);
+            }
+        }).fail(function () {
+            renderStatus(data.requestFailed, false);
+        }).always(function () {
+            $btn.prop('disabled', false).text(original);
+        });
+    });
+    $('#rtbcb-test-rag').on('click', function () {
+        var $btn = $(this);
+        var original = $btn.text();
+        var data = $btn.data();
+        $btn.prop('disabled', true).text(rtbcbAdmin.strings.testing);
+        $.post(ajaxurl, {
+            action: 'rtbcb_test_rag',
+            nonce: data.nonce
+        }).done(function (response) {
+            if (response.success) {
+                var ragMsg = response.data && response.data.status ? response.data.status : data.success;
+                renderStatus(ragMsg, true);
+            } else {
+                var failMsg = response.data && response.data.message ? response.data.message : data.failure;
+                renderStatus(failMsg, false);
+            }
+        }).fail(function () {
+            renderStatus(data.requestFailed, false);
+        }).always(function () {
+            $btn.prop('disabled', false).text(original);
+        });
+    });
+    $('#rtbcb-set-company').on('click', function () {
+        var $btn = $(this);
+        var original = $btn.text();
+        var data = $btn.data();
+        var name = $('#rtbcb-company-name').val();
+        $btn.prop('disabled', true).text(data.saving);
+        $.post(ajaxurl, {
+            action: 'rtbcb_set_test_company',
+            nonce: $('#rtbcb_set_test_company_nonce').val(),
+            company_name: name
+        }).done(function (response) {
+            if (response.success) {
+                renderStatus(response.data.message, true);
+                $('#rtbcb-test-results-summary tbody').html('<tr><td colspan="5">' + data.noResults + '</td></tr>');
+            } else {
+                var failMsg = response.data && response.data.message ? response.data.message : data.requestFailed;
+                renderStatus(failMsg, false);
+            }
+        }).fail(function () {
+            renderStatus(data.requestFailed, false);
+        }).always(function () {
+            $btn.prop('disabled', false).text(original);
+        });
+    });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    rtbcb_set_ajaxurl();
+    rtbcb_bind_regenerate('rtbcb-rerun-company-overview', 'rtbcb-generate-company-overview');
+    rtbcb_bind_regenerate('rtbcb-rerun-real-treasury', 'rtbcb-generate-real-treasury-overview');
+    rtbcb_bind_regenerate('rtbcb-rerun-treasury-tech', 'rtbcb-generate-treasury-tech-overview');
+    rtbcb_bind_regenerate('rtbcb-rerun-report-preview', 'rtbcb-generate-report');
+    rtbcb_bind_regenerate('rtbcb-rerun-benefits', 'rtbcb-benefits-estimate-form', 'submit');
+    rtbcb_bind_regenerate('rtbcb-rerun-industry-overview', 'rtbcb-industry-overview-form', 'submit');
+    rtbcb_bind_regenerate('rtbcb-rerun-category', 'rtbcb-generate-category-recommendation');
+    rtbcb_bind_regenerate('rtbcb-rerun-report-test', 'rtbcb-generate-report');
+    rtbcb_init_api_test();
+    rtbcb_init_connectivity_tests();
+});

--- a/admin/partials/test-api.php
+++ b/admin/partials/test-api.php
@@ -27,61 +27,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div id="rtbcb-api-test-card" class="rtbcb-result-card">
     <details>
         <summary><?php esc_html_e( 'Test Output', 'rtbcb' ); ?></summary>
-        <div id="rtbcb-test-results" style="margin: 20px 0;">
+        <div id="rtbcb-test-results">
             <p><?php esc_html_e( 'Click the button below to test your OpenAI API connection:', 'rtbcb' ); ?></p>
         </div>
     </details>
 </div>
-<button type="button" id="rtbcb-test-api-btn" class="button button-primary">
+<button
+    type="button"
+    id="rtbcb-test-api-btn"
+    class="button button-primary"
+    data-nonce="<?php echo esc_attr( wp_create_nonce( 'rtbcb_test_api' ) ); ?>"
+    data-testing="<?php echo esc_attr__( 'Testing...', 'rtbcb' ); ?>"
+    data-testing-msg="<?php echo esc_attr__( 'Testing OpenAI API connection...', 'rtbcb' ); ?>"
+    data-success="<?php echo esc_attr__( '✅ OpenAI API connection successful', 'rtbcb' ); ?>"
+    data-available="<?php echo esc_attr__( 'Available models:', 'rtbcb' ); ?>"
+    data-http="<?php echo esc_attr__( 'HTTP Code:', 'rtbcb' ); ?>"
+    data-fail="<?php echo esc_attr__( 'Request failed', 'rtbcb' ); ?>"
+    data-ajax-fail="<?php echo esc_attr__( 'Unable to connect to WordPress AJAX handler.', 'rtbcb' ); ?>"
+    data-label="<?php echo esc_attr__( 'Test API Connection', 'rtbcb' ); ?>"
+>
     <?php esc_html_e( 'Test API Connection', 'rtbcb' ); ?>
 </button>
-<script>
-jQuery(function($){
-    $('#rtbcb-test-api-btn').on('click', function(){
-        var $btn = $(this);
-        var $results = $('#rtbcb-test-results');
-        $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
-        $results.html('<p><?php echo esc_js( __( 'Testing OpenAI API connection...', 'rtbcb' ) ); ?></p>');
-        $.post(ajaxurl, {
-            action: 'rtbcb_test_api',
-            nonce: '<?php echo wp_create_nonce( 'rtbcb_test_api' ); ?>'
-        }).done(function(response){
-            if (response.success) {
-                var html = '<div class="notice notice-success"><p><strong><?php echo esc_js( '✅ ' . __( 'OpenAI API connection successful', 'rtbcb' ) ); ?></strong></p>' +
-                    '<p>' + response.data.details + '</p>';
-                if (response.data.models_available) {
-                    html += '<p><strong><?php echo esc_js( __( 'Available models:', 'rtbcb' ) ); ?></strong> ' + response.data.models_available.join(', ') + '</p>';
-                }
-                html += '</div>';
-                $results.html(html);
-            } else {
-                var errorHtml = '<div class="notice notice-error"><p><strong>❌ ' + response.data.message + '</strong></p>' +
-                    '<p>' + response.data.details + '</p>';
-                if (response.data.http_code) {
-                    errorHtml += '<p><?php echo esc_js( __( 'HTTP Code:', 'rtbcb' ) ); ?> ' + response.data.http_code + '</p>';
-                }
-                errorHtml += '</div>';
-                $results.html(errorHtml);
-            }
-        }).fail(function(){
-            $results.html('<div class="notice notice-error"><p><strong>❌ <?php echo esc_js( __( 'Request failed', 'rtbcb' ) ); ?></strong></p><p><?php echo esc_js( __( 'Unable to connect to WordPress AJAX handler.', 'rtbcb' ) ); ?></p></div>');
-        }).always(function(){
-            $btn.prop('disabled', false).text('<?php echo esc_js( __( 'Test API Connection', 'rtbcb' ) ); ?>');
-        });
-    });
-});
-</script>
-<style>
-#rtbcb-test-results .notice {
-    padding: 15px;
-    margin: 15px 0;
-}
-#rtbcb-test-results .notice-success {
-    border-left: 4px solid #00a32a;
-    background: #f0f8ff;
-}
-#rtbcb-test-results .notice-error {
-    border-left: 4px solid #d63638;
-    background: #fff8f8;
-}
-</style>

--- a/admin/partials/test-company-overview.php
+++ b/admin/partials/test-company-overview.php
@@ -62,25 +62,5 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <?php esc_html_e( 'Copy to Clipboard', 'rtbcb' ); ?>
             </button>
         </p>
-    </details>
+</details>
 </div>
-<style>
-#rtbcb-company-overview-card details {
-    margin-top: 20px;
-}
-#rtbcb-company-overview-results div[style*="background"] {
-    white-space: pre-wrap;
-    line-height: 1.6;
-}
-#rtbcb-company-overview-meta {
-    margin-top: 10px;
-}
-</style>
-<script>
-<?php if ( ! isset( $GLOBALS['ajaxurl'] ) || empty( $GLOBALS['ajaxurl'] ) ) : ?>
-var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
-<?php endif; ?>
-document.getElementById( 'rtbcb-rerun-company-overview' )?.addEventListener( 'click', function() {
-    document.getElementById( 'rtbcb-generate-company-overview' ).click();
-});
-</script>

--- a/admin/partials/test-dashboard-connectivity-card.php
+++ b/admin/partials/test-dashboard-connectivity-card.php
@@ -51,114 +51,49 @@ $company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_d
         </tbody>
     </table>
     <p class="submit">
-        <button type="button" id="rtbcb-test-openai" class="button"><?php esc_html_e( 'Test OpenAI API', 'rtbcb' ); ?></button>
-        <button type="button" id="rtbcb-test-portal" class="button"><?php esc_html_e( 'Test Portal Connection', 'rtbcb' ); ?></button>
-        <button type="button" id="rtbcb-test-rag" class="button"><?php esc_html_e( 'Test RAG Index', 'rtbcb' ); ?></button>
+        <button
+            type="button"
+            id="rtbcb-test-openai"
+            class="button"
+            data-nonce="<?php echo esc_attr( wp_create_nonce( 'rtbcb_test_api' ) ); ?>"
+            data-success="<?php echo esc_attr__( 'Connection successful.', 'rtbcb' ); ?>"
+            data-failure="<?php echo esc_attr__( 'Connection failed.', 'rtbcb' ); ?>"
+            data-request-failed="<?php echo esc_attr__( 'Request failed.', 'rtbcb' ); ?>"
+        ><?php esc_html_e( 'Test OpenAI API', 'rtbcb' ); ?></button>
+        <button
+            type="button"
+            id="rtbcb-test-portal"
+            class="button"
+            data-nonce="<?php echo esc_attr( wp_create_nonce( 'rtbcb_test_portal' ) ); ?>"
+            data-success="<?php echo esc_attr__( 'Portal test successful.', 'rtbcb' ); ?>"
+            data-failure="<?php echo esc_attr__( 'Test failed.', 'rtbcb' ); ?>"
+            data-request-failed="<?php echo esc_attr__( 'Request failed.', 'rtbcb' ); ?>"
+            data-vendor-label="<?php echo esc_attr__( 'Vendor count:', 'rtbcb' ); ?>"
+        ><?php esc_html_e( 'Test Portal Connection', 'rtbcb' ); ?></button>
+        <button
+            type="button"
+            id="rtbcb-test-rag"
+            class="button"
+            data-nonce="<?php echo esc_attr( wp_create_nonce( 'rtbcb_test_rag' ) ); ?>"
+            data-success="<?php echo esc_attr__( 'RAG index healthy.', 'rtbcb' ); ?>"
+            data-failure="<?php echo esc_attr__( 'Test failed.', 'rtbcb' ); ?>"
+            data-request-failed="<?php echo esc_attr__( 'Request failed.', 'rtbcb' ); ?>"
+        ><?php esc_html_e( 'Test RAG Index', 'rtbcb' ); ?></button>
     </p>
     <p>
         <label for="rtbcb-company-name"><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></label>
         <input type="text" id="rtbcb-company-name" class="regular-text" value="<?php echo esc_attr( $company_name ); ?>" />
-        <button type="button" id="rtbcb-set-company" class="button"><?php esc_html_e( 'Set Company', 'rtbcb' ); ?></button>
+        <button
+            type="button"
+            id="rtbcb-set-company"
+            class="button"
+            data-saving="<?php echo esc_attr__( 'Saving...', 'rtbcb' ); ?>"
+            data-request-failed="<?php echo esc_attr__( 'Request failed.', 'rtbcb' ); ?>"
+            data-no-results="<?php echo esc_attr__( 'No test results found.', 'rtbcb' ); ?>"
+        ><?php esc_html_e( 'Set Company', 'rtbcb' ); ?></button>
         <?php wp_nonce_field( 'rtbcb_set_test_company', 'rtbcb_set_test_company_nonce' ); ?>
     </p>
     <p id="rtbcb-connectivity-status"></p>
 
     <?php include RTBCB_DIR . 'admin/partials/dashboard-test-results.php'; ?>
 </div>
-<script>
-(function($){
-    function renderStatus($el, message, success){
-        var cls = success ? 'notice notice-success' : 'notice notice-error';
-        $el.html('<div class="' + cls + '"><p>' + message + '</p></div>');
-    }
-
-    $('#rtbcb-test-openai').on('click', function(){
-        var $btn = $(this);
-        var original = $btn.text();
-        var $status = $('#rtbcb-connectivity-status');
-        $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
-        $.post(ajaxurl, {
-            action: 'rtbcb_test_api',
-            nonce: '<?php echo wp_create_nonce( 'rtbcb_test_api' ); ?>'
-        }).done(function(response){
-            if (response.success) {
-                renderStatus($status, response.data.message || '<?php echo esc_js( __( 'Connection successful.', 'rtbcb' ) ); ?>', true);
-            } else {
-                renderStatus($status, response.data.message || '<?php echo esc_js( __( 'Connection failed.', 'rtbcb' ) ); ?>', false);
-            }
-        }).fail(function(){
-            renderStatus($status, '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);
-        }).always(function(){
-            $btn.prop('disabled', false).text(original);
-        });
-    });
-
-    $('#rtbcb-test-portal').on('click', function(){
-        var $btn = $(this);
-        var original = $btn.text();
-        var $status = $('#rtbcb-connectivity-status');
-        $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
-        $.post(ajaxurl, {
-            action: 'rtbcb_test_portal',
-            nonce: '<?php echo wp_create_nonce( 'rtbcb_test_portal' ); ?>'
-        }).done(function(response){
-            if (response.success) {
-                var msg = response.data && response.data.vendor_count !== undefined ? '<?php echo esc_js( __( 'Vendor count:', 'rtbcb' ) ); ?> ' + response.data.vendor_count : (response.data.message || '<?php echo esc_js( __( 'Portal test successful.', 'rtbcb' ) ); ?>');
-                renderStatus($status, msg, true);
-            } else {
-                renderStatus($status, (response.data && response.data.message) ? response.data.message : '<?php echo esc_js( __( 'Test failed.', 'rtbcb' ) ); ?>', false);
-            }
-        }).fail(function(){
-            renderStatus($status, '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);
-        }).always(function(){
-            $btn.prop('disabled', false).text(original);
-        });
-    });
-
-    $('#rtbcb-test-rag').on('click', function(){
-        var $btn = $(this);
-        var original = $btn.text();
-        var $status = $('#rtbcb-connectivity-status');
-        $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
-        $.post(ajaxurl, {
-            action: 'rtbcb_test_rag',
-            nonce: '<?php echo wp_create_nonce( 'rtbcb_test_rag' ); ?>'
-        }).done(function(response){
-            if (response.success) {
-                var ragMsg = response.data && response.data.status ? response.data.status : '<?php echo esc_js( __( 'RAG index healthy.', 'rtbcb' ) ); ?>';
-                renderStatus($status, ragMsg, true);
-            } else {
-                renderStatus($status, (response.data && response.data.message) ? response.data.message : '<?php echo esc_js( __( 'Test failed.', 'rtbcb' ) ); ?>', false);
-            }
-        }).fail(function(){
-            renderStatus($status, '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);
-        }).always(function(){
-            $btn.prop('disabled', false).text(original);
-        });
-    });
-
-    $('#rtbcb-set-company').on('click', function(){
-        var $btn = $(this);
-        var original = $btn.text();
-        var $status = $('#rtbcb-connectivity-status');
-        var name = $('#rtbcb-company-name').val();
-        $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Saving...', 'rtbcb' ) ); ?>');
-        $.post(ajaxurl, {
-            action: 'rtbcb_set_test_company',
-            nonce: $('#rtbcb_set_test_company_nonce').val(),
-            company_name: name
-        }).done(function(response){
-            if (response.success) {
-                renderStatus($status, response.data.message, true);
-                $('#rtbcb-test-results-summary tbody').html('<tr><td colspan="5"><?php echo esc_js( __( 'No test results found.', 'rtbcb' ) ); ?></td></tr>');
-            } else {
-                renderStatus($status, (response.data && response.data.message) ? response.data.message : '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);
-            }
-        }).fail(function(){
-            renderStatus($status, '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);
-        }).always(function(){
-            $btn.prop('disabled', false).text(original);
-        });
-    });
-})(jQuery);
-</script>

--- a/admin/partials/test-estimated-benefits.php
+++ b/admin/partials/test-estimated-benefits.php
@@ -94,8 +94,3 @@ $categories           = RTBCB_Category_Recommender::get_all_categories();
         <div id="rtbcb-benefits-estimate-results"></div>
     </details>
 </div>
-<script>
-document.getElementById( 'rtbcb-rerun-benefits' )?.addEventListener( 'click', function() {
-    jQuery( '#rtbcb-benefits-estimate-form' ).trigger( 'submit' );
-});
-</script>

--- a/admin/partials/test-industry-overview.php
+++ b/admin/partials/test-industry-overview.php
@@ -73,8 +73,3 @@ $company_ind  = isset( $company['industry'] ) ? sanitize_text_field( $company['i
         <div id="rtbcb-industry-overview-results"></div>
     </details>
 </div>
-<script>
-document.getElementById( 'rtbcb-rerun-industry-overview' )?.addEventListener( 'click', function() {
-    jQuery( '#rtbcb-industry-overview-form' ).trigger( 'submit' );
-});
-</script>

--- a/admin/partials/test-real-treasury-overview.php
+++ b/admin/partials/test-real-treasury-overview.php
@@ -100,22 +100,5 @@ if ( empty( $company ) ) {
             <button type="button" id="rtbcb-regenerate-real-treasury-overview" class="button"><?php esc_html_e( 'Regenerate', 'rtbcb' ); ?></button>
             <button type="button" id="rtbcb-copy-real-treasury-overview" class="button"><?php esc_html_e( 'Copy', 'rtbcb' ); ?></button>
         </p>
-    </details>
+</details>
 </div>
-<style>
-#rtbcb-real-treasury-overview-card details {
-    margin-top: 20px;
-}
-#rtbcb-real-treasury-overview-results div[style*="background"] {
-    white-space: pre-wrap;
-    line-height: 1.6;
-}
-</style>
-<script>
-<?php if ( ! isset( $GLOBALS['ajaxurl'] ) || empty( $GLOBALS['ajaxurl'] ) ) : ?>
-var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
-<?php endif; ?>
-document.getElementById( 'rtbcb-rerun-real-treasury' )?.addEventListener( 'click', function() {
-    document.getElementById( 'rtbcb-generate-real-treasury-overview' ).click();
-});
-</script>

--- a/admin/partials/test-recommended-category.php
+++ b/admin/partials/test-recommended-category.php
@@ -85,8 +85,3 @@ $treasury_challenges = get_option( 'rtbcb_treasury_challenges', '' );
         </p>
     </details>
 </div>
-<script>
-document.getElementById( 'rtbcb-rerun-category' )?.addEventListener( 'click', function() {
-    document.getElementById( 'rtbcb-generate-category-recommendation' ).click();
-});
-</script>

--- a/admin/partials/test-report-preview.php
+++ b/admin/partials/test-report-preview.php
@@ -78,10 +78,5 @@ if ( empty( $company ) ) {
         <div id="rtbcb-report-preview">
             <iframe id="rtbcb-report-iframe"></iframe>
         </div>
-    </details>
+</details>
 </div>
-<script>
-document.getElementById( 'rtbcb-rerun-report-preview' )?.addEventListener( 'click', function() {
-    document.getElementById( 'rtbcb-generate-report' ).click();
-});
-</script>

--- a/admin/partials/test-report.php
+++ b/admin/partials/test-report.php
@@ -124,8 +124,3 @@ if ( empty( $company ) ) {
     </div>
 </div>
 <div id="rtbcb-report-preview" style="display:none;"></div>
-<script>
-document.getElementById( 'rtbcb-rerun-report-test' )?.addEventListener( 'click', function() {
-    document.getElementById( 'rtbcb-generate-report' ).click();
-});
-</script>

--- a/admin/partials/test-treasury-tech-overview.php
+++ b/admin/partials/test-treasury-tech-overview.php
@@ -111,22 +111,5 @@ if ( empty( $suggested_focus_areas ) && ! empty( $company_size ) ) {
             <button type="button" id="rtbcb-regenerate-treasury-tech-overview" class="button"><?php esc_html_e( 'Regenerate', 'rtbcb' ); ?></button>
             <button type="button" id="rtbcb-copy-treasury-tech-overview" class="button"><?php esc_html_e( 'Copy', 'rtbcb' ); ?></button>
         </p>
-    </details>
+</details>
 </div>
-<style>
-#rtbcb-treasury-tech-overview-card details {
-    margin-top: 20px;
-}
-#rtbcb-treasury-tech-overview-results div[style*="background"] {
-    white-space: pre-wrap;
-    line-height: 1.6;
-}
-</style>
-<script>
-<?php if ( ! isset( $GLOBALS['ajaxurl'] ) || empty( $GLOBALS['ajaxurl'] ) ) : ?>
-var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
-<?php endif; ?>
-document.getElementById( 'rtbcb-rerun-treasury-tech' )?.addEventListener( 'click', function() {
-    document.getElementById( 'rtbcb-generate-treasury-tech-overview' ).click();
-});
-</script>


### PR DESCRIPTION
## Summary
- Consolidate all test partial styles into `rtbcb-admin.css`
- Move inline JavaScript to `rtbcb-admin.js` with reusable helpers
- Bind test actions via IDs and data attributes in partial templates

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68af6c86352083318e2ab24df8d1bf1a