### PR TITLE
Persist Real Treasury challenges in company option

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -765,25 +765,35 @@ class RTBCB_Admin {
      */
     public function ajax_test_real_treasury_overview() {
         check_ajax_referer( 'rtbcb_test_real_treasury_overview', 'nonce' );
-
+        
         $include_portal = isset( $_POST['include_portal'] ) ? (bool) intval( wp_unslash( $_POST['include_portal'] ) ) : false;
         $categories     = isset( $_POST['categories'] ) ? (array) wp_unslash( $_POST['categories'] ) : [];
         $categories     = array_filter( array_map( 'sanitize_text_field', $categories ) );
 
-        $inputs       = rtbcb_get_sample_inputs();
-        $company_data = [
-            'include_portal' => $include_portal,
-            'company_size'   => sanitize_text_field( $inputs['company_size'] ?? '' ),
-            'industry'       => sanitize_text_field( $inputs['industry'] ?? '' ),
-            'challenges'     => array_map( 'sanitize_text_field', $inputs['pain_points'] ?? [] ),
-        ];
+        $inputs     = rtbcb_get_sample_inputs();
+        $challenges = array_map( 'sanitize_text_field', $inputs['pain_points'] ?? [] );
 
-        if ( ! empty( $categories ) ) {
-            $company_data['categories'] = $categories;
+        $company = rtbcb_get_current_company();
+        if ( ! is_array( $company ) ) {
+            $company = [];
         }
 
+        if ( ! empty( $challenges ) ) {
+            $existing_challenges   = isset( $company['challenges'] ) ? (array) $company['challenges'] : [];
+            $merged_challenges     = array_values( array_unique( array_merge( $existing_challenges, $challenges ) ) );
+            $company['challenges'] = array_filter( array_map( 'sanitize_text_field', $merged_challenges ) );
+        }
+
+        if ( ! empty( $categories ) ) {
+            $existing_categories   = isset( $company['categories'] ) ? (array) $company['categories'] : [];
+            $merged_categories     = array_values( array_unique( array_merge( $existing_categories, $categories ) ) );
+            $company['categories'] = array_filter( array_map( 'sanitize_text_field', $merged_categories ) );
+        }
+
+        update_option( 'rtbcb_current_company', $company );
+
         $start    = microtime( true );
-        $overview = rtbcb_test_generate_real_treasury_overview( $company_data );
+        $overview = rtbcb_test_generate_real_treasury_overview( $include_portal, $categories );
         $elapsed  = round( microtime( true ) - $start, 2 );
 
         if ( is_wp_error( $overview ) ) {


### PR DESCRIPTION
## Summary
- Merge sanitized challenges and selected categories into `rtbcb_current_company` before generating Real Treasury overview
- Call overview generator with portal flag and category list

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68afbfb77438833185f40453a00e63d8