### PR TITLE
Scope dependency warnings to dashboard tabs

### DIFF
--- a/admin/css/rtbcb-admin.css
+++ b/admin/css/rtbcb-admin.css
@@ -19,6 +19,14 @@
     margin-left: 5px;
 }
 
+.rtbcb-warning {
+    margin: 15px 0;
+    padding: 10px 15px;
+    border-left: 4px solid #d63638;
+    background: #fff;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+}
+
 #rtbcb-report-preview {
     margin-top: 20px;
 }

--- a/admin/partials/test-post-delivery.php
+++ b/admin/partials/test-post-delivery.php
@@ -15,60 +15,56 @@ if ( ! defined( 'ABSPATH' ) ) {
     <?php esc_html_e( 'Diagnostics for engagement tracking and follow-up sequences.', 'rtbcb' ); ?>
 </p>
 
-<?php if ( rtbcb_require_completed_steps( 'rtbcb-test-tracking-script' ) ) : ?>
-    <?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-tracking-script', $test_results ?? [] ); ?>
-    <?php if ( $rtbcb_last ) : ?>
-        <div class="notice notice-info" role="status">
-            <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
-            <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
-            <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
-            <p class="submit">
-                <button type="button" class="button" id="rtbcb-rerun-tracking-script" data-section="rtbcb-test-tracking-script">
-                    <?php esc_html_e( 'Re-run', 'rtbcb' ); ?>
-                </button>
-            </p>
-        </div>
-    <?php endif; ?>
-    <div class="card">
-        <h3 class="title"><?php esc_html_e( 'Tracking Script Injection', 'rtbcb' ); ?></h3>
-        <p><?php esc_html_e( 'Paste a tracking script snippet and verify it fires a test event.', 'rtbcb' ); ?></p>
-        <textarea id="rtbcb-tracking-snippet" class="large-text" rows="4" placeholder="<?php esc_attr_e( 'Paste script snippet…', 'rtbcb' ); ?>"></textarea>
-        <?php wp_nonce_field( 'rtbcb_test_tracking_script', 'rtbcb_test_tracking_script_nonce' ); ?>
+<?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-tracking-script', $test_results ?? [] ); ?>
+<?php if ( $rtbcb_last ) : ?>
+    <div class="notice notice-info" role="status">
+        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
         <p class="submit">
-            <button type="button" id="rtbcb-run-tracking-script" class="button button-primary">
-                <?php esc_html_e( 'Inject &amp; Test', 'rtbcb' ); ?>
+            <button type="button" class="button" id="rtbcb-rerun-tracking-script" data-section="rtbcb-test-tracking-script">
+                <?php esc_html_e( 'Re-run', 'rtbcb' ); ?>
             </button>
         </p>
     </div>
-    <div id="rtbcb-tracking-script-result" class="rtbcb-result-card"></div>
 <?php endif; ?>
+<div class="card">
+    <h3 class="title"><?php esc_html_e( 'Tracking Script Injection', 'rtbcb' ); ?></h3>
+    <p><?php esc_html_e( 'Paste a tracking script snippet and verify it fires a test event.', 'rtbcb' ); ?></p>
+    <textarea id="rtbcb-tracking-snippet" class="large-text" rows="4" placeholder="<?php esc_attr_e( 'Paste script snippet…', 'rtbcb' ); ?>"></textarea>
+    <?php wp_nonce_field( 'rtbcb_test_tracking_script', 'rtbcb_test_tracking_script_nonce' ); ?>
+    <p class="submit">
+        <button type="button" id="rtbcb-run-tracking-script" class="button button-primary">
+            <?php esc_html_e( 'Inject &amp; Test', 'rtbcb' ); ?>
+        </button>
+    </p>
+</div>
+<div id="rtbcb-tracking-script-result" class="rtbcb-result-card"></div>
 
-<?php if ( rtbcb_require_completed_steps( 'rtbcb-test-follow-up-email' ) ) : ?>
-    <?php $rtbcb_last_email = rtbcb_get_last_test_result( 'rtbcb-test-follow-up-email', $test_results ?? [] ); ?>
-    <?php if ( $rtbcb_last_email ) : ?>
-        <div class="notice notice-info" role="status">
-            <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last_email['status'] ); ?></p>
-            <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last_email['message'] ); ?></p>
-            <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last_email['timestamp'] ); ?></p>
-            <p class="submit">
-                <button type="button" class="button" id="rtbcb-rerun-follow-up" data-section="rtbcb-test-follow-up-email">
-                    <?php esc_html_e( 'Re-run', 'rtbcb' ); ?>
-                </button>
-            </p>
-        </div>
-    <?php endif; ?>
-    <div class="card">
-        <h3 class="title"><?php esc_html_e( 'Follow-up Email Queue', 'rtbcb' ); ?></h3>
-        <p><?php esc_html_e( 'Trigger personalized follow-up emails and inspect queued messages.', 'rtbcb' ); ?></p>
-        <?php wp_nonce_field( 'rtbcb_test_follow_up_email', 'rtbcb_test_follow_up_email_nonce' ); ?>
+<?php $rtbcb_last_email = rtbcb_get_last_test_result( 'rtbcb-test-follow-up-email', $test_results ?? [] ); ?>
+<?php if ( $rtbcb_last_email ) : ?>
+    <div class="notice notice-info" role="status">
+        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last_email['status'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last_email['message'] ); ?></p>
+        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last_email['timestamp'] ); ?></p>
         <p class="submit">
-            <button type="button" id="rtbcb-run-follow-up" class="button button-primary">
-                <?php esc_html_e( 'Queue Email', 'rtbcb' ); ?>
+            <button type="button" class="button" id="rtbcb-rerun-follow-up" data-section="rtbcb-test-follow-up-email">
+                <?php esc_html_e( 'Re-run', 'rtbcb' ); ?>
             </button>
         </p>
     </div>
-    <div id="rtbcb-follow-up-result" class="rtbcb-result-card"></div>
 <?php endif; ?>
+<div class="card">
+    <h3 class="title"><?php esc_html_e( 'Follow-up Email Queue', 'rtbcb' ); ?></h3>
+    <p><?php esc_html_e( 'Trigger personalized follow-up emails and inspect queued messages.', 'rtbcb' ); ?></p>
+    <?php wp_nonce_field( 'rtbcb_test_follow_up_email', 'rtbcb_test_follow_up_email_nonce' ); ?>
+    <p class="submit">
+        <button type="button" id="rtbcb-run-follow-up" class="button button-primary">
+            <?php esc_html_e( 'Queue Email', 'rtbcb' ); ?>
+        </button>
+    </p>
+</div>
+<div id="rtbcb-follow-up-result" class="rtbcb-result-card"></div>
 
 <script>
 (function($){

--- a/admin/partials/test-report-assembly.php
+++ b/admin/partials/test-report-assembly.php
@@ -9,11 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-$allowed = rtbcb_require_completed_steps( 'rtbcb-test-report-assembly' );
-if ( ! $allowed ) {
-    return;
-}
-
 $summary = get_option( 'rtbcb_executive_summary', [] );
 ?>
 <h2><?php esc_html_e( 'Report Assembly & Delivery', 'rtbcb' ); ?></h2>

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -103,10 +103,38 @@ $company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_d
         <?php include RTBCB_DIR . 'admin/partials/test-estimated-benefits.php'; ?>
     </div>
     <div id="rtbcb-phase4" class="rtbcb-tab-panel" style="display:none;">
-        <?php include RTBCB_DIR . 'admin/partials/test-report-assembly.php'; ?>
+        <?php
+        $dependency = rtbcb_get_first_incomplete_dependency( 'rtbcb-test-report-assembly', $sections );
+        if ( null === $dependency ) {
+            include RTBCB_DIR . 'admin/partials/test-report-assembly.php';
+        } else {
+            $phase  = isset( $sections[ $dependency ]['phase'] ) ? (int) $sections[ $dependency ]['phase'] : 0;
+            $anchor = $phase ? '#rtbcb-phase' . $phase : '#';
+            echo '<div class="rtbcb-warning"><p>' .
+                sprintf(
+                    esc_html__( 'Please complete %s first.', 'rtbcb' ),
+                    '<a href="' . esc_url( $anchor ) . '" class="rtbcb-jump-tab">' . esc_html( $sections[ $dependency ]['label'] ) . '</a>'
+                ) .
+                '</p></div>';
+        }
+        ?>
     </div>
     <div id="rtbcb-phase5" class="rtbcb-tab-panel" style="display:none;">
-        <?php include RTBCB_DIR . 'admin/partials/test-post-delivery.php'; ?>
+        <?php
+        $dependency = rtbcb_get_first_incomplete_dependency( 'rtbcb-test-tracking-script', $sections );
+        if ( null === $dependency ) {
+            include RTBCB_DIR . 'admin/partials/test-post-delivery.php';
+        } else {
+            $phase  = isset( $sections[ $dependency ]['phase'] ) ? (int) $sections[ $dependency ]['phase'] : 0;
+            $anchor = $phase ? '#rtbcb-phase' . $phase : '#';
+            echo '<div class="rtbcb-warning"><p>' .
+                sprintf(
+                    esc_html__( 'Please complete %s first.', 'rtbcb' ),
+                    '<a href="' . esc_url( $anchor ) . '" class="rtbcb-jump-tab">' . esc_html( $sections[ $dependency ]['label'] ) . '</a>'
+                ) .
+                '</p></div>';
+        }
+        ?>
     </div>
 
     <script>


### PR DESCRIPTION
## Summary
- Detect missing prerequisites before loading Phase 4 and Phase 5 test sections and show inline warnings when needed
- Drop internal dependency checks from report assembly and post-delivery partials
- Add `.rtbcb-warning` style for inline admin messages

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b119a432888331b2349e89f1d630cf