### PR TITLE
refactor: centralize category map and fix leads page

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -318,7 +318,10 @@ class RTBCB_Admin {
 
         $leads_data = RTBCB_Leads::get_all_leads( $args );
         $categories = RTBCB_Category_Recommender::get_all_categories();
-        
+        if ( ! is_array( $categories ) ) {
+            $categories = [];
+        }
+
         include RTBCB_DIR . 'admin/leads-page-enhanced.php';
     }
 

--- a/inc/class-rtbcb-category-recommender.php
+++ b/inc/class-rtbcb-category-recommender.php
@@ -14,13 +14,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class RTBCB_Category_Recommender {
     /**
-     * Recommend a category based on user inputs.
+     * Get all available categories.
      *
-     * @param array $user_inputs User input data.
-     * @return array Recommendation details.
+     * @return array Category map with names and descriptions.
      */
-    public static function recommend_category( $user_inputs ) {
-        $categories = [
+    public static function get_all_categories() {
+        return [
             'cash_tools' => [
                 'name'        => __( 'Cash Management Tools', 'rtbcb' ),
                 'description' => __( 'Basic cash visibility and forecasting tools', 'rtbcb' ),
@@ -34,6 +33,16 @@ class RTBCB_Category_Recommender {
                 'description' => __( 'Enterprise treasury platform', 'rtbcb' ),
             ],
         ];
+    }
+
+    /**
+     * Recommend a category based on user inputs.
+     *
+     * @param array $user_inputs User input data.
+     * @return array Recommendation details.
+     */
+    public static function recommend_category( $user_inputs ) {
+        $categories = self::get_all_categories();
 
         $company_size = isset( $user_inputs['company_size'] ) ? sanitize_text_field( $user_inputs['company_size'] ) : '';
         $recommended  = 'tms_lite';
@@ -63,20 +72,7 @@ class RTBCB_Category_Recommender {
      * @return array|null Category data or null if not found.
      */
     public static function get_category_info( $category ) {
-        $categories = [
-            'cash_tools' => [
-                'name'        => __( 'Cash Management Tools', 'rtbcb' ),
-                'description' => __( 'Basic cash visibility and forecasting tools', 'rtbcb' ),
-            ],
-            'tms_lite'   => [
-                'name'        => __( 'Treasury Management System (Lite)', 'rtbcb' ),
-                'description' => __( 'Mid-tier treasury platform', 'rtbcb' ),
-            ],
-            'trms'       => [
-                'name'        => __( 'Treasury & Risk Management System', 'rtbcb' ),
-                'description' => __( 'Enterprise treasury platform', 'rtbcb' ),
-            ],
-        ];
+        $categories = self::get_all_categories();
 
         $key = sanitize_key( $category );
         return $categories[ $key ] ?? null;


### PR DESCRIPTION
## Summary
- add `RTBCB_Category_Recommender::get_all_categories()` to expose shared category definitions
- refactor category recommendation and info lookup to use centralized map
- guard admin leads page with a valid categories array

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b2019e3d148331bcd70fe67d1f3e26