### PR TITLE
Add treasury maturity assessment method

### DIFF
--- a/inc/class-rtbcb-maturity-model.php
+++ b/inc/class-rtbcb-maturity-model.php
@@ -39,4 +39,42 @@ class RTBCB_Maturity_Model {
             'score'      => rand( 60, 90 ),
         ];
     }
+
+    /**
+     * Assess treasury maturity from user inputs.
+     *
+     * Sanitizes provided data and derives a maturity level
+     * with explanatory rationale.
+     *
+     * @param array $user_inputs User-provided data.
+     * @return array {
+     *     @type string $level     Maturity level.
+     *     @type string $rationale Explanation for the level.
+     * }
+     */
+    private function assess_treasury_maturity( $user_inputs ) {
+        $sanitized = [];
+
+        foreach ( $user_inputs as $key => $value ) {
+            $sanitized[ $key ] = sanitize_text_field( $value );
+        }
+
+        $ftes = isset( $sanitized['ftes'] ) ? floatval( $sanitized['ftes'] ) : 0.0;
+
+        if ( $ftes > 5 ) {
+            $level     = __( 'Advanced', 'rtbcb' );
+            $rationale = __( 'More than five dedicated treasury FTEs suggests advanced maturity.', 'rtbcb' );
+        } elseif ( $ftes > 2 ) {
+            $level     = __( 'Intermediate', 'rtbcb' );
+            $rationale = __( 'Between two and five FTEs indicates intermediate maturity.', 'rtbcb' );
+        } else {
+            $level     = __( 'Basic', 'rtbcb' );
+            $rationale = __( 'Limited FTEs dedicated to treasury keep maturity at a basic level.', 'rtbcb' );
+        }
+
+        return [
+            'level'     => $level,
+            'rationale' => $rationale,
+        ];
+    }
 }


### PR DESCRIPTION
## Summary
- add `assess_treasury_maturity` private method to RTBCB_Maturity_Model
- sanitize user input and provide maturity level with rationale

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b240942cdc8331a3f965c1a4fdc1e1