### PR TITLE
Send business case reports via email with progress indicator

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -94,22 +94,28 @@ class RTBCB_Router {
             $leads   = new RTBCB_Leads();
             $lead_id = $leads->save_lead( $form_data, $business_case_data );
 
-            // Write report HTML to temporary file.
+            // Write report HTML to temporary file in uploads directory.
             $upload_dir  = wp_upload_dir();
             $reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
             if ( ! file_exists( $reports_dir ) ) {
                 wp_mkdir_p( $reports_dir );
             }
 
-            $report_path = trailingslashit( $reports_dir ) . 'report-' . $lead_id . '.html';
-            file_put_contents( $report_path, $report_html );
+            $filepath = trailingslashit( $reports_dir ) . 'report-' . $lead_id . '.html';
+            file_put_contents( $filepath, $report_html );
 
-            // Send report email.
-            rtbcb_send_report_email( $form_data, $report_path );
+            // Prepare and send the report email.
+            $to      = sanitize_email( $form_data['email'] );
+            $subject = sprintf(
+                __( 'Your Business Case from %s', 'rtbcb' ),
+                get_bloginfo( 'name' )
+            );
+            $message = __( 'Thank you for using the Business Case Builder. Your report is attached.', 'rtbcb' );
+            wp_mail( $to, $subject, $message, [], [ $filepath ] );
 
             // Clean up temporary file.
-            if ( file_exists( $report_path ) ) {
-                unlink( $report_path );
+            if ( file_exists( $filepath ) ) {
+                unlink( $filepath );
             }
 
             // Send success response.

--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -96,8 +96,13 @@ async function handleSubmit(e) {
         formContainer.style.display = 'none';
     }
     if (progressContainer) {
+        var progressText = progressContainer.querySelector('.rtbcb-progress-text');
         if (rtbcbAjax && rtbcbAjax.strings && rtbcbAjax.strings.generating) {
-            progressContainer.textContent = rtbcbAjax.strings.generating;
+            if (progressText) {
+                progressText.textContent = rtbcbAjax.strings.generating;
+            } else {
+                progressContainer.textContent = rtbcbAjax.strings.generating;
+            }
         }
         progressContainer.style.display = 'block';
     }
@@ -157,12 +162,22 @@ async function handleSubmit(e) {
         return;
     }
 
-    // On success, show confirmation message
+    // On success, show confirmation message then hide progress indicator
     if (progressContainer) {
+        var progressTextSuccess = progressContainer.querySelector('.rtbcb-progress-text');
         if (rtbcbAjax && rtbcbAjax.strings && rtbcbAjax.strings.email_confirmation) {
-            progressContainer.textContent = rtbcbAjax.strings.email_confirmation;
+            if (progressTextSuccess) {
+                progressTextSuccess.textContent = rtbcbAjax.strings.email_confirmation;
+            } else {
+                progressContainer.textContent = rtbcbAjax.strings.email_confirmation;
+            }
         }
-        progressContainer.style.display = 'block';
+        setTimeout(() => {
+            progressContainer.style.display = 'none';
+            if (formContainer) {
+                formContainer.style.display = 'block';
+            }
+        }, 3000);
     }
 
     rtbcbIsSubmitting = false;

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -437,17 +437,15 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 
         </div>
                 </form>
-            <div id="rtbcb-progress-container" class="rtbcb-progress" style="display:none"></div>
-            </div>
             <div id="rtbcbSuccessMessage" class="rtbcb-success-message" style="display:none"></div>
+            </div>
+            <div id="rtbcb-progress-container" class="rtbcb-progress-overlay" style="display: none;">
+                <div class="rtbcb-progress-content">
+                    <div class="rtbcb-progress-spinner"></div>
+                    <div class="rtbcb-progress-text"><?php esc_html_e( 'Generating your business case. It will arrive by email shortly...', 'rtbcb' ); ?></div>
+                </div>
+            </div>
         </div>
-    </div>
-</div>
-
-<div id="rtbcb-progress-container" class="rtbcb-progress-overlay" style="display: none;">
-    <div class="rtbcb-progress-content">
-        <div class="rtbcb-progress-spinner"></div>
-        <div class="rtbcb-progress-text"><?php esc_html_e( 'Generating Your Business Case...', 'rtbcb' ); ?></div>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Save generated report HTML to uploads and email it to the user before cleanup
- Display localized progress overlay during form submission and hide it after completion
- Update JavaScript to toggle the progress overlay and restore the form when finished

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` (phpunit missing)


------
https://chatgpt.com/codex/tasks/task_e_68b27b122d308331891f8a70b27439f4