### PR TITLE
docs: add test instructions

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,11 @@
+# AI Test Guidelines
+
+- Before committing changes, run `bash tests/run-tests.sh` from the repository root.
+- The `run-tests.sh` script performs:
+    - PHP linting and unit tests via `phpunit`.
+    - JavaScript tests using Node.js.
+- Ensure the following environment variables are set when running tests:
+    - `OPENAI_API_KEY`
+    - `RTBCB_OPENAI_API_KEY`
+    - `RTBCB_TEST_MODEL`
+    - Any other variables required by the test suite.


### PR DESCRIPTION
## Summary
- add AGENTS guidelines for running test suite in tests directory

## Testing
- `bash tests/run-tests.sh` (phpunit: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b215f8158483319dbcc129b9d556cf