### PR TITLE
Update ABSPATH example in root AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - Use four spaces for indentation.
 - Prefix global functions with `rtbcb_`.
 - Prefix class names with `RTBCB_`.
-- Start each PHP file with `defined('ABSPATH') || exit;`.
+- Start each PHP file with `defined( 'ABSPATH' ) || exit;`.
 - Sanitize and escape all input and output with the appropriate `esc_*` function.
 - Wrap user visible strings in translation functions like `__( 'text', 'rtbcb' )`.
 - Do not modify code in the `vendor/` directory; it contains third-party dependencies.


### PR DESCRIPTION
## Summary
- align ABSPATH guard example with WordPress spacing conventions in root AGENTS instructions

## Testing
- `bash tests/run-tests.sh` *(fails: phpunit: command not found; tests complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b2859c3d288331a89da0a9c8720d82