### PR TITLE
Add workflow tracker and visualizer

### DIFF
--- a/admin/css/rtbcb-admin.css
+++ b/admin/css/rtbcb-admin.css
@@ -320,3 +320,181 @@
     overflow-y: auto;
 }
 
+/* Workflow Visualizer Styles */
+.rtbcb-workflow-visualizer {
+margin: 20px;
+}
+
+.rtbcb-workflow-controls {
+margin: 20px 0;
+padding: 15px;
+background: #f9f9f9;
+border-radius: 8px;
+}
+
+.rtbcb-workflow-controls .button {
+margin-right: 10px;
+}
+
+.rtbcb-workflow-pipeline {
+background: #fff;
+padding: 30px;
+border-radius: 12px;
+box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+margin: 20px 0;
+}
+
+.rtbcb-pipeline-container {
+display: flex;
+align-items: center;
+overflow-x: auto;
+padding: 20px 0;
+min-height: 200px;
+}
+
+.rtbcb-pipeline-step {
+background: #f8f9ff;
+border: 2px solid #e2e8f0;
+border-radius: 12px;
+padding: 20px;
+min-width: 200px;
+text-align: center;
+transition: all 0.3s ease;
+position: relative;
+}
+
+.rtbcb-pipeline-step.completed {
+background: #f0fdf4;
+border-color: #10b981;
+}
+
+.rtbcb-pipeline-step.running {
+background: #fffbeb;
+border-color: #f59e0b;
+animation: pulse 2s infinite;
+}
+
+.rtbcb-pipeline-step.error {
+background: #fef2f2;
+border-color: #ef4444;
+}
+
+.rtbcb-step-icon {
+font-size: 24px;
+margin-bottom: 8px;
+}
+
+.rtbcb-step-title {
+font-weight: 600;
+margin-bottom: 4px;
+color: #1f2937;
+}
+
+.rtbcb-step-description {
+font-size: 12px;
+color: #6b7280;
+margin-bottom: 10px;
+}
+
+.rtbcb-step-metrics {
+font-size: 11px;
+color: #4b5563;
+}
+
+.rtbcb-step-duration {
+background: #e5e7eb;
+padding: 2px 6px;
+border-radius: 4px;
+margin-right: 4px;
+}
+
+.rtbcb-step-status {
+padding: 2px 6px;
+border-radius: 4px;
+font-weight: 500;
+}
+
+.rtbcb-step-status.completed {
+background: #d1fae5;
+color: #065f46;
+}
+
+.rtbcb-step-status.running {
+background: #fef3c7;
+color: #92400e;
+}
+
+.rtbcb-step-status.error {
+background: #fee2e2;
+color: #991b1b;
+}
+
+.rtbcb-step-details {
+margin-top: 8px;
+padding-top: 8px;
+border-top: 1px solid #e5e7eb;
+font-size: 11px;
+}
+
+.rtbcb-pipeline-arrow {
+font-size: 20px;
+color: #9ca3af;
+margin: 0 10px;
+flex-shrink: 0;
+}
+
+.rtbcb-workflow-summary {
+display: flex;
+gap: 30px;
+margin-top: 20px;
+padding: 20px;
+background: #f8f9ff;
+border-radius: 8px;
+}
+
+.rtbcb-summary-item strong {
+display: block;
+color: #374151;
+}
+
+.rtbcb-summary-item small {
+color: #6b7280;
+}
+
+.rtbcb-workflow-history {
+background: #fff;
+padding: 20px;
+border-radius: 8px;
+box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+margin: 20px 0;
+}
+
+@keyframes pulse {
+0%, 100% { opacity: 1; }
+50% { opacity: 0.8; }
+}
+
+.rtbcb-debug-interface {
+background: #fff;
+padding: 20px;
+border-radius: 8px;
+margin-top: 20px;
+}
+
+.rtbcb-debug-tabs {
+border-bottom: 1px solid #e5e7eb;
+margin-bottom: 20px;
+}
+
+.rtbcb-tab-button {
+background: none;
+border: none;
+padding: 10px 20px;
+cursor: pointer;
+border-bottom: 2px solid transparent;
+}
+
+.rtbcb-tab-button.active {
+border-bottom-color: #7216f4;
+color: #7216f4;
+}

--- a/admin/js/workflow-visualizer.js
+++ b/admin/js/workflow-visualizer.js
@@ -1,0 +1,39 @@
+jQuery(function($) {
+function loadHistory() {
+$.post(rtbcbWorkflow.ajax_url, {
+action: 'rtbcb_get_workflow_history',
+nonce: rtbcbWorkflow.nonce
+}).done(function(response) {
+if (response.success) {
+$('#rtbcb-workflow-history-container').text(JSON.stringify(response.data.history));
+alert(rtbcbWorkflow.strings.refresh_success);
+} else {
+alert(rtbcbWorkflow.strings.error);
+}
+}).fail(function() {
+alert(rtbcbWorkflow.strings.error);
+});
+}
+
+$('#rtbcb-refresh-workflow').on('click', function() {
+loadHistory();
+});
+
+$('#rtbcb-clear-workflow').on('click', function() {
+$.post(rtbcbWorkflow.ajax_url, {
+action: 'rtbcb_clear_workflow_history',
+nonce: rtbcbWorkflow.nonce
+}).done(function(response) {
+if (response.success) {
+$('#rtbcb-workflow-history-container').empty();
+alert(rtbcbWorkflow.strings.clear_success);
+} else {
+alert(rtbcbWorkflow.strings.error);
+}
+}).fail(function() {
+alert(rtbcbWorkflow.strings.error);
+});
+});
+
+loadHistory();
+});

--- a/admin/workflow-visualizer-page.php
+++ b/admin/workflow-visualizer-page.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Workflow Visualizer admin page.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+<div class="wrap rtbcb-workflow-visualizer">
+<h1><?php echo esc_html__( 'Treasury Report Workflow Visualizer', 'rtbcb' ); ?></h1>
+
+<div class="rtbcb-workflow-controls">
+<button type="button" id="rtbcb-refresh-workflow" class="button button-primary">
+<?php echo esc_html__( 'Refresh Workflow History', 'rtbcb' ); ?>
+</button>
+<button type="button" id="rtbcb-clear-workflow" class="button">
+<?php echo esc_html__( 'Clear History', 'rtbcb' ); ?>
+</button>
+<button type="button" id="rtbcb-export-workflow" class="button">
+<?php echo esc_html__( 'Export Debug Data', 'rtbcb' ); ?>
+</button>
+</div>
+
+<!-- Workflow Pipeline Visualization -->
+<div class="rtbcb-workflow-pipeline">
+<h2><?php echo esc_html__( 'Enhanced Workflow Pipeline', 'rtbcb' ); ?></h2>
+<div class="rtbcb-pipeline-container">
+<div class="rtbcb-pipeline-step" data-step="input_validation">
+<div class="rtbcb-step-icon">📝</div>
+<div class="rtbcb-step-title"><?php echo esc_html__( 'Input Validation', 'rtbcb' ); ?></div>
+<div class="rtbcb-step-description"><?php echo esc_html__( 'Validate and sanitize user inputs', 'rtbcb' ); ?></div>
+<div class="rtbcb-step-metrics">
+<span class="rtbcb-step-duration">-</span>
+<span class="rtbcb-step-status">pending</span>
+</div>
+</div>
+
+<div class="rtbcb-pipeline-arrow">→</div>
+
+<div class="rtbcb-pipeline-step" data-step="ai_enrichment">
+<div class="rtbcb-step-icon">🧠</div>
+<div class="rtbcb-step-title"><?php echo esc_html__( 'AI Company Enrichment', 'rtbcb' ); ?></div>
+<div class="rtbcb-step-description"><?php echo esc_html__( 'Single consolidated AI analysis', 'rtbcb' ); ?></div>
+<div class="rtbcb-step-metrics">
+<span class="rtbcb-step-duration">-</span>
+<span class="rtbcb-step-status">pending</span>
+</div>
+<div class="rtbcb-step-details">
+<div class="rtbcb-detail-item">
+<strong><?php echo esc_html__( 'AI Calls:', 'rtbcb' ); ?></strong> <span class="rtbcb-ai-calls">1</span>
+</div>
+</div>
+</div>
+
+<div class="rtbcb-pipeline-arrow">→</div>
+
+<div class="rtbcb-pipeline-step" data-step="enhanced_roi_calculation">
+<div class="rtbcb-step-icon">💰</div>
+<div class="rtbcb-step-title"><?php echo esc_html__( 'Enhanced ROI Calculation', 'rtbcb' ); ?></div>
+<div class="rtbcb-step-description"><?php echo esc_html__( 'AI-enhanced financial modeling', 'rtbcb' ); ?></div>
+<div class="rtbcb-step-metrics">
+<span class="rtbcb-step-duration">-</span>
+<span class="rtbcb-step-status">pending</span>
+</div>
+</div>
+
+<div class="rtbcb-pipeline-arrow">→</div>
+
+<div class="rtbcb-pipeline-step" data-step="intelligent_recommendations">
+<div class="rtbcb-step-icon">🎯</div>
+<div class="rtbcb-step-title"><?php echo esc_html__( 'Intelligent Recommendations', 'rtbcb' ); ?></div>
+<div class="rtbcb-step-description"><?php echo esc_html__( 'AI-enhanced category selection', 'rtbcb' ); ?></div>
+<div class="rtbcb-step-metrics">
+<span class="rtbcb-step-duration">-</span>
+<span class="rtbcb-step-status">pending</span>
+</div>
+</div>
+
+<div class="rtbcb-pipeline-arrow">→</div>
+
+<div class="rtbcb-pipeline-step" data-step="hybrid_rag_analysis">
+<div class="rtbcb-step-icon">🔍</div>
+<div class="rtbcb-step-title"><?php echo esc_html__( 'Hybrid RAG Analysis', 'rtbcb' ); ?></div>
+<div class="rtbcb-step-description"><?php echo esc_html__( 'RAG + AI strategic analysis', 'rtbcb' ); ?></div>
+<div class="rtbcb-step-metrics">
+<span class="rtbcb-step-duration">-</span>
+<span class="rtbcb-step-status">pending</span>
+</div>
+<div class="rtbcb-step-details">
+<div class="rtbcb-detail-item">
+<strong><?php echo esc_html__( 'AI Calls:', 'rtbcb' ); ?></strong> <span class="rtbcb-ai-calls">1</span>
+</div>
+</div>
+</div>
+
+<div class="rtbcb-pipeline-arrow">→</div>
+
+<div class="rtbcb-pipeline-step" data-step="data_structuring">
+<div class="rtbcb-step-icon">📊</div>
+<div class="rtbcb-step-title"><?php echo esc_html__( 'Data Structuring', 'rtbcb' ); ?></div>
+<div class="rtbcb-step-description"><?php echo esc_html__( 'Prepare structured report data', 'rtbcb' ); ?></div>
+<div class="rtbcb-step-metrics">
+<span class="rtbcb-step-duration">-</span>
+<span class="rtbcb-step-status">pending</span>
+</div>
+</div>
+</div>
+
+<div class="rtbcb-workflow-summary">
+<div class="rtbcb-summary-item">
+<strong><?php echo esc_html__( 'Total AI Calls:', 'rtbcb' ); ?></strong>
+<span id="rtbcb-total-ai-calls">2</span>
+<small><?php echo esc_html__( '(vs 5-8 in old workflow)', 'rtbcb' ); ?></small>
+</div>
+<div class="rtbcb-summary-item">
+<strong><?php echo esc_html__( 'Expected Duration:', 'rtbcb' ); ?></strong>
+<span>30-60s</span>
+<small><?php echo esc_html__( '(vs 90-180s previously)', 'rtbcb' ); ?></small>
+</div>
+<div class="rtbcb-summary-item">
+<strong><?php echo esc_html__( 'Data Flow:', 'rtbcb' ); ?></strong>
+<span><?php echo esc_html__( 'AI First → Enhanced Logic → Template', 'rtbcb' ); ?></span>
+</div>
+</div>
+</div>
+
+<!-- Recent Workflow Executions -->
+<div class="rtbcb-workflow-history">
+<h2><?php echo esc_html__( 'Recent Workflow Executions', 'rtbcb' ); ?></h2>
+<div id="rtbcb-workflow-history-container">
+<div class="rtbcb-loading"><?php echo esc_html__( 'Loading workflow history...', 'rtbcb' ); ?></div>
+</div>
+</div>
+
+<!-- Debug Interface -->
+<div class="rtbcb-debug-interface" style="display: none;">
+<h2><?php echo esc_html__( 'Debug Information', 'rtbcb' ); ?></h2>
+<div class="rtbcb-debug-tabs">
+<button type="button" class="rtbcb-tab-button active" data-tab="prompts">
+<?php echo esc_html__( 'AI Prompts', 'rtbcb' ); ?>
+</button>
+<button type="button" class="rtbcb-tab-button" data-tab="responses">
+<?php echo esc_html__( 'AI Responses', 'rtbcb' ); ?>
+</button>
+<button type="button" class="rtbcb-tab-button" data-tab="performance">
+<?php echo esc_html__( 'Performance', 'rtbcb' ); ?>
+</button>
+<button type="button" class="rtbcb-tab-button" data-tab="errors">
+<?php echo esc_html__( 'Errors & Warnings', 'rtbcb' ); ?>
+</button>
+</div>
+<div id="rtbcb-debug-content"></div>
+</div>
+</div>


### PR DESCRIPTION
## Summary
- expand workflow tracker to record step timings, warnings, and AI call counts
- add workflow visualizer admin page with dedicated script and stylesheet rules
- wire up new admin menu and AJAX handlers for workflow history management

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found; several JS tests output errors)*
- `phpcs --standard=WordPress` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b302b408a083318fa9af3b50b1c257