### PR TITLE
Fix lead detail HTML string construction

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -599,13 +599,14 @@ jQuery(document).ready(function($) {
                 var roi = $row.find('.column-roi').text().trim();
                 var date = $row.find('.column-date').text().trim();
                 
-                var html = '<div class="rtbcb-lead-detail-grid">' +
-                    '<div class="rtbcb-detail-item"><label>Email:</label><span>' + email + '</span></div>' +
-                    '<div class="rtbcb-detail-item"><label>Company Size:</label><span>' + size + '</span></div>' +
-                    '<div class="rtbcb-detail-item"><label>Category:</label><span>' + category + '</span></div>' +
-                    '<div class="rtbcb-detail-item"><label>ROI:</label><span>' + roi + '</span></div>' +
-                    '<div class="rtbcb-detail-item"><label>Date:</label><span>' + date + '</span></div>' +
-                    '</div>';
+                var html = `
+                    <div class="rtbcb-lead-detail-grid">
+                        <div class="rtbcb-detail-item"><label>Email:</label><span>${email}</span></div>
+                        <div class="rtbcb-detail-item"><label>Company Size:</label><span>${size}</span></div>
+                        <div class="rtbcb-detail-item"><label>Category:</label><span>${category}</span></div>
+                        <div class="rtbcb-detail-item"><label>ROI:</label><span>${roi}</span></div>
+                        <div class="rtbcb-detail-item"><label>Date:</label><span>${date}</span></div>
+                    </div>`;
                 
                 $('#rtbcb-lead-details').html(html);
                 $('#rtbcb-lead-modal').show();


### PR DESCRIPTION
## Summary
- Build lead detail modal with a template literal to avoid syntax errors when viewing lead details

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b0c5ad5d6c8331a78de273c891bf1d