### PR TITLE
Add PHP limit and AJAX headers in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,16 @@
+# Increase PHP limits for RTBCB
+php_value memory_limit 512M
+php_value max_execution_time 300
+php_value max_input_time 300
+php_value post_max_size 50M
+php_value upload_max_filesize 50M
+
+# Disable output compression for AJAX
+<IfModule mod_env.c>
+SetEnvIf Request_URI "admin-ajax\.php" no-gzip dont-vary
+</IfModule>
+
+# Ensure proper content type for AJAX
+<FilesMatch "admin-ajax\.php$">
+Header set Content-Type "application/json; charset=utf-8"
+</FilesMatch>


### PR DESCRIPTION
## Summary
- configure PHP memory, execution, and upload limits via `.htaccess`
- disable output compression and enforce JSON content type for `admin-ajax.php`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4 bash tests/run-tests.sh` *(phpunit not installed, temperature-model test threw SyntaxError)*
- `phpcs --standard=WordPress` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b30b916ad883319639359223b20ed7