### PR TITLE
feat(logging): instrument API route with structured logs

### DIFF
--- a/inc/class-rtbcb-logger.php
+++ b/inc/class-rtbcb-logger.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Structured logging utilities.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Structured logging for API interactions.
+ */
+class RTBCB_Logger {
+    /**
+     * Send a structured log record.
+     *
+     * @param string $event   Event name.
+     * @param array  $context Context data.
+     * @return void
+     */
+    public static function log( $event, $context = [] ) {
+        $record = [
+            'timestamp' => gmdate( 'c' ),
+            'event'     => $event,
+            'context'   => $context,
+        ];
+
+        error_log( 'RTBCB_LOG: ' . wp_json_encode( $record ) );
+
+        $endpoint = sanitize_text_field( get_option( 'rtbcb_log_endpoint', '' ) );
+        if ( $endpoint ) {
+            wp_remote_post(
+                $endpoint,
+                [
+                    'headers' => [ 'Content-Type' => 'application/json' ],
+                    'body'    => wp_json_encode( $record ),
+                    'timeout' => 2,
+                ]
+            );
+        }
+    }
+
+    /**
+     * Log request details on shutdown.
+     *
+     * @param float $start_time Request start time.
+     * @param array $payload    Sanitized request payload.
+     * @return void
+     */
+    public static function log_shutdown( $start_time, $payload ) {
+        $duration = ( microtime( true ) - $start_time ) * 1000;
+        $code     = http_response_code();
+
+        $log = [
+            'payload'          => $payload,
+            'response_time_ms' => round( $duration ),
+            'status_code'      => $code,
+        ];
+
+        $error = error_get_last();
+        if ( $error ) {
+            $log['error'] = $error['message'];
+        }
+
+        if ( 504 === $code || ( isset( $log['error'] ) && false !== stripos( $log['error'], 'timeout' ) ) ) {
+            self::record_timeout();
+        }
+
+        self::log( 'generate_case', $log );
+    }
+
+    /**
+     * Increment timeout counter and trigger alert if threshold exceeded.
+     *
+     * @return void
+     */
+    public static function record_timeout() {
+        $count = (int) get_transient( 'rtbcb_timeout_count' );
+        $count++;
+        set_transient( 'rtbcb_timeout_count', $count, 300 );
+
+        if ( $count >= 3 ) {
+            self::send_timeout_alert( $count );
+            delete_transient( 'rtbcb_timeout_count' );
+        }
+    }
+
+    /**
+     * Send timeout alert email.
+     *
+     * @param int $count Timeout count.
+     * @return void
+     */
+    private static function send_timeout_alert( $count ) {
+        $admin_email = get_option( 'admin_email' );
+        $subject     = __( 'Business Case Builder timeout alert', 'rtbcb' );
+        $message     = sprintf(
+            __( 'The Business Case Builder API timed out %d times in the last five minutes.', 'rtbcb' ),
+            $count
+        );
+        wp_mail( $admin_email, $subject, $message );
+    }
+}
+

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -551,6 +551,23 @@ function rtbcb_get_client_ip() {
     return isset( $_SERVER['REMOTE_ADDR'] ) ? wp_unslash( $_SERVER['REMOTE_ADDR'] ) : '';
 }
 
+/**
+ * Recursively sanitize values using sanitize_text_field.
+ *
+ * @param mixed $data Data to sanitize.
+ * @return mixed Sanitized data.
+ */
+function rtbcb_recursive_sanitize_text_field( $data ) {
+    if ( is_array( $data ) ) {
+        foreach ( $data as $key => $value ) {
+            $data[ $key ] = rtbcb_recursive_sanitize_text_field( $value );
+        }
+
+        return $data;
+    }
+
+    return sanitize_text_field( (string) $data );
+}
 
 /**
  * Log API debug messages.

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -137,6 +137,7 @@ class Real_Treasury_BCB {
         require_once RTBCB_DIR . 'inc/class-rtbcb-validator.php';
         require_once RTBCB_DIR . 'inc/class-rtbcb-api-tester.php';
         require_once RTBCB_DIR . 'inc/helpers.php';
+        require_once RTBCB_DIR . 'inc/class-rtbcb-logger.php';
 
         // Admin functionality
         if ( is_admin() ) {
@@ -694,6 +695,10 @@ class Real_Treasury_BCB {
      * Enhanced AJAX handler with memory management
      */
     public function ajax_generate_comprehensive_case() {
+        $request_start   = microtime( true );
+        $request_payload = rtbcb_recursive_sanitize_text_field( wp_unslash( $_POST ) );
+        register_shutdown_function( [ 'RTBCB_Logger', 'log_shutdown' ], $request_start, $request_payload );
+
         rtbcb_setup_ajax_logging();
 
         // STEP 1: Increase memory limit and log initial state


### PR DESCRIPTION
## Summary
- log Business Case Builder API requests with sanitized payloads and response metrics
- add structured logger that can forward events to external endpoint and alert on repeated timeouts

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2778d7fe48331b9b6599f01035075