### PR TITLE
Add sortable and filterable test results table

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -1416,6 +1416,71 @@ function rtbcb_init_connectivity_tests() {
     });
 }
 
+function rtbcb_sort_test_results(table, column) {
+    var headers = table.querySelectorAll('th');
+    var tbody = table.querySelector('tbody');
+    var direction = headers[column].getAttribute('aria-sort') === 'ascending' ? 'descending' : 'ascending';
+    headers.forEach(function (th) {
+        th.setAttribute('aria-sort', 'none');
+    });
+    headers[column].setAttribute('aria-sort', direction);
+    var rows = Array.from(tbody.querySelectorAll('tr')).filter(function (row) {
+        return !row.classList.contains('rtbcb-no-results');
+    });
+    rows.sort(function (a, b) {
+        var aText = a.children[column].textContent.trim().toLowerCase();
+        var bText = b.children[column].textContent.trim().toLowerCase();
+        if (direction === 'ascending') {
+            return aText.localeCompare(bText);
+        }
+        return bText.localeCompare(aText);
+    });
+    rows.forEach(function (row) {
+        tbody.appendChild(row);
+    });
+}
+
+function rtbcb_init_test_results_table() {
+    var table = document.getElementById('rtbcb-test-results-summary');
+    if (!table) {
+        return;
+    }
+    var search = document.getElementById('rtbcb-test-results-search');
+    var headers = table.querySelectorAll('th');
+    headers.forEach(function (th, index) {
+        th.addEventListener('click', function () {
+            rtbcb_sort_test_results(table, index);
+        });
+        th.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                rtbcb_sort_test_results(table, index);
+            }
+        });
+    });
+    if (search) {
+        search.addEventListener('input', function () {
+            var query = search.value.toLowerCase();
+            var rows = Array.from(table.querySelectorAll('tbody tr')).filter(function (row) {
+                return !row.classList.contains('rtbcb-no-results');
+            });
+            var visible = 0;
+            rows.forEach(function (row) {
+                var text = row.textContent.toLowerCase();
+                var match = text.indexOf(query) !== -1;
+                row.style.display = match ? '' : 'none';
+                if (match) {
+                    visible++;
+                }
+            });
+            var noResults = table.querySelector('tbody .rtbcb-no-results');
+            if (noResults) {
+                noResults.style.display = visible === 0 ? '' : 'none';
+            }
+        });
+    }
+}
+
 document.addEventListener('DOMContentLoaded', function () {
     rtbcb_set_ajaxurl();
     rtbcb_bind_regenerate('rtbcb-rerun-company-overview', 'rtbcb-generate-company-overview');
@@ -1428,4 +1493,5 @@ document.addEventListener('DOMContentLoaded', function () {
     rtbcb_bind_regenerate('rtbcb-rerun-report-test', 'rtbcb-generate-report');
     rtbcb_init_api_test();
     rtbcb_init_connectivity_tests();
+    rtbcb_init_test_results_table();
 });

--- a/admin/partials/dashboard-test-results.php
+++ b/admin/partials/dashboard-test-results.php
@@ -23,14 +23,16 @@ $sections     = rtbcb_get_dashboard_sections();
 </div>
 
 <h2 class="title"><?php esc_html_e( 'Recent Test Results', 'rtbcb' ); ?></h2>
-<table class="widefat striped" id="rtbcb-test-results-summary">
+<label for="rtbcb-test-results-search" class="screen-reader-text"><?php esc_html_e( 'Search test results', 'rtbcb' ); ?></label>
+<input type="search" id="rtbcb-test-results-search" placeholder="<?php esc_attr_e( 'Filter results...', 'rtbcb' ); ?>" aria-controls="rtbcb-test-results-summary" />
+<table class="widefat striped" id="rtbcb-test-results-summary" role="grid">
     <thead>
         <tr>
-            <th><?php esc_html_e( 'Section', 'rtbcb' ); ?></th>
-            <th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
-            <th><?php esc_html_e( 'Message', 'rtbcb' ); ?></th>
-            <th><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
-            <th><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
+            <th scope="col" tabindex="0" aria-sort="none"><?php esc_html_e( 'Section', 'rtbcb' ); ?></th>
+            <th scope="col" tabindex="0" aria-sort="none"><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
+            <th scope="col" tabindex="0" aria-sort="none"><?php esc_html_e( 'Message', 'rtbcb' ); ?></th>
+            <th scope="col" tabindex="0" aria-sort="none"><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
+            <th scope="col" tabindex="0" aria-sort="none"><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
         </tr>
     </thead>
     <tbody>
@@ -55,10 +57,13 @@ $sections     = rtbcb_get_dashboard_sections();
             </tr>
         <?php endforeach; ?>
     <?php else : ?>
-        <tr>
+        <tr class="rtbcb-no-results">
             <td colspan="5"><?php esc_html_e( 'No test results found.', 'rtbcb' ); ?></td>
         </tr>
     <?php endif; ?>
+        <tr class="rtbcb-no-results" style="display:none;">
+            <td colspan="5"><?php esc_html_e( 'No matching results found.', 'rtbcb' ); ?></td>
+        </tr>
     </tbody>
 </table>
 <script>


### PR DESCRIPTION
## Summary
- add search input and aria-sortable headers to Recent Test Results table
- implement vanilla JS sorting and live filtering

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `node --check admin/js/rtbcb-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68af70b743b48331813b141162574ead