### PR TITLE
docs: add wizard workflow and API call documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# Real Treasury Business Case Builder - Enhanced Version 2.1.6
+# Real Treasury Business Case Builder - Enhanced Version 2.1.7
 
 A comprehensive WordPress plugin that helps treasury teams quantify the benefits of modern treasury tools, generate professional business case reports, and track lead engagement with advanced analytics.
 
-## 🚀 What's New in Version 2.1.6
+## 🚀 What's New in Version 2.1.7
 
-### 🔧 Maintenance Release
-- Loaded wizard script in the page head so modal handlers are available immediately.
+- 📚 Added detailed wizard and API flow documentation in [docs/WIZARD_FORM_API_FLOW.md](docs/WIZARD_FORM_API_FLOW.md).
 
 ## 📋 Installation & Setup
 
@@ -100,7 +99,7 @@ before the closing `</body>` tag.
 - `inc/` – Core classes and helper functions.
 - `public/` – Front-end hooks, shortcodes, and assets.
 - `templates/` – PHP templates rendered for reports and forms.
-- `docs/` – Project documentation including [End-to-End Workflow](docs/END_TO_END_WORKFLOW.md).
+- `docs/` – Project documentation including [End-to-End Workflow](docs/END_TO_END_WORKFLOW.md) and [Wizard Form & API Flow](docs/WIZARD_FORM_API_FLOW.md).
 - `tests/` – Automated tests and diagnostics.
 - `vendor/` – Composer-managed third-party libraries (do not modify).
 

--- a/docs/END_TO_END_WORKFLOW.md
+++ b/docs/END_TO_END_WORKFLOW.md
@@ -1,6 +1,6 @@
 # End-to-End Workflow
 
-This document summarizes the workflow from internal company research to delivering the public report. It reflects the current implementation in the LLM classes and related components.
+This document summarizes the workflow from internal company research to delivering the public report. It reflects the current implementation in the LLM classes and related components. For a detailed walkthrough of the public wizard and API interactions, see [Wizard Form & API Flow](WIZARD_FORM_API_FLOW.md).
 
 ## 1. Admin Research (Internal)
 

--- a/docs/WIZARD_FORM_API_FLOW.md
+++ b/docs/WIZARD_FORM_API_FLOW.md
@@ -1,0 +1,66 @@
+# Wizard Form & API Flow
+
+## Wizard Steps and Fields
+
+1. **Company**
+   - `company_name`
+   - `company_size`
+   - `industry`
+2. **Operations**
+   - `hours_reconciliation`
+   - `hours_cash_positioning`
+   - `num_banks`
+   - `ftes`
+3. **Challenges**
+   - `pain_points[]` (multiple choice)
+4. **Strategy**
+   - `current_tech`
+   - `business_objective`
+   - `implementation_timeline`
+   - `decision_makers[]`
+   - `budget_range`
+5. **Contact**
+   - `email`
+   - `consent`
+
+Field definitions come from `templates/business-case-form.php` and the field registry in `public/js/rtbcb-wizard.js`.
+
+## AJAX Submission
+
+`public/js/rtbcb-wizard.js` serializes the form and posts it to WordPress’s AJAX endpoint with the action `rtbcb_generate_case`. On success, the returned report data is rendered in the page; otherwise an error overlay is displayed.
+
+## Server-side Processing
+
+`Real_Treasury_BCB::ajax_generate_comprehensive_case()` validates the request and orchestrates report generation:
+
+1. **ROI Calculation** – `RTBCB_Calculator::calculate_roi()` builds conservative, base, and optimistic scenarios.
+2. **Category Recommendation** – `RTBCB_Category_Recommender::recommend_category()` scores the selected challenges to suggest a treasury solution type.
+3. **RAG Search** – `RTBCB_RAG::search_similar()` retrieves supporting context using the company profile and pain points.
+4. **OpenAI Call** – `RTBCB_LLM::generate_comprehensive_business_case()` combines user inputs, ROI data, and RAG context to produce narrative analysis.
+5. **Report Assembly** – `get_comprehensive_report_html()` renders the final HTML which is returned in the AJAX response.
+
+## End-to-End Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant JS as Wizard JS
+    participant WP as ajax_generate_comprehensive_case
+    participant ROI as Calculator
+    participant Cat as Recommender
+    participant RAG as RAG
+    participant LLM as OpenAI
+    participant HTML as Report
+
+    U->>JS: Complete wizard
+    JS->>WP: POST rtbcb_generate_case
+    WP->>ROI: calculate_roi()
+    WP->>Cat: recommend_category()
+    WP->>RAG: search_similar()
+    WP->>LLM: generate_comprehensive_business_case()
+    LLM-->>WP: analysis
+    WP->>HTML: get_comprehensive_report_html()
+    WP-->>JS: JSON report
+    JS-->>U: Display results
+```
+


### PR DESCRIPTION
## Summary
- document wizard steps and backend call flow
- link wizard/API docs from workflow guide and README
- note new documentation in release notes

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2837fb3648331ae0686ee0880cfb9