### PR TITLE
Add visible launch button for Business Case Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The plugin automatically creates required database tables on activation:
 - `wp_rtbcb_rag_index` - Retrieval-augmented generation index
 
 ### Step 4: Display the Form
-Add the shortcode to any page or post:
+Add the shortcode to any page or post to display a “Generate Business Case” button that launches the form in a modal:
 ```
 [rt_business_case_builder]
 ```

--- a/readme.txt
+++ b/readme.txt
@@ -135,7 +135,7 @@ requests.
 
 == Frequently Asked Questions ==
 = How do I display the calculator? =
-Add the `[rt_business_case_builder]` shortcode to a post or page.
+Add the `[rt_business_case_builder]` shortcode to a post or page to show a button that opens the form in a modal window.
 
 = Does the plugin generate PDF reports? =
 Reports are rendered as HTML in the browser. Use your browser's print or save functionality to generate PDFs.

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -5,6 +5,10 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 ?>
+<button type="button" class="rtbcb-open-modal button button-primary" onclick="window.openBusinessCaseModal()">
+    <?php esc_html_e( 'Generate Business Case', 'rtbcb' ); ?>
+</button>
+
 <div id="rtbcbModalOverlay" class="rtbcb-modal-overlay">
     <div class="rtbcb-modal">
         <div class="rtbcb-modal-header">
@@ -69,13 +73,3 @@
 </div>
 
 <div id="rtbcbResults" style="display:none;"></div>
-
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    const button = document.createElement('button');
-    button.textContent = <?php echo wp_json_encode( __( 'Generate Business Case', 'rtbcb' ) ); ?>;
-    button.className = 'button button-primary';
-    button.onclick = window.openBusinessCaseModal;
-    document.body.appendChild(button);
-});
-</script>


### PR DESCRIPTION
## Summary
- Render a "Generate Business Case" button directly in the shortcode template instead of injecting it via JavaScript
- Document that `[rt_business_case_builder]` outputs a launch button for the modal form

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fe88aed08331a9f2243f46a19960