### PR TITLE
Add nonces and expand test dashboard coverage

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -104,6 +104,8 @@ class RTBCB_Admin {
             'complete_report_nonce'      => wp_create_nonce( 'rtbcb_test_generate_complete_report' ),
             'test_dashboard_nonce'       => wp_create_nonce( 'rtbcb_test_dashboard' ),
             'roi_nonce'                  => wp_create_nonce( 'rtbcb_test_calculate_roi' ),
+            'real_treasury_overview_nonce' => wp_create_nonce( 'rtbcb_test_real_treasury_overview' ),
+            'category_recommendation_nonce' => wp_create_nonce( 'rtbcb_test_category_recommendation' ),
             'page'                       => $page,
             'company'                    => $company_data,
             'strings'                    => [

--- a/admin/partials/dashboard-test-results.php
+++ b/admin/partials/dashboard-test-results.php
@@ -33,8 +33,22 @@ $sections     = rtbcb_get_dashboard_sections();
     <?php if ( ! empty( $recent_results ) ) : ?>
         <?php foreach ( $recent_results as $result ) : ?>
             <?php
-            $section_id    = isset( $result['section'] ) ? sanitize_text_field( $result['section'] ) : '';
-            $section_label = isset( $sections[ $section_id ]['label'] ) ? $sections[ $section_id ]['label'] : $section_id;
+            $section_id = isset( $result['section'] ) ? sanitize_text_field( $result['section'] ) : '';
+            $section_label = '';
+            if ( isset( $sections[ $section_id ] ) ) {
+                $section_label = $sections[ $section_id ]['label'];
+            } else {
+                foreach ( $sections as $id => $section ) {
+                    if ( $section['label'] === $section_id ) {
+                        $section_label = $section['label'];
+                        $section_id    = $id;
+                        break;
+                    }
+                }
+                if ( '' === $section_label ) {
+                    $section_label = $section_id;
+                }
+            }
             ?>
             <tr>
                 <td><?php echo esc_html( $section_label ); ?></td>


### PR DESCRIPTION
## Summary
- expose real treasury overview and category recommendation nonces to admin JS
- expand "Test All Sections" dashboard script to cover every section and send sample payloads
- ensure saved test results store section IDs for accurate links

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68af8e84f8d08331af087b5014ad3c28