### PR TITLE
Load wizard script earlier for modal initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ Add the shortcode to any page or post to display a “Generate Business Case” 
    style="modern"]
 ```
 
+The wizard requires `public/js/rtbcb-wizard.js` to be loaded before the button is clicked.
+In WordPress this happens automatically when `enqueue_assets()` runs and your theme
+calls both `wp_head()` and `wp_footer()` so enqueued scripts render.
+If testing the template outside WordPress, manually include:
+
+```html
+<script src="/path/to/public/js/rtbcb-wizard.js"></script>
+```
+
+before the closing `</body>` tag.
+
 ## 🗂️ Repository Structure
 
 - `admin/` – WordPress dashboard pages, settings, and nonces.

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -389,12 +389,13 @@ class Real_Treasury_BCB {
         );
 
         $wizard_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb-wizard.js' : 'rtbcb-wizard.min.js';
+        // Load the wizard script in the header so modal functions are available before interaction.
         wp_enqueue_script(
             'rtbcb-wizard',
             RTBCB_URL . 'public/js/' . $wizard_file,
             [ 'jquery' ],
             RTBCB_VERSION,
-            true
+            false
         );
 
         wp_enqueue_script(


### PR DESCRIPTION
## Summary
- Load `rtbcb-wizard.js` in the page header so modal functions exist before the trigger button is clicked
- Document how to ensure the wizard script is loaded in WordPress and standalone environments

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b219ee45648331b17b3a11ad786aac