### PR TITLE
docs: require ABSPATH check in templates

### DIFF
--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -1,6 +1,7 @@
 # AI Instructions for templates/
 
 - PHP template files included by the plugin live here.
+- Start each template file with `defined( 'ABSPATH' ) || exit;`.
 - Keep templates focused on markup; move heavy logic to classes.
 - Escape variables with appropriate `esc_*` functions.
 - Wrap translatable text in `__()` or `_e()` using the `rtbcb` text domain.


### PR DESCRIPTION
## Summary
- specify that every template file must start with `defined( 'ABSPATH' ) || exit;` to block direct access

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b215fb9b008331b9e421af9a9c217c