### PR TITLE
Display meta details for company and industry overviews

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -289,11 +289,45 @@ jQuery(document).ready(function($) {
                     company_name: company,
                     nonce: nonce
                 },
-                async: false,
                 success: function(response) {
                     if (response.success && response.data) {
                         $results.html('<div class="notice notice-success"><p>' +
                             (response.data.overview || 'Generated successfully') + '</p></div>');
+
+                        var $meta = $('#rtbcb-company-overview-meta');
+                        if ($meta.length) {
+                            var labels = window.rtbcbAdmin.strings || {};
+                            $meta.empty();
+                            if (response.data.word_count) {
+                                $('<p/>').text((labels.word_count || 'Word Count') + ': ' + response.data.word_count).appendTo($meta);
+                            }
+                            if (response.data.elapsed) {
+                                $('<p/>').text((labels.elapsed || 'Elapsed') + ': ' + response.data.elapsed + 's').appendTo($meta);
+                            }
+                            if (response.data.recommendations && response.data.recommendations.length) {
+                                $('<p/>').text((labels.recommendations || 'Recommendations') + ':').appendTo($meta);
+                                var $ul = $('<ul/>');
+                                response.data.recommendations.forEach(function(rec) {
+                                    $('<li/>').text(rec).appendTo($ul);
+                                });
+                                $meta.append($ul);
+                            }
+                            if (response.data.references && response.data.references.length) {
+                                $('<p/>').text((labels.references || 'References') + ':').appendTo($meta);
+                                var $ulRef = $('<ul/>');
+                                response.data.references.forEach(function(ref) {
+                                    $('<li/>').append(
+                                        $('<a/>', {
+                                            text: ref,
+                                            href: ref,
+                                            target: '_blank',
+                                            rel: 'noopener noreferrer'
+                                        })
+                                    ).appendTo($ulRef);
+                                });
+                                $meta.append($ulRef);
+                            }
+                        }
 
                         if (response.data.metrics) {
                             window.rtbcbAdmin = window.rtbcbAdmin || {};
@@ -342,11 +376,47 @@ jQuery(document).ready(function($) {
                     company_data: JSON.stringify(companyData),
                     nonce: nonce
                 },
-                async: false,
                 success: function(response) {
                     if (response.success && response.data) {
-                        $results.html('<div class="notice notice-success"><p>' +
-                            (response.data.overview || 'Generated successfully') + '</p></div>');
+                        var $meta = $('#rtbcb-industry-overview-meta');
+                        $results.empty();
+                        $('<div class="notice notice-success" />')
+                            .append($('<p/>').text(response.data.overview || 'Generated successfully'))
+                            .appendTo($results);
+                        if ($meta.length) {
+                            var labels = window.rtbcbAdmin.strings || {};
+                            $meta.empty();
+                            if (response.data.word_count) {
+                                $('<p/>').text((labels.word_count || 'Word Count') + ': ' + response.data.word_count).appendTo($meta);
+                            }
+                            if (response.data.elapsed) {
+                                $('<p/>').text((labels.elapsed || 'Elapsed') + ': ' + response.data.elapsed + 's').appendTo($meta);
+                            }
+                            if (response.data.recommendations && response.data.recommendations.length) {
+                                $('<p/>').text((labels.recommendations || 'Recommendations') + ':').appendTo($meta);
+                                var $ul = $('<ul/>');
+                                response.data.recommendations.forEach(function(rec) {
+                                    $('<li/>').text(rec).appendTo($ul);
+                                });
+                                $meta.append($ul);
+                            }
+                            if (response.data.references && response.data.references.length) {
+                                $('<p/>').text((labels.references || 'References') + ':').appendTo($meta);
+                                var $ulRef = $('<ul/>');
+                                response.data.references.forEach(function(ref) {
+                                    $('<li/>').append(
+                                        $('<a/>', {
+                                            text: ref,
+                                            href: ref,
+                                            target: '_blank',
+                                            rel: 'noopener noreferrer'
+                                        })
+                                    ).appendTo($ulRef);
+                                });
+                                $meta.append($ulRef);
+                            }
+                            $results.append($meta);
+                        }
                     } else {
                         $results.html('<div class="notice notice-error"><p>' +
                             (response.data && response.data.message ? response.data.message : 'Generation failed') + '</p></div>');

--- a/admin/partials/test-company-overview.php
+++ b/admin/partials/test-company-overview.php
@@ -52,8 +52,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div id="rtbcb-company-overview-card" class="rtbcb-result-card" style="display:none;">
     <details>
         <summary><?php esc_html_e( 'Generated Overview', 'rtbcb' ); ?></summary>
-        <div id="rtbcb-company-overview-results"></div>
-        <div id="rtbcb-company-overview-meta" class="rtbcb-meta"></div>
+        <div id="<?php echo esc_attr( 'rtbcb-company-overview-results' ); ?>"></div>
+        <div id="<?php echo esc_attr( 'rtbcb-company-overview-meta' ); ?>" class="rtbcb-meta"></div>
         <p class="rtbcb-actions">
             <button type="button" id="rtbcb-regenerate-company-overview" class="button">
                 <?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>

--- a/admin/partials/test-industry-overview.php
+++ b/admin/partials/test-industry-overview.php
@@ -72,7 +72,9 @@ $company_size = isset( $company['size'] ) ? sanitize_text_field( $company['size'
 <div id="rtbcb-industry-overview-card" class="rtbcb-result-card">
     <details>
         <summary><?php esc_html_e( 'Generated Overview', 'rtbcb' ); ?></summary>
-        <div id="rtbcb-industry-overview-results"></div>
+        <div id="<?php echo esc_attr( 'rtbcb-industry-overview-results' ); ?>">
+            <div id="<?php echo esc_attr( 'rtbcb-industry-overview-meta' ); ?>" class="rtbcb-meta"></div>
+        </div>
     </details>
 </div>
 <script>


### PR DESCRIPTION
## Summary
- Add localized meta output (word count, elapsed time, recommendations, references) to company and industry overview AJAX handlers.
- Remove deprecated synchronous AJAX usage in overview tests.
- Ensure overview partials include escaped containers for meta information.

## Testing
- `npm test` *(fails: package.json not found)*
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b10c6f422c8331a87923ba8aaf9bb8