### PR TITLE
feat: emphasize consolidated test dashboard workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A comprehensive WordPress plugin that helps treasury teams quantify the benefits
 ### 🔧 Test Dashboard Improvements
 - `Set Company` uses the main company name input for all tests.
 - First and last name fields stay synchronized across interactions.
-- "Test All Sections" now includes the company name parameter for complete coverage.
+- "Run All Tests" now includes the company name parameter for complete coverage and appears before individual test tools.
 
 ### ✨ Major Enhancements
 
@@ -442,16 +442,17 @@ add_filter('rtbcb_category_scores', function($scores, $inputs) {
 ## 🧪 Testing and Quality Assurance
 
 ### Testing Dashboard
-Use the unified testing dashboard to verify each report component. This
-dashboard replaces individual test pages from earlier versions. Navigate to
-**Real Treasury → Test Dashboard** in the WordPress admin to access it. The
-page is restricted to users with the `manage_options` capability. AJAX
-actions from the dashboard require nonces such as `rtbcb_test_company_overview`,
-`rtbcb_test_estimated_benefits`, and `rtbcb_test_dashboard` when saving
-results. Click **Run Diagnostics** to execute the full test suite defined in
-`tests/run-tests.sh` and display the latest results. A visual overview of the
-end-to-end reporting flow and diagnostics is available in
-[docs/TEST_DASHBOARD_FLOW.md](docs/TEST_DASHBOARD_FLOW.md).
+Use the unified testing dashboard to verify each report component. Begin by
+clicking **Run All Tests** to execute the complete suite; individual test tools
+will appear afterward if needed. This dashboard replaces individual test pages
+from earlier versions. Navigate to **Real Treasury → Test Dashboard** in the
+WordPress admin to access it. The page is restricted to users with the
+`manage_options` capability. AJAX actions from the dashboard require nonces such
+as `rtbcb_test_company_overview`, `rtbcb_test_estimated_benefits`, and
+`rtbcb_test_dashboard` when saving results. Click **Run Diagnostics** to execute
+the full test suite defined in `tests/run-tests.sh` and display the latest
+results. A visual overview of the end-to-end reporting flow and diagnostics is
+available in [docs/TEST_DASHBOARD_FLOW.md](docs/TEST_DASHBOARD_FLOW.md).
 
 ### Automated Tests
 The plugin includes integration tests for all major components. These can be run from the settings page via the **Run Diagnostics** button or programmatically:

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -59,6 +59,13 @@ jQuery(document).ready(function($) {
             if ($('#rtbcb-test-tabs').length) {
                 this.initTabs();
             }
+
+            if ($('#rtbcb-test-all-sections').length) {
+                $('#rtbcb-test-all-sections').addClass('rtbcb-primary-action').focus();
+                if (window.rtbcbAdmin && window.rtbcbAdmin.auto_run_all) {
+                    $('#rtbcb-test-all-sections').trigger('click');
+                }
+            }
         },
         
         testApi: function(e) {
@@ -599,6 +606,8 @@ jQuery(document).ready(function($) {
             } catch (error) {
                 console.error('Failed to save test results', error);
             }
+
+            $('#rtbcb-section-tests').slideDown();
         },
         
         initLeadsManager: function() {

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -14,6 +14,23 @@ $company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_d
 <div class="wrap rtbcb-admin-page">
     <h1><?php esc_html_e( 'Treasury Report Section Testing Dashboard', 'rtbcb' ); ?></h1>
     <?php rtbcb_render_start_new_analysis_button(); ?>
+    <div class="card">
+        <h2 class="title"><?php esc_html_e( 'Run All Tests', 'rtbcb' ); ?></h2>
+        <p>
+            <label for="rtbcb-company-name"><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></label>
+            <input type="text" id="rtbcb-company-name" class="regular-text" value="<?php echo esc_attr( $company_name ); ?>" />
+            <button type="button" id="rtbcb-set-company" class="button"><?php esc_html_e( 'Set Company', 'rtbcb' ); ?></button>
+            <?php wp_nonce_field( 'rtbcb_set_test_company', 'rtbcb_set_test_company_nonce' ); ?>
+        </p>
+        <p class="description"><?php esc_html_e( 'Run the complete test suite. Individual test tools will be available after completion.', 'rtbcb' ); ?></p>
+        <p class="submit">
+            <button type="button" id="rtbcb-test-all-sections" class="button button-primary">
+                <?php esc_html_e( 'Run All Tests', 'rtbcb' ); ?>
+            </button>
+            <?php wp_nonce_field( 'rtbcb_test_dashboard', 'rtbcb_test_dashboard_nonce' ); ?>
+        </p>
+        <p id="rtbcb-test-status"></p>
+    </div>
 
     <?php
     $sections = rtbcb_get_dashboard_sections();
@@ -58,83 +75,71 @@ $company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_d
         </ul>
     </div>
 
-    <div class="card">
-        <h2 class="title"><?php esc_html_e( 'Test Tools', 'rtbcb' ); ?></h2>
-        <p>
-            <label for="rtbcb-company-name"><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></label>
-            <input type="text" id="rtbcb-company-name" class="regular-text" value="<?php echo esc_attr( $company_name ); ?>" />
-            <button type="button" id="rtbcb-set-company" class="button"><?php esc_html_e( 'Set Company', 'rtbcb' ); ?></button>
-            <?php wp_nonce_field( 'rtbcb_set_test_company', 'rtbcb_set_test_company_nonce' ); ?>
-        </p>
-        <p class="submit">
-            <button type="button" id="rtbcb-test-all-sections" class="button button-primary">
-                <?php esc_html_e( 'Test All Sections', 'rtbcb' ); ?>
-            </button>
-            <?php wp_nonce_field( 'rtbcb_test_dashboard', 'rtbcb_test_dashboard_nonce' ); ?>
-        </p>
-        <p id="rtbcb-test-status"></p>
-    </div>
-
     <?php include RTBCB_DIR . 'admin/partials/dashboard-connectivity.php'; ?>
 
-    <h2 class="nav-tab-wrapper" id="rtbcb-test-tabs">
-        <a href="#rtbcb-phase1" class="nav-tab nav-tab-active"><?php echo esc_html( $phases[1] ); ?></a>
-        <a href="#rtbcb-phase2" class="nav-tab"><?php echo esc_html( $phases[2] ); ?></a>
-        <a href="#rtbcb-phase3" class="nav-tab"><?php echo esc_html( $phases[3] ); ?></a>
-        <a href="#rtbcb-phase4" class="nav-tab"><?php echo esc_html( $phases[4] ); ?></a>
-        <a href="#rtbcb-phase5" class="nav-tab"><?php echo esc_html( $phases[5] ); ?></a>
-    </h2>
+    <div id="rtbcb-section-tests" style="display:none;">
+        <h2 class="title"><?php esc_html_e( 'Individual Test Tools', 'rtbcb' ); ?></h2>
+        <p><?php esc_html_e( 'These tools are optional and available after running all tests.', 'rtbcb' ); ?></p>
 
-    <div id="rtbcb-phase1" class="rtbcb-tab-panel" style="display:block;">
-        <?php include RTBCB_DIR . 'admin/partials/test-company-overview.php'; ?>
-        <?php include RTBCB_DIR . 'admin/partials/test-data-enrichment.php'; ?>
-        <?php include RTBCB_DIR . 'admin/partials/test-data-storage.php'; ?>
-    </div>
-    <div id="rtbcb-phase2" class="rtbcb-tab-panel" style="display:none;">
-        <?php include RTBCB_DIR . 'admin/partials/test-maturity-model.php'; ?>
-        <?php include RTBCB_DIR . 'admin/partials/test-rag-market-analysis.php'; ?>
-        <?php include RTBCB_DIR . 'admin/partials/test-value-proposition.php'; ?>
-        <?php include RTBCB_DIR . 'admin/partials/test-industry-overview.php'; ?>
-        <?php include RTBCB_DIR . 'admin/partials/test-real-treasury-overview.php'; ?>
-    </div>
-    <div id="rtbcb-phase3" class="rtbcb-tab-panel" style="display:none;">
-        <?php include RTBCB_DIR . 'admin/partials/test-roadmap-generator.php'; ?>
-        <?php include RTBCB_DIR . 'admin/partials/test-roi-calculator.php'; ?>
-        <?php include RTBCB_DIR . 'admin/partials/test-estimated-benefits.php'; ?>
-    </div>
-    <div id="rtbcb-phase4" class="rtbcb-tab-panel" style="display:none;">
-        <?php
-        $dependency = rtbcb_get_first_incomplete_dependency( 'rtbcb-test-report-assembly', $sections );
-        if ( null === $dependency ) {
-            include RTBCB_DIR . 'admin/partials/test-report-assembly.php';
-        } else {
-            $phase  = isset( $sections[ $dependency ]['phase'] ) ? (int) $sections[ $dependency ]['phase'] : 0;
-            $anchor = $phase ? '#rtbcb-phase' . $phase : '#';
-            echo '<div class="rtbcb-warning"><p>' .
-                sprintf(
-                    esc_html__( 'Please complete %s first.', 'rtbcb' ),
-                    '<a href="' . esc_url( $anchor ) . '" class="rtbcb-jump-tab">' . esc_html( $sections[ $dependency ]['label'] ) . '</a>'
-                ) .
-                '</p></div>';
-        }
-        ?>
-    </div>
-    <div id="rtbcb-phase5" class="rtbcb-tab-panel" style="display:none;">
-        <?php
-        $dependency = rtbcb_get_first_incomplete_dependency( 'rtbcb-test-tracking-script', $sections );
-        if ( null === $dependency ) {
-            include RTBCB_DIR . 'admin/partials/test-post-delivery.php';
-        } else {
-            $phase  = isset( $sections[ $dependency ]['phase'] ) ? (int) $sections[ $dependency ]['phase'] : 0;
-            $anchor = $phase ? '#rtbcb-phase' . $phase : '#';
-            echo '<div class="rtbcb-warning"><p>' .
-                sprintf(
-                    esc_html__( 'Please complete %s first.', 'rtbcb' ),
-                    '<a href="' . esc_url( $anchor ) . '" class="rtbcb-jump-tab">' . esc_html( $sections[ $dependency ]['label'] ) . '</a>'
-                ) .
-                '</p></div>';
-        }
-        ?>
+        <h2 class="nav-tab-wrapper" id="rtbcb-test-tabs">
+            <a href="#rtbcb-phase1" class="nav-tab nav-tab-active"><?php echo esc_html( $phases[1] ); ?></a>
+            <a href="#rtbcb-phase2" class="nav-tab"><?php echo esc_html( $phases[2] ); ?></a>
+            <a href="#rtbcb-phase3" class="nav-tab"><?php echo esc_html( $phases[3] ); ?></a>
+            <a href="#rtbcb-phase4" class="nav-tab"><?php echo esc_html( $phases[4] ); ?></a>
+            <a href="#rtbcb-phase5" class="nav-tab"><?php echo esc_html( $phases[5] ); ?></a>
+        </h2>
+
+        <div id="rtbcb-phase1" class="rtbcb-tab-panel" style="display:block;">
+            <?php include RTBCB_DIR . 'admin/partials/test-company-overview.php'; ?>
+            <?php include RTBCB_DIR . 'admin/partials/test-data-enrichment.php'; ?>
+            <?php include RTBCB_DIR . 'admin/partials/test-data-storage.php'; ?>
+        </div>
+        <div id="rtbcb-phase2" class="rtbcb-tab-panel" style="display:none;">
+            <?php include RTBCB_DIR . 'admin/partials/test-maturity-model.php'; ?>
+            <?php include RTBCB_DIR . 'admin/partials/test-rag-market-analysis.php'; ?>
+            <?php include RTBCB_DIR . 'admin/partials/test-value-proposition.php'; ?>
+            <?php include RTBCB_DIR . 'admin/partials/test-industry-overview.php'; ?>
+            <?php include RTBCB_DIR . 'admin/partials/test-real-treasury-overview.php'; ?>
+        </div>
+        <div id="rtbcb-phase3" class="rtbcb-tab-panel" style="display:none;">
+            <?php include RTBCB_DIR . 'admin/partials/test-roadmap-generator.php'; ?>
+            <?php include RTBCB_DIR . 'admin/partials/test-roi-calculator.php'; ?>
+            <?php include RTBCB_DIR . 'admin/partials/test-estimated-benefits.php'; ?>
+        </div>
+        <div id="rtbcb-phase4" class="rtbcb-tab-panel" style="display:none;">
+            <?php
+            $dependency = rtbcb_get_first_incomplete_dependency( 'rtbcb-test-report-assembly', $sections );
+            if ( null === $dependency ) {
+                include RTBCB_DIR . 'admin/partials/test-report-assembly.php';
+            } else {
+                $phase  = isset( $sections[ $dependency ]['phase'] ) ? (int) $sections[ $dependency ]['phase'] : 0;
+                $anchor = $phase ? '#rtbcb-phase' . $phase : '#';
+                echo '<div class="rtbcb-warning"><p>' .
+                    sprintf(
+                        esc_html__( 'Please complete %s first.', 'rtbcb' ),
+                        '<a href="' . esc_url( $anchor ) . '" class="rtbcb-jump-tab">' . esc_html( $sections[ $dependency ]['label'] ) . '</a>'
+                    ) .
+                    '</p></div>';
+            }
+            ?>
+        </div>
+        <div id="rtbcb-phase5" class="rtbcb-tab-panel" style="display:none;">
+            <?php
+            $dependency = rtbcb_get_first_incomplete_dependency( 'rtbcb-test-tracking-script', $sections );
+            if ( null === $dependency ) {
+                include RTBCB_DIR . 'admin/partials/test-post-delivery.php';
+            } else {
+                $phase  = isset( $sections[ $dependency ]['phase'] ) ? (int) $sections[ $dependency ]['phase'] : 0;
+                $anchor = $phase ? '#rtbcb-phase' . $phase : '#';
+                echo '<div class="rtbcb-warning"><p>' .
+                    sprintf(
+                        esc_html__( 'Please complete %s first.', 'rtbcb' ),
+                        '<a href="' . esc_url( $anchor ) . '" class="rtbcb-jump-tab">' . esc_html( $sections[ $dependency ]['label'] ) . '</a>'
+                    ) .
+                    '</p></div>';
+            }
+            ?>
+        </div>
     </div>
 
     <script>

--- a/docs/TEST_DASHBOARD_FLOW.md
+++ b/docs/TEST_DASHBOARD_FLOW.md
@@ -103,7 +103,7 @@ Objective: Convert the report into an ongoing conversation and nurture the lead.
 
 The WordPress admin includes a dedicated **Test Dashboard** (`admin/test-dashboard-page.php`) for validating key dependencies and running diagnostics:
 
-The **Set Company** button uses the company name input and applies it to all tests. When running **Test All Sections**, the selected company name is passed to every test for accurate coverage.
+The **Set Company** button uses the company name input and applies it to all tests. Begin with **Run All Tests** to validate the entire flow—the selected company name is passed to every test for accurate coverage. Individual tools can be used afterward if deeper inspection is needed.
 
 1. **OpenAI connectivity** — verifies API key configuration.
 2. **Portal integration** — checks the content portal connection.

--- a/readme.txt
+++ b/readme.txt
@@ -20,11 +20,12 @@ Use the `[rt_business_case_builder]` shortcode to embed the calculator on any pa
 3. Navigate to **Real Treasury → Settings** to configure ROI defaults and API keys.
 
 == Testing Dashboard ==
-From the WordPress admin, go to **Real Treasury → Test Dashboard** to run
-section tests for company overview, recommended category, and more. The
-dashboard replaces the individual test pages from earlier versions. Access
-requires the `manage_options` capability and each test action uses a dedicated
-nonce such as `rtbcb_test_company_overview` to protect requests.
+From the WordPress admin, go to **Real Treasury → Test Dashboard** and click
+**Run All Tests** to execute the full suite. Individual section tools appear
+after this pass and can be used as needed. The dashboard replaces the individual
+test pages from earlier versions. Access requires the `manage_options`
+capability and each test action uses a dedicated nonce such as
+`rtbcb_test_company_overview` to protect requests.
 
 == Repository Structure ==
 
@@ -141,7 +142,7 @@ The analytics dashboard uses Chart.js for its visualizations. The library is bun
 == Changelog ==
 = 2.1.2 =
 * Improved Test Dashboard: `Set Company` uses a single company name input.
-* "Test All Sections" now includes the company name parameter for comprehensive checks.
+* "Run All Tests" now includes the company name parameter for comprehensive checks.
 = 2.1.1 =
 * Bump plugin version to 2.1.1.
 


### PR DESCRIPTION
## Summary
- Highlight consolidated **Run All Tests** control at top of Test Dashboard and defer individual section tools until after completion
- Focus attention on Run All Tests button via JS, optionally auto-running, and reveal section tools when finished
- Update docs to direct users toward the Run All Tests workflow

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit missing; partial suite executed)*

------
https://chatgpt.com/codex/tasks/task_e_68b11bb9a914833180d8db66b41ceb9f