### PR TITLE
Add ABSPATH guard to LLM class

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -5,6 +5,8 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
+defined( 'ABSPATH' ) || exit;
+
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/helpers.php';
 


### PR DESCRIPTION
## Summary
- add WordPress ABSPATH guard to `RTBCB_LLM` class file to prevent direct access

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b23df22ed08331958d49a64ef0d8a9