### PR TITLE
Use portal-specific nonce for portal test handler

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -948,7 +948,7 @@ class RTBCB_Admin {
      * @return void
      */
     public function ajax_test_portal() {
-        check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
+        check_ajax_referer( 'rtbcb_test_portal', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
             wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );


### PR DESCRIPTION
## Summary
- ensure `ajax_test_portal` validates the `rtbcb_test_portal` nonce

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `php /tmp/test_portal.php`

------
https://chatgpt.com/codex/tasks/task_e_68b0d2851cc88331ad7d48207ac96ce1