### PR TITLE
Align nonce action with rtbcb_generate

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -20,7 +20,7 @@ class RTBCB_Router {
         // Nonce verification.
         if (
             ! isset( $_POST['rtbcb_nonce'] )
-            || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ), 'rtbcb_form_action' )
+            || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ), 'rtbcb_generate' )
         ) {
             wp_send_json_error( [ 'message' => __( 'Nonce verification failed.', 'rtbcb' ) ], 403 );
             return;

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -412,7 +412,7 @@ class Real_Treasury_BCB {
             'rtbcbAjax',
             [
                 'ajax_url'    => admin_url( 'admin-ajax.php' ),
-                'nonce'       => wp_create_nonce( 'rtbcb_form_action' ),
+                'nonce'       => wp_create_nonce( 'rtbcb_generate' ),
                 'strings'     => [
                     'error'                   => __( 'An error occurred. Please try again.', 'rtbcb' ),
                     'generating'              => __( 'Generating your comprehensive business case...', 'rtbcb' ),

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -434,7 +434,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
                 <span class="rtbcb-nav-icon">→</span>
             </button>
 
-            <?php wp_nonce_field( 'rtbcb_form_action', 'rtbcb_nonce' ); ?>
+            <?php wp_nonce_field( 'rtbcb_generate', 'rtbcb_nonce' ); ?>
 
             <button type="submit" id="rtbcb-submit-button" class="rtbcb-nav-btn rtbcb-nav-submit" style="display: none;">
                 <span class="rtbcb-nav-icon">🚀</span>

--- a/tests/handle-server-error-display.test.js
+++ b/tests/handle-server-error-display.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
-global.rtbcbAjax = { ajax_url: 'test-url' };
+global.rtbcbAjax = { ajax_url: 'test-url', nonce: 'test-nonce' };
 
 class SimpleFormData {
     constructor(form) {

--- a/tests/handle-submit-error.test.js
+++ b/tests/handle-submit-error.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
-global.rtbcbAjax = { ajax_url: 'test-url' };
+global.rtbcbAjax = { ajax_url: 'test-url', nonce: 'test-nonce' };
 
 class SimpleFormData {
     constructor(form) {

--- a/tests/handle-submit-success.test.js
+++ b/tests/handle-submit-success.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
-global.rtbcbAjax = { ajax_url: 'test-url' };
+global.rtbcbAjax = { ajax_url: 'test-url', nonce: 'test-nonce' };
 
 class SimpleFormData {
     constructor(form) {


### PR DESCRIPTION
## Summary
- localize JS with `rtbcb_generate` nonce
- verify form nonce using `rtbcb_generate`
- update tests to pass nonce through AJAX helper

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2346e93cc8331982592829e95991e