### PR TITLE
Align GPT-5 min token defaults across PHP and JS

### DIFF
--- a/public/js/rtbcb-report.js
+++ b/public/js/rtbcb-report.js
@@ -3,10 +3,10 @@
  */
 
 const RTBCB_GPT5_MAX_TOKENS = 128000;
-const RTBCB_GPT5_MIN_TOKENS = 1;
+const RTBCB_GPT5_MIN_TOKENS = 256;
 const RTBCB_GPT5_DEFAULTS = {
     max_output_tokens: RTBCB_GPT5_MAX_TOKENS,
-    min_output_tokens: 256,
+    min_output_tokens: RTBCB_GPT5_MIN_TOKENS,
     text: { verbosity: 'medium' },
     temperature: 0.7,
     store: true,
@@ -60,8 +60,14 @@ async function generateProfessionalReport(businessContext, onChunk) {
         ...(typeof rtbcbReport !== 'undefined' ? rtbcbReport : {})
     };
     cfg.model = rtbcbReport.report_model;
-    const adminLimit = Math.min(RTBCB_GPT5_MAX_TOKENS, parseInt(cfg.max_output_tokens, 10) || RTBCB_GPT5_MAX_TOKENS);
-    const adminMin = Math.max(RTBCB_GPT5_MIN_TOKENS, parseInt(cfg.min_output_tokens, 10) || RTBCB_GPT5_MIN_TOKENS);
+    const adminLimit = Math.min(
+        RTBCB_GPT5_MAX_TOKENS,
+        parseInt(cfg.max_output_tokens, 10) || RTBCB_GPT5_MAX_TOKENS
+    );
+    const adminMin = Math.max(
+        1,
+        parseInt(cfg.min_output_tokens, 10) || RTBCB_GPT5_MIN_TOKENS
+    );
     const desiredWords = 1000;
     cfg.max_output_tokens = Math.max(adminMin, Math.min(adminLimit, estimateTokens(desiredWords)));
     if (!supportsTemperature(cfg.model)) {

--- a/tests/gpt5-config-defaults.test.js
+++ b/tests/gpt5-config-defaults.test.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const { execSync } = require('child_process');
+
+async function runTests() {
+    const code = fs.readFileSync('public/js/rtbcb-report.js', 'utf8');
+    vm.runInThisContext(code);
+
+    const phpMin = parseInt(execSync("php -r \"function get_option(\\$n, \\$d=false){return \\$d;} define('ABSPATH', __DIR__); include 'inc/config.php'; echo rtbcb_get_gpt5_config()['min_output_tokens'];\"").toString(), 10);
+
+    assert.strictEqual(
+        RTBCB_GPT5_MIN_TOKENS,
+        phpMin,
+        'JS default min tokens should match PHP default'
+    );
+}
+
+runTests().then(() => console.log('GPT-5 config defaults test passed.'));

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -68,6 +68,7 @@ node tests/handle-invalid-server-response.test.js
 node tests/handle-string-error-response.test.js
 node tests/temperature-model.test.js
 node tests/min-output-tokens.test.js
+node tests/gpt5-config-defaults.test.js
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then


### PR DESCRIPTION
## Summary
- Match JS `RTBCB_GPT5_MIN_TOKENS` to PHP's 256-token default and honor a 1-token lower bound when computing `adminMin`
- Add regression test ensuring PHP and JS GPT-5 defaults stay in sync
- Update test runner to execute the new default-alignment test

## Testing
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b315a6f32c833181ff2b63d7a3fdd0