### PR TITLE
Refactor phase completion calculation into helper

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -1669,28 +1669,8 @@ class RTBCB_Admin {
     public function ajax_get_phase_completion() {
         check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
 
-        $sections = rtbcb_get_dashboard_sections();
-        $totals   = [];
-        $done     = [];
-
-        foreach ( $sections as $section ) {
-            $phase = isset( $section['phase'] ) ? (int) $section['phase'] : 0;
-            if ( $phase ) {
-                if ( ! isset( $totals[ $phase ] ) ) {
-                    $totals[ $phase ] = 0;
-                    $done[ $phase ]   = 0;
-                }
-                $totals[ $phase ]++;
-                if ( ! empty( $section['completed'] ) ) {
-                    $done[ $phase ]++;
-                }
-            }
-        }
-
-        $percentages = [];
-        foreach ( $totals as $phase => $total ) {
-            $percentages[ $phase ] = $total ? round( ( $done[ $phase ] / $total ) * 100 ) : 0;
-        }
+        $sections    = rtbcb_get_dashboard_sections();
+        $percentages = rtbcb_calculate_phase_completion( $sections );
 
         wp_send_json_success( [ 'percentages' => $percentages ] );
     }

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -42,24 +42,15 @@ $company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_d
         4 => __( 'Phase 4: Report Assembly & Delivery', 'rtbcb' ),
         5 => __( 'Phase 5: Post-Delivery Engagement', 'rtbcb' ),
     ];
-    $sections_by_phase   = [];
-    $phase_totals        = array_fill_keys( array_keys( $phases ), 0 );
-    $phase_completed     = array_fill_keys( array_keys( $phases ), 0 );
+    $sections_by_phase = [];
     foreach ( $sections as $id => $section ) {
         $phase = isset( $section['phase'] ) ? (int) $section['phase'] : 0;
         if ( $phase ) {
             $sections_by_phase[ $phase ][ $id ] = $section;
-            $phase_totals[ $phase ]++;
-            if ( ! empty( $section['completed'] ) ) {
-                $phase_completed[ $phase ]++;
-            }
         }
     }
-    $phase_percentages = [];
-    foreach ( $phase_totals as $phase_num => $total ) {
-        $phase_percentages[ $phase_num ] = $total ? round( ( $phase_completed[ $phase_num ] / $total ) * 100 ) : 0;
-    }
-    $phase_keys = array_keys( $phases );
+    $phase_keys        = array_keys( $phases );
+    $phase_percentages = rtbcb_calculate_phase_completion( $sections, $phase_keys );
     ?>
     <div class="card">
         <h2 class="title"><?php esc_html_e( 'Analysis Progress', 'rtbcb' ); ?></h2>

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -173,6 +173,43 @@ function rtbcb_get_dashboard_sections() {
 }
 
 /**
+ * Calculate completion percentages for each phase.
+ *
+ * @param array $sections Dashboard sections.
+ * @param array $phases   Optional phase numbers to include in the result.
+ * @return array Percentages keyed by phase number.
+ */
+function rtbcb_calculate_phase_completion( $sections, $phases = [] ) {
+    $totals = [];
+    $done   = [];
+
+    foreach ( $sections as $section ) {
+        $phase = isset( $section['phase'] ) ? (int) $section['phase'] : 0;
+        if ( $phase ) {
+            if ( ! isset( $totals[ $phase ] ) ) {
+                $totals[ $phase ] = 0;
+                $done[ $phase ]   = 0;
+            }
+            $totals[ $phase ]++;
+            if ( ! empty( $section['completed'] ) ) {
+                $done[ $phase ]++;
+            }
+        }
+    }
+
+    $phase_keys  = $phases ? $phases : array_keys( $totals );
+    $percentages = array_fill_keys( $phase_keys, 0 );
+
+    foreach ( $totals as $phase => $total ) {
+        $percentages[ $phase ] = $total ? round( ( $done[ $phase ] / $total ) * 100 ) : 0;
+    }
+
+    ksort( $percentages );
+
+    return $percentages;
+}
+
+/**
  * Get the first incomplete dependency for a section.
  *
  * Recursively checks the dependency chain and returns the earliest section


### PR DESCRIPTION
## Summary
- add `rtbcb_calculate_phase_completion()` helper
- simplify test dashboard and AJAX phase completion to use new helper

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b1a14dc31483319d38c5aaf0261277