### PR TITLE
Add nonce to AJAX submissions

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -393,6 +393,7 @@ class BusinessCaseBuilder {
             }
         }
         formData.append('action', 'rtbcb_generate_case');
+        formData.append('rtbcb_nonce', rtbcbAjax.nonce);
 
         console.log('RTBCB: Submitting form data:', Object.fromEntries(formData));
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -408,6 +408,7 @@ class Real_Treasury_BCB {
             'rtbcbAjax',
             [
                 'ajax_url'    => admin_url( 'admin-ajax.php' ),
+                'nonce'       => wp_create_nonce( 'rtbcb_generate' ),
                 'strings'     => [
                     'error'                   => __( 'An error occurred. Please try again.', 'rtbcb' ),
                     'generating'              => __( 'Generating your comprehensive business case...', 'rtbcb' ),


### PR DESCRIPTION
## Summary
- include `rtbcbAjax.nonce` when submitting business case forms
- expose nonce via `wp_localize_script` in `enqueue_assets`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f91000188331a475268a8c1e4e96