### PR TITLE
Add global timeout and smarter retry handling

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -37,15 +37,16 @@ function rtbcb_get_default_model( $tier ) {
  */
 function rtbcb_get_gpt5_config( $overrides = [] ) {
     $defaults = [
-        'model'             => 'gpt-5-mini',
-        'max_output_tokens' => 8000,
-        'temperature'       => 0.7,
-        'store'             => true,
-        'timeout'           => 180,
-        'max_retries'       => 2,
-        'reasoning_effort'  => 'medium',
-        'text_verbosity'    => 'medium',
-    ];
+'model'             => 'gpt-5-mini',
+'max_output_tokens' => 8000,
+'temperature'       => 0.7,
+'store'             => true,
+'timeout'           => 180,
+'max_retries'       => 2,
+'global_timeout'    => 300,
+'reasoning_effort'  => 'medium',
+'text_verbosity'    => 'medium',
+];
 
     $file_overrides = [];
     $config_path    = dirname( __DIR__ ) . '/rtbcb-config.json';


### PR DESCRIPTION
## Summary
- introduce configurable `global_timeout` for GPT-5 requests
- implement exponential backoff with jitter and early abort for unrecoverable errors
- add helper to classify recoverable LLM errors

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-5-mini bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b28ec34ef88331881e24b8205625f6