### PR TITLE
Add configurable OpenAI timeout

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -433,6 +433,7 @@ class RTBCB_Admin {
         register_setting( 'rtbcb_settings', 'rtbcb_embedding_model', [ 'sanitize_callback' => 'sanitize_text_field' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_labor_cost_per_hour', [ 'sanitize_callback' => 'floatval' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_bank_fee_baseline', [ 'sanitize_callback' => 'floatval' ] );
+        register_setting( 'rtbcb_settings', 'rtbcb_gpt5_timeout', [ 'sanitize_callback' => 'intval' ] );
     }
 
     /**

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -15,6 +15,7 @@ $advanced_model  = get_option( 'rtbcb_advanced_model', rtbcb_get_default_model( 
 $embedding_model = get_option( 'rtbcb_embedding_model', rtbcb_get_default_model( 'embedding' ) );
 $labor_cost      = get_option( 'rtbcb_labor_cost_per_hour', '' );
 $bank_fee        = get_option( 'rtbcb_bank_fee_baseline', '' );
+$gpt5_timeout    = get_option( 'rtbcb_gpt5_timeout', 180 );
 
 $chat_models = [
     'gpt-5'             => 'gpt-5',
@@ -90,6 +91,15 @@ $embedding_models = [
                             <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $advanced_model, $value ); ?>><?php echo esc_html( $label ); ?></option>
                         <?php endforeach; ?>
                     </select>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="rtbcb_gpt5_timeout"><?php echo esc_html__( 'API Request Timeout (seconds)', 'rtbcb' ); ?></label>
+                </th>
+                <td>
+                    <input type="number" id="rtbcb_gpt5_timeout" name="rtbcb_gpt5_timeout" value="<?php echo esc_attr( $gpt5_timeout ); ?>" class="small-text" />
+                    <p class="description"><?php echo esc_html__( 'Maximum time to wait for OpenAI responses.', 'rtbcb' ); ?></p>
                 </td>
             </tr>
             <tr>

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -11,6 +11,12 @@ require_once __DIR__ . '/helpers.php';
 class RTBCB_LLM {
     private $api_key;
     private $current_inputs = [];
+
+    /**
+     * GPT-5 configuration settings.
+     *
+     * @var array
+     */
     private $gpt5_config;
 
     /**
@@ -30,7 +36,13 @@ class RTBCB_LLM {
     public function __construct() {
         $this->api_key = get_option( 'rtbcb_openai_api_key' );
 
-        $config     = rtbcb_get_gpt5_config( get_option( 'rtbcb_gpt5_config', [] ) );
+        $timeout = intval( get_option( 'rtbcb_gpt5_timeout', 180 ) );
+        $config  = rtbcb_get_gpt5_config(
+            array_merge(
+                get_option( 'rtbcb_gpt5_config', [] ),
+                [ 'timeout' => $timeout ]
+            )
+        );
         $this->gpt5_config = $config;
 
         if ( empty( $this->api_key ) ) {
@@ -1330,13 +1342,15 @@ Respond with valid JSON only, following the specified schema exactly. Ensure all
             $body['store'] = (bool) $this->gpt5_config['store'];
         }
 
+        $timeout = intval( $this->gpt5_config['timeout'] ?? 180 );
+
         $args = [
             'headers' => [
                 'Authorization' => 'Bearer ' . $this->api_key,
                 'Content-Type' => 'application/json',
             ],
             'body'    => wp_json_encode( $body ),
-            'timeout' => 60, // Reasonable timeout for model requests
+            'timeout' => $timeout,
         ];
 
         $this->last_request = $body;

--- a/public/js/rtbcb-report.js
+++ b/public/js/rtbcb-report.js
@@ -7,7 +7,7 @@ const RTBCB_GPT5_DEFAULTS = {
     text: { verbosity: 'medium' },
     temperature: 0.7,
     store: true,
-    timeout: 120,
+    timeout: 180,
     max_retries: 3
 };
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -444,7 +444,13 @@ class Real_Treasury_BCB {
         $api_key      = sanitize_text_field( get_option( 'rtbcb_openai_api_key', '' ) );
         $report_model = sanitize_text_field( get_option( 'rtbcb_advanced_model', 'gpt-5-mini' ) );
 
-        $config = rtbcb_get_gpt5_config( get_option( 'rtbcb_gpt5_config', [] ) );
+        $timeout = intval( get_option( 'rtbcb_gpt5_timeout', 180 ) );
+        $config  = rtbcb_get_gpt5_config(
+            array_merge(
+                get_option( 'rtbcb_gpt5_config', [] ),
+                [ 'timeout' => $timeout ]
+            )
+        );
 
         $config_localized = [
             'model'              => sanitize_text_field( $config['model'] ),


### PR DESCRIPTION
## Summary
- Allow administrators to configure OpenAI request timeouts via new `rtbcb_gpt5_timeout` setting.
- Pass sanitized timeout through GPT‑5 config so API calls honor site setting and default to 180 seconds.
- Expose timeout field on settings page and update frontend defaults.

## Testing
- `bash tests/run-tests.sh` *(fails: WPDB_Stub::get_var undefined, phpunit not found, JS ReferenceError)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c24920848331aa7196d74754f1cf