### PR TITLE
Refactor OpenAI request handling to run asynchronously

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -99,6 +99,8 @@ class Real_Treasury_BCB {
         add_action( 'wp_ajax_nopriv_rtbcb_generate_case', [ $this, 'ajax_generate_comprehensive_case_debug' ] );
         add_action( 'wp_ajax_rtbcb_openai_responses', 'rtbcb_proxy_openai_responses' );
         add_action( 'wp_ajax_nopriv_rtbcb_openai_responses', 'rtbcb_proxy_openai_responses' );
+        add_action( 'wp_ajax_rtbcb_openai_responses_status', 'rtbcb_get_openai_responses_status' );
+        add_action( 'wp_ajax_nopriv_rtbcb_openai_responses_status', 'rtbcb_get_openai_responses_status' );
 
         $this->init_hooks_debug();
     }

--- a/tests/temperature-model.test.js
+++ b/tests/temperature-model.test.js
@@ -23,17 +23,26 @@ async function runTests() {
         let capturedBody;
         global.rtbcbReport = { report_model: model, model_capabilities: capabilities, ajax_url: 'https://example.com', template_url: 'template.html' };
 
+        let requestCount = 0;
         global.fetch = (url, options) => {
             if (!options) {
                 return Promise.resolve({ ok: true, text: () => Promise.resolve(templateHtml) });
             }
-            capturedBody = JSON.parse(options.body.store.body);
+            requestCount++;
+            if (requestCount === 1) {
+                capturedBody = JSON.parse(options.body.store.body);
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ success: true, data: { job_id: 'job-1' } }),
+                    status: 200,
+                    statusText: 'OK'
+                });
+            }
             return Promise.resolve({
                 ok: true,
-                json: () => Promise.resolve({ output_text: '<html></html>' }),
+                json: () => Promise.resolve({ success: true, data: { status: 'complete', response: { output_text: '<html></html>' } } }),
                 status: 200,
-                statusText: 'OK',
-                text: () => Promise.resolve('')
+                statusText: 'OK'
             });
         };
 


### PR DESCRIPTION
## Summary
- offload OpenAI calls to a scheduled background job and expose a polling endpoint for results
- register AJAX hooks for job status
- update front-end reporting JS to poll for OpenAI job completion
- adjust temperature model test for asynchronous flow

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`
- `phpcs --standard=WordPress inc/helpers.php real-treasury-business-case-builder.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2882b53a88331af19790a9e363d5a