### PR TITLE
Use stored company data when industry overview payload missing

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -716,7 +716,11 @@ class RTBCB_Admin {
         $company_data = json_decode( $raw_data, true );
 
         if ( empty( $company_data ) || ! is_array( $company_data ) ) {
-            wp_send_json_error( [ 'message' => __( 'Invalid company data.', 'rtbcb' ) ] );
+            $company_data = rtbcb_get_current_company();
+
+            if ( empty( $company_data ) || ! is_array( $company_data ) ) {
+                wp_send_json_error( [ 'message' => __( 'Invalid company data.', 'rtbcb' ) ] );
+            }
         }
 
         $start    = microtime( true );


### PR DESCRIPTION
## Summary
- Fallback to stored company information in `ajax_test_industry_overview` when no payload is provided
- Maintain error response only if both POST data and stored option are invalid

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b12642c42c8331bbea6dbde6bd9564