### PR TITLE
Use single OpenAI API key from settings

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -8,19 +8,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Retrieve the OpenAI API key from a secure source.
+ * Retrieve the OpenAI API key from plugin settings.
  *
- * Checks for a defined constant first to allow configuration via
- * environment variables or wp-config.php. Falls back to the value stored
- * in the WordPress options table.
+ * Reads the value stored in the WordPress options table.
  *
  * @return string Sanitized API key.
  */
 function rtbcb_get_openai_api_key() {
-    if ( defined( 'RTBCB_OPENAI_API_KEY' ) && ! empty( RTBCB_OPENAI_API_KEY ) ) {
-        return sanitize_text_field( RTBCB_OPENAI_API_KEY );
-    }
-
     $api_key = get_option( 'rtbcb_openai_api_key', '' );
 
     return sanitize_text_field( $api_key );

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -6,6 +6,5 @@
     - JavaScript tests using Node.js.
 - Ensure the following environment variables are set when running tests:
     - `OPENAI_API_KEY`
-    - `RTBCB_OPENAI_API_KEY`
     - `RTBCB_TEST_MODEL`
     - Any other variables required by the test suite.

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -5,7 +5,6 @@ echo "================================================"
 
 # Ensure required environment variables for tests
 export OPENAI_API_KEY="${OPENAI_API_KEY:-sk-test}"
-export RTBCB_OPENAI_API_KEY="${RTBCB_OPENAI_API_KEY:-sk-test}"
 export RTBCB_TEST_MODEL="${RTBCB_TEST_MODEL:-gpt-5-mini}"
 
 # PHP Lint


### PR DESCRIPTION
## Summary
- Simplify OpenAI key retrieval to rely solely on plugin settings
- Drop deprecated `RTBCB_OPENAI_API_KEY` usage from tests
- Update test guidelines accordingly

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found; phpcs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2175547408331983b34e32624f6e4