### PR TITLE
Load wizard script earlier for modal initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-# Real Treasury Business Case Builder - Enhanced Version 2.1.5
+# Real Treasury Business Case Builder - Enhanced Version 2.1.6
 
 A comprehensive WordPress plugin that helps treasury teams quantify the benefits of modern treasury tools, generate professional business case reports, and track lead engagement with advanced analytics.
 
-## 🚀 What's New in Version 2.1.5
+## 🚀 What's New in Version 2.1.6
 
 ### 🔧 Maintenance Release
-- Cleaned up wizard form styling to align with WordPress conventions.
-- Bumped plugin version and updated asset cache busting.
+- Loaded wizard script in the page head so modal handlers are available immediately.
 
 ## 📋 Installation & Setup
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: realtreasury
 Tags: business, case, builder, roi, treasury
 Requires at least: 6.0
 Tested up to: 6.0
-Stable tag: 2.1.5
+Stable tag: 2.1.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -144,6 +144,8 @@ Reports are rendered as HTML in the browser. Use your browser's print or save fu
 The analytics dashboard uses Chart.js for its visualizations. The library is bundled with the plugin to reduce blocking by privacy tools, but strict ad blockers may still prevent it from loading. Allow the plugin's scripts in your browser to enable the charts.
 
 == Changelog ==
+= 2.1.6 =
+* Load wizard script earlier so modal handlers initialize before user interaction.
 = 2.1.5 =
 * Clean up wizard form styling and update asset version.
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Real Treasury - Business Case Builder (Enhanced Pro)
  * Description: Professional-grade ROI calculator and comprehensive business case generator for treasury technology with advanced analysis and consultant-style reports.
- * Version: 2.1.5
+ * Version: 2.1.6
  * Requires PHP: 7.4
  * Author: Real Treasury
  * Text Domain: rtbcb
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'RTBCB_VERSION', '2.1.5' );
+define( 'RTBCB_VERSION', '2.1.6' );
 define( 'RTBCB_FILE', __FILE__ );
 define( 'RTBCB_URL', plugin_dir_url( RTBCB_FILE ) );
 define( 'RTBCB_DIR', plugin_dir_path( RTBCB_FILE ) );
@@ -389,12 +389,13 @@ class Real_Treasury_BCB {
         );
 
         $wizard_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb-wizard.js' : 'rtbcb-wizard.min.js';
+        // Load wizard early so modal handlers are available before user interaction.
         wp_enqueue_script(
             'rtbcb-wizard',
             RTBCB_URL . 'public/js/' . $wizard_file,
             [ 'jquery' ],
             RTBCB_VERSION,
-            true
+            false
         );
 
         wp_enqueue_script(


### PR DESCRIPTION
## Summary
- Load rtbcb-wizard.js in the page head so `openBusinessCaseModal` is available immediately
- Bump plugin version to 2.1.6

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `phpcs --standard=WordPress --ignore=vendor .` *(error: the "WordPress" coding standard is not installed)*
- `bash tests/run-tests.sh` *(phpunit: command not found; WordPress coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b219bf81788331ba8599c7119ca3c4