### PR TITLE
docs: clarify indentation guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AI Coding Guidelines for Real Treasury Business Case Builder
 
 - Follow [WordPress PHP coding standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/).
-- Use four spaces for indentation.
+- Use tabs for indentation; spaces only for alignment per WordPress PHP standards.
 - Prefix global functions with `rtbcb_`.
 - Prefix class names with `RTBCB_`.
 - Start each PHP file with `defined('ABSPATH') || exit;`.


### PR DESCRIPTION
## Summary
- specify using tabs for indentation per WordPress standards, with spaces only for alignment

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2859fc69883319848c6f4142d44cb