### PR TITLE
feat: show generation progress and confirmation

### DIFF
--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -92,8 +92,15 @@ async function handleSubmit(e) {
     var formContainer = document.querySelector('.rtbcb-form-container');
 
     // Show progress indicator
-    if (formContainer) formContainer.style.display = 'none';
-    if (progressContainer) progressContainer.style.display = 'block';
+    if (formContainer) {
+        formContainer.style.display = 'none';
+    }
+    if (progressContainer) {
+        if (rtbcbAjax && rtbcbAjax.strings && rtbcbAjax.strings.generating) {
+            progressContainer.textContent = rtbcbAjax.strings.generating;
+        }
+        progressContainer.style.display = 'block';
+    }
     if (typeof rtbcbAjax === 'undefined' || !rtbcbAjax.ajax_url) {
         handleSubmissionError('Unable to submit form. Please refresh the page and try again.', '');
         rtbcbIsSubmitting = false;
@@ -150,26 +157,12 @@ async function handleSubmit(e) {
         return;
     }
 
-    // On success, display the report
-    var reportContainer = document.getElementById('rtbcb-report-container');
-    if (progressContainer) progressContainer.style.display = 'none';
-    if (reportContainer) {
-        // Sanitize server-provided HTML before injecting to prevent XSS.
-        // Only allow expected markup needed for business case output.
-        var allowedTags = [
-            'a', 'p', 'br', 'strong', 'em', 'ul', 'ol', 'li',
-            'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'span',
-            'table', 'thead', 'tbody', 'tr', 'th', 'td'
-        ];
-        var allowedAttr = { a: [ 'href', 'title', 'target', 'rel' ], '*': [ 'style' ] };
-        var sanitized = typeof DOMPurify !== 'undefined'
-            ? DOMPurify.sanitize(
-                result.data.report_html,
-                { ALLOWED_TAGS: allowedTags, ALLOWED_ATTR: allowedAttr }
-            )
-            : result.data.report_html;
-        reportContainer.innerHTML = sanitized;
-        reportContainer.style.display = 'block';
+    // On success, show confirmation message
+    if (progressContainer) {
+        if (rtbcbAjax && rtbcbAjax.strings && rtbcbAjax.strings.email_confirmation) {
+            progressContainer.textContent = rtbcbAjax.strings.email_confirmation;
+        }
+        progressContainer.style.display = 'block';
     }
 
     rtbcbIsSubmitting = false;

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -426,6 +426,7 @@ class Real_Treasury_BCB {
                     'invalid_email'           => __( 'Please enter a valid email address.', 'rtbcb' ),
                     'required_field'          => __( 'This field is required.', 'rtbcb' ),
                     'select_pain_points'      => __( 'Please select at least one pain point.', 'rtbcb' ),
+                    'email_confirmation'     => __( 'Your report will arrive by email shortly.', 'rtbcb' ),
                 ],
                 'settings'    => [
                     'pdf_enabled'            => get_option( 'rtbcb_pdf_enabled', true ),

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -437,6 +437,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 
         </div>
                 </form>
+            <div id="rtbcb-progress-container" class="rtbcb-progress" style="display:none"></div>
             </div>
             <div id="rtbcbSuccessMessage" class="rtbcb-success-message" style="display:none"></div>
         </div>


### PR DESCRIPTION
## Summary
- add placeholder progress container after business case form
- show generating and confirmation messages in rtbcb.js submission handler
- expose email confirmation string via localized script data

## Testing
- `/bin/bash tests/run-tests.sh` *(fails: find: No such file or directory; php: No such file or directory; node: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b279219c9083318849da3b273207bd