### PR TITLE
feat: allow configurable API request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ before the closing `</body>` tag.
 - **API Configuration**: OpenAI models and authentication
 - **ROI Assumptions**: Labor costs, efficiency rates, fee baselines
 - **Portal Integration**: Real Treasury portal connectivity
+- **API Timeout**: Adjust external request duration via the `rtbcb_api_timeout` filter and match server-level `proxy_read_timeout`/`fastcgi_read_timeout`.
 
 ## 🔧 Technical Architecture
 

--- a/inc/class-rtbcb-api-tester.php
+++ b/inc/class-rtbcb-api-tester.php
@@ -56,7 +56,7 @@ class RTBCB_API_Tester {
             $body['temperature'] = 0.1;
         }
 
-        $timeout = intval( get_option( 'rtbcb_gpt5_timeout', 180 ) );
+        $timeout = intval( get_option( 'rtbcb_gpt5_timeout', rtbcb_get_api_timeout() ) );
 
         $args = [
             'headers' => [

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -45,7 +45,7 @@ class RTBCB_LLM {
     public function __construct() {
         $this->api_key = rtbcb_get_openai_api_key();
 
-        $timeout = intval( get_option( 'rtbcb_gpt5_timeout', 180 ) );
+        $timeout = intval( get_option( 'rtbcb_gpt5_timeout', rtbcb_get_api_timeout() ) );
         $config  = rtbcb_get_gpt5_config(
             array_merge(
                 get_option( 'rtbcb_gpt5_config', [] ),
@@ -1574,7 +1574,7 @@ USER,
             $body['store'] = (bool) $this->gpt5_config['store'];
         }
 
-        $timeout = intval( $this->gpt5_config['timeout'] ?? 180 );
+        $timeout = intval( $this->gpt5_config['timeout'] ?? rtbcb_get_api_timeout() );
 
         $args = [
             'headers' => [

--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -184,7 +184,7 @@ class RTBCB_RAG {
                     'input' => $text,
                 ]
             ),
-            'timeout' => 60,
+            'timeout' => rtbcb_get_api_timeout(),
         ];
 
         $response = wp_remote_post( $endpoint, $args );

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -32,6 +32,28 @@ function rtbcb_has_openai_api_key() {
 }
 
 /**
+ * Retrieve the timeout for external API requests.
+ *
+ * Allows customization via the `rtbcb_api_timeout` filter so site owners can
+ * increase execution limits when necessary.
+ *
+ * @return int Timeout in seconds.
+ */
+function rtbcb_get_api_timeout() {
+    /**
+     * Filter the timeout value for outbound API requests.
+     *
+     * @param int $timeout Default timeout in seconds.
+     */
+    $timeout = 60;
+    if ( function_exists( 'apply_filters' ) ) {
+        $timeout = (int) apply_filters( 'rtbcb_api_timeout', $timeout );
+    }
+
+    return max( 1, $timeout );
+}
+
+/**
  * Determine if an error indicates an OpenAI configuration issue.
  *
  * Checks for common phrases like a missing API key or invalid model.
@@ -733,7 +755,7 @@ function rtbcb_test_generate_category_recommendation( $analysis ) {
                         'input'        => $input,
                     ]
                 ),
-                'timeout' => 60,
+                'timeout' => rtbcb_get_api_timeout(),
             ]
         );
 
@@ -1148,9 +1170,9 @@ function rtbcb_proxy_openai_responses() {
     $body_array['max_output_tokens'] = $max_output_tokens;
     $body              = wp_json_encode( $body_array );
 
-    $timeout = intval( get_option( 'rtbcb_responses_timeout', 120 ) );
+    $timeout = intval( get_option( 'rtbcb_responses_timeout', rtbcb_get_api_timeout() ) );
     if ( $timeout <= 0 ) {
-        $timeout = 120;
+        $timeout = rtbcb_get_api_timeout();
     }
 
     $response = wp_remote_post(

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -445,7 +445,7 @@ class Real_Treasury_BCB {
         $api_key      = sanitize_text_field( get_option( 'rtbcb_openai_api_key', '' ) );
         $report_model = sanitize_text_field( get_option( 'rtbcb_advanced_model', 'gpt-5-mini' ) );
 
-        $timeout = intval( get_option( 'rtbcb_gpt5_timeout', 180 ) );
+        $timeout = intval( get_option( 'rtbcb_gpt5_timeout', rtbcb_get_api_timeout() ) );
         $config  = rtbcb_get_gpt5_config(
             array_merge(
                 get_option( 'rtbcb_gpt5_config', [] ),
@@ -701,7 +701,10 @@ class Real_Treasury_BCB {
         rtbcb_log_memory_usage( 'start' );
 
         // STEP 2: Set longer execution time
-        $timeout    = min( absint( get_option( 'rtbcb_gpt5_timeout', 60 ) ), 55 );
+        $timeout    = min(
+            absint( get_option( 'rtbcb_gpt5_timeout', rtbcb_get_api_timeout() ) ),
+            rtbcb_get_api_timeout()
+        );
         $start_time = time();
 
         if ( ! ini_get( 'safe_mode' ) ) {


### PR DESCRIPTION
## Summary
- add `rtbcb_api_timeout` filter to configure external request duration
- use new timeout helper across OpenAI calls and document server timeout coordination

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*
- `curl -I https://api.openai.com/v1/embeddings`


------
https://chatgpt.com/codex/tasks/task_e_68b277855a208331b6a1e4f0155a4244