### PR TITLE
Add email delivery for generated reports

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -94,6 +94,24 @@ class RTBCB_Router {
             $leads   = new RTBCB_Leads();
             $lead_id = $leads->save_lead( $form_data, $business_case_data );
 
+            // Write report HTML to temporary file.
+            $upload_dir  = wp_upload_dir();
+            $reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
+            if ( ! file_exists( $reports_dir ) ) {
+                wp_mkdir_p( $reports_dir );
+            }
+
+            $report_path = trailingslashit( $reports_dir ) . 'report-' . $lead_id . '.html';
+            file_put_contents( $report_path, $report_html );
+
+            // Send report email.
+            rtbcb_send_report_email( $form_data, $report_path );
+
+            // Clean up temporary file.
+            if ( file_exists( $report_path ) ) {
+                unlink( $report_path );
+            }
+
             // Send success response.
             wp_send_json_success(
                 [


### PR DESCRIPTION
## Summary
- Email generated business-case reports using Contact Form 7 when available, or fall back to wp_mail
- Store report HTML in a temporary uploads file, send it, then clean up

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b2792bbbec83319c5403254a54d1b6