### PR TITLE
Require company name before running dashboard tests

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -127,6 +127,7 @@ class RTBCB_Admin {
                 'retry'               => __( 'Retry', 'rtbcb' ),
                 'view'                => __( 'View', 'rtbcb' ),
                 'rerun'               => __( 'Re-run', 'rtbcb' ),
+                'company_required'    => __( 'Company name is required.', 'rtbcb' ),
             ],
         ] );
 

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -486,9 +486,22 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
       var status = $('#rtbcb-test-status');
       var tableBody = $('#rtbcb-test-results-summary tbody');
       var originalText = button.text();
+      var nameInput = $('#rtbcb-company-name');
+      var toggleButtonState = function toggleButtonState() {};
+      if (nameInput.length) {
+        toggleButtonState = function toggleButtonState() {
+          button.prop('disabled', !nameInput.val().trim());
+        };
+        toggleButtonState();
+        nameInput.on('input', toggleButtonState);
+      }
       var runTests = _async(function () {
+        var companyName = $('#rtbcb-company-name').val().trim();
+        if (!companyName) {
+          alert(rtbcbAdmin.strings.company_required);
+          return _await();
+        }
         var company = rtbcbAdmin.company = rtbcbAdmin.company || {};
-        var companyName = company.name || $('#rtbcb-company-name').val() || 'Sample Company';
         company.name = companyName;
         if (typeof rtbcb_set_test_company === 'function') {
           rtbcb_set_test_company({ name: companyName });
@@ -608,7 +621,8 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
           alert("".concat(rtbcbAdmin.strings.error, " ").concat(err.message));
         }).finally(function () {
           status.text('');
-          button.prop('disabled', false).text(originalText);
+          button.text(originalText);
+          toggleButtonState();
         });
       });
     },


### PR DESCRIPTION
## Summary
- alert when trying to run dashboard tests without a company name and remove fallback name
- disable Test All Sections button until a company name is entered
- localize new `company_required` string for translations

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68afc76dc9f883318af0f0683d277099