### PR TITLE
Refine Real Treasury overview prompt

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -493,21 +493,21 @@ USER,
         }
 
         $model  = $this->get_model( 'mini' );
-        $prompt = 'Provide a Real Treasury platform overview for a ' . ( $company_size ?: __( 'company', 'rtbcb' ) ) . ' in the ' . ( $industry ?: __( 'unspecified', 'rtbcb' ) ) . ' industry.';
+        $prompt = 'Provide an overview of Real Treasury, a treasury consulting company that helps organizations optimize treasury operations, benchmark market practices, and evaluate technology options for a ' . ( $company_size ?: __( 'company', 'rtbcb' ) ) . ' in the ' . ( $industry ?: __( 'unspecified', 'rtbcb' ) ) . ' industry.';
 
         if ( ! empty( $challenges ) ) {
             $prompt .= ' Address these challenges: ' . implode( ', ', $challenges ) . '.';
         }
 
         if ( ! empty( $categories ) ) {
-            $prompt .= ' Highlight vendor categories: ' . implode( ', ', $categories ) . '.';
+            $prompt .= ' Highlight how Real Treasury advises on vendor categories: ' . implode( ', ', $categories ) . '.';
         }
 
         if ( $include_portal ) {
-            $prompt .= ' Include how the Real Treasury portal complements the platform.';
+            $prompt .= ' Include how clients access Real Treasury research and tools through a client portal.';
         }
 
-        $prompt .= ' Provide sections for platform capabilities, portal integration benefits, vendor ecosystem overview, Real Treasury differentiators, implementation approach, and support/community aspects.';
+        $prompt .= ' Provide sections for consulting services, vendor ecosystem advisory, Real Treasury differentiators, implementation approach, and support/community aspects.';
 
         $history  = [
             [


### PR DESCRIPTION
## Summary
- adjust Real Treasury overview generation to highlight advisory services and client portal resources without portraying it as a software vendor
- remove language suggesting Real Treasury hosts the plugin

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b22b0036648331b263fac2d9a68385