### PR TITLE
Bump plugin version to 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Real Treasury Business Case Builder - Enhanced Version 2.1.0
+# Real Treasury Business Case Builder - Enhanced Version 2.1.1
 
 A comprehensive WordPress plugin that helps treasury teams quantify the benefits of modern treasury tools, generate professional business case reports, and track lead engagement with advanced analytics.
 
-## 🚀 What's New in Version 2.1.0
+## 🚀 What's New in Version 2.1.1
 
 ### ✨ Major Enhancements
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: realtreasury
 Tags: business, case, builder, roi, treasury
 Requires at least: 6.0
 Tested up to: 6.0
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -139,6 +139,9 @@ Reports are rendered as HTML in the browser. Use your browser's print or save fu
 The analytics dashboard uses Chart.js for its visualizations. The library is bundled with the plugin to reduce blocking by privacy tools, but strict ad blockers may still prevent it from loading. Allow the plugin's scripts in your browser to enable the charts.
 
 == Changelog ==
+= 2.1.1 =
+* Bump plugin version to 2.1.1.
+
 = 2.1.0 =
 * Introduced HTML report rendering with print-to-PDF support.
 * Added an analytics dashboard with Chart.js visualizations.

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Real Treasury - Business Case Builder (Enhanced Pro)
  * Description: Professional-grade ROI calculator and comprehensive business case generator for treasury technology with advanced analysis and consultant-style reports.
- * Version: 2.1.0
+ * Version: 2.1.1
  * Requires PHP: 7.4
  * Author: Real Treasury
  * Text Domain: rtbcb
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'RTBCB_VERSION', '2.1.0' );
+define( 'RTBCB_VERSION', '2.1.1' );
 define( 'RTBCB_FILE', __FILE__ );
 define( 'RTBCB_URL', plugin_dir_url( RTBCB_FILE ) );
 define( 'RTBCB_DIR', plugin_dir_path( RTBCB_FILE ) );


### PR DESCRIPTION
## Summary
- Update plugin header and constant to version 2.1.1
- Refresh README and readme.txt to reference 2.1.1 and note changelog

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c72493c88331836c7e437616e9c4