### PR TITLE
Ensure test dashboard progress bar reaches completion

### DIFF
--- a/admin/css/rtbcb-admin.css
+++ b/admin/css/rtbcb-admin.css
@@ -86,6 +86,7 @@
     width: 100%;
     height: 20px;
     margin-top: 10px;
+    display: block;
 }
 
 #rtbcb-test-progress::-webkit-progress-bar {

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -624,7 +624,7 @@ jQuery(document).ready(function($) {
             var $config = $('#rtbcb-test-config');
         
             $btn.prop('disabled', true).text(window.rtbcbAdmin.strings.testing || 'Testing...');
-            $progress.val(0).removeClass('rtbcb-complete');
+            $progress.val(0).attr('aria-valuenow', 0).removeClass('rtbcb-complete');
             $status.text(window.rtbcbAdmin.strings.starting_tests || 'Starting tests...');
             $step.text('');
             $config.text('');
@@ -684,12 +684,12 @@ jQuery(document).ready(function($) {
                 }
         
                 var pct = Math.round(((i + 1) / sections.length) * 100);
-                $progress.val(pct);
+                $progress.val(pct).attr('aria-valuenow', pct);
                 await RTBCB.Admin.refreshPhaseChart();
             }
-        
+
             await RTBCB.Admin.saveTestResults(results);
-            $progress.addClass('rtbcb-complete');
+            $progress.val(100).attr('aria-valuenow', 100).addClass('rtbcb-complete');
             $status.text('✅ ' + (window.rtbcbAdmin.strings.all_sections_done || 'All sections completed'));
             $('#rtbcb-section-tests').slideDown();
         

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -30,7 +30,7 @@ $test_results = get_option( 'rtbcb_test_results', [] );
             </button>
             <?php wp_nonce_field( 'rtbcb_test_dashboard', 'rtbcb_test_dashboard_nonce' ); ?>
         </p>
-        <progress id="rtbcb-test-progress" class="rtbcb-test-progress" max="100" value="0" aria-label="<?php esc_attr_e( 'Test progress', 'rtbcb' ); ?>"></progress>
+        <progress id="rtbcb-test-progress" class="rtbcb-test-progress" max="100" value="0" role="progressbar" aria-label="<?php esc_attr_e( 'Test progress', 'rtbcb' ); ?>" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></progress>
         <p id="rtbcb-test-status" role="status" aria-live="polite"></p>
         <p id="rtbcb-test-step"></p>
         <pre id="rtbcb-test-config" class="rtbcb-config-snippet"></pre>


### PR DESCRIPTION
## Summary
- Add ARIA attributes to the test dashboard progress element so assistive tech receives completion updates.
- Update runAllTests to update `aria-valuenow` and explicitly set progress to 100% when all sections finish.
- Display progress bar as block to guarantee it fills the container when complete.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d0ae6204833194ef6c630de59091