### PR TITLE
Add centralized OpenAI API key helper and preflight API check

### DIFF
--- a/inc/class-rtbcb-api-tester.php
+++ b/inc/class-rtbcb-api-tester.php
@@ -16,7 +16,7 @@ class RTBCB_API_Tester {
      * @return array Test result.
      */
     public static function test_connection( $api_key = null ) {
-        $api_key = $api_key ?: get_option( 'rtbcb_openai_api_key' );
+        $api_key = $api_key ?: rtbcb_get_openai_api_key();
 
         if ( empty( $api_key ) ) {
             return [

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -34,7 +34,7 @@ class RTBCB_LLM {
     protected $last_response;
 
     public function __construct() {
-        $this->api_key = get_option( 'rtbcb_openai_api_key' );
+        $this->api_key = rtbcb_get_openai_api_key();
 
         $timeout = intval( get_option( 'rtbcb_gpt5_timeout', 180 ) );
         $config  = rtbcb_get_gpt5_config(

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -8,6 +8,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Retrieve the OpenAI API key from a secure source.
+ *
+ * Checks for a defined constant first to allow configuration via
+ * environment variables or wp-config.php. Falls back to the value stored
+ * in the WordPress options table.
+ *
+ * @return string Sanitized API key.
+ */
+function rtbcb_get_openai_api_key() {
+    if ( defined( 'RTBCB_OPENAI_API_KEY' ) && ! empty( RTBCB_OPENAI_API_KEY ) ) {
+        return sanitize_text_field( RTBCB_OPENAI_API_KEY );
+    }
+
+    $api_key = get_option( 'rtbcb_openai_api_key', '' );
+
+    return sanitize_text_field( $api_key );
+}
+
+/**
  * Retrieve current company data.
  *
  * @return array Current company data.

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -880,21 +880,21 @@ class Real_Treasury_BCB {
 
                     rtbcb_log_memory_usage( 'before_llm_generation' );
 
-                    if ( empty( get_option( 'rtbcb_openai_api_key' ) ) ) {
-                        $error_code = 'E_NO_API_KEY';
-                        rtbcb_log_error( $error_code . ': OpenAI API key not configured' );
-                        $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
-                        $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
-                        if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
-                            $response_message = __( 'OpenAI API key not configured.', 'rtbcb' ) . ' ' . $guidance;
+                    $api_key = rtbcb_get_openai_api_key();
+                    if ( class_exists( 'RTBCB_API_Tester' ) ) {
+                        $connection_test = RTBCB_API_Tester::test_connection( $api_key );
+                        if ( empty( $connection_test['success'] ) ) {
+                            $error_code = 'E_API_TEST_FAILURE';
+                            rtbcb_log_error( $error_code . ': ' . $connection_test['message'] );
+                            wp_send_json_error(
+                                [
+                                    'message'    => $connection_test['message'],
+                                    'details'    => $connection_test['details'] ?? '',
+                                    'error_code' => $error_code,
+                                ],
+                                500
+                            );
                         }
-                        wp_send_json_error(
-                            [
-                                'message'    => $response_message,
-                                'error_code' => $error_code,
-                            ],
-                            500
-                        );
                     }
 
                     rtbcb_log_api_debug( 'Calling LLM for comprehensive business case' );


### PR DESCRIPTION
## Summary
- add `rtbcb_get_openai_api_key()` helper for retrieving the OpenAI API key from a constant or option
- update LLM and API tester classes to use the new helper
- run API connection test in `ajax_generate_comprehensive_case` and report failures

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash ./tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f25491d48331926ad60b446144b6