### PR TITLE
Localize rtbcbAjax and update front-end scripts

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -375,7 +375,7 @@ class BusinessCaseBuilder {
     handleSubmit() {
         // Show loading state
         this.showProgress();
-        if (typeof ajaxObj === 'undefined' || !ajaxObj.ajax_url) {
+        if (typeof rtbcbAjax === 'undefined' || !rtbcbAjax.ajax_url) {
             this.showError('Unable to submit form. Please refresh the page and try again.');
             return;
         }
@@ -398,7 +398,7 @@ class BusinessCaseBuilder {
 
         try {
             const xhr = new XMLHttpRequest();
-            xhr.open('POST', ajaxObj.ajax_url, false);
+            xhr.open('POST', rtbcbAjax.ajax_url, false);
             xhr.send(formData);
 
             if (xhr.status >= 200 && xhr.status < 300) {

--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -74,7 +74,7 @@ function handleSubmit(e) {
     // Show progress indicator
     if (formContainer) formContainer.style.display = 'none';
     if (progressContainer) progressContainer.style.display = 'block';
-    if (typeof ajaxObj === 'undefined' || !ajaxObj.ajax_url) {
+    if (typeof rtbcbAjax === 'undefined' || !rtbcbAjax.ajax_url) {
         handleSubmissionError('Unable to submit form. Please refresh the page and try again.');
         return;
     }
@@ -84,7 +84,7 @@ function handleSubmit(e) {
 
     var xhr = new XMLHttpRequest();
     try {
-        xhr.open('POST', ajaxObj.ajax_url, false); // Synchronous request
+        xhr.open('POST', rtbcbAjax.ajax_url, false); // Synchronous request
         xhr.send(formData);
     } catch (networkError) {
         handleSubmissionError('Network error. Please try again later.');

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -403,35 +403,32 @@ class Real_Treasury_BCB {
             true
         );
 
-        // CRITICAL FIX: Check if ajaxObj already exists to prevent override
-        if ( ! wp_script_is( 'rtbcb-script', 'done' ) ) {
-            wp_localize_script(
-                'rtbcb-script',
-                'ajaxObj',
-                [
-                    'ajax_url'    => admin_url( 'admin-ajax.php' ),
-                    'strings'     => [
-                        'error'                   => __( 'An error occurred. Please try again.', 'rtbcb' ),
-                        'generating'              => __( 'Generating your comprehensive business case...', 'rtbcb' ),
-                        'analyzing'               => __( 'Analyzing your treasury operations...', 'rtbcb' ),
-                        'financial_modeling'      => __( 'Building financial models...', 'rtbcb' ),
-                        'risk_assessment'         => __( 'Conducting risk assessment...', 'rtbcb' ),
-                        'industry_benchmarking'   => __( 'Performing industry benchmarking...', 'rtbcb' ),
-                        'implementation_planning' => __( 'Creating implementation roadmap...', 'rtbcb' ),
-                        'vendor_evaluation'       => __( 'Preparing vendor evaluation framework...', 'rtbcb' ),
-                        'finalizing_report'       => __( 'Finalizing professional report...', 'rtbcb' ),
-                        'invalid_email'           => __( 'Please enter a valid email address.', 'rtbcb' ),
-                        'required_field'          => __( 'This field is required.', 'rtbcb' ),
-                        'select_pain_points'      => __( 'Please select at least one pain point.', 'rtbcb' ),
-                    ],
-                    'settings'    => [
-                        'pdf_enabled'            => get_option( 'rtbcb_pdf_enabled', true ),
-                        'comprehensive_analysis' => get_option( 'rtbcb_comprehensive_analysis', true ),
-                        'professional_reports'   => get_option( 'rtbcb_professional_reports', true ),
-                    ],
-                ]
-            );
-        }
+        wp_localize_script(
+            'rtbcb-script',
+            'rtbcbAjax',
+            [
+                'ajax_url'    => admin_url( 'admin-ajax.php' ),
+                'strings'     => [
+                    'error'                   => __( 'An error occurred. Please try again.', 'rtbcb' ),
+                    'generating'              => __( 'Generating your comprehensive business case...', 'rtbcb' ),
+                    'analyzing'               => __( 'Analyzing your treasury operations...', 'rtbcb' ),
+                    'financial_modeling'      => __( 'Building financial models...', 'rtbcb' ),
+                    'risk_assessment'         => __( 'Conducting risk assessment...', 'rtbcb' ),
+                    'industry_benchmarking'   => __( 'Performing industry benchmarking...', 'rtbcb' ),
+                    'implementation_planning' => __( 'Creating implementation roadmap...', 'rtbcb' ),
+                    'vendor_evaluation'       => __( 'Preparing vendor evaluation framework...', 'rtbcb' ),
+                    'finalizing_report'       => __( 'Finalizing professional report...', 'rtbcb' ),
+                    'invalid_email'           => __( 'Please enter a valid email address.', 'rtbcb' ),
+                    'required_field'          => __( 'This field is required.', 'rtbcb' ),
+                    'select_pain_points'      => __( 'Please select at least one pain point.', 'rtbcb' ),
+                ],
+                'settings'    => [
+                    'pdf_enabled'            => get_option( 'rtbcb_pdf_enabled', true ),
+                    'comprehensive_analysis' => get_option( 'rtbcb_comprehensive_analysis', true ),
+                    'professional_reports'   => get_option( 'rtbcb_professional_reports', true ),
+                ],
+            ]
+        );
 
         wp_enqueue_script(
             'rtbcb-report',

--- a/tests/cosine-similarity-search.test.php
+++ b/tests/cosine-similarity-search.test.php
@@ -20,6 +20,11 @@ class WPDB_Stub {
         return $this->last_query;
     }
 
+    public function get_var( $sql ) {
+        $this->last_query = $sql;
+        return 'rtbcb_rag_index';
+    }
+
     public function get_results( $sql, $output ) {
         $this->last_query = $sql;
         return [

--- a/tests/handle-server-error-display.test.js
+++ b/tests/handle-server-error-display.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
-global.ajaxObj = { ajax_url: 'test-url' };
+global.rtbcbAjax = { ajax_url: 'test-url' };
 
 class SimpleFormData {
     constructor(form) {

--- a/tests/handle-submit-error.test.js
+++ b/tests/handle-submit-error.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
-global.ajaxObj = { ajax_url: 'test-url' };
+global.rtbcbAjax = { ajax_url: 'test-url' };
 
 class SimpleFormData {
     constructor(form) {

--- a/tests/handle-submit-success.test.js
+++ b/tests/handle-submit-success.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
-global.ajaxObj = { ajax_url: 'test-url' };
+global.rtbcbAjax = { ajax_url: 'test-url' };
 
 class SimpleFormData {
     constructor(form) {


### PR DESCRIPTION
## Summary
- Localize `rtbcbAjax` object when enqueueing scripts and remove redundant `wp_script_is` check
- Reference `rtbcbAjax` in front-end wizard logic and submission handler
- Adjust tests and stubs for new AJAX object and to satisfy RAG search tests

## Testing
- `php -l real-treasury-business-case-builder.php`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b1e8cf52008331a107ab02920ce927