### PR TITLE
Centralize ajaxurl handling in admin scripts

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -1,4 +1,10 @@
 /* Real Treasury Business Case Builder Admin JS */
+
+// Ensure ajaxurl is defined for AJAX requests.
+if ( typeof ajaxurl === 'undefined' ) {
+    var ajaxurl = window.location.origin + '/wp-admin/admin-ajax.php';
+}
+
 jQuery(document).ready(function($) {
     'use strict';
     

--- a/admin/partials/test-company-overview.php
+++ b/admin/partials/test-company-overview.php
@@ -64,10 +64,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 </style>
 <script>
-<?php if ( ! isset( $GLOBALS['ajaxurl'] ) || empty( $GLOBALS['ajaxurl'] ) ) : ?>
-var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
-<?php endif; ?>
-document.getElementById( 'rtbcb-rerun-company-overview' )?.addEventListener( 'click', function() {
-    document.getElementById( 'rtbcb-generate-company-overview' ).click();
-});
+    document.getElementById( 'rtbcb-rerun-company-overview' )?.addEventListener( 'click', function() {
+        document.getElementById( 'rtbcb-generate-company-overview' ).click();
+    });
 </script>

--- a/admin/partials/test-maturity-model.php
+++ b/admin/partials/test-maturity-model.php
@@ -45,19 +45,16 @@ if ( ! rtbcb_require_completed_steps( 'rtbcb-test-maturity-model' ) ) {
     </details>
 </div>
 <script>
-<?php if ( ! isset( $GLOBALS['ajaxurl'] ) || empty( $GLOBALS['ajaxurl'] ) ) : ?>
-var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
-<?php endif; ?>
- jQuery('#rtbcb-generate-maturity-model').on('click', function(){
-    const btn = jQuery(this);
-    const original = rtbcbTestUtils.showLoading(btn);
-    jQuery.post(ajaxurl, {
-        action: 'rtbcb_test_maturity_model',
-        nonce: jQuery('#rtbcb_test_maturity_model_nonce').val()
-    }).done(function(response){
-        if (response.success) {
-            const data = response.data;
-            rtbcbTestUtils.renderSuccess(jQuery('#rtbcb-maturity-model-results'), data.assessment, null, data);
+    jQuery('#rtbcb-generate-maturity-model').on('click', function(){
+        const btn = jQuery(this);
+        const original = rtbcbTestUtils.showLoading(btn);
+        jQuery.post(ajaxurl, {
+            action: 'rtbcb_test_maturity_model',
+            nonce: jQuery('#rtbcb_test_maturity_model_nonce').val()
+        }).done(function(response){
+            if (response.success) {
+                const data = response.data;
+                rtbcbTestUtils.renderSuccess(jQuery('#rtbcb-maturity-model-results'), data.assessment, null, data);
             jQuery('#rtbcb-maturity-model-card').show();
         } else {
             rtbcbTestUtils.renderError(jQuery('#rtbcb-maturity-model-results'), response.data.message);

--- a/admin/partials/test-rag-market-analysis.php
+++ b/admin/partials/test-rag-market-analysis.php
@@ -45,19 +45,16 @@ if ( ! rtbcb_require_completed_steps( 'rtbcb-test-rag-market-analysis' ) ) {
     </details>
 </div>
 <script>
-<?php if ( ! isset( $GLOBALS['ajaxurl'] ) || empty( $GLOBALS['ajaxurl'] ) ) : ?>
-var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
-<?php endif; ?>
- jQuery('#rtbcb-run-rag-analysis').on('click', function(){
-    const btn = jQuery(this);
-    const original = rtbcbTestUtils.showLoading(btn);
-    jQuery.post(ajaxurl, {
-        action: 'rtbcb_test_rag_market_analysis',
-        nonce: jQuery('#rtbcb_test_rag_market_analysis_nonce').val()
-    }).done(function(response){
-        if (response.success) {
-            const list = jQuery('#rtbcb-rag-market-analysis-results').empty();
-            response.data.vendors.forEach(function(v){
+    jQuery('#rtbcb-run-rag-analysis').on('click', function(){
+        const btn = jQuery(this);
+        const original = rtbcbTestUtils.showLoading(btn);
+        jQuery.post(ajaxurl, {
+            action: 'rtbcb_test_rag_market_analysis',
+            nonce: jQuery('#rtbcb_test_rag_market_analysis_nonce').val()
+        }).done(function(response){
+            if (response.success) {
+                const list = jQuery('#rtbcb-rag-market-analysis-results').empty();
+                response.data.vendors.forEach(function(v){
                 list.append('<li>' + v + '</li>');
             });
             jQuery('#rtbcb-rag-market-analysis-card').show();

--- a/admin/partials/test-real-treasury-overview.php
+++ b/admin/partials/test-real-treasury-overview.php
@@ -112,10 +112,7 @@ $overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
 }
 </style>
 <script>
-<?php if ( ! isset( $GLOBALS['ajaxurl'] ) || empty( $GLOBALS['ajaxurl'] ) ) : ?>
-var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
-<?php endif; ?>
-document.getElementById( 'rtbcb-rerun-real-treasury' )?.addEventListener( 'click', function() {
-    document.getElementById( 'rtbcb-generate-real-treasury-overview' ).click();
-});
+    document.getElementById( 'rtbcb-rerun-real-treasury' )?.addEventListener( 'click', function() {
+        document.getElementById( 'rtbcb-generate-real-treasury-overview' ).click();
+    });
 </script>

--- a/admin/partials/test-value-proposition.php
+++ b/admin/partials/test-value-proposition.php
@@ -45,19 +45,16 @@ if ( ! rtbcb_require_completed_steps( 'rtbcb-test-value-proposition' ) ) {
     </details>
 </div>
 <script>
-<?php if ( ! isset( $GLOBALS['ajaxurl'] ) || empty( $GLOBALS['ajaxurl'] ) ) : ?>
-var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
-<?php endif; ?>
- jQuery('#rtbcb-generate-value-proposition').on('click', function(){
-    const btn = jQuery(this);
-    const original = rtbcbTestUtils.showLoading(btn);
-    jQuery.post(ajaxurl, {
-        action: 'rtbcb_test_value_proposition',
-        nonce: jQuery('#rtbcb_test_value_proposition_nonce').val()
-    }).done(function(response){
-        if (response.success) {
-            const data = response.data;
-            rtbcbTestUtils.renderSuccess(jQuery('#rtbcb-value-proposition-results'), data.paragraph, null, data);
+    jQuery('#rtbcb-generate-value-proposition').on('click', function(){
+        const btn = jQuery(this);
+        const original = rtbcbTestUtils.showLoading(btn);
+        jQuery.post(ajaxurl, {
+            action: 'rtbcb_test_value_proposition',
+            nonce: jQuery('#rtbcb_test_value_proposition_nonce').val()
+        }).done(function(response){
+            if (response.success) {
+                const data = response.data;
+                rtbcbTestUtils.renderSuccess(jQuery('#rtbcb-value-proposition-results'), data.paragraph, null, data);
             jQuery('#rtbcb-value-proposition-card').show();
         } else {
             rtbcbTestUtils.renderError(jQuery('#rtbcb-value-proposition-results'), response.data.message);


### PR DESCRIPTION
## Summary
- remove redundant ajaxurl definitions from test partials
- define a single ajaxurl fallback in `rtbcb-admin.js`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b1a217e7e483319ae33b9c5062bdd0