### PR TITLE
Move mobile form styles into main stylesheet

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -1922,6 +1922,22 @@
     }
 }
 
+/* Mobile modal layout overrides moved from template */
+@media (max-width: 768px) {
+    .rtbcb-modal-container {
+        max-width: 95vw;
+        border-radius: 16px;
+    }
+
+    .rtbcb-modal-header {
+        padding: 24px 28px 16px 28px;
+    }
+
+    .rtbcb-form-container {
+        padding: 20px;
+    }
+}
+
 /* 10. FOCUS STATES FOR ACCESSIBILITY */
 
 /* Button focus states */

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -370,10 +370,9 @@ class Real_Treasury_BCB {
         }
 
         // Styles
-        $style_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb.css' : 'rtbcb.min.css';
         wp_enqueue_style(
             'rtbcb-style',
-            RTBCB_URL . 'public/css/' . $style_file,
+            RTBCB_URL . 'public/css/rtbcb.css',
             [],
             RTBCB_VERSION
         );

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -473,20 +473,4 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
     </div>
 </div>
 
-<style>
-/* Only mobile-specific overrides needed here */
-@media (max-width: 768px) {
-    .rtbcb-modal-container {
-        max-width: 95vw;
-        border-radius: 16px;
-    }
-    
-    .rtbcb-modal-header {
-        padding: 24px 28px 16px 28px;
-    }
-    
-    .rtbcb-form-container {
-        padding: 20px;
-    }
-}
-</style>
+


### PR DESCRIPTION
## Summary
- Remove inline mobile overrides from the business case form template.
- Consolidate responsive modal styles in `rtbcb.css`.
- Always enqueue the primary stylesheet for the form on the frontend.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b272bf164483319f5f84e29883fceb