### PR TITLE
Align form and modal selectors

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -56,7 +56,7 @@
 }
 
 /* Reset and isolate modal container */
-.rtbcb-modal-container {
+.rtbcb-modal {
     all: unset;
     display: block !important;
     background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(248, 248, 248, 0.98) 50%, rgba(255, 255, 255, 0.95)) !important;
@@ -121,10 +121,10 @@
 }
 
 /* Form field styling fixes */
-.rtbcb-form input[type="text"],
-.rtbcb-form input[type="email"],
-.rtbcb-form input[type="number"],
-.rtbcb-form select {
+.rtbcb-wizard-form input[type="text"],
+.rtbcb-wizard-form input[type="email"],
+.rtbcb-wizard-form input[type="number"],
+.rtbcb-wizard-form select {
     all: unset !important;
     display: block !important;
     width: 100% !important;
@@ -143,7 +143,7 @@
 }
 
 /* Select dropdown arrow */
-.rtbcb-form select {
+.rtbcb-wizard-form select {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236b7280' d='M10.293 3.293L6 7.586 1.707 3.293A1 1 0 00.293 4.707l5 5a1 1 0 001.414 0l5-5a1 1 0 10-1.414-1.414z'/%3E%3C/svg%3E") !important;
     background-repeat: no-repeat !important;
     background-position: right 12px center !important;
@@ -151,8 +151,8 @@
     padding-right: 40px !important;
 }
 
-.rtbcb-form input:focus,
-.rtbcb-form select:focus {
+.rtbcb-wizard-form input:focus,
+.rtbcb-wizard-form select:focus {
     border-color: #7216f4 !important;
     outline: none !important;
     box-shadow: 0 0 0 3px rgba(114, 22, 244, 0.1) !important;
@@ -261,7 +261,7 @@
         padding: 10px !important;
     }
 
-    .rtbcb-modal-container {
+    .rtbcb-modal {
         max-width: 95vw !important;
     }
 
@@ -306,7 +306,7 @@
     to { opacity: 1; transform: scale(1); }
 }
 
-.rtbcb-modal-overlay.active .rtbcb-modal-container {
+.rtbcb-modal-overlay.active .rtbcb-modal {
     animation: rtbcb-fadeIn 0.3s ease-out !important;
 }
 
@@ -351,7 +351,7 @@
 }
 
 /* Enhanced Form Styles */
-.rtbcb-form {
+.rtbcb-wizard-form {
     position: relative;
 }
 
@@ -811,7 +811,7 @@
 }
 
 /* Enhanced Form Elements */
-.rtbcb-form label {
+.rtbcb-wizard-form label {
     display: block;
     margin-bottom: 8px;
     font-weight: 600;
@@ -819,10 +819,10 @@
     font-size: 15px;
 }
 
-.rtbcb-form input[type="text"],
-.rtbcb-form input[type="email"],
-.rtbcb-form input[type="number"],
-.rtbcb-form select {
+.rtbcb-wizard-form input[type="text"],
+.rtbcb-wizard-form input[type="email"],
+.rtbcb-wizard-form input[type="number"],
+.rtbcb-wizard-form select {
     width: 100%;
     padding: 12px 16px;
     border: 2px solid var(--border-light);
@@ -835,8 +835,8 @@
 }
 
 
-.rtbcb-form input:focus,
-.rtbcb-form select:focus {
+.rtbcb-wizard-form input:focus,
+.rtbcb-wizard-form select:focus {
     border-color: var(--secondary-purple);
     outline: none;
     box-shadow: 0 0 0 3px rgba(114,22,244,0.1);
@@ -1128,7 +1128,7 @@
 }
 
 /* Modal Container - Glassmorphic design */
-.rtbcb-modal-container {
+.rtbcb-modal {
     background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(248, 248, 248, 0.98) 50%, rgba(255, 255, 255, 0.95));
     backdrop-filter: blur(25px) saturate(140%);
     -webkit-backdrop-filter: blur(25px) saturate(140%);
@@ -1145,12 +1145,12 @@
     position: relative;
 }
 
-.rtbcb-modal-overlay.active .rtbcb-modal-container {
+.rtbcb-modal-overlay.active .rtbcb-modal {
     transform: scale(1) translateY(0);
 }
 
 /* Purple top bar accent */
-.rtbcb-modal-container::before {
+.rtbcb-modal::before {
     content: "";
     position: absolute;
     top: 0;
@@ -1399,7 +1399,7 @@
 .rtbcb-field input {
     color: #1f2937;
 }
-.rtbcb-form select,
+.rtbcb-wizard-form select,
 .rtbcb-field select {
     font-size: 16px;
     line-height: 1.4;
@@ -1573,7 +1573,7 @@
         padding: 15px;
     }
 
-    .rtbcb-modal-container {
+    .rtbcb-modal {
         width: 95vw;
     }
 
@@ -1947,7 +1947,7 @@
 
 /* Field labels - make darker and larger */
 .rtbcb-field label,
-.rtbcb-form label {
+.rtbcb-wizard-form label {
     color: var(--text-primary) !important;    /* Much darker for better readability */
     font-size: 15px !important;               /* Increase from 14px */
     font-weight: 600 !important;

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -17,7 +17,7 @@
         </div>
         <div class="rtbcb-modal-body">
             <div class="rtbcb-form-container">
-                <form id="rtbcbForm" class="rtbcb-wizard-form">
+                <form id="rtbcbForm" class="rtbcb-wizard-form rtbcb-form">
                     <?php wp_nonce_field( 'rtbcb_generate', 'rtbcb_nonce' ); ?>
 
                     <!-- Step 1: Company Info -->


### PR DESCRIPTION
## Summary
- Add missing `rtbcb-form` class to the business case form.
- Rename CSS selectors to use `rtbcb-wizard-form` and switch modal container selector to `rtbcb-modal`.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `php templates/business-case-form.php` *(fails: Call to undefined function esc_html_e)*

------
https://chatgpt.com/codex/tasks/task_e_68b20013ebb48331ae80f608b29df3c7