### PR TITLE
Expose dashboard section list to admin JS

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -107,6 +107,27 @@ class RTBCB_Admin {
             }
         }
 
+        $sections_js = [];
+        if ( function_exists( 'rtbcb_get_dashboard_sections' ) ) {
+            $raw_sections = rtbcb_get_dashboard_sections();
+            foreach ( $raw_sections as $id => $section ) {
+                $section_data = [
+                    'id'        => sanitize_key( $id ),
+                    'label'     => isset( $section['label'] ) ? sanitize_text_field( $section['label'] ) : '',
+                    'option'    => isset( $section['option'] ) ? sanitize_key( $section['option'] ) : '',
+                    'requires'  => isset( $section['requires'] ) ? array_map( 'sanitize_key', (array) $section['requires'] ) : [],
+                    'phase'     => isset( $section['phase'] ) ? (int) $section['phase'] : 0,
+                    'completed' => ! empty( $section['completed'] ),
+                ];
+                if ( ! empty( $section['action'] ) ) {
+                    $action = sanitize_key( $section['action'] );
+                    $section_data['action'] = $action;
+                    $section_data['nonce']  = wp_create_nonce( $action );
+                }
+                $sections_js[] = $section_data;
+            }
+        }
+
         wp_localize_script( 'rtbcb-admin', 'rtbcbAdmin', [
             'ajax_url'                   => admin_url( 'admin-ajax.php' ),
             'nonce'                      => wp_create_nonce( 'rtbcb_nonce' ),
@@ -126,6 +147,7 @@ class RTBCB_Admin {
             'follow_up_email_nonce'      => wp_create_nonce( 'rtbcb_test_follow_up_email' ),
             'page'                       => $page,
             'company'                    => $company_data,
+            'sections'                   => $sections_js,
             'strings'                    => [
                 'confirm_delete'      => __( 'Are you sure you want to delete this lead?', 'rtbcb' ),
                 'confirm_bulk_delete' => __( 'Are you sure you want to delete the selected leads?', 'rtbcb' ),

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -530,21 +530,11 @@ jQuery(document).ready(function($) {
                 console.error('Failed to fetch company data', error);
             }
 
-            var tests = [
-                { action: 'rtbcb_test_company_overview', label: 'Company Overview', nonce: window.rtbcbAdmin.company_overview_nonce },
-                { action: 'rtbcb_test_data_enrichment', label: 'Data Enrichment', nonce: $('#rtbcb_test_data_enrichment_nonce').val() },
-                { action: 'rtbcb_test_data_storage', label: 'Data Storage', nonce: $('#rtbcb_test_data_storage_nonce').val() },
-                { action: 'rtbcb_test_maturity_model', label: 'Maturity Model', nonce: window.rtbcbAdmin.maturity_model_nonce || $('#rtbcb_test_maturity_model_nonce').val() },
-                { action: 'rtbcb_test_rag_market_analysis', label: 'RAG Market Analysis', nonce: window.rtbcbAdmin.rag_market_analysis_nonce || $('#rtbcb_test_rag_market_analysis_nonce').val() },
-                { action: 'rtbcb_test_value_proposition', label: 'Value Proposition', nonce: window.rtbcbAdmin.value_proposition_nonce || $('#rtbcb_test_value_proposition_nonce').val() },
-                { action: 'rtbcb_test_industry_overview', label: 'Industry Overview', nonce: window.rtbcbAdmin.industry_overview_nonce || $('#rtbcb_test_industry_overview_nonce').val() },
-                { action: 'rtbcb_test_real_treasury_overview', label: 'Real Treasury Overview', nonce: window.rtbcbAdmin.real_treasury_overview_nonce || $('#rtbcb_test_real_treasury_overview_nonce').val() },
-                { action: 'rtbcb_test_calculate_roi', label: 'ROI Calculator', nonce: window.rtbcbAdmin.roi_nonce },
-                { action: 'rtbcb_test_estimated_benefits', label: 'Estimated Benefits', nonce: window.rtbcbAdmin.benefits_estimate_nonce || $('#rtbcb_test_estimated_benefits_nonce').val() },
-                { action: 'rtbcb_test_report_assembly', label: 'Report Assembly & Delivery', nonce: window.rtbcbAdmin.report_assembly_nonce || $('#rtbcb_test_report_assembly_nonce').val() },
-                { action: 'rtbcb_test_tracking_script', label: 'Tracking Scripts', nonce: window.rtbcbAdmin.tracking_script_nonce || $('#rtbcb_test_tracking_script_nonce').val() },
-                { action: 'rtbcb_test_follow_up_email', label: 'Follow-up Emails', nonce: window.rtbcbAdmin.follow_up_email_nonce || $('#rtbcb_test_follow_up_email_nonce').val() }
-            ];
+            var tests = Array.isArray(window.rtbcbAdmin.sections)
+                ? window.rtbcbAdmin.sections.filter(function(section) {
+                    return section.action;
+                })
+                : [];
             var results = [];
             var total = tests.length;
             $progress.attr('max', total);

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -59,8 +59,8 @@ function rtbcb_model_supports_temperature( $model ) {
  * Get testing dashboard sections and their completion state.
  *
  * The returned array is keyed by section ID and contains the section label,
- * related option key, dependencies, and whether the section has been
- * completed.
+ * related option key, AJAX action, dependencies, and whether the section has
+ * been completed.
  *
  * @return array[] Section data keyed by section ID.
  */
@@ -71,48 +71,56 @@ function rtbcb_get_dashboard_sections() {
             'option'   => 'rtbcb_current_company',
             'requires' => [],
             'phase'    => 1,
+            'action'   => 'rtbcb_test_company_overview',
         ],
         'rtbcb-test-data-enrichment'       => [
             'label'    => __( 'Data Enrichment', 'rtbcb' ),
             'option'   => 'rtbcb_data_enrichment',
             'requires' => [ 'rtbcb-test-company-overview' ],
             'phase'    => 1,
+            'action'   => 'rtbcb_test_data_enrichment',
         ],
         'rtbcb-test-data-storage'          => [
             'label'    => __( 'Data Storage', 'rtbcb' ),
             'option'   => 'rtbcb_data_storage',
             'requires' => [ 'rtbcb-test-company-overview' ],
             'phase'    => 1,
+            'action'   => 'rtbcb_test_data_storage',
         ],
         'rtbcb-test-maturity-model'        => [
             'label'    => __( 'Maturity Model', 'rtbcb' ),
             'option'   => 'rtbcb_maturity_model',
             'requires' => [ 'rtbcb-test-company-overview' ],
             'phase'    => 2,
+            'action'   => 'rtbcb_test_maturity_model',
         ],
         'rtbcb-test-rag-market-analysis'   => [
             'label'    => __( 'RAG Market Analysis', 'rtbcb' ),
             'option'   => 'rtbcb_rag_market_analysis',
             'requires' => [ 'rtbcb-test-company-overview' ],
             'phase'    => 2,
+            'action'   => 'rtbcb_test_rag_market_analysis',
         ],
         'rtbcb-test-value-proposition'     => [
             'label'    => __( 'Value Proposition', 'rtbcb' ),
             'option'   => 'rtbcb_value_proposition',
             'requires' => [ 'rtbcb-test-company-overview' ],
             'phase'    => 2,
+            'action'   => 'rtbcb_test_value_proposition',
         ],
         'rtbcb-test-industry-overview'      => [
             'label'    => __( 'Industry Overview', 'rtbcb' ),
             'option'   => 'rtbcb_industry_insights',
             'requires' => [ 'rtbcb-test-company-overview' ],
             'phase'    => 2,
+            'action'   => 'rtbcb_test_industry_overview',
         ],
         'rtbcb-test-real-treasury-overview' => [
             'label'    => __( 'Real Treasury Overview', 'rtbcb' ),
             'option'   => 'rtbcb_real_treasury_overview',
             'requires' => [ 'rtbcb-test-company-overview' ],
             'phase'    => 2,
+            'action'   => 'rtbcb_test_real_treasury_overview',
         ],
         'rtbcb-test-roadmap-generator'      => [
             'label'    => __( 'Roadmap Generator', 'rtbcb' ),
@@ -125,30 +133,35 @@ function rtbcb_get_dashboard_sections() {
             'option'   => 'rtbcb_roi_results',
             'requires' => [ 'rtbcb-test-company-overview' ],
             'phase'    => 3,
+            'action'   => 'rtbcb_test_calculate_roi',
         ],
         'rtbcb-test-estimated-benefits'     => [
             'label'    => __( 'Estimated Benefits', 'rtbcb' ),
             'option'   => 'rtbcb_estimated_benefits',
             'requires' => [ 'rtbcb-test-company-overview' ],
             'phase'    => 3,
+            'action'   => 'rtbcb_test_estimated_benefits',
         ],
         'rtbcb-test-report-assembly'        => [
             'label'    => __( 'Report Assembly & Delivery', 'rtbcb' ),
             'option'   => 'rtbcb_executive_summary',
             'requires' => [ 'rtbcb-test-estimated-benefits' ],
             'phase'    => 4,
+            'action'   => 'rtbcb_test_report_assembly',
         ],
         'rtbcb-test-tracking-script'        => [
             'label'    => __( 'Tracking Scripts', 'rtbcb' ),
             'option'   => 'rtbcb_tracking_script',
             'requires' => [ 'rtbcb-test-report-assembly' ],
             'phase'    => 5,
+            'action'   => 'rtbcb_test_tracking_script',
         ],
         'rtbcb-test-follow-up-email'        => [
             'label'    => __( 'Follow-up Emails', 'rtbcb' ),
             'option'   => 'rtbcb_follow_up_queue',
             'requires' => [ 'rtbcb-test-report-assembly' ],
             'phase'    => 5,
+            'action'   => 'rtbcb_test_follow_up_email',
         ],
     ];
 


### PR DESCRIPTION
## Summary
- add AJAX action info to `rtbcb_get_dashboard_sections` as canonical source
- localize dashboard sections (with nonces) when enqueuing admin script
- use localized section list in admin JS instead of hard-coded tests

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b19c2c94448331a820490745971154