### PR TITLE
Add configurable minimum output tokens setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A comprehensive WordPress plugin that helps treasury teams quantify the benefits
    - **Premium Model**: `gpt-5` (for complex requests)
    - **Embedding Model**: `text-embedding-3-small` (for RAG)
 
-   **Minimum Output Tokens:** set `max_output_tokens` to at least `256` when using `gpt-5-mini`.
+   **Minimum Output Tokens:** configure `min_output_tokens` (default `256`) to avoid truncated responses.
 
    ```php
    $client->chat()->create([
@@ -44,9 +44,10 @@ A comprehensive WordPress plugin that helps treasury teams quantify the benefits
 
    The API tester uses this value to verify connectivity.
 
-By default, the plugin configures `max_output_tokens` to `8000` for GPT-5 models.
-You can adjust this value up to `128000` tokens via the plugin settings,
-by setting an environment variable, or by creating a configuration file:
+By default, the plugin configures `max_output_tokens` to `8000` and
+`min_output_tokens` to `256` for GPT-5 models. You can adjust these values
+via the plugin settings, by setting environment variables, or by creating a
+configuration file:
 
 - **Environment variable**: `RTBCB_MAX_OUTPUT_TOKENS=128000`
 - **Config file**: create `rtbcb-config.json` in the project root with

--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -492,6 +492,7 @@ class RTBCB_Admin {
         register_setting( 'rtbcb_settings', 'rtbcb_bank_fee_baseline', [ 'sanitize_callback' => 'floatval' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_timeout', [ 'sanitize_callback' => 'intval' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_max_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_max_output_tokens' ] );
+        register_setting( 'rtbcb_settings', 'rtbcb_gpt5_min_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_min_output_tokens' ] );
     }
 
     /**

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -17,6 +17,7 @@ $labor_cost      = get_option( 'rtbcb_labor_cost_per_hour', '' );
 $bank_fee        = get_option( 'rtbcb_bank_fee_baseline', '' );
 $gpt5_timeout    = get_option( 'rtbcb_gpt5_timeout', 300 );
 $gpt5_max_output_tokens = get_option( 'rtbcb_gpt5_max_output_tokens', 8000 );
+$gpt5_min_output_tokens = get_option( 'rtbcb_gpt5_min_output_tokens', 256 );
 
 $chat_models = [
     'gpt-5'             => 'gpt-5',
@@ -107,6 +108,15 @@ $embedding_models = [
                 <td>
                     <input type="number" id="rtbcb_gpt5_timeout" name="rtbcb_gpt5_timeout" value="<?php echo esc_attr( $gpt5_timeout ); ?>" class="small-text" />
                     <p class="description"><?php echo esc_html__( 'Maximum time to wait for OpenAI responses.', 'rtbcb' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="rtbcb_gpt5_min_output_tokens"><?php echo esc_html__( 'Min Output Tokens', 'rtbcb' ); ?></label>
+                </th>
+                <td>
+                    <input type="number" id="rtbcb_gpt5_min_output_tokens" name="rtbcb_gpt5_min_output_tokens" value="<?php echo esc_attr( $gpt5_min_output_tokens ); ?>" class="small-text" min="1" max="128000" />
+                    <p class="description"><?php echo esc_html__( 'Minimum tokens returned by OpenAI.', 'rtbcb' ); ?></p>
                 </td>
             </tr>
             <tr>

--- a/inc/class-rtbcb-api-tester.php
+++ b/inc/class-rtbcb-api-tester.php
@@ -48,10 +48,12 @@ class RTBCB_API_Tester {
     private static function test_completion( $api_key ) {
         $model = get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) );
 
+        $min_tokens = intval( get_option( 'rtbcb_gpt5_min_output_tokens', 256 ) );
+
         $body = [
-            'model' => rtbcb_normalize_model_name( $model ),
-            'input' => 'Test connection - respond with exactly: "API connection successful"',
-            'max_output_tokens' => 256,
+            'model'             => rtbcb_normalize_model_name( $model ),
+            'input'             => 'Test connection - respond with exactly: "API connection successful"',
+            'max_output_tokens' => max( 256, $min_tokens ),
         ];
 
         if ( rtbcb_model_supports_temperature( $model ) ) {

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -105,12 +105,13 @@ class RTBCB_LLM {
      * @return int Estimated token count capped by configuration.
      */
     private function estimate_tokens( $words ) {
-        $words  = max( 0, intval( $words ) );
-        $tokens = (int) ceil( $words * 1.5 );
-$limit  = intval( $this->gpt5_config['max_output_tokens'] ?? 8000 );
-$limit  = min( 128000, max( 256, $limit ) );
+        $words       = max( 0, intval( $words ) );
+        $tokens      = (int) ceil( $words * 1.5 );
+        $limit       = intval( $this->gpt5_config['max_output_tokens'] ?? 8000 );
+        $min_tokens  = intval( $this->gpt5_config['min_output_tokens'] ?? 1 );
+        $limit       = min( 128000, max( $min_tokens, $limit ) );
 
-        return min( $tokens, $limit );
+        return max( $min_tokens, min( $tokens, $limit ) );
     }
 
     /**
@@ -2348,7 +2349,8 @@ return $analysis;
 
             if ( $attempt < $max_retries ) {
                 if ( null !== $current_tokens ) {
-                    $current_tokens = max( 256, (int) ( $current_tokens * 0.9 ) );
+                    $min_tokens    = intval( $this->gpt5_config['min_output_tokens'] ?? 1 );
+                    $current_tokens = max( $min_tokens, (int) ( $current_tokens * 0.9 ) );
                 }
 
                 $current_timeout = min( $current_timeout + 5, $max_retry_time );
@@ -2420,7 +2422,8 @@ return $analysis;
         $model_name       = rtbcb_normalize_model_name( $model_name );
         $default_tokens    = intval( $this->gpt5_config['max_output_tokens'] ?? 8000 );
         $max_output_tokens = intval( $max_output_tokens ?? $default_tokens );
-$max_output_tokens = min( 128000, max( 256, $max_output_tokens ) );
+        $min_tokens        = intval( $this->gpt5_config['min_output_tokens'] ?? 1 );
+        $max_output_tokens = min( 128000, max( $min_tokens, $max_output_tokens ) );
 
         if ( is_array( $prompt ) && isset( $prompt['input'] ) ) {
             $instructions = sanitize_textarea_field( $prompt['instructions'] ?? '' );

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -140,6 +140,20 @@ function rtbcb_sanitize_max_output_tokens( $value ) {
 }
 
 /**
+ * Sanitize the min output tokens option.
+ *
+ * Ensures the value stays within the allowed 1-128000 token range.
+ *
+ * @param mixed $value Raw option value.
+ * @return int Sanitized token count.
+ */
+function rtbcb_sanitize_min_output_tokens( $value ) {
+	$value = intval( $value );
+
+	return min( 128000, max( 1, $value ) );
+}
+
+/**
  * Get testing dashboard sections and their completion state.
  *
  * The returned array is keyed by section ID and contains the section label,
@@ -1222,7 +1236,8 @@ function rtbcb_proxy_openai_responses() {
 
     $config            = rtbcb_get_gpt5_config();
     $max_output_tokens = intval( $body_array['max_output_tokens'] ?? $config['max_output_tokens'] );
-    $max_output_tokens = min( 128000, max( 256, $max_output_tokens ) );
+    $min_tokens        = intval( $config['min_output_tokens'] );
+    $max_output_tokens = min( 128000, max( $min_tokens, $max_output_tokens ) );
     $body_array['max_output_tokens'] = $max_output_tokens;
     $body_array['stream']            = true;
     $payload                         = wp_json_encode( $body_array );

--- a/public/js/rtbcb-report.js
+++ b/public/js/rtbcb-report.js
@@ -3,8 +3,10 @@
  */
 
 const RTBCB_GPT5_MAX_TOKENS = 128000;
+const RTBCB_GPT5_MIN_TOKENS = 1;
 const RTBCB_GPT5_DEFAULTS = {
     max_output_tokens: RTBCB_GPT5_MAX_TOKENS,
+    min_output_tokens: 256,
     text: { verbosity: 'medium' },
     temperature: 0.7,
     store: true,
@@ -59,8 +61,9 @@ async function generateProfessionalReport(businessContext, onChunk) {
     };
     cfg.model = rtbcbReport.report_model;
     const adminLimit = Math.min(RTBCB_GPT5_MAX_TOKENS, parseInt(cfg.max_output_tokens, 10) || RTBCB_GPT5_MAX_TOKENS);
+    const adminMin = Math.max(RTBCB_GPT5_MIN_TOKENS, parseInt(cfg.min_output_tokens, 10) || RTBCB_GPT5_MIN_TOKENS);
     const desiredWords = 1000;
-    cfg.max_output_tokens = Math.min(adminLimit, estimateTokens(desiredWords));
+    cfg.max_output_tokens = Math.max(adminMin, Math.min(adminLimit, estimateTokens(desiredWords)));
     if (!supportsTemperature(cfg.model)) {
         delete cfg.temperature;
     }

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -460,33 +460,36 @@ class Real_Treasury_BCB {
         $api_key      = sanitize_text_field( get_option( 'rtbcb_openai_api_key', '' ) );
         $report_model = sanitize_text_field( get_option( 'rtbcb_advanced_model', 'gpt-5-mini' ) );
 
-        $timeout           = rtbcb_get_api_timeout();
-        $max_output_tokens = intval( get_option( 'rtbcb_gpt5_max_output_tokens', 8000 ) );
-        $config            = rtbcb_get_gpt5_config(
+        $timeout            = rtbcb_get_api_timeout();
+        $max_output_tokens  = intval( get_option( 'rtbcb_gpt5_max_output_tokens', 8000 ) );
+        $min_output_tokens  = intval( get_option( 'rtbcb_gpt5_min_output_tokens', 256 ) );
+        $config             = rtbcb_get_gpt5_config(
             array_merge(
                 get_option( 'rtbcb_gpt5_config', [] ),
                 [
                     'timeout'           => $timeout,
                     'max_output_tokens' => $max_output_tokens,
+                    'min_output_tokens' => $min_output_tokens,
                 ]
             )
         );
 
         $config_localized = [
-            'model'              => sanitize_text_field( $config['model'] ),
-            'max_output_tokens'  => intval( $config['max_output_tokens'] ),
-            'text'               => [ 'verbosity' => sanitize_text_field( $config['text']['verbosity'] ?? '' ) ],
-            'store'              => (bool) $config['store'],
-            'timeout'            => intval( $config['timeout'] ),
-            'max_retries'        => intval( $config['max_retries'] ),
-            'max_retry_time'     => intval( $config['max_retry_time'] ),
+            'model'             => sanitize_text_field( $config['model'] ),
+            'max_output_tokens' => intval( $config['max_output_tokens'] ),
+            'min_output_tokens' => intval( $config['min_output_tokens'] ),
+            'text'              => [ 'verbosity' => sanitize_text_field( $config['text']['verbosity'] ?? '' ) ],
+            'store'             => (bool) $config['store'],
+            'timeout'           => intval( $config['timeout'] ),
+            'max_retries'       => intval( $config['max_retries'] ),
+            'max_retry_time'    => intval( $config['max_retry_time'] ),
         ];
 
         if ( rtbcb_model_supports_temperature( $config['model'] ) ) {
             $config_localized['temperature'] = floatval( $config['temperature'] );
         }
 
-        $supported = [ 'model', 'max_output_tokens', 'text', 'temperature', 'store', 'timeout', 'max_retries', 'max_retry_time' ];
+        $supported = [ 'model', 'max_output_tokens', 'min_output_tokens', 'text', 'temperature', 'store', 'timeout', 'max_retries', 'max_retry_time' ];
         $config_localized = array_intersect_key( $config_localized, array_flip( $supported ) );
 
         $model_capabilities = rtbcb_get_model_capabilities();
@@ -495,12 +498,13 @@ class Real_Treasury_BCB {
             'rtbcb-report',
             'rtbcbReport',
             [
-                'report_model'       => $report_model,
-                'max_output_tokens'  => intval( $config['max_output_tokens'] ),
-                'defaults'           => $config_localized,
-                'model_capabilities' => $model_capabilities,
-                'ajax_url'           => admin_url( 'admin-ajax.php' ),
-                'template_url'       => RTBCB_URL . 'public/templates/report-template.html',
+                'report_model'      => $report_model,
+                'max_output_tokens' => intval( $config['max_output_tokens'] ),
+                'min_output_tokens' => intval( $config['min_output_tokens'] ),
+                'defaults'          => $config_localized,
+                'model_capabilities'=> $model_capabilities,
+                'ajax_url'          => admin_url( 'admin-ajax.php' ),
+                'template_url'      => RTBCB_URL . 'public/templates/report-template.html',
             ]
         );
     }

--- a/tests/helpers/capture-call-openai-body.php
+++ b/tests/helpers/capture-call-openai-body.php
@@ -1,6 +1,10 @@
 <?php
 // Generate a mock server-side OpenAI request body for temperature tests.
 
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ . '/../../' );
+}
+
 $model = getenv( 'RTBCB_TEST_MODEL' );
 $model = $model ? preg_replace( '/[^A-Za-z0-9\-_.]/', '', $model ) : 'gpt-5-mini';
 $model = preg_replace( '/^(gpt-[^\s]+?)(?:-\d{4}-\d{2}-\d{2})$/', '$1', $model );

--- a/tests/min-output-tokens.test.js
+++ b/tests/min-output-tokens.test.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+async function runTests() {
+    const code = fs.readFileSync('public/js/rtbcb-report.js', 'utf8');
+    vm.runInThisContext(code);
+
+    global.FormData = class { constructor() { this.store = {}; } append(k, v) { this.store[k] = v; } };
+    global.document = { getElementById: () => null };
+    global.DOMPurify = { sanitize: (html) => html };
+
+    let capturedBody;
+    global.rtbcbReport = {
+        report_model: 'gpt-5-mini',
+        model_capabilities: {},
+        ajax_url: 'https://example.com',
+        template_url: 'template.html',
+        min_output_tokens: 4000,
+        max_output_tokens: 8000
+    };
+
+    global.fetch = (url, options) => {
+        if (!options) {
+            return Promise.resolve({ ok: true, text: () => Promise.resolve('<html></html>') });
+        }
+        capturedBody = JSON.parse(options.body.store.body);
+        return Promise.resolve({
+            ok: true,
+            body: { getReader: () => ({ read: () => Promise.resolve({ done: true }) }) }
+        });
+    };
+
+    await generateProfessionalReport('context');
+    assert.strictEqual(capturedBody.max_output_tokens, 4000, 'Should apply min_output_tokens');
+}
+
+runTests().then(() => console.log('Min output tokens test passed.'));

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -67,6 +67,7 @@ node tests/handle-server-error-display.test.js
 node tests/handle-invalid-server-response.test.js
 node tests/handle-string-error-response.test.js
 node tests/temperature-model.test.js
+node tests/min-output-tokens.test.js
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then


### PR DESCRIPTION
## Summary
- Allow administrators to set a minimum output token count alongside the existing maximum
- Enforce minimum token constraints in configuration, LLM calls, and front-end generation
- Add test coverage for the new minimum token behavior

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: `phpunit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68b310cdfd0c83319098825c9ac7967f