### PR TITLE
Include additional company fields in admin script

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -89,6 +89,14 @@ class RTBCB_Admin {
                     'geography'      => isset( $raw_company['geography'] ) ? sanitize_text_field( $raw_company['geography'] ) : '',
                     'business_model' => isset( $raw_company['business_model'] ) ? sanitize_text_field( $raw_company['business_model'] ) : '',
                 ];
+
+                $company_data['focus_areas'] = isset( $raw_company['focus_areas'] )
+                    ? array_filter( array_map( 'sanitize_text_field', (array) $raw_company['focus_areas'] ) )
+                    : [];
+                $company_data['complexity']  = isset( $raw_company['complexity'] ) ? sanitize_text_field( $raw_company['complexity'] ) : '';
+                $company_data['challenges']  = isset( $raw_company['challenges'] )
+                    ? array_filter( array_map( 'sanitize_text_field', (array) $raw_company['challenges'] ) )
+                    : [];
             }
         }
 


### PR DESCRIPTION
## Summary
- Sanitize and expose company `focus_areas`, `complexity`, and `challenges` via localized admin script
- Ensure these fields are passed through the `rtbcbAdmin.company` object for JavaScript usage

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68afbe0a18888331a3bec1a3e1b30aea