### PR TITLE
Add treasury maturity assessment method

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -986,6 +986,51 @@ USER,
     }
 
     /**
+     * Assess treasury maturity based on user inputs.
+     *
+     * @param array $user_inputs Sanitized user inputs.
+     * @return array {
+     *     @type string $level     Assessed maturity level.
+     *     @type string $rationale Rationale for the assessment.
+     * }
+     */
+    private function assess_treasury_maturity( $user_inputs ) {
+        $company_data = [
+            'ftes' => isset( $user_inputs['ftes'] ) ? floatval( $user_inputs['ftes'] ) : 0,
+        ];
+
+        if ( class_exists( 'RTBCB_Maturity_Model' ) ) {
+            $model      = new RTBCB_Maturity_Model();
+            $assessment = $model->assess( $company_data );
+
+            return [
+                'level'     => sanitize_text_field( $assessment['level'] ?? '' ),
+                'rationale' => sanitize_text_field( $assessment['assessment'] ?? '' ),
+            ];
+        }
+
+        $ftes  = $company_data['ftes'];
+        $level = __( 'Basic', 'rtbcb' );
+
+        if ( $ftes > 5 ) {
+            $level = __( 'Advanced', 'rtbcb' );
+        } elseif ( $ftes > 2 ) {
+            $level = __( 'Intermediate', 'rtbcb' );
+        }
+
+        $rationale = sprintf(
+            /* translators: %d: number of treasury FTEs */
+            __( 'Assessment based on %d treasury FTEs.', 'rtbcb' ),
+            $ftes
+        );
+
+        return [
+            'level'     => sanitize_text_field( $level ),
+            'rationale' => sanitize_text_field( $rationale ),
+        ];
+    }
+
+    /**
      * Analyze industry context using the LLM.
      *
      * @param array $user_inputs Sanitized user inputs.


### PR DESCRIPTION
## Summary
- add `assess_treasury_maturity` to LLM class to gauge maturity level and rationale from sanitized user inputs

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found; JS tests passed)*
- `phpcs --standard=WordPress inc/class-rtbcb-llm.php` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b23f9629108331b5ced250ce38c9b4