### PR TITLE
Sync company name inputs after save

### DIFF
--- a/admin/partials/dashboard-connectivity.php
+++ b/admin/partials/dashboard-connectivity.php
@@ -151,9 +151,13 @@ if ( ! defined( 'ABSPATH' ) ) {
         var $btn = $(this);
         var original = $btn.text();
         var $status = $('#rtbcb-connectivity-status');
-        // Company name input resides in the Test Tools card; fetch safely.
-        var nameInput = $('#rtbcb-company-name');
-        var name = nameInput.length ? nameInput.val() : '';
+        // Fetch company name from dashboard input; fall back to test tool field if empty.
+        var primaryInput = $('#rtbcb-company-name');
+        var secondaryInput = $('#rtbcb-test-company-name');
+        var name = primaryInput.length ? primaryInput.val().trim() : '';
+        if (!name && secondaryInput.length) {
+            name = secondaryInput.val().trim();
+        }
         $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Saving...', 'rtbcb' ) ); ?>');
         $.ajax({
             url: ajaxurl,
@@ -168,6 +172,10 @@ if ( ! defined( 'ABSPATH' ) ) {
                 if (response.success) {
                     renderStatus($status, response.data.message, true);
                     $('#rtbcb-test-results-summary tbody').html('<tr><td colspan="7"><?php echo esc_js( __( 'No test results found.', 'rtbcb' ) ); ?></td></tr>');
+                    if (response.data.name) {
+                        primaryInput.val(response.data.name);
+                        secondaryInput.val(response.data.name);
+                    }
                 } else {
                     renderStatus($status, (response.data && response.data.message) ? response.data.message : '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);
                 }


### PR DESCRIPTION
## Summary
- Ensure `#rtbcb-set-company` reads company name from main input and falls back to test input.
- Populate both dashboard and test tool fields with returned company name after saving.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b1140ddf288331b91f85686e4fef20