### PR TITLE
Allow higher max output tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ A comprehensive WordPress plugin that helps treasury teams quantify the benefits
 
    The API tester uses this value to verify connectivity.
 
-   By default, the plugin configures `max_output_tokens` to `8000` for GPT-5 models.
-   You can adjust this value up to `8000` tokens via the plugin settings,
-   by setting an environment variable, or by creating a configuration file:
+By default, the plugin configures `max_output_tokens` to `8000` for GPT-5 models.
+You can adjust this value up to `128000` tokens via the plugin settings,
+by setting an environment variable, or by creating a configuration file:
 
-   - **Environment variable**: `RTBCB_MAX_OUTPUT_TOKENS=8000`
-   - **Config file**: create `rtbcb-config.json` in the project root with
-     `{ "max_output_tokens": 8000 }`
+- **Environment variable**: `RTBCB_MAX_OUTPUT_TOKENS=128000`
+- **Config file**: create `rtbcb-config.json` in the project root with
+`{ "max_output_tokens": 128000 }`
 
-   Values outside the `256`–`8000` range are ignored.
+Values outside the `256`–`128000` range are ignored.
 
 #### Model Temperature Support
 

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -114,8 +114,8 @@ $embedding_models = [
                     <label for="rtbcb_gpt5_max_output_tokens"><?php echo esc_html__( 'Max Output Tokens', 'rtbcb' ); ?></label>
                 </th>
                 <td>
-                    <input type="number" id="rtbcb_gpt5_max_output_tokens" name="rtbcb_gpt5_max_output_tokens" value="<?php echo esc_attr( $gpt5_max_output_tokens ); ?>" class="small-text" min="256" max="8000" />
-                    <p class="description"><?php echo esc_html__( 'Maximum tokens returned by OpenAI (max 8000).', 'rtbcb' ); ?></p>
+                    <input type="number" id="rtbcb_gpt5_max_output_tokens" name="rtbcb_gpt5_max_output_tokens" value="<?php echo esc_attr( $gpt5_max_output_tokens ); ?>" class="small-text" min="256" max="128000" />
+                    <p class="description"><?php echo esc_html__( 'Maximum tokens returned by OpenAI (max 128000).', 'rtbcb' ); ?></p>
                 </td>
             </tr>
             <tr>

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -107,8 +107,8 @@ class RTBCB_LLM {
     private function estimate_tokens( $words ) {
         $words  = max( 0, intval( $words ) );
         $tokens = (int) ceil( $words * 1.5 );
-        $limit  = intval( $this->gpt5_config['max_output_tokens'] ?? 8000 );
-        $limit  = min( 8000, max( 256, $limit ) );
+$limit  = intval( $this->gpt5_config['max_output_tokens'] ?? 8000 );
+$limit  = min( 128000, max( 256, $limit ) );
 
         return min( $tokens, $limit );
     }
@@ -1809,7 +1809,7 @@ SYSTEM;
         $model_name       = rtbcb_normalize_model_name( $model_name );
         $default_tokens    = intval( $this->gpt5_config['max_output_tokens'] ?? 8000 );
         $max_output_tokens = intval( $max_output_tokens ?? $default_tokens );
-        $max_output_tokens = min( 8000, max( 256, $max_output_tokens ) );
+$max_output_tokens = min( 128000, max( 256, $max_output_tokens ) );
 
         if ( is_array( $prompt ) && isset( $prompt['input'] ) ) {
             $instructions = sanitize_textarea_field( $prompt['instructions'] ?? '' );

--- a/inc/config.php
+++ b/inc/config.php
@@ -70,7 +70,7 @@ function rtbcb_get_gpt5_config( $overrides = [] ) {
     $overrides = array_merge( $file_overrides, $overrides );
 
     $config = array_merge( $defaults, array_intersect_key( $overrides, $defaults ) );
-    $config['max_output_tokens'] = min( 8000, max( 256, intval( $config['max_output_tokens'] ) ) );
+    $config['max_output_tokens'] = min( 128000, max( 256, intval( $config['max_output_tokens'] ) ) );
     $config['max_retry_time']    = max( 1, intval( $config['max_retry_time'] ) );
 
     return $config;

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -128,7 +128,7 @@ function rtbcb_model_supports_temperature( $model ) {
 /**
  * Sanitize the max output tokens option.
  *
- * Ensures the value stays within the allowed 256-8000 token range.
+ * Ensures the value stays within the allowed 256-128000 token range.
  *
  * @param mixed $value Raw option value.
  * @return int Sanitized token count.
@@ -136,7 +136,7 @@ function rtbcb_model_supports_temperature( $model ) {
 function rtbcb_sanitize_max_output_tokens( $value ) {
     $value = intval( $value );
 
-    return min( 8000, max( 256, $value ) );
+    return min( 128000, max( 256, $value ) );
 }
 
 /**
@@ -1222,7 +1222,7 @@ function rtbcb_proxy_openai_responses() {
 
     $config            = rtbcb_get_gpt5_config();
     $max_output_tokens = intval( $body_array['max_output_tokens'] ?? $config['max_output_tokens'] );
-    $max_output_tokens = min( 8000, max( 256, $max_output_tokens ) );
+    $max_output_tokens = min( 128000, max( 256, $max_output_tokens ) );
     $body_array['max_output_tokens'] = $max_output_tokens;
     $body_array['stream']            = true;
     $payload                         = wp_json_encode( $body_array );

--- a/public/js/rtbcb-report.js
+++ b/public/js/rtbcb-report.js
@@ -2,7 +2,7 @@
  * Generate and display professional reports using OpenAI.
  */
 
-const RTBCB_GPT5_MAX_TOKENS = 8000;
+const RTBCB_GPT5_MAX_TOKENS = 128000;
 const RTBCB_GPT5_DEFAULTS = {
     max_output_tokens: RTBCB_GPT5_MAX_TOKENS,
     text: { verbosity: 'medium' },

--- a/readme.txt
+++ b/readme.txt
@@ -21,14 +21,14 @@ Use the `[rt_business_case_builder]` shortcode to embed the calculator on any pa
 
 == Configuration ==
 By default, OpenAI responses are limited to 8,000 tokens. You can adjust this limit
-up to a maximum of 8,000 tokens through the plugin settings, by setting the `RTBCB_MAX_OUTPUT_TOKENS`
+up to a maximum of 128,000 tokens through the plugin settings, by setting the `RTBCB_MAX_OUTPUT_TOKENS`
 environment variable, or by creating a `rtbcb-config.json` file in the plugin directory with:
 
 ```
-{ "max_output_tokens": 8000 }
+{ "max_output_tokens": 128000 }
 ```
 
-Values outside the 256–8,000 range are ignored.
+Values outside the 256–128,000 range are ignored.
 
 == Testing Dashboard ==
 From the WordPress admin, go to **Real Treasury → Test Dashboard** and click


### PR DESCRIPTION
## Summary
- allow configuring up to 128k output tokens
- sanitize and enforce new token limit in helpers, config, and LLM code
- document new maximum token limit

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit missing; temperature-model.test.js JSON parse error)*
- `phpcs --standard=WordPress` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f08ba1cc8331a58c276d9a4f1c08