### PR TITLE
Use class-based form container selector

### DIFF
--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -74,7 +74,7 @@ function handleSubmit(e) {
     var form = e.target;
     var formData = new FormData(form);
     var progressContainer = document.getElementById('rtbcb-progress-container');
-    var formContainer = document.getElementById('rtbcb-form-container');
+    var formContainer = document.querySelector('.rtbcb-form-container');
 
     // Show progress indicator
     if (formContainer) formContainer.style.display = 'none';
@@ -153,7 +153,7 @@ function handleSubmit(e) {
 // Ensure the form submission is handled by our new function
 // eslint-disable-next-line @wordpress/no-global-event-listener
 document.addEventListener('DOMContentLoaded', function() {
-    const form = document.getElementById('rtbcb-form');
+    const form = document.getElementById('rtbcbForm');
     if (form) {
         form.addEventListener('submit', handleSubmit);
     }


### PR DESCRIPTION
## Summary
- Use querySelector for `.rtbcb-form-container` instead of `getElementById`
- Target `rtbcbForm` in DOMContentLoaded handler

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b21222a9d883318bc626c70d0f6330