### PR TITLE
Add ABSPATH guards to inc PHP files

### DIFF
--- a/inc/class-rtbcb-api-log.php
+++ b/inc/class-rtbcb-api-log.php
@@ -1,4 +1,6 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * API log management class.
  *

--- a/inc/class-rtbcb-api-tester.php
+++ b/inc/class-rtbcb-api-tester.php
@@ -1,4 +1,6 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * API connection testing utilities.
  *

--- a/inc/class-rtbcb-calculator.php
+++ b/inc/class-rtbcb-calculator.php
@@ -1,4 +1,6 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * ROI calculation utilities.
  *

--- a/inc/class-rtbcb-category-recommender.php
+++ b/inc/class-rtbcb-category-recommender.php
@@ -1,4 +1,6 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Treasury tool category recommendation engine.
  *

--- a/inc/class-rtbcb-db.php
+++ b/inc/class-rtbcb-db.php
@@ -1,4 +1,6 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Database management and migration handling.
  *

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -1,4 +1,6 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Enhanced leads management for tracking form submissions.
  *

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -1,11 +1,11 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Enhanced LLM integration with comprehensive business analysis
  *
  * @package RealTreasuryBusinessCaseBuilder
  */
-
-defined( 'ABSPATH' ) || exit;
 
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/helpers.php';

--- a/inc/class-rtbcb-logger.php
+++ b/inc/class-rtbcb-logger.php
@@ -1,11 +1,11 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Structured logging utilities.
  *
  * @package RealTreasuryBusinessCaseBuilder
  */
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * Structured logging for API interactions.

--- a/inc/class-rtbcb-maturity-model.php
+++ b/inc/class-rtbcb-maturity-model.php
@@ -1,13 +1,11 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Simple treasury maturity model.
  *
  * @package RealTreasuryBusinessCaseBuilder
  */
-
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
 
 /**
  * Provides a basic maturity assessment.

--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -1,4 +1,6 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Implements Retrieval-Augmented Generation logic for the plugin.
  *

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -1,11 +1,11 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Routes model selection based on request complexity.
  *
  * @package RealTreasuryBusinessCaseBuilder
  */
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * Class RTBCB_Router.

--- a/inc/class-rtbcb-settings.php
+++ b/inc/class-rtbcb-settings.php
@@ -1,4 +1,6 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Settings management for default ROI assumptions.
  *

--- a/inc/class-rtbcb-tests.php
+++ b/inc/class-rtbcb-tests.php
@@ -1,4 +1,6 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Integration test utilities.
  *

--- a/inc/class-rtbcb-validator.php
+++ b/inc/class-rtbcb-validator.php
@@ -1,4 +1,6 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Data validation utilities.
  *

--- a/inc/config.php
+++ b/inc/config.php
@@ -1,11 +1,11 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Configuration defaults for Real Treasury Business Case Builder.
  *
  * @package RealTreasuryBusinessCaseBuilder
  */
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * Retrieve the default model for a given tier.

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1,11 +1,9 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Helper functions for the Real Treasury Business Case Builder plugin.
  */
-
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
 
 require_once __DIR__ . '/config.php';
 

--- a/inc/model-capabilities.php
+++ b/inc/model-capabilities.php
@@ -1,4 +1,6 @@
 <?php
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Model capability configuration.
  *


### PR DESCRIPTION
## Summary
- ensure all PHP files in `inc/` exit when accessed directly

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found; SyntaxError in temperature-model.test.js)*
- `phpcs --standard=WordPress` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2859897808331a7233f1fee37e330