### PR TITLE
Handle relocated company name field

### DIFF
--- a/admin/js/report-test.js
+++ b/admin/js/report-test.js
@@ -1,5 +1,11 @@
 jQuery( function( $ ) {
     var latestReportText = '';
+
+    // Company name input now lives in the Test Tools card; fetch safely.
+    function getCompanyName() {
+        var input = $( '#rtbcb-company-name' );
+        return input.length ? input.val().trim() : '';
+    }
     function setStatus( message, isError, retryFn ) {
         var status = $( '#rtbcb-report-status' );
         status.removeClass( 'error' ).empty();
@@ -32,7 +38,7 @@ jQuery( function( $ ) {
     }
 
     function generateReport() {
-        var company = $( '#rtbcb-company-name' ).val().trim();
+        var company = getCompanyName();
         var focusRaw = $( '#rtbcb-focus-areas' ).val().trim();
         var complexity = $( '#rtbcb-complexity' ).val();
         if ( ! company || ! focusRaw ) {
@@ -141,7 +147,7 @@ jQuery( function( $ ) {
     } );
 
     function regenerateCompany() {
-        var company = $( '#rtbcb-company-name' ).val().trim();
+        var company = getCompanyName();
         if ( ! company ) {
             alert( rtbcbAdmin.strings.error );
             return;

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -321,7 +321,9 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
       var results = $('#rtbcb-company-overview-results');
       var submitBtn = form.find('button[type="submit"]');
       var original = RTBCBAdmin.utils.setLoading(submitBtn, rtbcbAdmin.strings.processing);
-      var company = $('#rtbcb-company-name').val();
+      // Company name field resides in Test Tools card; guard against missing input.
+      var companyInput = $('#rtbcb-company-name');
+      var company = companyInput.length ? companyInput.val() : '';
       var nonce = form.find('[name="nonce"]').val();
       var start = performance.now();
       var formData = new FormData();
@@ -486,6 +488,7 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
       var status = $('#rtbcb-test-status');
       var tableBody = $('#rtbcb-test-results-summary tbody');
       var originalText = button.text();
+      // Company name input moved to Test Tools card; cache for reuse.
       var nameInput = $('#rtbcb-company-name');
       var toggleButtonState = function toggleButtonState() {};
       if (nameInput.length) {
@@ -496,7 +499,7 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
         nameInput.on('input', toggleButtonState);
       }
       var runTests = _async(function () {
-        var companyName = $('#rtbcb-company-name').val().trim();
+        var companyName = nameInput.length ? nameInput.val().trim() : '';
         if (!companyName) {
           alert(rtbcbAdmin.strings.company_required);
           return _await();

--- a/admin/partials/dashboard-connectivity.php
+++ b/admin/partials/dashboard-connectivity.php
@@ -112,7 +112,9 @@ if ( ! defined( 'ABSPATH' ) ) {
         var $btn = $(this);
         var original = $btn.text();
         var $status = $('#rtbcb-connectivity-status');
-        var name = $('#rtbcb-company-name').val();
+        // Company name input resides in the Test Tools card; fetch safely.
+        var nameInput = $('#rtbcb-company-name');
+        var name = nameInput.length ? nameInput.val() : '';
         $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Saving...', 'rtbcb' ) ); ?>');
         $.post(ajaxurl, {
             action: 'rtbcb_set_test_company',


### PR DESCRIPTION
## Summary
- Safely fetch the company name from its new Test Tools location in report generation scripts
- Guard admin dashboard logic against missing company name input and reuse a cached reference
- Update connectivity test script to safely access the relocated company name input

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `./tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68afc8b174e48331b32eb61e548c385b