### PR TITLE
Store company details after overview

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -650,13 +650,19 @@ class RTBCB_Admin {
             $word_count   = str_word_count( wp_strip_all_tags( $analysis ) );
             $elapsed_time = microtime( true ) - $start_time;
 
-            update_option( 'rtbcb_current_company', [
+            $existing = rtbcb_get_current_company();
+            $company_data = [
                 'name'            => $company_name,
                 'summary'         => sanitize_textarea_field( wp_strip_all_tags( $analysis ) ),
                 'recommendations' => $recommendations,
                 'references'      => $references,
                 'generated_at'    => current_time( 'mysql' ),
-            ] );
+                'focus_areas'     => array_map( 'sanitize_text_field', (array) ( $existing['focus_areas'] ?? [] ) ),
+                'industry'        => isset( $existing['industry'] ) ? sanitize_text_field( $existing['industry'] ) : '',
+                'size'            => isset( $existing['size'] ) ? sanitize_text_field( $existing['size'] ) : '',
+            ];
+
+            update_option( 'rtbcb_current_company', $company_data );
 
             wp_send_json_success(
                 [
@@ -667,6 +673,9 @@ class RTBCB_Admin {
                     'generated'       => current_time( 'mysql' ),
                     'recommendations' => $recommendations,
                     'references'      => $references,
+                    'focus_areas'     => $company_data['focus_areas'],
+                    'industry'        => $company_data['industry'],
+                    'size'            => $company_data['size'],
                 ]
             );
 


### PR DESCRIPTION
## Summary
- Preserve existing company attributes when generating overview and return them for client use
- Update dashboard tests to use stored company data and record new attributes after company overview

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash ./tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b057137538833185ddcb755d7e70c5