### PR TITLE
docs: add documentation guidelines

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,29 @@
+# Documentation Contribution Guidelines
+
+Follow these instructions for files inside `docs/`.
+
+## Markdown Style
+
+- Use Title Case for headings.
+- Leave one blank line after headings and between paragraphs.
+- Use `-` for unordered lists and incrementing numbers for ordered lists.
+- Keep lines under 120 characters when practical; do not force line wraps in the middle of sentences.
+- Add language identifiers to fenced code blocks.
+
+## Linting and Link Checking
+
+Run the following commands from the repository root after modifying documentation:
+
+```bash
+npx --yes markdownlint-cli@latest "docs/**/*.md" --disable MD013
+npx --yes markdown-link-check@latest docs/<file>.md
+```
+
+`markdownlint-cli` enforces style rules with the long-line rule disabled (`MD013`).
+`markdown-link-check` verifies that all links resolve.
+
+## Additional Standards
+
+- Store documentation in the `docs/` directory.
+- Prefer relative links to other documents in this repository.
+- Keep code examples minimal and focused on illustrating behavior.


### PR DESCRIPTION
## Summary
- document markdown style conventions and lint commands
- outline link checking requirements
- note repo-specific documentation standards

## Testing
- `npx --yes markdownlint-cli@latest docs/AGENTS.md --disable MD013`
- `npx --yes markdownlint-cli@latest "docs/**/*.md" --disable MD013`
- `npx --yes markdown-link-check@latest docs/AGENTS.md`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b285957bcc8331ac6e4d47cb0cfdc8