### PR TITLE
Clamp token limits and honor max token settings

### DIFF
--- a/inc/class-rtbcb-api-tester.php
+++ b/inc/class-rtbcb-api-tester.php
@@ -46,14 +46,13 @@ class RTBCB_API_Tester {
      * @return array Test result.
      */
     private static function test_completion( $api_key ) {
-        $model = get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) );
-
-        $min_tokens = intval( get_option( 'rtbcb_gpt5_min_output_tokens', 256 ) );
+        $model  = get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) );
+        $config = rtbcb_get_gpt5_config();
 
         $body = [
             'model'             => rtbcb_normalize_model_name( $model ),
             'input'             => 'Test connection - respond with exactly: "API connection successful"',
-            'max_output_tokens' => max( 256, $min_tokens ),
+            'max_output_tokens' => $config['max_output_tokens'],
         ];
 
         if ( rtbcb_model_supports_temperature( $model ) ) {

--- a/public/js/rtbcb-report.js
+++ b/public/js/rtbcb-report.js
@@ -63,7 +63,8 @@ async function generateProfessionalReport(businessContext, onChunk) {
     const adminLimit = Math.min(RTBCB_GPT5_MAX_TOKENS, parseInt(cfg.max_output_tokens, 10) || RTBCB_GPT5_MAX_TOKENS);
     const adminMin = Math.max(RTBCB_GPT5_MIN_TOKENS, parseInt(cfg.min_output_tokens, 10) || RTBCB_GPT5_MIN_TOKENS);
     const desiredWords = 1000;
-    cfg.max_output_tokens = Math.max(adminMin, Math.min(adminLimit, estimateTokens(desiredWords)));
+    const bufferedTokens = estimateTokens(desiredWords) * 2;
+    cfg.max_output_tokens = Math.min(adminLimit, Math.max(adminMin, bufferedTokens));
     if (!supportsTemperature(cfg.model)) {
         delete cfg.temperature;
     }

--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
@@ -5,15 +5,20 @@ if ( ! class_exists( 'WP_Error' ) ) {
     class WP_Error {
         private $code;
         private $message;
-        public function __construct( $code = '', $message = '' ) {
+        private $data;
+        public function __construct( $code = '', $message = '', $data = [] ) {
             $this->code    = $code;
             $this->message = $message;
+            $this->data    = $data;
         }
         public function get_error_message() {
             return $this->message;
         }
         public function get_error_code() {
             return $this->code;
+        }
+        public function get_error_data() {
+            return $this->data;
         }
     }
 }

--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
@@ -5,15 +5,20 @@ if ( ! class_exists( 'WP_Error' ) ) {
     class WP_Error {
         private $code;
         private $message;
-        public function __construct( $code = '', $message = '' ) {
+        private $data;
+        public function __construct( $code = '', $message = '', $data = [] ) {
             $this->code    = $code;
             $this->message = $message;
+            $this->data    = $data;
         }
         public function get_error_message() {
             return $this->message;
         }
         public function get_error_code() {
             return $this->code;
+        }
+        public function get_error_data() {
+            return $this->data;
         }
     }
 }

--- a/tests/min-output-tokens.test.js
+++ b/tests/min-output-tokens.test.js
@@ -33,6 +33,30 @@ async function runTests() {
 
     await generateProfessionalReport('context');
     assert.strictEqual(capturedBody.max_output_tokens, 4000, 'Should apply min_output_tokens');
+
+    global.rtbcbReport = {
+        report_model: 'gpt-5-mini',
+        model_capabilities: {},
+        ajax_url: 'https://example.com',
+        template_url: 'template.html',
+        min_output_tokens: 5000,
+        max_output_tokens: 2500
+    };
+
+    await generateProfessionalReport('context');
+    assert.strictEqual(capturedBody.max_output_tokens, 2500, 'Should not exceed max_output_tokens');
+
+    global.rtbcbReport = {
+        report_model: 'gpt-5-mini',
+        model_capabilities: {},
+        ajax_url: 'https://example.com',
+        template_url: 'template.html',
+        min_output_tokens: 1,
+        max_output_tokens: 8000
+    };
+
+    await generateProfessionalReport('context');
+    assert.strictEqual(capturedBody.max_output_tokens, 3000, 'Should include buffer in token estimate');
 }
 
 runTests().then(() => console.log('Min output tokens test passed.'));

--- a/tests/temperature-model.test.js
+++ b/tests/temperature-model.test.js
@@ -44,8 +44,8 @@ async function runTests() {
 
         assert.strictEqual(
             capturedBody.max_output_tokens,
-            1500,
-            'Client request body should include max_output_tokens 1500'
+            3000,
+            'Client request body should include max_output_tokens 3000'
         );
 
         if (shouldInclude) {


### PR DESCRIPTION
## Summary
- ensure report generator never exceeds configured max tokens
- make API tester respect sanitized max token setting
- cover token limit edge cases with new tests
- double front-end token estimate to provide a 100% buffer

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-5-mini bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b3138ca92c8331a01f38dfadfbb1e2