### PR TITLE
Handle errors in test dashboard and reset button state

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -592,14 +592,17 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
               var row = '<tr><td>' + label + '</td><td>' + item.status + '</td><td>' + item.message + '</td><td>' + new Date().toLocaleString() + '</td><td>' + actions + '</td></tr>';
               tableBody.append(row);
             });
-            status.text('');
-            button.prop('disabled', false).text(originalText);
           });
         });
       });
       button.on('click', function () {
         button.prop('disabled', true).text(rtbcbAdmin.strings.testing);
-        runTests();
+        runTests().catch(function (err) {
+          alert("".concat(rtbcbAdmin.strings.error, " ").concat(err.message));
+        }).finally(function () {
+          status.text('');
+          button.prop('disabled', false).text(originalText);
+        });
       });
     },
     testApiConnection: function testApiConnection(e) {


### PR DESCRIPTION
## Summary
- wrap test dashboard runTests call in catch/finally to surface errors and restore button state
- simplify runTests cleanup logic

## Testing
- `npx --no-install eslint admin/js/rtbcb-admin.js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68afc0f9dcfc8331994ad2913dfd4adf