### PR TITLE
Add spacing containers for consent and preview sections

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -1662,13 +1662,19 @@
     text-decoration: underline;
 }
 
+/* Contact Step Containers */
+.rtbcb-consent-container,
+.rtbcb-preview-container {
+    margin-top: 24px;
+    font-size: 14px;
+}
+
 /* Results Preview */
 .rtbcb-results-preview {
     background: linear-gradient(135deg, #f8f9ff, #ffffff);
     border: 1px solid #7216f4;
     border-radius: 8px;
     padding: 20px;
-    margin-top: 24px;
 }
 
 .rtbcb-results-preview h4 {

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -376,34 +376,38 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
                         </div>
                     </div>
 
-                    <div class="rtbcb-field">
-                        <div class="rtbcb-consent-wrapper">
-                            <label class="rtbcb-consent-label">
-                                <input type="checkbox" name="consent" required />
-                                <span class="rtbcb-consent-text">
-                                    <?php 
-                                    printf(
-                                        wp_kses(
-                                            __( 'I agree to receive my business case report and occasional treasury insights. You can unsubscribe at any time. View our <a href="%s" target="_blank">privacy policy</a>.', 'rtbcb' ),
-                                            [ 'a' => [ 'href' => [], 'target' => [] ] ]
-                                        ),
-                                        '#'
-                                    );
-                                    ?>
-                                </span>
-                            </label>
+                    <div class="rtbcb-consent-container">
+                        <div class="rtbcb-field">
+                            <div class="rtbcb-consent-wrapper">
+                                <label class="rtbcb-consent-label">
+                                    <input type="checkbox" name="consent" required />
+                                    <span class="rtbcb-consent-text">
+                                        <?php
+                                        printf(
+                                            wp_kses(
+                                                __( 'I agree to receive my business case report and occasional treasury insights. You can unsubscribe at any time. View our <a href="%s" target="_blank">privacy policy</a>.', 'rtbcb' ),
+                                                [ 'a' => [ 'href' => [], 'target' => [] ] ]
+                                            ),
+                                            '#'
+                                        );
+                                        ?>
+                                    </span>
+                                </label>
+                            </div>
                         </div>
                     </div>
 
                     <!-- What You'll Receive Preview -->
-                    <div class="rtbcb-results-preview">
-                        <h4><?php esc_html_e( 'What You\'ll Receive:', 'rtbcb' ); ?></h4>
-                        <ul class="rtbcb-preview-list">
-                            <li>📊 <?php esc_html_e( 'Detailed ROI projections (conservative, base case, optimistic)', 'rtbcb' ); ?></li>
-                            <li>🎯 <?php esc_html_e( 'Personalized solution category recommendation', 'rtbcb' ); ?></li>
-                            <li>📄 <?php esc_html_e( 'Professional PDF report ready for stakeholders', 'rtbcb' ); ?></li>
-                            <li>🗺️ <?php esc_html_e( 'Implementation roadmap and next steps', 'rtbcb' ); ?></li>
-                        </ul>
+                    <div class="rtbcb-preview-container">
+                        <div class="rtbcb-results-preview">
+                            <h4><?php esc_html_e( 'What You\'ll Receive:', 'rtbcb' ); ?></h4>
+                            <ul class="rtbcb-preview-list">
+                                <li>📊 <?php esc_html_e( 'Detailed ROI projections (conservative, base case, optimistic)', 'rtbcb' ); ?></li>
+                                <li>🎯 <?php esc_html_e( 'Personalized solution category recommendation', 'rtbcb' ); ?></li>
+                                <li>📄 <?php esc_html_e( 'Professional PDF report ready for stakeholders', 'rtbcb' ); ?></li>
+                                <li>🗺️ <?php esc_html_e( 'Implementation roadmap and next steps', 'rtbcb' ); ?></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Wrap consent checkbox and result preview list in dedicated containers for cleaner spacing
- Add CSS for new containers and adjust preview styles for consistent fonts and gaps

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b272bbbbb08331a66b329233b98cb5