### PR TITLE
Align test dashboard with phased workflow

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -581,18 +581,25 @@ jQuery(document).ready(function($) {
             $('#rtbcb-bulk-form button[type="submit"]').prop('disabled', count === 0);
         },
         
-        initTabs: function() {
-            $('#rtbcb-test-tabs a').on('click', function(e) {
-                e.preventDefault();
-                var target = $(this).attr('href');
-                
-                $('#rtbcb-test-tabs a').removeClass('nav-tab-active');
-                $(this).addClass('nav-tab-active');
-                
-                $('.rtbcb-tab-panel').hide();
-                $(target).show();
-            });
-        }
+         initTabs: function() {
+             function showTab(target) {
+                 $('#rtbcb-test-tabs a').removeClass('nav-tab-active');
+                 $('#rtbcb-test-tabs a[href="' + target + '"]').addClass('nav-tab-active');
+                 $('.rtbcb-tab-panel').hide();
+                 $(target).show();
+             }
+             $('#rtbcb-test-tabs a').on('click', function(e) {
+                 e.preventDefault();
+                 showTab($(this).attr('href'));
+             });
+             $('.rtbcb-jump-tab').on('click', function(e) {
+                 e.preventDefault();
+                 showTab($(this).attr('href'));
+             });
+             if (window.location.hash && $('#rtbcb-test-tabs a[href="' + window.location.hash + '"]').length) {
+                 showTab(window.location.hash);
+             }
+         }
 
     };
     

--- a/admin/partials/test-estimated-benefits.php
+++ b/admin/partials/test-estimated-benefits.php
@@ -15,7 +15,7 @@ if ( ! rtbcb_require_completed_steps( 'rtbcb-test-estimated-benefits' ) ) {
 
 $company = rtbcb_get_current_company();
 if ( empty( $company ) ) {
-    $overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-test-company-overview' );
+$overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
     echo '<div class="notice notice-error"><p>' . sprintf(
         esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
         '<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'

--- a/admin/partials/test-industry-overview.php
+++ b/admin/partials/test-industry-overview.php
@@ -16,7 +16,7 @@ if ( ! $allowed ) {
 
 $company = rtbcb_get_current_company();
 if ( empty( $company ) ) {
-    $overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-test-company-overview' );
+$overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
     echo '<div class="notice notice-error"><p>' . sprintf(
         esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
         '<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'

--- a/admin/partials/test-post-delivery.php
+++ b/admin/partials/test-post-delivery.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Placeholder for post-delivery engagement tests.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<h2><?php esc_html_e( 'Post-Delivery Engagement', 'rtbcb' ); ?></h2>
+<p class="description">
+    <?php esc_html_e( 'Diagnostics for engagement tracking and follow-up sequences will be added here.', 'rtbcb' ); ?>
+</p>
+

--- a/admin/partials/test-real-treasury-overview.php
+++ b/admin/partials/test-real-treasury-overview.php
@@ -15,7 +15,7 @@ if ( ! rtbcb_require_completed_steps( 'rtbcb-test-real-treasury-overview' ) ) {
 
 $company = rtbcb_get_current_company();
 if ( empty( $company ) ) {
-    $overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-test-company-overview' );
+$overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
     echo '<div class="notice notice-error"><p>' . sprintf(
         esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
         '<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'

--- a/admin/partials/test-recommended-category.php
+++ b/admin/partials/test-recommended-category.php
@@ -15,7 +15,7 @@ if ( ! rtbcb_require_completed_steps( 'rtbcb-test-recommended-category' ) ) {
 
 $company = rtbcb_get_current_company();
 if ( empty( $company ) ) {
-    $overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-test-company-overview' );
+$overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
     echo '<div class="notice notice-error"><p>' . sprintf(
         esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
         '<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'

--- a/admin/partials/test-report-assembly.php
+++ b/admin/partials/test-report-assembly.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Placeholder for report assembly and delivery tests.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<h2><?php esc_html_e( 'Report Assembly & Delivery', 'rtbcb' ); ?></h2>
+<p class="description">
+    <?php esc_html_e( 'Tools for validating report generation and delivery will appear here in future iterations.', 'rtbcb' ); ?>
+</p>
+

--- a/admin/partials/test-treasury-tech-overview.php
+++ b/admin/partials/test-treasury-tech-overview.php
@@ -15,7 +15,7 @@ if ( ! rtbcb_require_completed_steps( 'rtbcb-test-treasury-tech-overview' ) ) {
 
 $company = rtbcb_get_current_company();
 if ( empty( $company ) ) {
-    $overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-test-company-overview' );
+$overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
     echo '<div class="notice notice-error"><p>' . sprintf(
         esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
         '<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -17,17 +17,42 @@ $company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_d
 
     <?php
     $sections = rtbcb_get_dashboard_sections();
+    $phases   = [
+        1 => __( 'Phase 1: Data Collection & Enrichment', 'rtbcb' ),
+        2 => __( 'Phase 2: Analysis & Content Generation', 'rtbcb' ),
+        3 => __( 'Phase 3: ROI & Strategic Recommendation', 'rtbcb' ),
+        4 => __( 'Phase 4: Report Assembly & Delivery', 'rtbcb' ),
+        5 => __( 'Phase 5: Post-Delivery Engagement', 'rtbcb' ),
+    ];
+    $sections_by_phase = [];
+    foreach ( $sections as $id => $section ) {
+        $phase = isset( $section['phase'] ) ? (int) $section['phase'] : 0;
+        if ( $phase ) {
+            $sections_by_phase[ $phase ][ $id ] = $section;
+        }
+    }
     ?>
     <div class="card">
         <h2 class="title"><?php esc_html_e( 'Analysis Progress', 'rtbcb' ); ?></h2>
         <ul>
-            <?php foreach ( $sections as $id => $section ) : ?>
-                <?php $done = ! empty( $section['completed'] ); ?>
-                <li class="<?php echo $done ? 'completed' : 'missing'; ?>">
-                    <a href="#<?php echo esc_attr( $id ); ?>">
-                        <?php echo esc_html( $section['label'] ); ?>
-                    </a>
-                    - <?php echo $done ? esc_html__( 'Complete', 'rtbcb' ) : esc_html__( 'Incomplete', 'rtbcb' ); ?>
+            <?php foreach ( $phases as $phase_num => $phase_label ) : ?>
+                <li>
+                    <strong><?php echo esc_html( $phase_label ); ?></strong>
+                    <?php if ( ! empty( $sections_by_phase[ $phase_num ] ) ) : ?>
+                        <ul>
+                            <?php foreach ( $sections_by_phase[ $phase_num ] as $id => $section ) : ?>
+                                <?php $done = ! empty( $section['completed'] ); ?>
+                                <li class="<?php echo $done ? 'completed' : 'missing'; ?>">
+                                    <a href="#rtbcb-phase<?php echo esc_attr( $phase_num ); ?>" class="rtbcb-jump-tab">
+                                        <?php echo esc_html( $section['label'] ); ?>
+                                    </a>
+                                    - <?php echo $done ? esc_html__( 'Complete', 'rtbcb' ) : esc_html__( 'Incomplete', 'rtbcb' ); ?>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php else : ?>
+                        - <?php esc_html_e( 'No tests yet.', 'rtbcb' ); ?>
+                    <?php endif; ?>
                 </li>
             <?php endforeach; ?>
         </ul>
@@ -53,43 +78,33 @@ $company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_d
     <?php include RTBCB_DIR . 'admin/partials/dashboard-connectivity.php'; ?>
 
     <h2 class="nav-tab-wrapper" id="rtbcb-test-tabs">
-        <a href="#rtbcb-test-company-overview" class="nav-tab nav-tab-active"><?php esc_html_e( 'Company Overview', 'rtbcb' ); ?></a>
-        <a href="#rtbcb-test-treasury-tech-overview" class="nav-tab"><?php esc_html_e( 'Treasury Tech', 'rtbcb' ); ?></a>
-        <a href="#rtbcb-test-industry-overview" class="nav-tab"><?php esc_html_e( 'Industry', 'rtbcb' ); ?></a>
-        <a href="#rtbcb-test-real-treasury-overview" class="nav-tab"><?php esc_html_e( 'Real Treasury', 'rtbcb' ); ?></a>
-        <a href="#rtbcb-test-recommended-category" class="nav-tab"><?php esc_html_e( 'Recommended Category', 'rtbcb' ); ?></a>
-        <a href="#rtbcb-test-estimated-benefits" class="nav-tab"><?php esc_html_e( 'Estimated Benefits', 'rtbcb' ); ?></a>
+        <a href="#rtbcb-phase1" class="nav-tab nav-tab-active"><?php echo esc_html( $phases[1] ); ?></a>
+        <a href="#rtbcb-phase2" class="nav-tab"><?php echo esc_html( $phases[2] ); ?></a>
+        <a href="#rtbcb-phase3" class="nav-tab"><?php echo esc_html( $phases[3] ); ?></a>
+        <a href="#rtbcb-phase4" class="nav-tab"><?php echo esc_html( $phases[4] ); ?></a>
+        <a href="#rtbcb-phase5" class="nav-tab"><?php echo esc_html( $phases[5] ); ?></a>
     </h2>
 
-    <div id="rtbcb-test-company-overview" class="rtbcb-tab-panel" style="display:block;">
+    <div id="rtbcb-phase1" class="rtbcb-tab-panel" style="display:block;">
         <?php include RTBCB_DIR . 'admin/partials/test-company-overview.php'; ?>
     </div>
-    <div id="rtbcb-test-treasury-tech-overview" class="rtbcb-tab-panel" style="display:none;">
+    <div id="rtbcb-phase2" class="rtbcb-tab-panel" style="display:none;">
         <?php include RTBCB_DIR . 'admin/partials/test-treasury-tech-overview.php'; ?>
-    </div>
-    <div id="rtbcb-test-industry-overview" class="rtbcb-tab-panel" style="display:none;">
         <?php include RTBCB_DIR . 'admin/partials/test-industry-overview.php'; ?>
-    </div>
-    <div id="rtbcb-test-real-treasury-overview" class="rtbcb-tab-panel" style="display:none;">
         <?php include RTBCB_DIR . 'admin/partials/test-real-treasury-overview.php'; ?>
     </div>
-    <div id="rtbcb-test-recommended-category" class="rtbcb-tab-panel" style="display:none;">
+    <div id="rtbcb-phase3" class="rtbcb-tab-panel" style="display:none;">
         <?php include RTBCB_DIR . 'admin/partials/test-recommended-category.php'; ?>
-    </div>
-    <div id="rtbcb-test-estimated-benefits" class="rtbcb-tab-panel" style="display:none;">
         <?php include RTBCB_DIR . 'admin/partials/test-estimated-benefits.php'; ?>
+    </div>
+    <div id="rtbcb-phase4" class="rtbcb-tab-panel" style="display:none;">
+        <?php include RTBCB_DIR . 'admin/partials/test-report-assembly.php'; ?>
+    </div>
+    <div id="rtbcb-phase5" class="rtbcb-tab-panel" style="display:none;">
+        <?php include RTBCB_DIR . 'admin/partials/test-post-delivery.php'; ?>
     </div>
 
     <script>
-    jQuery(function($){
-        $('#rtbcb-test-tabs a').on('click', function(e){
-            e.preventDefault();
-            var target = $(this).attr('href');
-            $('#rtbcb-test-tabs a').removeClass('nav-tab-active');
-            $(this).addClass('nav-tab-active');
-            $('.rtbcb-tab-panel').hide();
-            $(target).show();
-        });
-    });
+    // Tabs handled in admin/js/rtbcb-admin.js
     </script>
 </div>

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -68,31 +68,37 @@ function rtbcb_get_dashboard_sections() {
             'label'    => __( 'Company Overview', 'rtbcb' ),
             'option'   => 'rtbcb_current_company',
             'requires' => [],
+            'phase'    => 1,
         ],
         'rtbcb-test-treasury-tech-overview' => [
             'label'    => __( 'Treasury Tech Overview', 'rtbcb' ),
             'option'   => 'rtbcb_treasury_tech_overview',
             'requires' => [ 'rtbcb-test-company-overview' ],
+            'phase'    => 2,
         ],
         'rtbcb-test-industry-overview'      => [
             'label'    => __( 'Industry Overview', 'rtbcb' ),
             'option'   => 'rtbcb_industry_insights',
             'requires' => [ 'rtbcb-test-company-overview' ],
+            'phase'    => 2,
         ],
         'rtbcb-test-real-treasury-overview' => [
             'label'    => __( 'Real Treasury Overview', 'rtbcb' ),
             'option'   => 'rtbcb_real_treasury_overview',
             'requires' => [ 'rtbcb-test-company-overview' ],
+            'phase'    => 2,
         ],
         'rtbcb-test-recommended-category'   => [
             'label'    => __( 'Recommended Category', 'rtbcb' ),
             'option'   => 'rtbcb_recommended_category',
             'requires' => [ 'rtbcb-test-company-overview' ],
+            'phase'    => 3,
         ],
         'rtbcb-test-estimated-benefits'     => [
             'label'    => __( 'Estimated Benefits', 'rtbcb' ),
             'option'   => 'rtbcb_estimated_benefits',
             'requires' => [ 'rtbcb-test-company-overview' ],
+            'phase'    => 3,
         ],
     ];
 
@@ -121,7 +127,9 @@ function rtbcb_require_completed_steps( $current_section ) {
 
     foreach ( $sections[ $current_section ]['requires'] as $dependency ) {
         if ( empty( $sections[ $dependency ]['completed'] ) ) {
-            $url = admin_url( 'admin.php?page=rtbcb-test-dashboard#' . $dependency );
+            $phase  = isset( $sections[ $dependency ]['phase'] ) ? (int) $sections[ $dependency ]['phase'] : 0;
+            $anchor = $phase ? 'rtbcb-phase' . $phase : $dependency;
+            $url    = admin_url( 'admin.php?page=rtbcb-test-dashboard#' . $anchor );
             echo '<div class="notice notice-error"><p>' .
                 sprintf(
                     __( 'Please complete %s first.', 'rtbcb' ),
@@ -170,7 +178,7 @@ function rtbcb_get_last_test_result( $section_id, $test_results = null ) {
  * @return void
  */
 function rtbcb_render_start_new_analysis_button() {
-    $url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-test-company-overview' );
+    $url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
     echo '<p><a href="' . esc_url( $url ) . '" class="button">' .
         esc_html__( 'Start New Analysis', 'rtbcb' ) . '</a></p>';
 }


### PR DESCRIPTION
## Summary
- Group test dashboard sections under phase-based tabs and progress indicators
- Add phase metadata and updated dependency handling for dashboard sections
- Provide placeholder panels for report delivery and post-delivery engagement phases

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d10329c483318349778c40d92fa6