### PR TITLE
Ensure runTests cleanup runs in older browsers

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -653,7 +653,8 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
         button.prop('disabled', true).text(rtbcbAdmin.strings.testing);
         runTests().catch(function (err) {
           alert("".concat(rtbcbAdmin.strings.error, " ").concat(err.message));
-        }).finally(function () {
+          return Promise.resolve();
+        }).then(function () {
           status.text('');
           button.text(originalText);
           toggleButtonState();


### PR DESCRIPTION
## Summary
- Replace `.finally` with `.then` in `runTests` click handler
- Return a resolved promise in `catch` so cleanup always runs

## Testing
- `bash tests/run-tests.sh` *(phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b06dd9e9d88331ad607135f5ad8eff