### PR TITLE
feat: store company metrics

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -294,6 +294,14 @@ jQuery(document).ready(function($) {
                     if (response.success && response.data) {
                         $results.html('<div class="notice notice-success"><p>' +
                             (response.data.overview || 'Generated successfully') + '</p></div>');
+
+                        if (response.data.metrics) {
+                            window.rtbcbAdmin = window.rtbcbAdmin || {};
+                            rtbcbAdmin.company = rtbcbAdmin.company || {};
+                            rtbcbAdmin.company.revenue = response.data.metrics.revenue || 0;
+                            rtbcbAdmin.company.staff_count = response.data.metrics.staff_count || 0;
+                            rtbcbAdmin.company.efficiency = response.data.metrics.efficiency || 0;
+                        }
                     } else {
                         $results.html('<div class="notice notice-error"><p>' +
                             (response.data && response.data.message ? response.data.message : 'Generation failed') + '</p></div>');
@@ -359,15 +367,17 @@ jQuery(document).ready(function($) {
             
             $results.text(window.rtbcbAdmin.strings.processing || 'Processing...');
             
+            var company = window.rtbcbAdmin.company || {};
+
             $.ajax({
                 url: window.rtbcbAdmin.ajax_url,
                 method: 'POST',
                 data: {
                     action: 'rtbcb_test_estimated_benefits',
                     company_data: {
-                        revenue: $('#rtbcb-test-revenue').val(),
-                        staff_count: $('#rtbcb-test-staff-count').val(),
-                        efficiency: $('#rtbcb-test-efficiency').val()
+                        revenue: company.revenue,
+                        staff_count: company.staff_count,
+                        efficiency: company.efficiency
                     },
                     recommended_category: $('#rtbcb-test-category').val(),
                     nonce: window.rtbcbAdmin.benefits_estimate_nonce

--- a/admin/partials/test-estimated-benefits.php
+++ b/admin/partials/test-estimated-benefits.php
@@ -23,7 +23,7 @@ $overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
     return;
 }
 
-$company_data         = get_option( 'rtbcb_company_data', [] );
+$company_data         = $company;
 $recommended_category = get_option( 'rtbcb_last_recommended_category', '' );
 $categories           = RTBCB_Category_Recommender::get_all_categories();
 ?>
@@ -45,28 +45,16 @@ $categories           = RTBCB_Category_Recommender::get_all_categories();
 <form id="rtbcb-benefits-estimate-form">
     <table class="form-table">
         <tr>
-            <th scope="row">
-                <label for="rtbcb-test-revenue"><?php esc_html_e( 'Company Annual Revenue', 'rtbcb' ); ?></label>
-            </th>
-            <td>
-                <input type="number" id="rtbcb-test-revenue" value="<?php echo esc_attr( $company_data['revenue'] ?? '' ); ?>" />
-            </td>
+            <th scope="row"><?php esc_html_e( 'Company Annual Revenue', 'rtbcb' ); ?></th>
+            <td><?php echo esc_html( $company_data['revenue'] ?? '' ); ?></td>
         </tr>
         <tr>
-            <th scope="row">
-                <label for="rtbcb-test-staff-count"><?php esc_html_e( 'Treasury Staff Count', 'rtbcb' ); ?></label>
-            </th>
-            <td>
-                <input type="number" id="rtbcb-test-staff-count" value="<?php echo esc_attr( $company_data['staff_count'] ?? '' ); ?>" />
-            </td>
+            <th scope="row"><?php esc_html_e( 'Treasury Staff Count', 'rtbcb' ); ?></th>
+            <td><?php echo esc_html( $company_data['staff_count'] ?? '' ); ?></td>
         </tr>
         <tr>
-            <th scope="row">
-                <label for="rtbcb-test-efficiency"><?php esc_html_e( 'Current Process Efficiency', 'rtbcb' ); ?></label>
-            </th>
-            <td>
-                <input type="range" id="rtbcb-test-efficiency" min="1" max="10" value="<?php echo esc_attr( $company_data['efficiency'] ?? '' ); ?>" />
-            </td>
+            <th scope="row"><?php esc_html_e( 'Current Process Efficiency', 'rtbcb' ); ?></th>
+            <td><?php echo esc_html( $company_data['efficiency'] ?? '' ); ?></td>
         </tr>
         <tr>
             <th scope="row">


### PR DESCRIPTION
## Summary
- extend company overview generation to request revenue, staff, and efficiency metrics
- persist metrics in stored company data and expose via AJAX
- streamline benefits estimate form to use stored metrics instead of manual inputs

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dee54f2483319168b363f748816a