### PR TITLE
Add executive summary report assembly controls and tests

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -38,10 +38,13 @@ jQuery(document).ready(function($) {
             
             // Industry Overview Test
             $('#rtbcb-industry-overview-form').on('submit', this.testIndustryOverview);
-            
+
             // Benefits Test
             $('#rtbcb-benefits-estimate-form').on('submit', this.testBenefits);
-            
+
+            // Report Assembly Test
+            $('#rtbcb-report-assembly-form').on('submit', this.testReportAssembly);
+
             // Test Dashboard
             $('#rtbcb-test-all-sections').on('click', this.runAllTests);
         },
@@ -380,7 +383,45 @@ jQuery(document).ready(function($) {
                 }
             });
         },
-        
+
+        testReportAssembly: function(e) {
+            e.preventDefault();
+            var $form = $(this);
+            var $results = $('#rtbcb-report-assembly-results');
+            var $btn = $form.find('button[type="submit"]');
+            var original = $btn.text();
+
+            $btn.prop('disabled', true).text(window.rtbcbAdmin.strings.processing || 'Processing...');
+
+            $.ajax({
+                url: window.rtbcbAdmin.ajax_url,
+                method: 'POST',
+                data: {
+                    action: 'rtbcb_test_report_assembly',
+                    nonce: $form.find('[name="nonce"]').val() || window.rtbcbAdmin.report_assembly_nonce
+                },
+                async: false,
+                success: function(response) {
+                    if (response.success && response.data && response.data.summary) {
+                        var notice = $('<div class="notice notice-success" />');
+                        var pre = $('<pre />').text(JSON.stringify(response.data.summary, null, 2));
+                        notice.append(pre);
+                        $results.html(notice);
+                    } else {
+                        $results.html('<div class="notice notice-error"><p>' +
+                            (response.data && response.data.message ? response.data.message : 'Generation failed') +
+                            '</p></div>');
+                    }
+                },
+                error: function() {
+                    $results.html('<div class="notice notice-error"><p>Request failed</p></div>');
+                },
+                complete: function() {
+                    $btn.prop('disabled', false).text(original);
+                }
+            });
+        },
+
         runAllTests: function(e) {
             e.preventDefault();
             var $btn = $(this);

--- a/admin/partials/test-report-assembly.php
+++ b/admin/partials/test-report-assembly.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Placeholder for report assembly and delivery tests.
+ * Report assembly and delivery test section.
  *
  * @package RealTreasuryBusinessCaseBuilder
  */
@@ -8,9 +8,39 @@
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
+
+$allowed = rtbcb_require_completed_steps( 'rtbcb-test-report-assembly' );
+if ( ! $allowed ) {
+    return;
+}
+
+$summary = get_option( 'rtbcb_executive_summary', [] );
 ?>
 <h2><?php esc_html_e( 'Report Assembly & Delivery', 'rtbcb' ); ?></h2>
 <p class="description">
-    <?php esc_html_e( 'Tools for validating report generation and delivery will appear here in future iterations.', 'rtbcb' ); ?>
+    <?php esc_html_e( 'Generate an executive summary to verify report assembly.', 'rtbcb' ); ?>
 </p>
-
+<div class="card">
+    <h3 class="title"><?php esc_html_e( 'Executive Summary', 'rtbcb' ); ?></h3>
+    <form id="rtbcb-report-assembly-form">
+        <?php wp_nonce_field( 'rtbcb_test_report_assembly', 'nonce' ); ?>
+        <p class="submit">
+            <button type="submit" class="button button-primary">
+                <?php esc_html_e( 'Generate Summary', 'rtbcb' ); ?>
+            </button>
+            <button type="button" id="rtbcb-clear-report-summary" class="button">
+                <?php esc_html_e( 'Clear', 'rtbcb' ); ?>
+            </button>
+        </p>
+    </form>
+    <div id="rtbcb-report-assembly-results">
+        <?php if ( ! empty( $summary ) ) : ?>
+            <pre><?php echo esc_html( wp_json_encode( $summary, JSON_PRETTY_PRINT ) ); ?></pre>
+        <?php endif; ?>
+    </div>
+</div>
+<script>
+document.getElementById('rtbcb-clear-report-summary')?.addEventListener('click', function() {
+    document.getElementById('rtbcb-report-assembly-results').innerHTML = '';
+});
+</script>

--- a/tests/render-comprehensive-template.test.php
+++ b/tests/render-comprehensive-template.test.php
@@ -1,0 +1,49 @@
+<?php
+require_once __DIR__ . '/../inc/helpers.php';
+
+if ( ! function_exists( '__' ) ) {
+    function __( $text, $domain = null ) {
+        return $text;
+    }
+}
+if ( ! function_exists( 'esc_html__' ) ) {
+    function esc_html__( $text, $domain = null ) {
+        return $text;
+    }
+}
+if ( ! function_exists( 'esc_html' ) ) {
+    function esc_html( $text ) {
+        return $text;
+    }
+}
+if ( ! function_exists( 'esc_attr' ) ) {
+    function esc_attr( $text ) {
+        return $text;
+    }
+}
+if ( ! function_exists( 'current_time' ) ) {
+    function current_time( $type ) {
+        return '2024-01-01';
+    }
+}
+
+$business_case_data = [
+    'company_name'      => 'Demo Corp',
+    'executive_summary' => [
+        'strategic_positioning'   => 'Positioned well.',
+        'business_case_strength'  => 'Strong',
+        'key_value_drivers'       => [ 'Efficiency', 'Compliance' ],
+        'executive_recommendation'=> 'Proceed',
+    ],
+];
+
+ob_start();
+include __DIR__ . '/../templates/comprehensive-report-template.php';
+$output = ob_get_clean();
+
+if ( strpos( $output, 'rtbcb-executive-summary' ) === false ) {
+    echo "Executive summary not found\n";
+    exit( 1 );
+}
+
+echo "Comprehensive template render test passed.\n";

--- a/tests/report-interactivity.test.js
+++ b/tests/report-interactivity.test.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const container = {
+    childNodes: [],
+    innerHTML: '',
+    appendChild(node) {
+        this.childNodes.push(node);
+    }
+};
+
+global.document = {
+    getElementById(id) {
+        if (id === 'loading') {
+            return { style: { display: 'none' } };
+        }
+        if (id === 'error') {
+            return { style: { display: 'none' }, textContent: '' };
+        }
+        if (id === 'report-container') {
+            return container;
+        }
+        return null;
+    },
+    createElement(tag) {
+        return {
+            tagName: tag,
+            style: {},
+            appendChild() {},
+            set srcdoc(v) { this.srcdoc = v; },
+            srcdoc: '',
+            className: '',
+            textContent: '',
+            onclick: null
+        };
+    }
+};
+
+global.window = {};
+
+global.rtbcbReport = { ajax_url: '', model_capabilities: {} };
+
+const code = fs.readFileSync('public/js/rtbcb-report.js', 'utf8');
+vm.runInThisContext(code);
+
+generateProfessionalReport = () => '<!DOCTYPE html><html><body>Report</body></html>';
+
+generateAndDisplayReport({});
+
+const exportBtn = container.childNodes.find(node => node.textContent === 'Export to PDF');
+assert.ok(exportBtn, 'Export button not created');
+console.log('Report interactivity test passed.');

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -43,12 +43,18 @@ php tests/reasoning-first-output.test.php
 echo "10. Running OpenAI API key validation test..."
 php tests/openai-api-key-validation.test.php
 
+echo "11. Rendering comprehensive report template..."
+php tests/render-comprehensive-template.test.php
+
+echo "12. Running report interactivity test..."
+node tests/report-interactivity.test.js
+
 # AJAX error handling test (PHPUnit)
-echo "11. Running AJAX error handling test..."
+echo "13. Running AJAX error handling test..."
 phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
 
 # JavaScript tests
-echo "12. Running JavaScript tests..."
+echo "14. Running JavaScript tests..."
 node tests/handle-submit-error.test.js
 node tests/render-results-no-narrative.test.js
 node tests/handle-submit-success.test.js
@@ -57,10 +63,10 @@ node tests/temperature-model.test.js
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then
-    echo "13. Running WordPress coding standards check..."
+    echo "15. Running WordPress coding standards check..."
     phpcs --standard=WordPress --ignore=vendor .
 else
-    echo "13. Skipping WordPress coding standards (phpcs not installed)"
+    echo "15. Skipping WordPress coding standards (phpcs not installed)"
 fi
 
 echo "================================================"


### PR DESCRIPTION
## Summary
- add dashboard controls to generate executive summary via RTBCB_LLM
- mark report assembly section complete and provide helper
- add tests for comprehensive report template and report script interactivity

## Testing
- `bash tests/run-tests.sh`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b0d8753288833187fb5d4d668446a4