### PR TITLE
Load wizard script in header for earlier modal initialization

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -388,13 +388,14 @@ class Real_Treasury_BCB {
             true
         );
 
+        // Load wizard script early so modal helpers are available before user interaction.
         $wizard_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb-wizard.js' : 'rtbcb-wizard.min.js';
         wp_enqueue_script(
             'rtbcb-wizard',
             RTBCB_URL . 'public/js/' . $wizard_file,
             [ 'jquery' ],
             RTBCB_VERSION,
-            true
+            false
         );
 
         wp_enqueue_script(


### PR DESCRIPTION
## Summary
- Load `rtbcb-wizard.js` in the page header so modal helpers are ready before interaction

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b219bf81788331ba8599c7119ca3c4