### PR TITLE
Add progress indicator to test dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A comprehensive WordPress plugin that helps treasury teams quantify the benefits
 - `Set Company` uses the main company name input for all tests.
 - First and last name fields stay synchronized across interactions.
 - "Run All Tests" now includes the company name parameter for complete coverage and appears before individual test tools.
+- A progress bar tracks overall completion of the test suite.
 
 ### ✨ Major Enhancements
 

--- a/admin/css/rtbcb-admin.css
+++ b/admin/css/rtbcb-admin.css
@@ -62,6 +62,31 @@
     margin-right: 0;
 }
 
+#rtbcb-test-progress {
+    width: 100%;
+    height: 20px;
+    margin-top: 10px;
+}
+
+#rtbcb-test-progress::-webkit-progress-bar {
+    background-color: #eee;
+    border-radius: 2px;
+}
+
+#rtbcb-test-progress::-webkit-progress-value {
+    background-color: #7216f4;
+    border-radius: 2px;
+}
+
+#rtbcb-test-progress::-moz-progress-bar {
+    background-color: #7216f4;
+}
+
+#rtbcb-test-progress.rtbcb-complete::-webkit-progress-value,
+#rtbcb-test-progress.rtbcb-complete::-moz-progress-bar {
+    background-color: #46b450;
+}
+
 .rtbcb-company-overview .spinner {
     margin-left: 5px;
     visibility: hidden;

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -515,11 +515,13 @@ jQuery(document).ready(function($) {
             e.preventDefault();
             var $btn = $(this);
             var $status = $('#rtbcb-test-status');
+            var $progress = $('#rtbcb-test-progress');
             var original = $btn.text();
             var companyName = $('#rtbcb-company-name').val();
             var companyNameTests = ['rtbcb_test_company_overview'];
 
             $btn.prop('disabled', true).text(window.rtbcbAdmin.strings.testing || 'Testing...');
+            $progress.val(0).removeClass('rtbcb-complete');
             $status.text('Running tests...');
 
             var tests = [
@@ -539,10 +541,12 @@ jQuery(document).ready(function($) {
             ];
 
             var results = [];
-
+            var total = tests.length;
+            $progress.attr('max', total);
+            $status.text('Running tests... (0/' + total + ')');
             for (var i = 0; i < tests.length; i++) {
                 var test = tests[i];
-                $status.text('Testing ' + test.label + '...');
+                $status.text('Testing ' + test.label + ' (' + (i + 1) + '/' + total + ')');
 
                 try {
                     var requestData = {
@@ -578,9 +582,15 @@ jQuery(document).ready(function($) {
                         data: errData
                     });
                 }
+
+                var completed = i + 1;
+                $progress.val(completed);
+                var percent = Math.round((completed / total) * 100);
+                $status.text('Completed ' + completed + ' of ' + total + ' (' + percent + '%)');
             }
 
-            $status.text('Tests completed');
+            $progress.addClass('rtbcb-complete');
+            $status.text('Tests completed (' + total + '/' + total + ')');
             $btn.prop('disabled', false).text(original);
 
             var message = 'Test Results:\n';

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -29,7 +29,8 @@ $company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_d
             </button>
             <?php wp_nonce_field( 'rtbcb_test_dashboard', 'rtbcb_test_dashboard_nonce' ); ?>
         </p>
-        <p id="rtbcb-test-status"></p>
+        <progress id="rtbcb-test-progress" class="rtbcb-test-progress" max="100" value="0" aria-label="<?php esc_attr_e( 'Test progress', 'rtbcb' ); ?>"></progress>
+        <p id="rtbcb-test-status" role="status" aria-live="polite"></p>
     </div>
 
     <?php

--- a/docs/TEST_DASHBOARD_FLOW.md
+++ b/docs/TEST_DASHBOARD_FLOW.md
@@ -101,7 +101,7 @@ Objective: Convert the report into an ongoing conversation and nurture the lead.
 
 ## 🧪 Test Dashboard
 
-The WordPress admin includes a dedicated **Test Dashboard** (`admin/test-dashboard-page.php`) for validating key dependencies and running diagnostics:
+The WordPress admin includes a dedicated **Test Dashboard** (`admin/test-dashboard-page.php`) for validating key dependencies and running diagnostics. A progress bar displays overall completion as each test finishes:
 
 The **Set Company** button uses the company name input and applies it to all tests. Begin with **Run All Tests** to validate the entire flow—the selected company name is passed to every test for accurate coverage. Individual tools can be used afterward if deeper inspection is needed.
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,9 +21,10 @@ Use the `[rt_business_case_builder]` shortcode to embed the calculator on any pa
 
 == Testing Dashboard ==
 From the WordPress admin, go to **Real Treasury → Test Dashboard** and click
-**Run All Tests** to execute the full suite. Individual section tools appear
-after this pass and can be used as needed. The dashboard replaces the individual
-test pages from earlier versions. Access requires the `manage_options`
+**Run All Tests** to execute the full suite. A progress bar indicates overall
+completion as each test finishes. Individual section tools appear after this
+pass and can be used as needed. The dashboard replaces the individual test
+pages from earlier versions. Access requires the `manage_options`
 capability and each test action uses a dedicated nonce such as
 `rtbcb_test_company_overview` to protect requests.
 


### PR DESCRIPTION
## Summary
- add progress bar and status updates to Test Dashboard
- update runAllTests to drive progress indicator and show completion percentage
- style progress bar and document new indicator

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b11cfc0cc08331947a1c528626816c