### PR TITLE
Display notice on test result save failure

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -415,7 +415,11 @@ class RTBCB_Admin {
             $combined = array_slice( $combined, 0, $max_results );
         }
 
-        update_option( 'rtbcb_test_results', $combined );
+        $updated = update_option( 'rtbcb_test_results', $combined );
+
+        if ( false === $updated ) {
+            wp_send_json_error( [ 'message' => __( 'Failed to save test results.', 'rtbcb' ) ] );
+        }
 
         wp_send_json_success();
     }

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -918,9 +918,15 @@ jQuery(document).ready(function($) {
                 if (response.success) {
                     console.log('Test results saved');
                 } else {
-                    console.error(response.data && response.data.message ? response.data.message : 'Failed to save test results');
+                    var message = response.data && response.data.message ? response.data.message : (window.rtbcbAdmin.strings && window.rtbcbAdmin.strings.error ? window.rtbcbAdmin.strings.error : 'Failed to save test results');
+                    var safeMessage = $('<div>').text(message).html();
+                    $('#rtbcb-test-status').after('<div class="notice notice-error"><p>' + safeMessage + '</p></div>');
+                    console.error(safeMessage);
                 }
             } catch (error) {
+                var message = (error.responseJSON && error.responseJSON.data && error.responseJSON.data.message) ? error.responseJSON.data.message : (window.rtbcbAdmin.strings && window.rtbcbAdmin.strings.error ? window.rtbcbAdmin.strings.error : 'Failed to save test results');
+                var safeMessage = $('<div>').text(message).html();
+                $('#rtbcb-test-status').after('<div class="notice notice-error"><p>' + safeMessage + '</p></div>');
                 console.error('Failed to save test results', error);
             }
         },


### PR DESCRIPTION
## Summary
- Show a WordPress admin notice when saving test results fails, surfacing sanitized server messages.
- Return a descriptive error from `save_test_results` when the option update fails.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b1c6e515c8833188d03bca2f40f755