### PR TITLE
Handle missing AJAX URL in form submissions

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -387,6 +387,10 @@ class BusinessCaseBuilder {
     async handleSubmit() {
         // Show loading state
         this.showProgress();
+        if (typeof ajaxObj === 'undefined' || !ajaxObj.ajax_url) {
+            this.showError('Unable to submit form. Please refresh the page and try again.');
+            return;
+        }
 
         try {
             const formData = new FormData();

--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -74,6 +74,10 @@ async function handleSubmit(e) {
     // Show progress indicator
     if (formContainer) formContainer.style.display = 'none';
     if (progressContainer) progressContainer.style.display = 'block';
+    if (typeof ajaxObj === 'undefined' || !ajaxObj.ajax_url) {
+        handleSubmissionError('Unable to submit form. Please refresh the page and try again.');
+        return;
+    }
 
     try {
         const response = await fetch(ajaxObj.ajax_url, {

--- a/tests/handle-server-error-display.test.js
+++ b/tests/handle-server-error-display.test.js
@@ -18,7 +18,7 @@ global.document = {
     }
 };
 
-global.ajaxObj = { ajax_url: '' };
+global.ajaxObj = { ajax_url: 'test-url' };
 
 global.DOMPurify = { sanitize: (html) => html };
 

--- a/tests/handle-submit-error.test.js
+++ b/tests/handle-submit-error.test.js
@@ -18,7 +18,7 @@ global.document = {
     }
 };
 
-global.ajaxObj = { ajax_url: '' };
+global.ajaxObj = { ajax_url: 'test-url' };
 
 global.DOMPurify = { sanitize: (html) => html };
 

--- a/tests/handle-submit-success.test.js
+++ b/tests/handle-submit-success.test.js
@@ -18,7 +18,7 @@ global.document = {
     }
 };
 
-global.ajaxObj = { ajax_url: '' };
+global.ajaxObj = { ajax_url: 'test-url' };
 
 global.DOMPurify = { sanitize: (html) => html };
 


### PR DESCRIPTION
## Summary
- Guard handleSubmit functions against missing AJAX URLs
- Update JS tests to provide a mock AJAX URL

## Testing
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b05bd8498883319bf3d838fc1a2ef5