### PR TITLE
Check API key presence before LLM call and show admin notice

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -34,6 +34,12 @@ $embedding_models = [
 ];
 ?>
 
+<?php if ( ! rtbcb_has_openai_api_key() ) : ?>
+    <div class="notice notice-warning is-dismissible">
+        <p><?php echo esc_html__( 'OpenAI API key is missing. Please enter a valid key to enable AI features.', 'rtbcb' ); ?></p>
+    </div>
+<?php endif; ?>
+
 <div class="wrap">
     <h1><?php echo esc_html__( 'Business Case Builder Settings', 'rtbcb' ); ?></h1>
     <form action="options.php" method="post">

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -27,6 +27,15 @@ function rtbcb_get_openai_api_key() {
 }
 
 /**
+ * Determine if an OpenAI API key is configured.
+ *
+ * @return bool True if the API key is present.
+ */
+function rtbcb_has_openai_api_key() {
+    return ! empty( rtbcb_get_openai_api_key() );
+}
+
+/**
  * Retrieve current company data.
  *
  * @return array Current company data.

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -880,6 +880,18 @@ class Real_Treasury_BCB {
 
                     rtbcb_log_memory_usage( 'before_llm_generation' );
 
+                    if ( ! rtbcb_has_openai_api_key() ) {
+                        $error_code = 'E_API_KEY_MISSING';
+                        rtbcb_log_error( $error_code . ': ' . __( 'OpenAI API key not configured.', 'rtbcb' ) );
+                        wp_send_json_error(
+                            [
+                                'message'    => __( 'OpenAI API key not configured.', 'rtbcb' ),
+                                'error_code' => $error_code,
+                            ],
+                            500
+                        );
+                    }
+
                     $api_key = rtbcb_get_openai_api_key();
                     if ( class_exists( 'RTBCB_API_Tester' ) ) {
                         $connection_test = RTBCB_API_Tester::test_connection( $api_key );


### PR DESCRIPTION
## Summary
- add `rtbcb_has_openai_api_key()` helper and use it to verify API key configuration
- halt business case generation when API key is missing and return a dedicated error code
- surface a dismissible admin notice prompting for an API key

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f72005d08331a3b61c3b802acb98