### PR TITLE
Use dashboard nonce for saving test results

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -373,9 +373,9 @@ class RTBCB_Admin {
      * Save test results from dashboard.
      *
      * @return void
-     */
+    */
     public function save_test_results() {
-        check_ajax_referer( 'rtbcb_test_rag', 'nonce' );
+        check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
             wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );


### PR DESCRIPTION
## Summary
- Validate dashboard test result saving with the `rtbcb_test_dashboard` nonce
- Confirm `rtbcbAdmin` JS object still includes `test_dashboard_nonce`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c42c4384833189c3762812b51f04