### PR TITLE
Refine modal sizing and center form content

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -71,8 +71,7 @@
     border: 2px solid rgba(199, 125, 255, 0.3);
     border-radius: 20px;
     box-shadow: 0 25px 50px rgba(0, 0, 0, 0.25), 0 8px 32px rgba(114, 22, 244, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.8);
-    width: 100%;
-    max-width: 800px;
+    max-width: 700px;
     margin: 0 auto;
     overflow: auto;
     max-height: 85vh;
@@ -229,8 +228,8 @@
     }
 
     .rtbcb-modal {
-        width: 95vw;
-        max-width: 95vw;
+        width: 90vw;
+        max-width: 480px;
     }
 
     .rtbcb-form-container {
@@ -1155,6 +1154,8 @@
 
 .rtbcb-form-container {
     padding: 32px 40px 40px 40px;
+    max-width: 640px;
+    margin: 0 auto;
 }
 
 /* Progress Indicator - Glassmorphic */


### PR DESCRIPTION
## Summary
- Limit modal width and center it without forcing full width
- Narrow mobile modal dimensions for better centering
- Constrain and center form container content

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b273f910f4833185caab6c542efa35