### PR TITLE
feat: sequential dashboard testing

### DIFF
--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -32,6 +32,8 @@ $test_results = get_option( 'rtbcb_test_results', [] );
         </p>
         <progress id="rtbcb-test-progress" class="rtbcb-test-progress" max="100" value="0" aria-label="<?php esc_attr_e( 'Test progress', 'rtbcb' ); ?>"></progress>
         <p id="rtbcb-test-status" role="status" aria-live="polite"></p>
+        <p id="rtbcb-test-step"></p>
+        <pre id="rtbcb-test-config" class="rtbcb-config-snippet"></pre>
     </div>
 
     <div id="rtbcb-comprehensive-analysis" class="card" style="display:none;">


### PR DESCRIPTION
## Summary
- run all tests sequentially with per-section progress, config display, and chart refresh
- add status and config placeholders to the dashboard test page
- expose sanitized section config via new AJAX helper and localized strings

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68b1ccfda86c83318e33fb9c4f295570