### PR TITLE
Log stack trace for fatal LLM errors

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -977,8 +977,12 @@ class Real_Treasury_BCB {
                         500
                     );
                 } catch ( Error $e ) {
+                    // Developers: check server logs for E_LLM_FATAL stack trace.
                     $error_code = 'E_LLM_FATAL';
-                    rtbcb_log_error( $error_code . ': ' . $e->getMessage() );
+                    rtbcb_log_error(
+                        $error_code . ': ' . $e->getMessage(),
+                        $e->getTraceAsString()
+                    );
                     $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
                     $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
                     if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {


### PR DESCRIPTION
## Summary
- Log stack traces when fatal errors occur in LLM generation
- Guide developers to check server logs for E_LLM_FATAL issues

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*
- `phpcs --standard=WordPress` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2382930048331b88949d325009820