### PR TITLE
Refine wizard form styles and bump asset version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Real Treasury Business Case Builder - Enhanced Version 2.1.4
+# Real Treasury Business Case Builder - Enhanced Version 2.1.5
 
 A comprehensive WordPress plugin that helps treasury teams quantify the benefits of modern treasury tools, generate professional business case reports, and track lead engagement with advanced analytics.
 
-## 🚀 What's New in Version 2.1.4
+## 🚀 What's New in Version 2.1.5
 
 ### 🔧 Maintenance Release
-- Updated documentation to reflect current repository structure.
-- Bumped plugin version and performed minor maintenance.
+- Cleaned up wizard form styling to align with WordPress conventions.
+- Bumped plugin version and updated asset cache busting.
 
 ## 📋 Installation & Setup
 

--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -120,44 +120,6 @@
     margin: 0 auto !important;
 }
 
-/* Form field styling fixes */
-.rtbcb-wizard-form input[type="text"],
-.rtbcb-wizard-form input[type="email"],
-.rtbcb-wizard-form input[type="number"],
-.rtbcb-wizard-form select {
-    all: unset !important;
-    display: block !important;
-    width: 100% !important;
-    padding: 12px 16px !important;
-    border: 2px solid #e2e8f0 !important;
-    border-radius: 8px !important;
-    font-size: 16px !important;
-    font-family: inherit !important;
-    background: #ffffff !important;
-    color: #1f2937 !important;
-    transition: all 0.2s ease !important;
-    box-sizing: border-box !important;
-    appearance: none !important;
-    -webkit-appearance: none !important;
-    -moz-appearance: none !important;
-}
-
-/* Select dropdown arrow */
-.rtbcb-wizard-form select {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236b7280' d='M10.293 3.293L6 7.586 1.707 3.293A1 1 0 00.293 4.707l5 5a1 1 0 001.414 0l5-5a1 1 0 10-1.414-1.414z'/%3E%3C/svg%3E") !important;
-    background-repeat: no-repeat !important;
-    background-position: right 12px center !important;
-    background-size: 16px !important;
-    padding-right: 40px !important;
-}
-
-.rtbcb-wizard-form input:focus,
-.rtbcb-wizard-form select:focus {
-    border-color: #7216f4 !important;
-    outline: none !important;
-    box-shadow: 0 0 0 3px rgba(114, 22, 244, 0.1) !important;
-    z-index: 10 !important;
-}
 
 /* Pain Points Grid Layout Fix */
 .rtbcb-pain-points-grid {
@@ -828,12 +790,12 @@
     border: 2px solid var(--border-light);
     border-radius: 8px;
     font-size: 16px;
+    line-height: 1.4;
     background: #ffffff;
-    color: var(--dark-text);
+    color: var(--rtbcb-text-color, var(--dark-text));
     transition: all 0.2s ease;
     box-sizing: border-box;
 }
-
 
 .rtbcb-wizard-form input:focus,
 .rtbcb-wizard-form select:focus {
@@ -1399,13 +1361,8 @@
 .rtbcb-field input {
     color: #1f2937;
 }
-.rtbcb-wizard-form select,
 .rtbcb-field select {
-    font-size: 16px;
-    line-height: 1.4;
-    padding: 12px 16px;
     padding-right: 40px;
-    color: var(--rtbcb-text-color, var(--dark-text));
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: realtreasury
 Tags: business, case, builder, roi, treasury
 Requires at least: 6.0
 Tested up to: 6.0
-Stable tag: 2.1.4
+Stable tag: 2.1.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -144,6 +144,9 @@ Reports are rendered as HTML in the browser. Use your browser's print or save fu
 The analytics dashboard uses Chart.js for its visualizations. The library is bundled with the plugin to reduce blocking by privacy tools, but strict ad blockers may still prevent it from loading. Allow the plugin's scripts in your browser to enable the charts.
 
 == Changelog ==
+= 2.1.5 =
+* Clean up wizard form styling and update asset version.
+
 = 2.1.4 =
 * Update documentation to match current repository structure.
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Real Treasury - Business Case Builder (Enhanced Pro)
  * Description: Professional-grade ROI calculator and comprehensive business case generator for treasury technology with advanced analysis and consultant-style reports.
- * Version: 2.1.4
+ * Version: 2.1.5
  * Requires PHP: 7.4
  * Author: Real Treasury
  * Text Domain: rtbcb
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'RTBCB_VERSION', '2.1.4' );
+define( 'RTBCB_VERSION', '2.1.5' );
 define( 'RTBCB_FILE', __FILE__ );
 define( 'RTBCB_URL', plugin_dir_url( RTBCB_FILE ) );
 define( 'RTBCB_DIR', plugin_dir_path( RTBCB_FILE ) );


### PR DESCRIPTION
## Summary
- streamline `.rtbcb-wizard-form` input and select styles, removing `all: unset` reset and conflicting `!important` flags
- update select dropdown styling and focus states to better match WordPress forms
- bump plugin version and documentation to 2.1.5 for cache busting

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b2036f9a188331bfe56de43a04e5e2