### PR TITLE
docs: update contributing instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,5 @@
 - Wrap user visible strings in translation functions like `__( 'text', 'rtbcb' )`.
 - Do not modify code in the `vendor/` directory; it contains third-party dependencies.
 - After making changes to PHP files, run `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l` to check for syntax errors.
+- Run `bash tests/run-tests.sh` to execute PHP and JS tests as well as optional `phpcs` checks.
+- Ensure `phpcs --standard=WordPress` passes when available.


### PR DESCRIPTION
## Summary
- document test script `bash tests/run-tests.sh` and optional `phpcs` checks
- remind contributors to ensure `phpcs --standard=WordPress` passes when available

## Testing
- `bash tests/run-tests.sh`
- `phpcs --standard=WordPress` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b215e08338833196ab3e0662d6a731