### PR TITLE
Simplify report email handling

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -525,9 +525,6 @@ function rtbcb_normalize_model_name( $model ) {
 /**
  * Send the generated report to the user via email.
  *
- * Uses Contact Form 7 if available to leverage its mail settings,
- * otherwise falls back to wp_mail.
- *
  * @param array  $form_data   Form submission data.
  * @param string $report_path Absolute path to the HTML report file.
  *
@@ -538,33 +535,6 @@ function rtbcb_send_report_email( $form_data, $report_path ) {
 
     if ( empty( $email ) || ! is_readable( $report_path ) ) {
         return;
-    }
-
-    if ( class_exists( 'WPCF7_ContactForm' ) ) {
-        $form_id = (int) get_option( 'rtbcb_contact_form_id', 0 );
-
-        if ( $form_id ) {
-            $contact_form = \WPCF7_ContactForm::get_instance( $form_id );
-
-            if ( $contact_form ) {
-                $attachment_filter = function( $components ) use ( $report_path, $email ) {
-                    if ( ! isset( $components['attachments'] ) || ! is_array( $components['attachments'] ) ) {
-                        $components['attachments'] = [];
-                    }
-
-                    $components['attachments'][] = $report_path;
-                    $components['recipient']      = $email;
-
-                    return $components;
-                };
-
-                add_filter( 'wpcf7_mail_components', $attachment_filter );
-                $contact_form->submit();
-                remove_filter( 'wpcf7_mail_components', $attachment_filter );
-
-                return;
-            }
-        }
     }
 
     $subject = __( 'Your Business Case Report', 'rtbcb' );

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1373,6 +1373,7 @@ class Real_Treasury_BCB {
             'rtbcb_pdf_enabled',
             'rtbcb_last_indexed',
             'rtbcb_settings',
+            'rtbcb_contact_form_id',
         ];
 
         foreach ( $options as $option ) {


### PR DESCRIPTION
## Summary
- streamline report emailing by always using `wp_mail` with localized subject/body and sanitized recipient address
- ensure cleanup of obsolete `rtbcb_contact_form_id` option on uninstall

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b27d47a2ac8331964f49f3ef95230c