### PR TITLE
Improve mobile responsiveness of Recent Test Results table

### DIFF
--- a/admin/css/rtbcb-admin.css
+++ b/admin/css/rtbcb-admin.css
@@ -146,6 +146,32 @@
     visibility: visible;
 }
 
+.rtbcb-results-table-wrapper {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    position: relative;
+    margin-bottom: 15px;
+}
+
+.rtbcb-results-table-wrapper.rtbcb-scrollable:not(.rtbcb-scrolled-end)::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 30px;
+    height: 100%;
+    pointer-events: none;
+    background: linear-gradient(to left, #fff, rgba(255, 255, 255, 0));
+}
+
+.rtbcb-test-results-table .rtbcb-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    padding: 0 12px;
+}
+
 @media (max-width: 782px) {
     .rtbcb-admin-page .rtbcb-admin-header,
     .rtbcb-admin-page .rtbcb-dashboard {
@@ -160,5 +186,44 @@
 
     .rtbcb-result-actions .button:last-child {
         margin-bottom: 0;
+    }
+
+    .rtbcb-test-results-table thead {
+        display: none;
+    }
+
+    .rtbcb-test-results-table tbody tr {
+        display: block;
+        margin-bottom: 15px;
+        border: 1px solid #ccd0d4;
+        padding: 10px;
+        background: #fff;
+    }
+
+    .rtbcb-test-results-table tbody tr td {
+        display: flex;
+        justify-content: space-between;
+        padding: 6px 0;
+    }
+
+    .rtbcb-test-results-table tbody tr td:before {
+        content: attr(data-label);
+        font-weight: 600;
+        padding-right: 10px;
+    }
+
+    .rtbcb-test-results-table .rtbcb-word-count,
+    .rtbcb-test-results-table .rtbcb-elapsed {
+        display: none;
+    }
+
+    .rtbcb-test-results-table .rtbcb-actions {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+    }
+
+    .rtbcb-test-results-table .rtbcb-actions .rtbcb-action {
+        flex: 1 1 auto;
     }
 }

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -928,7 +928,27 @@ jQuery(document).ready(function($) {
     
     // Initialize when ready
     RTBCB.Admin.init();
-    
+
+    // Horizontal scroll indicator for results table
+    var $rtbcbResultsWrapper = $('.rtbcb-results-table-wrapper');
+    function rtbcbUpdateScrollIndicator($el) {
+        if ($el[0].scrollWidth > $el[0].clientWidth) {
+            $el.addClass('rtbcb-scrollable');
+            if ($el[0].scrollLeft + $el[0].clientWidth >= $el[0].scrollWidth - 1) {
+                $el.addClass('rtbcb-scrolled-end');
+            } else {
+                $el.removeClass('rtbcb-scrolled-end');
+            }
+        } else {
+            $el.removeClass('rtbcb-scrollable rtbcb-scrolled-end');
+        }
+    }
+    $rtbcbResultsWrapper.each(function(){ rtbcbUpdateScrollIndicator($(this)); });
+    $rtbcbResultsWrapper.on('scroll', function(){ rtbcbUpdateScrollIndicator($(this)); });
+    $(window).on('resize', function(){
+        $rtbcbResultsWrapper.each(function(){ rtbcbUpdateScrollIndicator($(this)); });
+    });
+
     // Export for external use
     window.RTBCBAdmin = RTBCB.Admin;
 });

--- a/admin/partials/dashboard-test-results.php
+++ b/admin/partials/dashboard-test-results.php
@@ -19,7 +19,8 @@ $sections     = rtbcb_get_dashboard_sections();
 ?>
 
 <h2 class="title"><?php esc_html_e( 'Recent Test Results', 'rtbcb' ); ?></h2>
-<table class="widefat striped" id="rtbcb-test-results-summary">
+<div class="rtbcb-results-table-wrapper">
+<table class="widefat striped rtbcb-test-results-table" id="rtbcb-test-results-summary">
     <thead>
         <tr>
             <th><?php esc_html_e( 'Section', 'rtbcb' ); ?></th>
@@ -69,17 +70,16 @@ $sections     = rtbcb_get_dashboard_sections();
             }
             ?>
             <tr>
-                <td><?php echo esc_html( $section_label ); ?></td>
-                <td><?php echo esc_html( $result['status'] ); ?></td>
-                <td><?php echo esc_html( $result['message'] ); ?></td>
-                <td><?php echo '' !== $word_count ? esc_html( $word_count ) : esc_html__( 'N/A', 'rtbcb' ); ?></td>
-                <td><?php echo '' !== $elapsed ? esc_html( $elapsed ) : esc_html__( 'N/A', 'rtbcb' ); ?></td>
-                <td><?php echo esc_html( $result['timestamp'] ); ?></td>
-                <td>
+                <td data-label="<?php echo esc_attr__( 'Section', 'rtbcb' ); ?>"><?php echo esc_html( $section_label ); ?></td>
+                <td data-label="<?php echo esc_attr__( 'Status', 'rtbcb' ); ?>"><?php echo esc_html( $result['status'] ); ?></td>
+                <td data-label="<?php echo esc_attr__( 'Message', 'rtbcb' ); ?>"><?php echo esc_html( $result['message'] ); ?></td>
+                <td class="rtbcb-word-count" data-label="<?php echo esc_attr__( 'Word Count', 'rtbcb' ); ?>"><?php echo '' !== $word_count ? esc_html( $word_count ) : esc_html__( 'N/A', 'rtbcb' ); ?></td>
+                <td class="rtbcb-elapsed" data-label="<?php echo esc_attr__( 'Elapsed (s)', 'rtbcb' ); ?>"><?php echo '' !== $elapsed ? esc_html( $elapsed ) : esc_html__( 'N/A', 'rtbcb' ); ?></td>
+                <td data-label="<?php echo esc_attr__( 'Timestamp', 'rtbcb' ); ?>"><?php echo esc_html( $result['timestamp'] ); ?></td>
+                <td class="rtbcb-actions" data-label="<?php echo esc_attr__( 'Actions', 'rtbcb' ); ?>">
                     <?php if ( $section_id ) : ?>
-                        <a href="#<?php echo esc_attr( $section_id ); ?>" class="rtbcb-jump-tab"><?php esc_html_e( 'View', 'rtbcb' ); ?></a>
-                        |
-                        <a href="#" class="rtbcb-rerun-test" data-section="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Re-run', 'rtbcb' ); ?></a>
+                        <a href="#<?php echo esc_attr( $section_id ); ?>" class="button button-secondary rtbcb-action rtbcb-jump-tab"><?php esc_html_e( 'View', 'rtbcb' ); ?></a>
+                        <a href="#" class="button button-secondary rtbcb-action rtbcb-rerun-test" data-section="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Re-run', 'rtbcb' ); ?></a>
                     <?php endif; ?>
                 </td>
             </tr>
@@ -91,6 +91,7 @@ $sections     = rtbcb_get_dashboard_sections();
     <?php endif; ?>
     </tbody>
 </table>
+</div>
 <script>
 (function($){
     $('#rtbcb-test-results-summary').on('click', '.rtbcb-jump-tab', function(e){


### PR DESCRIPTION
## Summary
- Make Recent Test Results table render as responsive cards on small screens
- Hide secondary columns on mobile and ensure action buttons are touch-friendly
- Add scroll indicator logic and styles for horizontal overflow

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b1b82d7fb0833194e89b3ce6e42431