### PR TITLE
Show additional metrics in test results table

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -354,11 +354,21 @@ class RTBCB_Admin {
 
         $sanitized = [];
         foreach ( $decoded as $item ) {
+            $data = [];
+            if ( isset( $item['data'] ) && is_array( $item['data'] ) ) {
+                foreach ( $item['data'] as $key => $value ) {
+                    if ( is_scalar( $value ) ) {
+                        $data[ sanitize_key( $key ) ] = is_numeric( $value ) ? ( 0 + $value ) : sanitize_text_field( $value );
+                    }
+                }
+            }
+
             $sanitized[] = [
                 'section'   => isset( $item['section'] ) ? sanitize_text_field( $item['section'] ) : '',
                 'status'    => isset( $item['status'] ) ? sanitize_text_field( $item['status'] ) : '',
                 'message'   => isset( $item['message'] ) ? sanitize_text_field( $item['message'] ) : '',
                 'timestamp' => current_time( 'mysql' ),
+                'data'      => $data,
             ];
         }
 

--- a/admin/partials/dashboard-connectivity.php
+++ b/admin/partials/dashboard-connectivity.php
@@ -167,7 +167,7 @@ if ( ! defined( 'ABSPATH' ) ) {
             success: function(response){
                 if (response.success) {
                     renderStatus($status, response.data.message, true);
-                    $('#rtbcb-test-results-summary tbody').html('<tr><td colspan="5"><?php echo esc_js( __( 'No test results found.', 'rtbcb' ) ); ?></td></tr>');
+                    $('#rtbcb-test-results-summary tbody').html('<tr><td colspan="7"><?php echo esc_js( __( 'No test results found.', 'rtbcb' ) ); ?></td></tr>');
                 } else {
                     renderStatus($status, (response.data && response.data.message) ? response.data.message : '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);
                 }

--- a/admin/partials/dashboard-test-results.php
+++ b/admin/partials/dashboard-test-results.php
@@ -25,6 +25,8 @@ $sections     = rtbcb_get_dashboard_sections();
             <th><?php esc_html_e( 'Section', 'rtbcb' ); ?></th>
             <th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
             <th><?php esc_html_e( 'Message', 'rtbcb' ); ?></th>
+            <th><?php esc_html_e( 'Word Count', 'rtbcb' ); ?></th>
+            <th><?php esc_html_e( 'Elapsed (s)', 'rtbcb' ); ?></th>
             <th><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
             <th><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
         </tr>
@@ -49,11 +51,29 @@ $sections     = rtbcb_get_dashboard_sections();
                     $section_label = $section_id;
                 }
             }
+
+            $word_count = '';
+            if ( isset( $result['word_count'] ) ) {
+                $word_count = (int) $result['word_count'];
+            } elseif ( isset( $result['data']['word_count'] ) ) {
+                $word_count = (int) $result['data']['word_count'];
+            }
+
+            $elapsed = '';
+            if ( isset( $result['elapsed'] ) ) {
+                $elapsed = (float) $result['elapsed'];
+            } elseif ( isset( $result['data']['elapsed'] ) ) {
+                $elapsed = (float) $result['data']['elapsed'];
+            } elseif ( isset( $result['data']['elapsed_time'] ) ) {
+                $elapsed = (float) $result['data']['elapsed_time'];
+            }
             ?>
             <tr>
                 <td><?php echo esc_html( $section_label ); ?></td>
                 <td><?php echo esc_html( $result['status'] ); ?></td>
                 <td><?php echo esc_html( $result['message'] ); ?></td>
+                <td><?php echo '' !== $word_count ? esc_html( $word_count ) : esc_html__( 'N/A', 'rtbcb' ); ?></td>
+                <td><?php echo '' !== $elapsed ? esc_html( $elapsed ) : esc_html__( 'N/A', 'rtbcb' ); ?></td>
                 <td><?php echo esc_html( $result['timestamp'] ); ?></td>
                 <td>
                     <?php if ( $section_id ) : ?>
@@ -66,7 +86,7 @@ $sections     = rtbcb_get_dashboard_sections();
         <?php endforeach; ?>
     <?php else : ?>
         <tr>
-            <td colspan="5"><?php esc_html_e( 'No test results found.', 'rtbcb' ); ?></td>
+            <td colspan="7"><?php esc_html_e( 'No test results found.', 'rtbcb' ); ?></td>
         </tr>
     <?php endif; ?>
     </tbody>


### PR DESCRIPTION
## Summary
- display `word_count` and `elapsed` for each test result
- persist arbitrary test metrics via `save_test_results`
- adjust dashboard JS for expanded test result table

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b1111338388331ad36f9263db77d57