### PR TITLE
Include company size in industry overview test

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -318,10 +318,12 @@ jQuery(document).ready(function($) {
             $btn.prop('disabled', true).text(window.rtbcbAdmin.strings.processing || 'Processing...');
             
             var industry = $('#rtbcb-industry-name').val();
+            var size = $('#rtbcb-company-size').val();
             var nonce = $form.find('[name="nonce"]').val() || window.rtbcbAdmin.industry_overview_nonce;
-            
+
             var companyData = {
-                industry: industry
+                industry: industry,
+                size: size
             };
             
             $.ajax({

--- a/admin/partials/test-industry-overview.php
+++ b/admin/partials/test-industry-overview.php
@@ -27,6 +27,7 @@ $overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
 $company_name = isset( $company['name'] ) ? sanitize_text_field( $company['name'] ) : '';
 $company_sum  = isset( $company['summary'] ) ? sanitize_textarea_field( $company['summary'] ) : '';
 $company_ind  = isset( $company['industry'] ) ? sanitize_text_field( $company['industry'] ) : '';
+$company_size = isset( $company['size'] ) ? sanitize_text_field( $company['size'] ) : '';
 ?>
 <h2><?php esc_html_e( 'Test Industry Overview', 'rtbcb' ); ?></h2>
 <p class="description"><?php esc_html_e( 'Generate insights about the company\'s industry to inform later recommendations.', 'rtbcb' ); ?></p>
@@ -50,6 +51,7 @@ $company_ind  = isset( $company['industry'] ) ? sanitize_text_field( $company['i
     <?php endif; ?>
 <?php endif; ?>
 <form id="rtbcb-industry-overview-form">
+    <input type="hidden" id="rtbcb-company-size" value="<?php echo esc_attr( $company_size ); ?>" />
     <table class="form-table">
         <tr>
             <th scope="row">


### PR DESCRIPTION
## Summary
- Surface stored company size in the Industry Overview test form via a hidden field
- Pass the company size along with industry in the AJAX request for industry overview generation

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh | tail -n 40`
- `phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68b0ddaea174833183ee80bac11258d8