### PR TITLE
Simplify company name input for test dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A comprehensive WordPress plugin that helps treasury teams quantify the benefits
 ## 🚀 What's New in Version 2.1.2
 
 ### 🔧 Test Dashboard Improvements
-- `Set Company` reads from both company name inputs, providing a fallback if one is empty.
+- `Set Company` uses the main company name input for all tests.
 - First and last name fields stay synchronized across interactions.
 - "Test All Sections" now includes the company name parameter for complete coverage.
 

--- a/admin/js/company-overview.js
+++ b/admin/js/company-overview.js
@@ -7,14 +7,6 @@
         const card = $('#rtbcb-company-overview-card');
         const metaDiv = $('#rtbcb-company-overview-meta');
 
-        function syncCompanyName() {
-            const name = $('#rtbcb-test-company-name').val().trim();
-            $('#rtbcb-company-name').val(name);
-            return name;
-        }
-
-        $('#rtbcb-test-company-name').on('input', syncCompanyName);
-
         function sendRequest(companyName) {
             console.log('Starting simple company overview request');
 
@@ -91,14 +83,12 @@
 
         generateBtn.on('click', function(e) {
             e.preventDefault();
-            const companyName = syncCompanyName();
+            const companyName = $('#rtbcb-company-name').val().trim();
             if (!companyName) {
                 alert('Please enter a company name.');
                 return;
             }
             sendRequest(companyName);
         });
-
-        syncCompanyName();
     });
 })(jQuery);

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -278,8 +278,8 @@ jQuery(document).ready(function($) {
             
             $btn.prop('disabled', true).text(window.rtbcbAdmin.strings.processing || 'Processing...');
             
-            var company = $('#rtbcb-test-company-name').val();
-            var nonce = $form.find('[name="nonce"]').val() || window.rtbcbAdmin.company_overview_nonce;
+            var company = $('#rtbcb-company-name').val();
+            var nonce = window.rtbcbAdmin.company_overview_nonce;
             
             $.ajax({
                 url: window.rtbcbAdmin.ajax_url,
@@ -516,7 +516,7 @@ jQuery(document).ready(function($) {
             $status.text('Running tests...');
 
             var tests = [
-                { action: 'rtbcb_test_company_overview', label: 'Company Overview', nonce: window.rtbcbAdmin.company_overview_nonce || $('#rtbcb_test_company_overview_nonce').val() },
+                { action: 'rtbcb_test_company_overview', label: 'Company Overview', nonce: window.rtbcbAdmin.company_overview_nonce },
                 { action: 'rtbcb_test_data_enrichment', label: 'Data Enrichment', nonce: $('#rtbcb_test_data_enrichment_nonce').val() },
                 { action: 'rtbcb_test_data_storage', label: 'Data Storage', nonce: $('#rtbcb_test_data_storage_nonce').val() },
                 { action: 'rtbcb_test_maturity_model', label: 'Maturity Model', nonce: window.rtbcbAdmin.maturity_model_nonce || $('#rtbcb_test_maturity_model_nonce').val() },

--- a/admin/partials/dashboard-connectivity.php
+++ b/admin/partials/dashboard-connectivity.php
@@ -151,13 +151,9 @@ if ( ! defined( 'ABSPATH' ) ) {
         var $btn = $(this);
         var original = $btn.text();
         var $status = $('#rtbcb-connectivity-status');
-        // Fetch company name from dashboard input; fall back to test tool field if empty.
-        var primaryInput = $('#rtbcb-company-name');
-        var secondaryInput = $('#rtbcb-test-company-name');
-        var name = primaryInput.length ? primaryInput.val().trim() : '';
-        if (!name && secondaryInput.length) {
-            name = secondaryInput.val().trim();
-        }
+        // Fetch company name from dashboard input.
+        var $companyInput = $('#rtbcb-company-name');
+        var name = $companyInput.val().trim();
         $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Saving...', 'rtbcb' ) ); ?>');
         $.ajax({
             url: ajaxurl,
@@ -173,8 +169,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                     renderStatus($status, response.data.message, true);
                     $('#rtbcb-test-results-summary tbody').html('<tr><td colspan="7"><?php echo esc_js( __( 'No test results found.', 'rtbcb' ) ); ?></td></tr>');
                     if (response.data.name) {
-                        primaryInput.val(response.data.name);
-                        secondaryInput.val(response.data.name);
+                        $companyInput.val(response.data.name);
                     }
                 } else {
                     renderStatus($status, (response.data && response.data.message) ? response.data.message : '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);

--- a/admin/partials/test-company-overview.php
+++ b/admin/partials/test-company-overview.php
@@ -26,20 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php endif; ?>
 <div class="card">
     <h3 class="title"><?php esc_html_e( 'Generate Company Overview', 'rtbcb' ); ?></h3>
-    <p><?php esc_html_e( 'Enter a company name to generate an AI-powered overview using the configured LLM.', 'rtbcb' ); ?></p>
-    <table class="form-table">
-        <tr>
-            <th scope="row">
-                <label for="rtbcb-test-company-name">
-                    <?php esc_html_e( 'Company Name', 'rtbcb' ); ?>
-                </label>
-            </th>
-            <td>
-                <input type="text" id="rtbcb-test-company-name" class="regular-text" placeholder="<?php esc_attr_e( 'Enter company name...', 'rtbcb' ); ?>" />
-                <?php wp_nonce_field( 'rtbcb_test_company_overview', 'rtbcb_test_company_overview_nonce' ); ?>
-            </td>
-        </tr>
-    </table>
+    <p><?php esc_html_e( 'Use the company name set above to generate an AI-powered overview using the configured LLM.', 'rtbcb' ); ?></p>
     <p class="submit">
         <button type="button" id="rtbcb-generate-company-overview" class="button button-primary">
             <?php esc_html_e( 'Generate Overview', 'rtbcb' ); ?>

--- a/docs/TEST_DASHBOARD_FLOW.md
+++ b/docs/TEST_DASHBOARD_FLOW.md
@@ -103,7 +103,7 @@ Objective: Convert the report into an ongoing conversation and nurture the lead.
 
 The WordPress admin includes a dedicated **Test Dashboard** (`admin/test-dashboard-page.php`) for validating key dependencies and running diagnostics:
 
-The **Set Company** button now reads from both available company name inputs and keeps the values synchronized. When running **Test All Sections**, the selected company name is passed to every test for accurate coverage.
+The **Set Company** button uses the company name input and applies it to all tests. When running **Test All Sections**, the selected company name is passed to every test for accurate coverage.
 
 1. **OpenAI connectivity** — verifies API key configuration.
 2. **Portal integration** — checks the content portal connection.

--- a/readme.txt
+++ b/readme.txt
@@ -140,7 +140,7 @@ The analytics dashboard uses Chart.js for its visualizations. The library is bun
 
 == Changelog ==
 = 2.1.2 =
-* Improved Test Dashboard: `Set Company` reads from both company name inputs and keeps name fields in sync.
+* Improved Test Dashboard: `Set Company` uses a single company name input.
 * "Test All Sections" now includes the company name parameter for comprehensive checks.
 = 2.1.1 =
 * Bump plugin version to 2.1.1.


### PR DESCRIPTION
## Summary
- remove redundant test company name field and nonce from the company overview test card
- fetch the company name directly from #rtbcb-company-name in overview and admin scripts
- document single company-name workflow across README and docs

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b119f0453483319e7090f81386c1ef