### PR TITLE
Improve company field validation in comprehensive case generator

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -756,8 +756,20 @@ class Real_Treasury_BCB {
                     ];
                     update_option( 'rtbcb_current_company', $company );
                 } else {
-                    wp_send_json_error( __( 'No company data found. Please run the company overview first.', 'rtbcb' ), 400 );
-                    return;
+                    if ( empty( $company_name ) ) {
+                        wp_send_json_error( __( 'Please enter your company name.', 'rtbcb' ), 400 );
+                        return;
+                    }
+
+                    if ( empty( $company_size ) ) {
+                        wp_send_json_error( __( 'Please select your company size.', 'rtbcb' ), 400 );
+                        return;
+                    }
+
+                    if ( empty( $industry ) ) {
+                        wp_send_json_error( __( 'Please select your industry.', 'rtbcb' ), 400 );
+                        return;
+                    }
                 }
             }
 

--- a/tests/handle-string-error-response.test.js
+++ b/tests/handle-string-error-response.test.js
@@ -27,7 +27,7 @@ class SimpleFormData {
 global.FormData = SimpleFormData;
 
 global.fetch = function() {
-    const payload = { success: false, data: 'No company data found.' };
+    const payload = { success: false, data: 'Please enter your company name.' };
     const response = {
         ok: false,
         status: 400,
@@ -71,7 +71,7 @@ builder.showError = (msg) => { errorMessage = msg; };
 
 (async () => {
     await builder.handleSubmit();
-    assert.ok(errorMessage.includes('No company data found'));
+    assert.ok(errorMessage.includes('Please enter your company name'));
     assert.ok(errorMessage.includes('AI configuration'));
     console.log('String error response test passed.');
 })().catch(err => {


### PR DESCRIPTION
## Summary
- ensure `ajax_generate_comprehensive_case` validates each company field individually and returns specific messages
- adjust string error-response test to expect specific company-name message

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit not found; temperature-model.test.js reported SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f116b9e0833191ad337c3a978b1b