### PR TITLE
feat: add collapsible progress stepper

### DIFF
--- a/admin/css/rtbcb-admin.css
+++ b/admin/css/rtbcb-admin.css
@@ -108,33 +108,87 @@
 }
 
 /* Progress overview */
-.rtbcb-progress-list {
-    list-style: none;
-    margin: 0;
-    padding-left: 0;
+.rtbcb-progress-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
 
 .rtbcb-progress-phase {
-    margin-bottom: 10px;
+    border-left: 4px solid #ddd;
+    padding-left: 12px;
+    position: relative;
+    transition: border-color 0.3s ease;
+}
+
+.rtbcb-progress-phase.completed {
+    border-color: #46b450;
+}
+
+.rtbcb-phase-toggle {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    background: none;
+    border: none;
+    padding: 8px 0;
+    font-size: 16px;
+    text-align: left;
+    cursor: pointer;
+}
+
+.rtbcb-phase-toggle:focus {
+    outline: none;
+    box-shadow: 0 0 0 1px #007cba;
+}
+
+.rtbcb-phase-toggle::before {
+    content: '\f347';
+    font-family: 'dashicons';
+    margin-right: 8px;
+    transition: transform 0.2s ease;
+}
+
+.rtbcb-progress-phase.expanded .rtbcb-phase-toggle::before {
+    transform: rotate(-180deg);
+}
+
+.rtbcb-phase-content {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+}
+
+.rtbcb-progress-phase.expanded .rtbcb-phase-content {
+    max-height: 500px;
 }
 
 .rtbcb-phase-desc {
     display: block;
     font-style: italic;
     font-size: 13px;
+    margin-bottom: 6px;
 }
 
-.rtbcb-phase-percent {
-    margin-left: 5px;
-    font-weight: normal;
+.rtbcb-section-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 4px 0;
 }
 
-.rtbcb-progress-item.completed {
+.rtbcb-section-item.completed .rtbcb-section-label::before {
+    content: '\f147';
+    font-family: 'dashicons';
     color: #46b450;
+    margin-right: 5px;
 }
 
-.rtbcb-progress-item.pending {
+.rtbcb-section-item.pending .rtbcb-section-label::before {
+    content: '\f534';
+    font-family: 'dashicons';
     color: #555d66;
+    margin-right: 5px;
 }
 
 .rtbcb-company-overview .spinner {

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -92,31 +92,30 @@ $test_results = get_option( 'rtbcb_test_results', [] );
     ?>
     <div class="card rtbcb-progress-card">
         <h2 class="title"><?php esc_html_e( 'Analysis Progress', 'rtbcb' ); ?></h2>
-        <canvas id="rtbcb-progress-chart" width="400" height="200"></canvas>
-        <ul class="rtbcb-progress-list">
+        <div id="rtbcb-progress-steps" class="rtbcb-progress-steps">
             <?php foreach ( $phases as $phase_num => $phase ) : ?>
-                <li class="rtbcb-progress-phase">
-                    <strong><?php echo esc_html( $phase['label'] ); ?></strong>
-                    <span class="rtbcb-phase-desc"><?php echo esc_html( $phase['description'] ); ?></span>
-                    <span class="rtbcb-phase-percent"><?php echo esc_html( $phase_percentages[ $phase_num ] ); ?>%</span>
-                    <?php if ( ! empty( $sections_by_phase[ $phase_num ] ) ) : ?>
-                        <ul>
+                <div class="rtbcb-progress-phase" data-phase="<?php echo esc_attr( $phase_num ); ?>">
+                    <button type="button" class="rtbcb-phase-toggle" aria-expanded="false" aria-controls="rtbcb-phase-content-<?php echo esc_attr( $phase_num ); ?>">
+                        <span class="rtbcb-phase-label"><?php echo esc_html( $phase['label'] ); ?></span>
+                        <span class="rtbcb-phase-percent"><?php echo esc_html( $phase_percentages[ $phase_num ] ); ?>%</span>
+                    </button>
+                    <div id="rtbcb-phase-content-<?php echo esc_attr( $phase_num ); ?>" class="rtbcb-phase-content">
+                        <span class="rtbcb-phase-desc"><?php echo esc_html( $phase['description'] ); ?></span>
+                        <?php if ( ! empty( $sections_by_phase[ $phase_num ] ) ) : ?>
                             <?php foreach ( $sections_by_phase[ $phase_num ] as $id => $section ) : ?>
                                 <?php $done = ! empty( $section['completed'] ); ?>
-                                <li class="rtbcb-progress-item <?php echo $done ? 'completed' : 'pending'; ?>">
-                                    <a href="#rtbcb-phase<?php echo esc_attr( $phase_num ); ?>" class="rtbcb-jump-tab">
-                                        <?php echo esc_html( $section['label'] ); ?>
-                                    </a>
-                                    - <?php echo $done ? esc_html__( '✓ Tested', 'rtbcb' ) : esc_html__( '⚪ Pending', 'rtbcb' ); ?>
-                                </li>
+                                <div class="rtbcb-section-item <?php echo $done ? 'completed' : 'pending'; ?>" data-completed="<?php echo $done ? '1' : '0'; ?>">
+                                    <span class="rtbcb-section-label"><?php echo esc_html( $section['label'] ); ?></span>
+                                    <span class="rtbcb-section-status"><?php echo $done ? esc_html__( '✓ Tested', 'rtbcb' ) : esc_html__( '⚪ Pending', 'rtbcb' ); ?></span>
+                                </div>
                             <?php endforeach; ?>
-                        </ul>
-                    <?php else : ?>
-                        - <?php esc_html_e( 'No tests yet.', 'rtbcb' ); ?>
-                    <?php endif; ?>
-                </li>
+                        <?php else : ?>
+                            <p class="rtbcb-no-tests"><?php esc_html_e( 'No tests yet.', 'rtbcb' ); ?></p>
+                        <?php endif; ?>
+                    </div>
+                </div>
             <?php endforeach; ?>
-        </ul>
+        </div>
     </div>
 
     <script>


### PR DESCRIPTION
## Summary
- replace progress chart with collapsible phase stepper on test dashboard
- add flexbox/transition styling and icons for new stepper
- update JS to highlight completed phases and sections without Chart.js

## Testing
- `npm test` (fails: Could not read package.json)
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68b1cb48060483319fe4d8ff876b7935