### PR TITLE
Move company name input to test tools

### DIFF
--- a/admin/partials/dashboard-connectivity.php
+++ b/admin/partials/dashboard-connectivity.php
@@ -8,9 +8,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
-
-$company_data = get_option( 'rtbcb_company_data', [] );
-$company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_data['name'] ) : '';
 ?>
 <div class="card">
     <h2 class="title"><?php esc_html_e( 'Connectivity Tests & Status', 'rtbcb' ); ?></h2>
@@ -34,12 +31,6 @@ $company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_d
         <button type="button" id="rtbcb-test-openai" class="button"><?php esc_html_e( 'Test OpenAI API', 'rtbcb' ); ?></button>
         <button type="button" id="rtbcb-test-portal" class="button"><?php esc_html_e( 'Test Portal Connection', 'rtbcb' ); ?></button>
         <button type="button" id="rtbcb-test-rag" class="button"><?php esc_html_e( 'Test RAG Index', 'rtbcb' ); ?></button>
-    </p>
-    <p>
-        <label for="rtbcb-company-name"><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></label>
-        <input type="text" id="rtbcb-company-name" class="regular-text" value="<?php echo esc_attr( $company_name ); ?>" />
-        <button type="button" id="rtbcb-set-company" class="button"><?php esc_html_e( 'Set Company', 'rtbcb' ); ?></button>
-        <?php wp_nonce_field( 'rtbcb_set_test_company', 'rtbcb_set_test_company_nonce' ); ?>
     </p>
     <p id="rtbcb-connectivity-status"></p>
 

--- a/admin/partials/test-report.php
+++ b/admin/partials/test-report.php
@@ -38,12 +38,6 @@ if ( empty( $company ) ) {
 <table class="form-table">
     <tr>
         <th scope="row">
-            <label for="rtbcb-company-name"><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></label>
-        </th>
-        <td><input type="text" id="rtbcb-company-name" class="regular-text" /></td>
-    </tr>
-    <tr>
-        <th scope="row">
             <label for="rtbcb-focus-areas"><?php esc_html_e( 'Focus Areas', 'rtbcb' ); ?></label>
         </th>
         <td>

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -8,8 +8,8 @@
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
-
-$company = rtbcb_get_current_company();
+$company_data = get_option( 'rtbcb_company_data', [] );
+$company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_data['name'] ) : '';
 ?>
 <div class="wrap rtbcb-admin-page">
     <h1><?php esc_html_e( 'Treasury Report Section Testing Dashboard', 'rtbcb' ); ?></h1>
@@ -35,6 +35,12 @@ $company = rtbcb_get_current_company();
 
     <div class="card">
         <h2 class="title"><?php esc_html_e( 'Test Tools', 'rtbcb' ); ?></h2>
+        <p>
+            <label for="rtbcb-company-name"><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></label>
+            <input type="text" id="rtbcb-company-name" class="regular-text" value="<?php echo esc_attr( $company_name ); ?>" />
+            <button type="button" id="rtbcb-set-company" class="button"><?php esc_html_e( 'Set Company', 'rtbcb' ); ?></button>
+            <?php wp_nonce_field( 'rtbcb_set_test_company', 'rtbcb_set_test_company_nonce' ); ?>
+        </p>
         <p class="submit">
             <button type="button" id="rtbcb-test-all-sections" class="button button-primary">
                 <?php esc_html_e( 'Test All Sections', 'rtbcb' ); ?>


### PR DESCRIPTION
## Summary
- add company name field and Set Company button to Test Tools card with nonce
- remove duplicate company name fields from connectivity and report test partials
- keep existing AJAX handler for setting the company

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `rg 'id="rtbcb-company-name"' -n`


------
https://chatgpt.com/codex/tasks/task_e_68afc6634df8833197886cb3a7db7691