### PR TITLE
Queue OpenAI responses in background

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -99,6 +99,8 @@ class Real_Treasury_BCB {
         add_action( 'wp_ajax_nopriv_rtbcb_generate_case', [ $this, 'ajax_generate_comprehensive_case_debug' ] );
         add_action( 'wp_ajax_rtbcb_openai_responses', 'rtbcb_proxy_openai_responses' );
         add_action( 'wp_ajax_nopriv_rtbcb_openai_responses', 'rtbcb_proxy_openai_responses' );
+        add_action( 'wp_ajax_rtbcb_openai_job_status', 'rtbcb_get_openai_job_status' );
+        add_action( 'wp_ajax_nopriv_rtbcb_openai_job_status', 'rtbcb_get_openai_job_status' );
 
         $this->init_hooks_debug();
     }

--- a/tests/temperature-model.test.js
+++ b/tests/temperature-model.test.js
@@ -27,14 +27,27 @@ async function runTests() {
             if (!options) {
                 return Promise.resolve({ ok: true, text: () => Promise.resolve(templateHtml) });
             }
-            capturedBody = JSON.parse(options.body.store.body);
-            return Promise.resolve({
-                ok: true,
-                json: () => Promise.resolve({ output_text: '<html></html>' }),
-                status: 200,
-                statusText: 'OK',
-                text: () => Promise.resolve('')
-            });
+            const action = options.body.store.action;
+            if (action === 'rtbcb_openai_responses') {
+                capturedBody = JSON.parse(options.body.store.body);
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ success: true, data: { job_id: 'job-123' } }),
+                    status: 200,
+                    statusText: 'OK',
+                    text: () => Promise.resolve('')
+                });
+            }
+            if (action === 'rtbcb_openai_job_status') {
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ output_text: '<html></html>' }),
+                    status: 200,
+                    statusText: 'OK',
+                    text: () => Promise.resolve('')
+                });
+            }
+            return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found', text: () => Promise.resolve('') });
         };
 
         global.document = { getElementById: () => null };


### PR DESCRIPTION
## Summary
- Queue OpenAI Responses API calls via `wp_schedule_single_event` and store results in transients
- Add AJAX endpoint for polling job status and hook it up on front end
- Update temperature model test for queued workflow

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b285169d148331a8e4c4282d7d472c