### PR TITLE
Add start new analysis button with AJAX reset

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -82,6 +82,7 @@ jQuery(document).ready(function($) {
                 }
             });
             $('#rtbcb-clear-analysis').on('click', this.clearAnalysis);
+            $('#rtbcb-start-new-analysis').on('click', this.startNewAnalysis);
             $('#rtbcb-company-name').on('change', function(){
                 if (window.rtbcbAdmin.comprehensive) {
                     alert('Stored analysis may be outdated for new company.');
@@ -928,6 +929,28 @@ jQuery(document).ready(function($) {
                 var safeMessage = $('<div>').text(message).html();
                 $('#rtbcb-test-status').after('<div class="notice notice-error"><p>' + safeMessage + '</p></div>');
                 console.error('Failed to save test results', error);
+            }
+        },
+
+        startNewAnalysis: async function(e) {
+            e.preventDefault();
+            var nonce = $('#rtbcb_clear_current_company_nonce').val();
+            try {
+                var response = await $.ajax({
+                    url: window.rtbcbAdmin.ajax_url,
+                    method: 'POST',
+                    data: {
+                        action: 'rtbcb_clear_current_company',
+                        nonce: nonce
+                    }
+                });
+                if (response.success) {
+                    window.location.href = 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1';
+                } else {
+                    alert('Request failed');
+                }
+            } catch (error) {
+                alert('Request failed');
             }
         },
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -324,9 +324,11 @@ function rtbcb_get_last_test_result( $section_id, $test_results = null ) {
  * @return void
  */
 function rtbcb_render_start_new_analysis_button() {
-    $url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
-    echo '<p><a href="' . esc_url( $url ) . '" class="button">' .
-        esc_html__( 'Start New Analysis', 'rtbcb' ) . '</a></p>';
+    echo '<p>';
+    echo '<button type="button" id="rtbcb-start-new-analysis" class="button">' .
+        esc_html__( 'Start New Analysis', 'rtbcb' ) . '</button>';
+    wp_nonce_field( 'rtbcb_test_company_overview', 'rtbcb_clear_current_company_nonce' );
+    echo '</p>';
 }
 
 function rtbcb_check_database_health() {


### PR DESCRIPTION
## Summary
- render Start New Analysis button with dedicated ID and nonce
- send AJAX request to clear current company and redirect to first phase
- keep button distinct from existing Clear All Stored Data action

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b1c807470083319720e10055fe27c1