### PR TITLE
Align nonce action across form, assets, and router

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -18,7 +18,10 @@ class RTBCB_Router {
      */
     public function handle_form_submission( $report_type = 'basic' ) {
         // Nonce verification.
-        if ( ! isset( $_POST['rtbcb_nonce'] ) || ! wp_verify_nonce( $_POST['rtbcb_nonce'], 'rtbcb_form_action' ) ) {
+        if (
+            ! isset( $_POST['rtbcb_nonce'] )
+            || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ), 'rtbcb_form_action' )
+        ) {
             wp_send_json_error( [ 'message' => __( 'Nonce verification failed.', 'rtbcb' ) ], 403 );
             return;
         }

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -408,7 +408,7 @@ class Real_Treasury_BCB {
             'rtbcbAjax',
             [
                 'ajax_url'    => admin_url( 'admin-ajax.php' ),
-                'nonce'       => wp_create_nonce( 'rtbcb_generate' ),
+                'nonce'       => wp_create_nonce( 'rtbcb_form_action' ),
                 'strings'     => [
                     'error'                   => __( 'An error occurred. Please try again.', 'rtbcb' ),
                     'generating'              => __( 'Generating your comprehensive business case...', 'rtbcb' ),

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -18,7 +18,7 @@
         <div class="rtbcb-modal-body">
             <div class="rtbcb-form-container">
                 <form id="rtbcbForm" class="rtbcb-wizard-form rtbcb-form">
-                    <?php wp_nonce_field( 'rtbcb_generate', 'rtbcb_nonce' ); ?>
+                    <?php wp_nonce_field( 'rtbcb_form_action', 'rtbcb_nonce' ); ?>
 
                     <!-- Step 1: Company Info -->
                     <div class="rtbcb-wizard-step active" data-step="1">


### PR DESCRIPTION
## Summary
- Use `rtbcb_form_action` for the form nonce field
- Localize the same nonce action when enqueuing assets
- Verify the localized nonce with sanitized input in the router

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b210b047b08331a93434b90762002e