### PR TITLE
Add API logs admin page with log management

### DIFF
--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * API logs admin page.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div class="wrap">
+    <h1><?php echo esc_html__( 'API Logs', 'rtbcb' ); ?></h1>
+    <p>
+        <button id="rtbcb-clear-logs" class="button" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+            <?php esc_html_e( 'Clear All Logs', 'rtbcb' ); ?>
+        </button>
+    </p>
+    <table class="widefat fixed striped">
+        <thead>
+            <tr>
+                <th><?php esc_html_e( 'ID', 'rtbcb' ); ?></th>
+                <th><?php esc_html_e( 'Request', 'rtbcb' ); ?></th>
+                <th><?php esc_html_e( 'Tokens', 'rtbcb' ); ?></th>
+                <th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
+                <th><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
+                <th><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if ( ! empty( $logs_data['logs'] ) ) : ?>
+                <?php foreach ( $logs_data['logs'] as $log ) :
+                    $request  = json_decode( $log['request_json'], true );
+                    $response = json_decode( $log['response_json'], true );
+                    $summary  = '';
+                    if ( isset( $request['messages'][0]['content'] ) ) {
+                        $summary = wp_trim_words( $request['messages'][0]['content'], 10, '...' );
+                    } else {
+                        $summary = wp_trim_words( $log['request_json'], 10, '...' );
+                    }
+                    $status = isset( $response['error'] ) ? __( 'Error', 'rtbcb' ) : __( 'OK', 'rtbcb' );
+                ?>
+                <tr data-id="<?php echo esc_attr( $log['id'] ); ?>" data-request="<?php echo esc_attr( $log['request_json'] ); ?>" data-response="<?php echo esc_attr( $log['response_json'] ); ?>">
+                    <td><?php echo esc_html( $log['id'] ); ?></td>
+                    <td><?php echo esc_html( $summary ); ?></td>
+                    <td><?php echo esc_html( $log['total_tokens'] ); ?></td>
+                    <td><?php echo esc_html( $status ); ?></td>
+                    <td><?php echo esc_html( $log['created_at'] ); ?></td>
+                    <td>
+                        <button class="button rtbcb-view-log">
+                            <?php esc_html_e( 'View', 'rtbcb' ); ?>
+                        </button>
+                        <button class="button rtbcb-delete-log" data-id="<?php echo esc_attr( $log['id'] ); ?>" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+                            <?php esc_html_e( 'Delete', 'rtbcb' ); ?>
+                        </button>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+            <?php else : ?>
+                <tr>
+                    <td colspan="6"><?php esc_html_e( 'No logs found.', 'rtbcb' ); ?></td>
+                </tr>
+            <?php endif; ?>
+        </tbody>
+    </table>
+    <?php
+    $total_pages = ceil( $logs_data['total'] / $per_page );
+    if ( $total_pages > 1 ) :
+        ?>
+        <div class="tablenav">
+            <div class="tablenav-pages">
+                <?php
+                echo wp_kses_post(
+                    paginate_links(
+                        [
+                            'base'      => add_query_arg( 'paged', '%#%' ),
+                            'format'    => '',
+                            'prev_text' => __( '&laquo;', 'rtbcb' ),
+                            'next_text' => __( '&raquo;', 'rtbcb' ),
+                            'total'     => $total_pages,
+                            'current'   => $paged,
+                        ]
+                    )
+                );
+                ?>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>
+<div id="rtbcb-log-modal" style="display:none;">
+    <div class="rtbcb-modal-content">
+        <pre id="rtbcb-log-detail"></pre>
+        <button class="button" id="rtbcb-close-log"><?php esc_html_e( 'Close', 'rtbcb' ); ?></button>
+    </div>
+</div>
+<script type="text/javascript">
+jQuery(function($){
+    $('#rtbcb-clear-logs').on('click', function(e){
+        e.preventDefault();
+        if (!confirm('<?php echo esc_js( __( 'Are you sure you want to clear all logs?', 'rtbcb' ) ); ?>')) {
+            return;
+        }
+        $.post(window.rtbcbAdmin.ajax_url, {
+            action: 'rtbcb_clear_logs',
+            nonce: $(this).data('nonce')
+        }, function(resp){
+            if (resp.success) {
+                location.reload();
+            } else {
+                alert(resp.data && resp.data.message ? resp.data.message : 'Error');
+            }
+        });
+    });
+    $('.rtbcb-delete-log').on('click', function(e){
+        e.preventDefault();
+        if (!confirm('<?php echo esc_js( __( 'Delete this log?', 'rtbcb' ) ); ?>')) {
+            return;
+        }
+        var id = $(this).data('id');
+        var nonce = $(this).data('nonce');
+        $.post(window.rtbcbAdmin.ajax_url, {
+            action: 'rtbcb_delete_log',
+            nonce: nonce,
+            id: id
+        }, function(resp){
+            if (resp.success) {
+                $('tr[data-id="' + id + '"]').remove();
+            } else {
+                alert(resp.data && resp.data.message ? resp.data.message : 'Error');
+            }
+        });
+    });
+    $('.rtbcb-view-log').on('click', function(e){
+        e.preventDefault();
+        var $row = $(this).closest('tr');
+        var req = $row.attr('data-request');
+        var res = $row.attr('data-response');
+        try { req = JSON.stringify(JSON.parse(req), null, 2); } catch (err) {}
+        try { res = JSON.stringify(JSON.parse(res), null, 2); } catch (err) {}
+        var content = 'Request:\n' + req + '\n\nResponse:\n' + res;
+        $('#rtbcb-log-detail').text(content);
+        $('#rtbcb-log-modal').show();
+    });
+    $('#rtbcb-close-log').on('click', function(){
+        $('#rtbcb-log-modal').hide();
+    });
+});
+</script>
+

--- a/inc/class-rtbcb-api-log.php
+++ b/inc/class-rtbcb-api-log.php
@@ -194,4 +194,78 @@ class RTBCB_API_Log {
             )
         );
     }
+
+    /**
+     * Delete a single log entry.
+     *
+     * @param int $id Log ID.
+     * @return int Rows deleted.
+     */
+    public static function delete_log( $id ) {
+        global $wpdb;
+
+        if ( empty( self::$table_name ) ) {
+            self::init();
+        }
+
+        $id = intval( $id );
+        if ( $id <= 0 ) {
+            return 0;
+        }
+
+        return $wpdb->delete( self::$table_name, [ 'id' => $id ], [ '%d' ] );
+    }
+
+    /**
+     * Clear all log entries.
+     *
+     * @return int Rows deleted.
+     */
+    public static function clear_logs() {
+        global $wpdb;
+
+        if ( empty( self::$table_name ) ) {
+            self::init();
+        }
+
+        return $wpdb->query( 'TRUNCATE TABLE ' . self::$table_name );
+    }
+
+    /**
+     * Retrieve logs with pagination support.
+     *
+     * @param int $paged    Current page number.
+     * @param int $per_page Items per page.
+     * @return array{
+     *     logs: array,
+     *     total: int
+     * }
+     */
+    public static function get_logs_paginated( $paged = 1, $per_page = 20 ) {
+        global $wpdb;
+
+        if ( empty( self::$table_name ) ) {
+            self::init();
+        }
+
+        $paged    = max( 1, intval( $paged ) );
+        $per_page = max( 1, intval( $per_page ) );
+        $offset   = ( $paged - 1 ) * $per_page;
+
+        $logs = $wpdb->get_results(
+            $wpdb->prepare(
+                'SELECT * FROM ' . self::$table_name . ' ORDER BY created_at DESC LIMIT %d OFFSET %d',
+                $per_page,
+                $offset
+            ),
+            ARRAY_A
+        );
+
+        $total = (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . self::$table_name );
+
+        return [
+            'logs'  => $logs,
+            'total' => $total,
+        ];
+    }
 }


### PR DESCRIPTION
## Summary
- add API logs submenu in admin area with nonce-protected table view
- implement log retrieval, deletion, and clearing utilities
- provide AJAX endpoints and JS handlers for managing log entries

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bc131e788331afba00ed8b6f31ab