### PR TITLE
Make BusinessCaseBuilder synchronous and update tests

### DIFF
--- a/tests/handle-submit-error.test.js
+++ b/tests/handle-submit-error.test.js
@@ -2,43 +2,48 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
-const progressContainer = { innerHTML: '', style: {} };
-const formContainer = { style: {} };
-const reportContainer = { innerHTML: '', style: {} };
+const form = { fields: {} };
 
+global.window = {};
 global.document = {
-    readyState: 'complete',
     addEventListener: () => {},
-    getElementById: (id) => {
-        if (id === 'rtbcb-progress-container') return progressContainer;
-        if (id === 'rtbcb-form-container') return formContainer;
-        if (id === 'rtbcb-report-container') return reportContainer;
-        if (id === 'rtbcb-form') return {};
-        return null;
-    }
+    getElementById: (id) => (id === 'rtbcbForm' ? form : null),
+    body: { style: {} }
 };
 
 global.ajaxObj = { ajax_url: 'test-url' };
 
-global.DOMPurify = { sanitize: (html) => html };
+global.FormData = class {
+    constructor(form) {
+        this.store = form && form.fields ? { ...form.fields } : {};
+    }
+    append(key, value) { this.store[key] = value; }
+    entries() { return Object.entries(this.store); }
+    [Symbol.iterator]() { return this.entries()[Symbol.iterator](); }
+};
 
-global.fetch = () => Promise.resolve({
-    ok: true,
-    json: () => Promise.resolve({ success: false, data: { message: 'Bad narrative' } }),
-    text: () => Promise.resolve('')
-});
+class MockXHR {
+    open() {}
+    send() {
+        this.status = 200;
+        this.responseText = JSON.stringify({ success: false, data: { message: 'Bad narrative' } });
+    }
+}
+global.XMLHttpRequest = MockXHR;
 
-global.FormData = class { constructor() {} };
-
-const code = fs.readFileSync('public/js/rtbcb.js', 'utf8');
+const code = fs.readFileSync('public/js/rtbcb-wizard.js', 'utf8');
 vm.runInThisContext(code);
 
-handleSubmit({ preventDefault() {}, target: {} })
-    .then(() => {
-        assert.ok(progressContainer.innerHTML.includes('Bad narrative'));
-        console.log('Error path test passed.');
-    })
-    .catch((error) => {
-        console.error(error);
-        process.exit(1);
-    });
+BusinessCaseBuilder.prototype.init = function() {};
+const builder = new BusinessCaseBuilder();
+builder.form = form;
+builder.showProgress = () => {};
+
+let errorMessage = null;
+builder.showResults = () => {};
+builder.showError = (msg) => { errorMessage = msg; };
+
+builder.handleSubmit();
+assert.strictEqual(errorMessage, 'Bad narrative');
+console.log('Error path test passed.');
+

--- a/tests/handle-submit-success.test.js
+++ b/tests/handle-submit-success.test.js
@@ -2,50 +2,50 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
-const progressContainer = { innerHTML: '', style: {} };
-const formContainer = { style: {} };
-const reportContainer = { innerHTML: '', style: {} };
+const form = {
+    fields: {},
+};
 
+global.window = {};
 global.document = {
-    readyState: 'complete',
     addEventListener: () => {},
-    getElementById: (id) => {
-        if (id === 'rtbcb-progress-container') return progressContainer;
-        if (id === 'rtbcb-form-container') return formContainer;
-        if (id === 'rtbcb-report-container') return reportContainer;
-        if (id === 'rtbcb-form') return {};
-        return null;
-    }
+    getElementById: (id) => (id === 'rtbcbForm' ? form : null),
+    body: { style: {} }
 };
 
 global.ajaxObj = { ajax_url: 'test-url' };
 
-global.DOMPurify = { sanitize: (html) => html };
+global.FormData = class {
+    constructor(form) {
+        this.store = form && form.fields ? { ...form.fields } : {};
+    }
+    append(key, value) { this.store[key] = value; }
+    entries() { return Object.entries(this.store); }
+    [Symbol.iterator]() { return this.entries()[Symbol.iterator](); }
+};
 
-global.fetch = () => Promise.resolve({
-    ok: true,
-    json: () => Promise.resolve({
-        success: true,
-        data: {
-            report_html: '<div>Report</div>',
-            download_url: 'http://example.com/test.pdf'
-        }
-    }),
-    text: () => Promise.resolve('')
-});
+class MockXHR {
+    open() {}
+    send() {
+        this.status = 200;
+        this.responseText = JSON.stringify({ success: true, data: { report: 'ok' } });
+    }
+}
+global.XMLHttpRequest = MockXHR;
 
-global.FormData = class { constructor() {} };
-
-const code = fs.readFileSync('public/js/rtbcb.js', 'utf8');
+const code = fs.readFileSync('public/js/rtbcb-wizard.js', 'utf8');
 vm.runInThisContext(code);
 
-handleSubmit({ preventDefault() {}, target: {} })
-    .then(() => {
-        assert.strictEqual(reportContainer.innerHTML, '<div>Report</div>');
-        assert.ok(!reportContainer.innerHTML.includes('test.pdf'));
-        console.log('Success path test passed.');
-    })
-    .catch((error) => {
-        console.error(error);
-        process.exit(1);
-    });
+BusinessCaseBuilder.prototype.init = function() {};
+const builder = new BusinessCaseBuilder();
+builder.form = form;
+builder.showProgress = () => {};
+
+let result = null;
+builder.showResults = (data) => { result = data; };
+builder.showError = () => {};
+
+builder.handleSubmit();
+assert.deepStrictEqual(result, { report: 'ok' });
+console.log('Success path test passed.');
+


### PR DESCRIPTION
## Summary
- Remove requestAnimationFrame and timer usage in the wizard, running progress and modal logic synchronously
- Rewrite handleSubmit to use synchronous XMLHttpRequest and direct response handling
- Update JS tests to mock XMLHttpRequest and verify synchronous success and error flows

## Testing
- `bash tests/run-tests.sh` *(phpunit: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b0bbe334488331b23c468c26f23b25