### PR TITLE
Load report template from HTML file

### DIFF
--- a/public/js/rtbcb-report.js
+++ b/public/js/rtbcb-report.js
@@ -22,10 +22,13 @@ async function buildEnhancedPrompt(businessContext) {
     const template = await response.text();
     const companyName = businessContext && businessContext.companyName ? businessContext.companyName : 'Company';
     const currentDate = businessContext && businessContext.currentDate ? businessContext.currentDate : new Date().toLocaleDateString();
-    const contextText = typeof businessContext === 'string' ? businessContext : (businessContext && businessContext.context ? businessContext.context : '');
+    const contextText = typeof businessContext === 'string'
+        ? businessContext
+        : (businessContext && businessContext.context ? businessContext.context : '');
     const filledTemplate = template
         .replace(/{{COMPANY_NAME}}/g, companyName)
-        .replace(/{{CURRENT_DATE}}/g, currentDate);
+        .replace(/{{CURRENT_DATE}}/g, currentDate)
+        .replace(/{{BUSINESS_CONTEXT}}/g, contextText);
     return `
 Generate a professional business consulting report in HTML format with the following requirements:
 
@@ -34,8 +37,6 @@ IMPORTANT: Output ONLY valid HTML code starting with <!DOCTYPE html>. Do not inc
 The report should follow this exact structure:
 
 ${filledTemplate}
-
-Context for analysis: ${contextText}
 
 Ensure the report is:
 - Exactly 2 pages when printed (approximately 800-1000 words)

--- a/public/templates/report-template.html
+++ b/public/templates/report-template.html
@@ -200,7 +200,8 @@
     </style>
 </head>
 <body>
-    [GENERATE THE REPORT CONTENT HERE FOLLOWING THIS STRUCTURE:]
+    <!-- BUSINESS CONTEXT: {{BUSINESS_CONTEXT}} -->
+    <!-- GENERATE THE REPORT CONTENT HERE FOLLOWING THIS STRUCTURE: -->
 
     <div class="header">
         <h1 class="report-title">{{COMPANY_NAME}} Strategic Analysis</h1>


### PR DESCRIPTION
## Summary
- Move report HTML scaffold to `public/templates/report-template.html` and include company, date, and business-context markers.
- Fetch template in `buildEnhancedPrompt` and inject runtime values before prompting the model.

## Testing
- `node tests/report-interactivity.test.js`
- `node tests/temperature-model.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1ffbf969c8331a47ef198d58857be