### PR TITLE
Use single OpenAI API key

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -17,8 +17,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return string Sanitized API key.
  */
 function rtbcb_get_openai_api_key() {
-    if ( defined( 'RTBCB_OPENAI_API_KEY' ) && ! empty( RTBCB_OPENAI_API_KEY ) ) {
-        return sanitize_text_field( RTBCB_OPENAI_API_KEY );
+    if ( defined( 'OPENAI_API_KEY' ) && ! empty( OPENAI_API_KEY ) ) {
+        return sanitize_text_field( OPENAI_API_KEY );
     }
 
     $api_key = get_option( 'rtbcb_openai_api_key', '' );

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -6,6 +6,5 @@
     - JavaScript tests using Node.js.
 - Ensure the following environment variables are set when running tests:
     - `OPENAI_API_KEY`
-    - `RTBCB_OPENAI_API_KEY`
     - `RTBCB_TEST_MODEL`
     - Any other variables required by the test suite.

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -5,7 +5,6 @@ echo "================================================"
 
 # Ensure required environment variables for tests
 export OPENAI_API_KEY="${OPENAI_API_KEY:-sk-test}"
-export RTBCB_OPENAI_API_KEY="${RTBCB_OPENAI_API_KEY:-sk-test}"
 export RTBCB_TEST_MODEL="${RTBCB_TEST_MODEL:-gpt-5-mini}"
 
 # PHP Lint


### PR DESCRIPTION
## Summary
- use `OPENAI_API_KEY` constant for plugin configuration
- drop `RTBCB_OPENAI_API_KEY` references in tests and docs

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2175547408331983b34e32624f6e4