### PR TITLE
Enable scrolling for API log modal

### DIFF
--- a/admin/css/rtbcb-admin.css
+++ b/admin/css/rtbcb-admin.css
@@ -300,6 +300,7 @@
     background: rgba(0, 0, 0, 0.5);
     display: none;
     z-index: 1000;
+    overflow: auto;
 }
 
 #rtbcb-log-modal .rtbcb-modal-content {
@@ -308,10 +309,14 @@
     padding: 20px;
     max-width: 600px;
     width: 90%;
+    max-height: 80vh;
+    overflow-y: auto;
 }
 
 #rtbcb-log-modal pre {
     white-space: pre-wrap;
     word-break: break-word;
+    max-height: 70vh;
+    overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- allow log modal overlay and content to scroll
- constrain log content height for better readability

## Testing
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b26c5e110883318e44245005173e9a