### PR TITLE
docs(admin): clarify translation and capability requirements

### DIFF
--- a/admin/AGENTS.md
+++ b/admin/AGENTS.md
@@ -4,3 +4,5 @@
 - Class files should use the `RTBCB_Admin` prefix.
 - Files ending in `-page.php` should render admin screens; escape all output.
 - Use WordPress nonce functions for form submissions.
+- Wrap user-visible strings in `__()` or `_e()` calls using the `rtbcb` text domain.
+- Verify user capabilities (e.g., `current_user_can('manage_options')`) before rendering admin pages.


### PR DESCRIPTION
## Summary
- note translation functions for user-visible strings with rtbcb text domain
- require verifying user capabilities before rendering admin pages

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68b215eabb408331b22fe4ddaf0c258a