### PR TITLE
feat: log and display workflow prompts

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -102,11 +102,12 @@ class RTBCB_Admin {
                 [
                     'ajax_url' => admin_url( 'admin-ajax.php' ),
                     'nonce'    => wp_create_nonce( 'rtbcb_workflow_visualizer' ),
-                    'strings'  => [
-                        'refresh_success' => __( 'Workflow history refreshed', 'rtbcb' ),
-                        'clear_success'   => __( 'Workflow history cleared', 'rtbcb' ),
-                        'error'           => __( 'An error occurred', 'rtbcb' ),
-                    ],
+                        'strings'  => [
+                                'refresh_success' => __( 'Workflow history refreshed', 'rtbcb' ),
+                                'clear_success'   => __( 'Workflow history cleared', 'rtbcb' ),
+                                'error'           => __( 'An error occurred', 'rtbcb' ),
+                                'no_history'      => __( 'No workflow history available.', 'rtbcb' ),
+                        ],
                 ]
             );
         }
@@ -2028,9 +2029,10 @@ class RTBCB_Admin {
 		wp_send_json_success();
 	}
 
-	private function get_workflow_history_from_logs() {
-		return [];
-	}
+       private function get_workflow_history_from_logs() {
+               $history = get_option( 'rtbcb_workflow_history', [] );
+               return is_array( $history ) ? $history : [];
+       }
 
 	private function calculate_average_duration( $history ) {
 		if ( empty( $history ) ) {

--- a/admin/js/workflow-visualizer.js
+++ b/admin/js/workflow-visualizer.js
@@ -4,12 +4,31 @@ $.post(rtbcbWorkflow.ajax_url, {
 action: 'rtbcb_get_workflow_history',
 nonce: rtbcbWorkflow.nonce
 }).done(function(response) {
-if (response.success) {
-$('#rtbcb-workflow-history-container').text(JSON.stringify(response.data.history));
-alert(rtbcbWorkflow.strings.refresh_success);
-} else {
-alert(rtbcbWorkflow.strings.error);
-}
+    if (response.success) {
+        var history = response.data.history || [];
+        var html = '';
+        history.forEach(function(item, index) {
+            if (item.prompts && item.prompts.length) {
+                html += '<h3>Execution ' + (index + 1) + '</h3><ul>';
+                item.prompts.forEach(function(p) {
+                    var txt = '';
+                    if (p.instructions) {
+                        txt += p.instructions + "\n";
+                    }
+                    txt += p.input;
+                    html += '<li><pre>' + $('<div>').text(txt).html() + '</pre></li>';
+                });
+                html += '</ul>';
+            }
+        });
+        if (!html) {
+            html = '<p>' + rtbcbWorkflow.strings.no_history + '</p>';
+        }
+        $('#rtbcb-workflow-history-container').html(html);
+        alert(rtbcbWorkflow.strings.refresh_success);
+    } else {
+        alert(rtbcbWorkflow.strings.error);
+    }
 }).fail(function() {
 alert(rtbcbWorkflow.strings.error);
 });

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2464,6 +2464,8 @@ $max_output_tokens = min( 128000, max( 256, $max_output_tokens ) );
         // Enable streaming so partial chunks are returned progressively.
         $body['stream'] = true;
 
+        do_action( 'rtbcb_llm_prompt_sent', $body );
+
         $timeout   = intval( $this->gpt5_config['timeout'] ?? 180 );
         $payload   = wp_json_encode( $body );
         $streamed  = '';

--- a/inc/class-rtbcb-workflow-tracker.php
+++ b/inc/class-rtbcb-workflow-tracker.php
@@ -50,6 +50,13 @@ private $errors = [];
 private $ai_calls = 0;
 
 /**
+ * Recorded prompts sent to the AI.
+ *
+ * @var array
+ */
+private $prompts = [];
+
+/**
  * Constructor.
  */
 public function __construct() {
@@ -160,6 +167,31 @@ $this->steps
 }
 
 /**
+ * Record a prompt sent to the AI service.
+ *
+ * @param array $prompt Prompt data containing 'instructions' and 'input'.
+ * @return void
+ */
+public function add_prompt( $prompt ) {
+$step_name      = $this->current_step ? $this->current_step['name'] : 'unknown';
+$this->prompts[] = [
+'step'         => $step_name,
+'instructions' => sanitize_textarea_field( $prompt['instructions'] ?? '' ),
+'input'        => sanitize_textarea_field( $prompt['input'] ?? '' ),
+'timestamp'    => microtime( true ),
+];
+}
+
+/**
+ * Retrieve recorded prompts.
+ *
+ * @return array
+ */
+public function get_prompts() {
+return $this->prompts;
+}
+
+/**
  * Get AI call count.
  *
  * @return int
@@ -190,6 +222,7 @@ return [
 'warnings_count' => count( $this->warnings ),
 'errors_count'   => count( $this->errors ),
 'steps'          => $this->get_completed_steps(),
+'prompts'        => $this->prompts,
 'warnings'       => $this->warnings,
 'errors'         => $this->errors,
 ];


### PR DESCRIPTION
## Summary
- track AI prompts in workflow tracker and expose them in debug info
- hook LLM calls to log prompts and persist workflow history
- surface saved prompts in admin workflow visualizer

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b30fd20f7883318c17017752612603