### PR TITLE
Add silent prerequisite checks with inline notices

### DIFF
--- a/admin/partials/test-company-overview.php
+++ b/admin/partials/test-company-overview.php
@@ -8,6 +8,13 @@
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
+
+if ( ! rtbcb_require_completed_steps( 'rtbcb-test-company-overview', false ) ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
+    return;
+}
 ?>
 <h2><?php esc_html_e( 'Test Company Overview', 'rtbcb' ); ?></h2>
 <p class="description"><?php esc_html_e( 'Generate a concise company profile using your configured AI model.', 'rtbcb' ); ?></p>

--- a/admin/partials/test-data-enrichment.php
+++ b/admin/partials/test-data-enrichment.php
@@ -9,7 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! rtbcb_require_completed_steps( 'rtbcb-test-data-enrichment' ) ) {
+if ( ! rtbcb_require_completed_steps( 'rtbcb-test-data-enrichment', false ) ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
     return;
 }
 ?>

--- a/admin/partials/test-data-storage.php
+++ b/admin/partials/test-data-storage.php
@@ -9,7 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! rtbcb_require_completed_steps( 'rtbcb-test-data-storage' ) ) {
+if ( ! rtbcb_require_completed_steps( 'rtbcb-test-data-storage', false ) ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
     return;
 }
 ?>

--- a/admin/partials/test-estimated-benefits.php
+++ b/admin/partials/test-estimated-benefits.php
@@ -9,7 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! rtbcb_require_completed_steps( 'rtbcb-test-estimated-benefits' ) ) {
+if ( ! rtbcb_require_completed_steps( 'rtbcb-test-estimated-benefits', false ) ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
     return;
 }
 

--- a/admin/partials/test-follow-up-email.php
+++ b/admin/partials/test-follow-up-email.php
@@ -9,7 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! rtbcb_require_completed_steps( 'rtbcb-test-follow-up-email' ) ) {
+if ( ! rtbcb_require_completed_steps( 'rtbcb-test-follow-up-email', false ) ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
     return;
 }
 

--- a/admin/partials/test-industry-overview.php
+++ b/admin/partials/test-industry-overview.php
@@ -9,8 +9,11 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-$allowed = rtbcb_require_completed_steps( 'rtbcb-test-industry-overview' );
+$allowed = rtbcb_require_completed_steps( 'rtbcb-test-industry-overview', false );
 if ( ! $allowed ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
     return;
 }
 

--- a/admin/partials/test-maturity-model.php
+++ b/admin/partials/test-maturity-model.php
@@ -9,7 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! rtbcb_require_completed_steps( 'rtbcb-test-maturity-model' ) ) {
+if ( ! rtbcb_require_completed_steps( 'rtbcb-test-maturity-model', false ) ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
     return;
 }
 

--- a/admin/partials/test-rag-market-analysis.php
+++ b/admin/partials/test-rag-market-analysis.php
@@ -9,7 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! rtbcb_require_completed_steps( 'rtbcb-test-rag-market-analysis' ) ) {
+if ( ! rtbcb_require_completed_steps( 'rtbcb-test-rag-market-analysis', false ) ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
     return;
 }
 

--- a/admin/partials/test-real-treasury-overview.php
+++ b/admin/partials/test-real-treasury-overview.php
@@ -9,7 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! rtbcb_require_completed_steps( 'rtbcb-test-real-treasury-overview' ) ) {
+if ( ! rtbcb_require_completed_steps( 'rtbcb-test-real-treasury-overview', false ) ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
     return;
 }
 

--- a/admin/partials/test-report-assembly.php
+++ b/admin/partials/test-report-assembly.php
@@ -9,8 +9,11 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-$allowed = rtbcb_require_completed_steps( 'rtbcb-test-report-assembly' );
+$allowed = rtbcb_require_completed_steps( 'rtbcb-test-report-assembly', false );
 if ( ! $allowed ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
     return;
 }
 

--- a/admin/partials/test-roadmap-generator.php
+++ b/admin/partials/test-roadmap-generator.php
@@ -9,7 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! rtbcb_require_completed_steps( 'rtbcb-test-roadmap-generator' ) ) {
+if ( ! rtbcb_require_completed_steps( 'rtbcb-test-roadmap-generator', false ) ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
     return;
 }
 

--- a/admin/partials/test-roi-calculator.php
+++ b/admin/partials/test-roi-calculator.php
@@ -9,7 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! rtbcb_require_completed_steps( 'rtbcb-test-roi-calculator' ) ) {
+if ( ! rtbcb_require_completed_steps( 'rtbcb-test-roi-calculator', false ) ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
     return;
 }
 

--- a/admin/partials/test-tracking-script.php
+++ b/admin/partials/test-tracking-script.php
@@ -9,7 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! rtbcb_require_completed_steps( 'rtbcb-test-tracking-script' ) ) {
+if ( ! rtbcb_require_completed_steps( 'rtbcb-test-tracking-script', false ) ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
     return;
 }
 

--- a/admin/partials/test-value-proposition.php
+++ b/admin/partials/test-value-proposition.php
@@ -9,7 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! rtbcb_require_completed_steps( 'rtbcb-test-value-proposition' ) ) {
+if ( ! rtbcb_require_completed_steps( 'rtbcb-test-value-proposition', false ) ) {
+    echo '<div class="notice notice-warning inline"><p>' .
+        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+        '</p></div>';
     return;
 }
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -259,9 +259,11 @@ function rtbcb_get_first_incomplete_dependency( $section_id, $sections, $visited
  * are missing.
  *
  * @param string $current_section Current section ID.
+ * @param bool   $display_notice  Optional. Whether to show an admin notice.
+ *                                Defaults to true.
  * @return bool True when allowed, false otherwise.
  */
-function rtbcb_require_completed_steps( $current_section ) {
+function rtbcb_require_completed_steps( $current_section, $display_notice = true ) {
     static $displayed = [];
 
     $sections   = rtbcb_get_dashboard_sections();
@@ -271,7 +273,7 @@ function rtbcb_require_completed_steps( $current_section ) {
         return true;
     }
 
-    if ( ! in_array( $dependency, $displayed, true ) ) {
+    if ( $display_notice && ! in_array( $dependency, $displayed, true ) ) {
         $phase  = isset( $sections[ $dependency ]['phase'] ) ? (int) $sections[ $dependency ]['phase'] : 0;
         $anchor = $phase ? 'rtbcb-phase' . $phase : $dependency;
         $url    = admin_url( 'admin.php?page=rtbcb-test-dashboard#' . $anchor );


### PR DESCRIPTION
## Summary
- Allow `rtbcb_require_completed_steps` to optionally suppress admin notices
- Guard dashboard section partials with silent prerequisite checks and inline warnings

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `phpunit` *(fails: configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bf02959483319109eaef858d77de