### PR TITLE
Use test dashboard nonces in overview scripts

### DIFF
--- a/admin/js/real-treasury-overview.js
+++ b/admin/js/real-treasury-overview.js
@@ -11,14 +11,15 @@
         const overrideCategories = $('#rtbcb-override-categories');
         const summaryDiv = $('#rtbcb-company-summary');
         const challengesList = $('#rtbcb-company-challenges');
+        const api = window.rtbcbAdmin || window.rtbcb_ajax;
 
         // Fetch stored company data
         $.ajax({
-            url: rtbcb_ajax.ajax_url,
+            url: api.ajax_url,
             type: 'POST',
             data: {
                 action: 'rtbcb_get_company_data',
-                nonce: rtbcb_ajax.nonce,
+                nonce: api.nonce,
             },
             success: function(response) {
                 if (response.success) {
@@ -42,8 +43,8 @@
         generateBtn.on('click', function() {
             const include = includePortal.is(':checked') ? 1 : 0;
             const categories = overrideCategories.is(':checked') ? (categoriesSelect.val() || []) : [];
-            const nonce = rtbcb_ajax.nonce;
-            const url = rtbcb_ajax.ajax_url;
+            const nonce = window.rtbcbAdmin ? rtbcbAdmin.real_treasury_overview_nonce : api.nonce;
+            const url = api.ajax_url;
 
             const start = performance.now();
             const original = rtbcbTestUtils.showLoading(generateBtn, 'Generating...');

--- a/admin/js/recommended-category.js
+++ b/admin/js/recommended-category.js
@@ -5,11 +5,12 @@
         const $generateBtn = $('#rtbcb-generate-category-recommendation');
         const $resultsDiv = $('#rtbcb-category-recommendation-results');
         const $card = $('#rtbcb-category-recommendation-card');
+        const api = window.rtbcbAdmin || window.rtbcb_ajax;
 
         function sendRequest() {
             const data = {
                 action: 'rtbcb_generate_category_recommendation',
-                nonce: rtbcb_ajax.nonce,
+                nonce: window.rtbcbAdmin ? rtbcbAdmin.category_recommendation_nonce : api.nonce,
                 extra_requirements: $('#rtbcb-extra-requirements').val()
             };
 
@@ -18,7 +19,7 @@
             $resultsDiv.html('<p>Generating recommendation...</p>');
 
             $.ajax({
-                url: rtbcb_ajax.ajax_url,
+                url: api.ajax_url,
                 type: 'POST',
                 data: data,
                 success: function(response) {


### PR DESCRIPTION
## Summary
- Ensure localized script data includes nonces for real treasury overview and category recommendation
- Update real-treasury-overview and recommended-category scripts to use `rtbcbAdmin` nonces when available

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit not installed; some tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68af9acf6ce48331aefa36bac141c32a