### PR TITLE
Use configurable timeout for API tests and note longer diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,8 @@ capability. AJAX actions from the dashboard require nonces such as
 `rtbcb_test_company_overview`, `rtbcb_test_estimated_benefits`, and
 `rtbcb_test_dashboard` when saving results. Click **Run Diagnostics** to execute
 the full test suite defined in `tests/run-tests.sh` and display the latest
-results. A visual overview of the end-to-end reporting flow and diagnostics is
+results. Diagnostics may take up to two minutes to complete due to longer API
+timeouts. A visual overview of the end-to-end reporting flow and diagnostics is
 available in [docs/TEST_DASHBOARD_FLOW.md](docs/TEST_DASHBOARD_FLOW.md).
 
 ### Automated Tests

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -54,7 +54,7 @@ $embedding_models = [
                 </th>
                 <td>
                     <button type="button" class="button" id="rtbcb-run-tests" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rtbcb_nonce' ) ); ?>"><?php echo esc_html__( 'Run Diagnostics', 'rtbcb' ); ?></button>
-                    <p class="description"><?php echo esc_html__( 'Verify integration and system health.', 'rtbcb' ); ?></p>
+                    <p class="description"><?php echo esc_html__( 'Verify integration and system health. Tests may take up to two minutes.', 'rtbcb' ); ?></p>
                 </td>
             </tr>
             <tr>

--- a/docs/TEST_DASHBOARD_FLOW.md
+++ b/docs/TEST_DASHBOARD_FLOW.md
@@ -110,7 +110,8 @@ The **Connectivity Tests & Status** panel groups the first three checks and repl
 1. **OpenAI connectivity** — verifies API key configuration.
 2. **Portal integration** — checks the content portal connection.
 3. **RAG health** — ensures the retrieval index is available.
-4. **Run Diagnostics** — executes the integration tests defined in `tests/run-tests.sh` and stores the latest results.
+4. **Run Diagnostics** — executes the integration tests defined in `tests/run-tests.sh` and stores the latest results. Tests may
+   take up to two minutes to finish.
 
 Developers can use the dashboard to quickly confirm environment health or trigger the test suite directly from the admin area.
 

--- a/inc/class-rtbcb-api-tester.php
+++ b/inc/class-rtbcb-api-tester.php
@@ -56,13 +56,15 @@ class RTBCB_API_Tester {
             $body['temperature'] = 0.1;
         }
 
+        $timeout = intval( get_option( 'rtbcb_gpt5_timeout', 180 ) );
+
         $args = [
             'headers' => [
                 'Authorization' => 'Bearer ' . $api_key,
                 'Content-Type' => 'application/json',
             ],
-            'body' => wp_json_encode( $body ),
-            'timeout' => 30,
+            'body'    => wp_json_encode( $body ),
+            'timeout' => $timeout,
         ];
 
         $response = wp_remote_post( 'https://api.openai.com/v1/responses', $args );


### PR DESCRIPTION
## Summary
- Switch API connection tester to use the plugin's configurable timeout instead of a fixed 30s value
- Update settings page and documentation to mention diagnostics may take up to two minutes

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b1c509ef68833184b9c2e32b4d64fc