### PR TITLE
Refresh test company data and clarify dashboard errors

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -658,14 +658,17 @@ class RTBCB_Admin {
                 'generated_at'    => current_time( 'mysql' ),
             ] );
 
-            wp_send_json_success( [
-                'overview'        => wp_kses_post( $analysis ),
-                'word_count'      => $word_count,
-                'elapsed'         => round( $elapsed_time, 2 ),
-                'generated'       => current_time( 'mysql' ),
-                'recommendations' => $recommendations,
-                'references'      => $references,
-            ] );
+            wp_send_json_success(
+                [
+                    'message'         => __( 'Company overview generated.', 'rtbcb' ),
+                    'overview'        => wp_kses_post( $analysis ),
+                    'word_count'      => $word_count,
+                    'elapsed'         => round( $elapsed_time, 2 ),
+                    'generated'       => current_time( 'mysql' ),
+                    'recommendations' => $recommendations,
+                    'references'      => $references,
+                ]
+            );
 
         } catch ( Exception $e ) {
             error_log( 'RTBCB Company Overview Error: ' . $e->getMessage() );
@@ -991,7 +994,12 @@ class RTBCB_Admin {
         update_option( 'rtbcb_company_data', [ 'name' => $company_name ] );
         delete_option( 'rtbcb_test_results' );
 
-        wp_send_json_success( [ 'message' => __( 'Company saved.', 'rtbcb' ) ] );
+        wp_send_json_success(
+            [
+                'message' => __( 'Company saved.', 'rtbcb' ),
+                'name'    => $company_name,
+            ]
+        );
     }
 
     /**

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -507,7 +507,14 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
         var company = rtbcbAdmin.company = rtbcbAdmin.company || {};
         company.name = companyName;
         if (typeof rtbcb_set_test_company === 'function') {
-          rtbcb_set_test_company({ name: companyName });
+          var setCompany = rtbcb_set_test_company({ name: companyName });
+          if (setCompany && typeof setCompany.then === 'function') {
+            setCompany.then(function (response) {
+              if (response && response.success && response.data && response.data.name) {
+                rtbcbAdmin.company.name = response.data.name;
+              }
+            })["catch"](function () {});
+          }
         }
         var tests = [{
           id: 'rtbcb-test-company-overview',
@@ -582,7 +589,7 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
                 rtbcbAdmin.company = rtbcbAdmin.company || {};
                 rtbcbAdmin.company.recommended_category = response.data.recommended.key || response.data.recommended;
               }
-              var message = response && response.data && response.data.message ? response.data.message : '';
+              var message = response && response.data && response.data.message ? response.data.message : 'Unknown error';
               results.push({
                 section: test.id,
                 status: response.success ? 'success' : 'error',


### PR DESCRIPTION
## Summary
- Refresh `rtbcbAdmin.company.name` after saving the test company and ensure the server returns the sanitized name.
- Default missing test loop messages to "Unknown error".
- Always return a message from `ajax_test_company_overview`.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b054d4a8e083318fced7053baa53a5