### PR TITLE
Use data attribute for report test company field

### DIFF
--- a/admin/js/report-test.js
+++ b/admin/js/report-test.js
@@ -1,9 +1,9 @@
 jQuery( function( $ ) {
     var latestReportText = '';
 
-    // Company name input now lives in the Test Tools card; fetch safely.
+    // Company name input uses a data attribute to avoid ID conflicts.
     function getCompanyName() {
-        var input = $( '#rtbcb-company-name' );
+        var input = $( '[data-company-name]' );
         return input.length ? input.val().trim() : '';
     }
     function setStatus( message, isError, retryFn ) {

--- a/admin/partials/test-report.php
+++ b/admin/partials/test-report.php
@@ -38,6 +38,14 @@ if ( empty( $company ) ) {
 <table class="form-table">
     <tr>
         <th scope="row">
+            <label for="rtbcb-report-company-name"><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></label>
+        </th>
+        <td>
+            <input type="text" id="rtbcb-report-company-name" class="regular-text" data-company-name value="<?php echo esc_attr( $company['name'] ?? '' ); ?>" />
+        </td>
+    </tr>
+    <tr>
+        <th scope="row">
             <label for="rtbcb-focus-areas"><?php esc_html_e( 'Focus Areas', 'rtbcb' ); ?></label>
         </th>
         <td>


### PR DESCRIPTION
## Summary
- replace duplicated `#rtbcb-company-name` input in report test with a data attribute
- adjust report test script to read the new data attribute
- confirm no other duplicate company name IDs exist

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afcb3e5428833189a2161a31ba72a7