### PR TITLE
Refactor report generation to synchronous flow

### DIFF
--- a/tests/temperature-model.test.js
+++ b/tests/temperature-model.test.js
@@ -17,77 +17,74 @@ function runTests() {
     };
 
     const models = [...unsupportedModels, ...supportedModels];
-    let chain = Promise.resolve();
 
     models.forEach((model) => {
-        chain = chain.then(() => {
-            let capturedBody;
-            global.rtbcbReport = { report_model: model, model_capabilities: capabilities, ajax_url: 'https://example.com' };
-            global.fetch = (url, options) => {
-                capturedBody = JSON.parse(options.body.store.body);
-                return Promise.resolve({ ok: true, json: () => Promise.resolve({ output_text: '<html></html>' }) });
+        let capturedBody;
+        global.rtbcbReport = { report_model: model, model_capabilities: capabilities, ajax_url: 'https://example.com' };
+
+        global.XMLHttpRequest = function() {
+            this.open = function(method, url, async) {
+                this.method = method;
+                this.url = url;
+                this.async = async;
             };
-            global.document = { getElementById: () => null };
-            global.DOMPurify = { sanitize: (html) => html };
+            this.send = function(formData) {
+                capturedBody = JSON.parse(formData.store.body);
+                this.status = 200;
+                this.responseText = JSON.stringify({ output_text: '<html></html>' });
+            };
+        };
 
-            return generateProfessionalReport('context').then(() => {
-                const shouldInclude = supportedModels.includes(model);
+        global.document = { getElementById: () => null };
+        global.DOMPurify = { sanitize: (html) => html };
 
-                assert.strictEqual(
-                    capturedBody.max_output_tokens,
-                    20000,
-                    'Client request body should include max_output_tokens 20000'
-                );
+        generateProfessionalReport('context');
+        const shouldInclude = supportedModels.includes(model);
 
-                if (shouldInclude) {
-                    assert.strictEqual(
-                        capturedBody.temperature,
-                        0.7,
-                        `Client request body for ${model} should include temperature 0.7`
-                    );
-                } else {
-                    assert.ok(
-                        !('temperature' in capturedBody),
-                        `Client request body for ${model} should not include temperature`
-                    );
-                }
+        assert.strictEqual(
+            capturedBody.max_output_tokens,
+            20000,
+            'Client request body should include max_output_tokens 20000'
+        );
 
-                const serverBody = JSON.parse(execSync('php tests/helpers/capture-call-openai-body.php 2>/dev/null', {
-                    encoding: 'utf8',
-                    env: { ...process.env, RTBCB_TEST_MODEL: model }
-                }));
+        if (shouldInclude) {
+            assert.strictEqual(
+                capturedBody.temperature,
+                0.7,
+                `Client request body for ${model} should include temperature 0.7`
+            );
+        } else {
+            assert.ok(
+                !('temperature' in capturedBody),
+                `Client request body for ${model} should not include temperature`
+            );
+        }
 
-                assert.strictEqual(
-                    serverBody.max_output_tokens,
-                    256,
-                    'Server request body should enforce minimum max_output_tokens of 256'
-                );
+        const serverBody = JSON.parse(execSync('php tests/helpers/capture-call-openai-body.php 2>/dev/null', {
+            encoding: 'utf8',
+            env: { ...process.env, RTBCB_TEST_MODEL: model }
+        }));
 
-                if (shouldInclude) {
-                    assert.strictEqual(
-                        serverBody.temperature,
-                        0.7,
-                        `Server request body for ${model} should include temperature 0.7`
-                    );
-                } else {
-                    assert.ok(
-                        !('temperature' in serverBody),
-                        `Server request body for ${model} should not include temperature`
-                    );
-                }
-            });
-        });
+        assert.strictEqual(
+            serverBody.max_output_tokens,
+            256,
+            'Server request body should enforce minimum max_output_tokens of 256'
+        );
+
+        if (shouldInclude) {
+            assert.strictEqual(
+                serverBody.temperature,
+                0.7,
+                `Server request body for ${model} should include temperature 0.7`
+            );
+        } else {
+            assert.ok(
+                !('temperature' in serverBody),
+                `Server request body for ${model} should not include temperature`
+            );
+        }
     });
-
-    return chain;
 }
-
-runTests()
-    .then(() => {
-        console.log('Model temperature test passed.');
-    })
-    .catch((error) => {
-        console.error(error);
-        process.exit(1);
-    });
+runTests();
+console.log('Model temperature test passed.');
 


### PR DESCRIPTION
## Summary
- Replace asynchronous fetch with synchronous `XMLHttpRequest` and sequential retries
- Simplify report display flow by calling the generator synchronously before updating the DOM
- Print reports directly without `requestAnimationFrame` or timed callbacks

## Testing
- `node tests/temperature-model.test.js`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68b0bbe909488331bc4c4ca0c189b392