### PR TITLE
chore: bump plugin version to 2.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Real Treasury Business Case Builder - Enhanced Version 2.1.6
+# Real Treasury Business Case Builder - Enhanced Version 2.1.7
 
 A comprehensive WordPress plugin that helps treasury teams quantify the benefits of modern treasury tools, generate professional business case reports, and track lead engagement with advanced analytics.
 
-## 🚀 What's New in Version 2.1.6
+## 🚀 What's New in Version 2.1.7
 
 ### 🔧 Maintenance Release
-- Loaded wizard script in the page head so modal handlers are available immediately.
+- Updated documentation references for the 2.1.7 release.
 
 ## 📋 Installation & Setup
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: realtreasury
 Tags: business, case, builder, roi, treasury
 Requires at least: 6.0
 Tested up to: 6.0
-Stable tag: 2.1.6
+Stable tag: 2.1.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -155,6 +155,8 @@ Reports are rendered as HTML in the browser. Use your browser's print or save fu
 The analytics dashboard uses Chart.js for its visualizations. The library is bundled with the plugin to reduce blocking by privacy tools, but strict ad blockers may still prevent it from loading. Allow the plugin's scripts in your browser to enable the charts.
 
 == Changelog ==
+= 2.1.7 =
+* Update documentation to reflect version 2.1.7.
 = 2.1.6 =
 * Load wizard script earlier so modal handlers initialize before user interaction.
 = 2.1.5 =

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Real Treasury - Business Case Builder (Enhanced Pro)
  * Description: Professional-grade ROI calculator and comprehensive business case generator for treasury technology with advanced analysis and consultant-style reports.
- * Version: 2.1.6
+ * Version: 2.1.7
  * Requires PHP: 7.4
  * Author: Real Treasury
  * Text Domain: rtbcb
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'RTBCB_VERSION', '2.1.6' );
+define( 'RTBCB_VERSION', '2.1.7' );
 define( 'RTBCB_FILE', __FILE__ );
 define( 'RTBCB_URL', plugin_dir_url( RTBCB_FILE ) );
 define( 'RTBCB_DIR', plugin_dir_path( RTBCB_FILE ) );


### PR DESCRIPTION
## Summary
- bump plugin version constant and header to 2.1.7
- update documentation stable tag and changelog for 2.1.7
- refresh README to reflect 2.1.7 release

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b28379ee788331a7ea1214ca74bda1