### PR TITLE
Ensure test progress bar reaches completion

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -624,15 +624,19 @@ jQuery(document).ready(function($) {
             var $config = $('#rtbcb-test-config');
         
             $btn.prop('disabled', true).text(window.rtbcbAdmin.strings.testing || 'Testing...');
-            $progress.val(0).removeClass('rtbcb-complete');
+            $progress.val(0).attr({ 'aria-valuenow': 0 }).removeClass('rtbcb-complete');
             $status.text(window.rtbcbAdmin.strings.starting_tests || 'Starting tests...');
             $step.text('');
             $config.text('');
-        
             var sections = (window.rtbcbAdmin.sections || []).filter(function(s) {
                 return s.action;
             });
             var results = [];
+            $progress.attr({
+                max: sections.length,
+                'aria-valuemax': sections.length,
+                'aria-valuetext': '0 of ' + sections.length
+            });
         
             for (var i = 0; i < sections.length; i++) {
                 var section = sections[i];
@@ -683,13 +687,22 @@ jQuery(document).ready(function($) {
                     $status.text('❌ ' + section.label);
                 }
         
-                var pct = Math.round(((i + 1) / sections.length) * 100);
-                $progress.val(pct);
+                var current = i + 1;
+                $progress.val(current).attr({
+                    'aria-valuenow': current,
+                    'aria-valuetext': current + ' of ' + sections.length
+                });
                 await RTBCB.Admin.refreshPhaseChart();
             }
-        
+
             await RTBCB.Admin.saveTestResults(results);
-            $progress.addClass('rtbcb-complete');
+            $progress
+                .val(sections.length)
+                .attr({
+                    'aria-valuenow': sections.length,
+                    'aria-valuetext': sections.length + ' of ' + sections.length
+                })
+                .addClass('rtbcb-complete');
             $status.text('✅ ' + (window.rtbcbAdmin.strings.all_sections_done || 'All sections completed'));
             $('#rtbcb-section-tests').slideDown();
         

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -8,9 +8,11 @@
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
-$company_data  = get_option( 'rtbcb_company_data', [] );
-$company_name  = isset( $company_data['name'] ) ? sanitize_text_field( $company_data['name'] ) : '';
-$test_results = get_option( 'rtbcb_test_results', [] );
+$company_data   = get_option( 'rtbcb_company_data', [] );
+$company_name   = isset( $company_data['name'] ) ? sanitize_text_field( $company_data['name'] ) : '';
+$test_results  = get_option( 'rtbcb_test_results', [] );
+$sections      = rtbcb_get_dashboard_sections( $test_results );
+$total_sections = count( $sections );
 ?>
 <div class="wrap rtbcb-admin-page">
     <h1><?php esc_html_e( 'Treasury Report Section Testing Dashboard', 'rtbcb' ); ?></h1>
@@ -30,7 +32,7 @@ $test_results = get_option( 'rtbcb_test_results', [] );
             </button>
             <?php wp_nonce_field( 'rtbcb_test_dashboard', 'rtbcb_test_dashboard_nonce' ); ?>
         </p>
-        <progress id="rtbcb-test-progress" class="rtbcb-test-progress" max="100" value="0" aria-label="<?php esc_attr_e( 'Test progress', 'rtbcb' ); ?>"></progress>
+        <progress id="rtbcb-test-progress" class="rtbcb-test-progress" max="<?php echo esc_attr( $total_sections ); ?>" value="0" role="progressbar" aria-valuemin="0" aria-valuemax="<?php echo esc_attr( $total_sections ); ?>" aria-valuenow="0" aria-label="<?php esc_attr_e( 'Test progress', 'rtbcb' ); ?>"></progress>
         <p id="rtbcb-test-status" role="status" aria-live="polite"></p>
         <p id="rtbcb-test-step"></p>
         <pre id="rtbcb-test-config" class="rtbcb-config-snippet"></pre>
@@ -59,7 +61,6 @@ $test_results = get_option( 'rtbcb_test_results', [] );
     </div>
 
     <?php
-    $sections = rtbcb_get_dashboard_sections( $test_results );
     $phases   = [
         1 => [
             'label'       => __( 'Phase 1: Data Collection & Enrichment', 'rtbcb' ),


### PR DESCRIPTION
## Summary
- Dynamically set test progress bar limits based on available sections and initialize ARIA attributes.
- Update runAllTests to increment progress by section, mark completion at max, and expose progress to assistive tech.

## Testing
- `bash tests/run-tests.sh`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b1d0ae6204833194ef6c630de59091