### PR TITLE
Guard company name retrieval to avoid JS errors

### DIFF
--- a/admin/js/company-overview.js
+++ b/admin/js/company-overview.js
@@ -83,11 +83,19 @@
 
         generateBtn.on('click', function(e) {
             e.preventDefault();
-            const companyName = $('#rtbcb-company-name').val().trim();
+            var $companyInput = $('#rtbcb-company-name');
+            var companyName = '';
+
+            if ($companyInput.length && typeof $companyInput.val === 'function') {
+                var value = $companyInput.val();
+                companyName = value ? value.trim() : '';
+            }
+
             if (!companyName) {
                 alert('Please enter a company name.');
                 return;
             }
+
             sendRequest(companyName);
         });
     });

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -612,8 +612,14 @@ jQuery(document).ready(function($) {
             e.preventDefault();
             var $btn = $(this);
             var original = $btn.text();
-            var companyName = $('#rtbcb-company-name').val().trim();
-        
+            var $companyInput = $('#rtbcb-company-name');
+            var companyName = '';
+
+            if ($companyInput.length && typeof $companyInput.val === 'function') {
+                var value = $companyInput.val();
+                companyName = value ? value.trim() : '';
+            }
+
             if (!companyName) {
                 alert(window.rtbcbAdmin.strings.company_required || 'Please enter a company name before running tests');
                 return;


### PR DESCRIPTION
## Summary
- Ensure company overview script checks for company name field before trimming
- Safeguard runAllTests routine against missing company name input

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b215d6b9508331af314b778482d016