### PR TITLE
Add dashboard phase completion chart

### DIFF
--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -42,16 +42,28 @@ $company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_d
         4 => __( 'Phase 4: Report Assembly & Delivery', 'rtbcb' ),
         5 => __( 'Phase 5: Post-Delivery Engagement', 'rtbcb' ),
     ];
-    $sections_by_phase = [];
+    $sections_by_phase   = [];
+    $phase_totals        = array_fill_keys( array_keys( $phases ), 0 );
+    $phase_completed     = array_fill_keys( array_keys( $phases ), 0 );
     foreach ( $sections as $id => $section ) {
         $phase = isset( $section['phase'] ) ? (int) $section['phase'] : 0;
         if ( $phase ) {
             $sections_by_phase[ $phase ][ $id ] = $section;
+            $phase_totals[ $phase ]++;
+            if ( ! empty( $section['completed'] ) ) {
+                $phase_completed[ $phase ]++;
+            }
         }
     }
+    $phase_percentages = [];
+    foreach ( $phase_totals as $phase_num => $total ) {
+        $phase_percentages[ $phase_num ] = $total ? round( ( $phase_completed[ $phase_num ] / $total ) * 100 ) : 0;
+    }
+    $phase_keys = array_keys( $phases );
     ?>
     <div class="card">
         <h2 class="title"><?php esc_html_e( 'Analysis Progress', 'rtbcb' ); ?></h2>
+        <canvas id="rtbcb-progress-chart" width="400" height="200"></canvas>
         <ul>
             <?php foreach ( $phases as $phase_num => $phase_label ) : ?>
                 <li>
@@ -75,6 +87,13 @@ $company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_d
             <?php endforeach; ?>
         </ul>
     </div>
+
+    <script>
+    window.rtbcbAdmin = window.rtbcbAdmin || {};
+    window.rtbcbAdmin.phaseLabels = <?php echo wp_json_encode( array_values( $phases ) ); ?>;
+    window.rtbcbAdmin.phaseKeys = <?php echo wp_json_encode( $phase_keys ); ?>;
+    window.rtbcbAdmin.phaseCompletion = <?php echo wp_json_encode( $phase_percentages ); ?>;
+    </script>
 
     <?php include RTBCB_DIR . 'admin/partials/dashboard-connectivity.php'; ?>
 


### PR DESCRIPTION
## Summary
- compute per-phase completion percentages and render Chart.js progress chart on test dashboard
- expose phase data to `rtbcb-admin.js` and refresh chart after test runs
- add AJAX endpoint for fetching phase completion and localize completion label

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b129d5c3c0833191c8a96b5f6da42f