### PR TITLE
Add progress and cancel controls to testing dashboard

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -485,6 +485,9 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
       }
       var status = $('#rtbcb-test-status');
       var tableBody = $('#rtbcb-test-results-summary tbody');
+      var cancelButton = $('#rtbcb-cancel-tests');
+      var progressBar = $('#rtbcb-test-progress');
+      var controller = null;
       var originalText = button.text();
       var sectionMap = {
         'Company Overview': 'rtbcb-test-company-overview',
@@ -495,11 +498,14 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
         'Estimated Benefits': 'rtbcb-test-estimated-benefits'
       };
       var runTests = _async(function () {
+        controller = new AbortController();
         var companyName = $('#rtbcb-company-name').val().trim() || (rtbcbAdmin.company && rtbcbAdmin.company.name ? rtbcbAdmin.company.name : '').trim();
         if (!companyName) {
           alert('Please enter a company name.');
           status.text('');
           button.prop('disabled', false).text(originalText);
+          cancelButton.hide();
+          progressBar.hide();
           return;
         }
         var tests = [{
@@ -516,38 +522,68 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
           label: 'Industry Overview'
         }];
         var results = [];
+        var completed = 0;
+        progressBar.attr('max', tests.length).val(0).show();
+        cancelButton.show().prop('disabled', false);
         return _continue(_forOf(tests, function (test) {
+          if (controller.signal.aborted) {
+            return;
+          }
           status.text('Testing ' + test.label + '...');
           return _continueIgnored(_catch(function () {
-            var postData = {
-              action: test.action,
-              nonce: test.nonce
-            };
+            var formData = new FormData();
+            formData.append('action', test.action);
+            formData.append('nonce', test.nonce);
             if (test.action === 'rtbcb_test_company_overview') {
-              postData.company_name = companyName;
+              formData.append('company_name', companyName);
             }
-            return _await($.post(rtbcbAdmin.ajax_url, postData), function (response) {
-              var message = response && response.data && response.data.message ? response.data.message : '';
-              results.push({
-                section: test.label,
-                status: response.success ? 'success' : 'error',
-                message: message
+            return _await(fetch(rtbcbAdmin.ajax_url, {
+              method: 'POST',
+              body: formData,
+              signal: controller.signal
+            }), function (response) {
+              if (!response.ok) {
+                throw new Error('Server responded ' + response.status);
+              }
+              return _await(response.json(), function (data) {
+                var message = data && data.data && data.data.message ? data.data.message : '';
+                results.push({
+                  section: test.label,
+                  status: data.success ? 'success' : 'error',
+                  message: message
+                });
               });
             });
           }, function (err) {
-            results.push({
-              section: test.label,
-              status: 'error',
-              message: err.message
-            });
-          }));
+            if (err.name !== 'AbortError') {
+              results.push({
+                section: test.label,
+                status: 'error',
+                message: err.message
+              });
+            }
+            controller.abort();
+          }), function () {
+            completed++;
+            progressBar.val(completed);
+          });
         }), function () {
+          cancelButton.hide();
+          progressBar.hide();
+          if (controller.signal.aborted) {
+            status.text('Testing cancelled.');
+            button.prop('disabled', false).text(originalText);
+            return;
+          }
           status.text('Saving results...');
           return _continue(_catch(function () {
-            return _awaitIgnored($.post(rtbcbAdmin.ajax_url, {
-              action: 'rtbcb_save_test_results',
-              nonce: rtbcbAdmin.test_dashboard_nonce,
-              results: JSON.stringify(results)
+            var saveData = new FormData();
+            saveData.append('action', 'rtbcb_save_test_results');
+            saveData.append('nonce', rtbcbAdmin.test_dashboard_nonce);
+            saveData.append('results', JSON.stringify(results));
+            return _awaitIgnored(fetch(rtbcbAdmin.ajax_url, {
+              method: 'POST',
+              body: saveData
             }));
           }, _empty), function () {
             tableBody.empty();
@@ -559,8 +595,15 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
             });
             status.text('');
             button.prop('disabled', false).text(originalText);
+            $(document).trigger('rtbcb-tests-complete');
           });
         });
+      });
+      cancelButton.on('click', function () {
+        if (controller) {
+          controller.abort();
+          cancelButton.prop('disabled', true);
+        }
       });
       button.on('click', function () {
         button.prop('disabled', true).text(rtbcbAdmin.strings.testing);

--- a/admin/partials/dashboard-test-results.php
+++ b/admin/partials/dashboard-test-results.php
@@ -18,6 +18,10 @@ if ( ! empty( $test_results ) && is_array( $test_results ) ) {
 $sections     = rtbcb_get_dashboard_sections();
 ?>
 
+<div id="rtbcb-tests-complete-toast" class="notice notice-success is-dismissible" style="display:none;">
+    <p><?php esc_html_e( 'All tests completed.', 'rtbcb' ); ?></p>
+</div>
+
 <h2 class="title"><?php esc_html_e( 'Recent Test Results', 'rtbcb' ); ?></h2>
 <table class="widefat striped" id="rtbcb-test-results-summary">
     <thead>
@@ -69,6 +73,13 @@ $sections     = rtbcb_get_dashboard_sections();
         var section = $(this).data('section');
         $('#rtbcb-test-tabs a[href="#' + section + '"]').trigger('click');
         $('#' + section).find('form').first().trigger('submit');
+    });
+    $(document).on('rtbcb-tests-complete', function(){
+        var toast = $('#rtbcb-tests-complete-toast');
+        toast.fadeIn();
+        setTimeout(function(){
+            toast.fadeOut();
+        }, 5000);
     });
 })(jQuery);
 </script>

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -39,8 +39,12 @@ $company = rtbcb_get_current_company();
             <button type="button" id="rtbcb-test-all-sections" class="button button-primary">
                 <?php esc_html_e( 'Test All Sections', 'rtbcb' ); ?>
             </button>
+            <button type="button" id="rtbcb-cancel-tests" class="button" style="display:none;">
+                <?php esc_html_e( 'Cancel', 'rtbcb' ); ?>
+            </button>
             <?php wp_nonce_field( 'rtbcb_test_dashboard', 'rtbcb_test_dashboard_nonce' ); ?>
         </p>
+        <progress id="rtbcb-test-progress" value="0" max="0" style="display:none;"></progress>
         <p id="rtbcb-test-status"></p>
     </div>
 


### PR DESCRIPTION
## Summary
- replace jQuery test loop with async/await fetch requests and AbortController support
- add dashboard progress bar and cancel button for test runs
- display toast when tests complete

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6f24edc48331a1a79908e1d44207