### PR TITLE
Refactor report generation to async fetch

### DIFF
--- a/tests/report-interactivity.test.js
+++ b/tests/report-interactivity.test.js
@@ -46,8 +46,9 @@ vm.runInThisContext(code);
 
 generateProfessionalReport = () => '<!DOCTYPE html><html><body>Report</body></html>';
 
-generateAndDisplayReport({});
-
-const exportBtn = container.childNodes.find(node => node.textContent === 'Export to PDF');
-assert.ok(exportBtn, 'Export button not created');
-console.log('Report interactivity test passed.');
+(async () => {
+    await generateAndDisplayReport({});
+    const exportBtn = container.childNodes.find(node => node.textContent === 'Export to PDF');
+    assert.ok(exportBtn, 'Export button not created');
+    console.log('Report interactivity test passed.');
+})();


### PR DESCRIPTION
## Summary
- Replace synchronous XMLHttpRequest with asynchronous `fetch` in report generation and return detailed error messages.
- Update report display routine to await asynchronous report generation.
- Adjust tests to accommodate Promise-based flow and stub `fetch` calls.

## Testing
- `node tests/temperature-model.test.js`
- `node tests/report-interactivity.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1e8bf4770833199a97138cfb5aefb