### PR TITLE
Propagate recommended category into benefits estimate

### DIFF
--- a/admin/js/recommended-category.js
+++ b/admin/js/recommended-category.js
@@ -25,6 +25,11 @@
                 success: function(response) {
                     if (response.success) {
                         const rec = response.data;
+                        if (window.rtbcbAdmin) {
+                            rtbcbAdmin.company = rtbcbAdmin.company || {};
+                            rtbcbAdmin.company.recommended_category = rec.recommended.key || rec.recommended;
+                            $('#rtbcb-test-category').val(rtbcbAdmin.company.recommended_category);
+                        }
                         let html = '<h2>' + $('<div/>').text(rec.recommended.name || rec.recommended.key).html() + '</h2>';
                         if (rec.reasoning) {
                             html += '<p><strong>Reasoning:</strong> ' + $('<div/>').text(rec.reasoning).html() + '</p>';

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -402,7 +402,7 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
           staff_count: $('#rtbcb-test-staff-count').val(),
           efficiency: $('#rtbcb-test-efficiency').val()
         },
-        recommended_category: $('#rtbcb-test-category').val(),
+        recommended_category: rtbcbAdmin.company && rtbcbAdmin.company.recommended_category ? rtbcbAdmin.company.recommended_category : $('#rtbcb-test-category').val(),
         nonce: rtbcbAdmin.benefits_estimate_nonce
       };
       $.post(rtbcbAdmin.ajax_url, data).done(function (response) {
@@ -558,7 +558,14 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
               action: test.action,
               nonce: test.nonce
             }, test.data || {});
+            if (test.id === 'rtbcb-test-estimated-benefits') {
+              payload.recommended_category = rtbcbAdmin.company && rtbcbAdmin.company.recommended_category ? rtbcbAdmin.company.recommended_category : payload.recommended_category;
+            }
             return _await($.post(rtbcbAdmin.ajax_url, payload), function (response) {
+              if (response.success && test.id === 'rtbcb-test-recommended-category' && response.data && response.data.recommended) {
+                rtbcbAdmin.company = rtbcbAdmin.company || {};
+                rtbcbAdmin.company.recommended_category = response.data.recommended.key || response.data.recommended;
+              }
               var message = response && response.data && response.data.message ? response.data.message : '';
               results.push({
                 section: test.id,


### PR DESCRIPTION
## Summary
- Save Recommended Category responses to `rtbcbAdmin.company.recommended_category`
- Use saved recommended category when requesting Estimated Benefits
- Sync test dashboard to inject updated recommended category into the benefits request

## Testing
- `npx eslint admin/js/recommended-category.js admin/js/rtbcb-admin.js` *(fails: ESLint couldn't find a config file)*
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68afc21372988331b7df03ed4b8790d7