### PR TITLE
Increase API timeouts to 600 seconds

### DIFF
--- a/admin/js/company-overview.js
+++ b/admin/js/company-overview.js
@@ -13,7 +13,7 @@
             $.ajax({
                 url: ajaxurl,
                 method: 'POST',
-                timeout: 30000,
+			timeout: 600000,
                 data: {
                     action: 'rtbcb_company_overview_simple',
                     company_name: companyName,

--- a/admin/partials/dashboard-connectivity.php
+++ b/admin/partials/dashboard-connectivity.php
@@ -219,7 +219,7 @@ if ( ! defined( 'ABSPATH' ) ) {
         $.ajax({
             url: ajaxurl,
             method: 'POST',
-            timeout: 30000,
+			timeout: 600000,
             data: {
                 action: 'rtbcb_set_test_company',
                 nonce: $('#rtbcb_set_test_company_nonce').val(),
@@ -254,7 +254,7 @@ if ( ! defined( 'ABSPATH' ) ) {
         $.ajax({
             url: ajaxurl,
             method: 'POST',
-            timeout: 60000,
+			timeout: 600000,
             data: {
                 action: 'rtbcb_generate_company_overview',
                 nonce: '<?php echo wp_create_nonce( 'rtbcb_test_company_overview' ); ?>',

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -15,7 +15,7 @@ $advanced_model  = get_option( 'rtbcb_advanced_model', rtbcb_get_default_model( 
 $embedding_model = get_option( 'rtbcb_embedding_model', rtbcb_get_default_model( 'embedding' ) );
 $labor_cost      = get_option( 'rtbcb_labor_cost_per_hour', '' );
 $bank_fee        = get_option( 'rtbcb_bank_fee_baseline', '' );
-$gpt5_timeout    = get_option( 'rtbcb_gpt5_timeout', 300 );
+$gpt5_timeout    = get_option( 'rtbcb_gpt5_timeout', 600 );
 $gpt5_max_output_tokens = get_option( 'rtbcb_gpt5_max_output_tokens', 8000 );
 $gpt5_min_output_tokens = get_option( 'rtbcb_gpt5_min_output_tokens', 256 );
 

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2308,10 +2308,10 @@ return $analysis;
 	 */
 	private function call_openai_with_retry( $model, $prompt, $max_output_tokens = null, $max_retries = null, $chunk_handler = null ) {
 	        $max_retries     = $max_retries ?? intval( $this->gpt5_config['max_retries'] );
-        $base_timeout    = intval( $this->gpt5_config['timeout'] ?? 180 );
-        $current_timeout = $base_timeout;
-        $current_tokens  = $max_output_tokens;
-        $max_retry_time  = intval( $this->gpt5_config['max_retry_time'] ?? 60 );
+		$base_timeout    = intval( $this->gpt5_config['timeout'] ?? 600 );
+		$current_timeout = $base_timeout;
+		$current_tokens  = $max_output_tokens;
+		$max_retry_time  = intval( $this->gpt5_config['max_retry_time'] ?? 600 );
         $start_time      = microtime( true );
 
         for ( $attempt = 1; $attempt <= $max_retries; $attempt++ ) {
@@ -2469,7 +2469,7 @@ return $analysis;
 
         do_action( 'rtbcb_llm_prompt_sent', $body );
 
-        $timeout   = intval( $this->gpt5_config['timeout'] ?? 180 );
+		$timeout   = intval( $this->gpt5_config['timeout'] ?? 600 );
         $payload   = wp_json_encode( $body );
         $streamed  = '';
         $ch        = curl_init( $endpoint );

--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -186,7 +186,7 @@ class RTBCB_RAG {
                     'input' => $text,
                 ]
             ),
-            'timeout' => 60,
+				'timeout' => 600,
         ];
 
         $response = wp_remote_post( $endpoint, $args );

--- a/inc/config.php
+++ b/inc/config.php
@@ -42,9 +42,9 @@ function rtbcb_get_gpt5_config( $overrides = [] ) {
         'min_output_tokens' => 256,
         'temperature'       => 0.7,
         'store'             => true,
-        'timeout'           => 180,
-        'max_retries'       => 2,
-        'max_retry_time'    => 60,
+		'timeout'           => 600,
+		'max_retries'       => 2,
+		'max_retry_time'    => 600,
         'reasoning_effort'  => 'medium',
         'text_verbosity'    => 'medium',
     ];

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -16,7 +16,7 @@ require_once __DIR__ . '/config.php';
  * @return int Timeout in seconds.
  */
 function rtbcb_get_api_timeout() {
-    $timeout = (int) get_option( 'rtbcb_gpt5_timeout', 180 );
+	$timeout = (int) get_option( 'rtbcb_gpt5_timeout', 600 );
 
     /**
      * Filter the API request timeout.
@@ -820,7 +820,7 @@ function rtbcb_test_generate_category_recommendation( $analysis ) {
                         'input'        => $input,
                     ]
                 ),
-                'timeout' => 60,
+					'timeout' => 600,
             ]
         );
 
@@ -1247,10 +1247,10 @@ function rtbcb_proxy_openai_responses() {
     header( 'Cache-Control: no-cache' );
     header( 'Connection: keep-alive' );
 
-    $timeout = intval( get_option( 'rtbcb_responses_timeout', 120 ) );
-    if ( $timeout <= 0 ) {
-        $timeout = 120;
-    }
+	$timeout = intval( get_option( 'rtbcb_responses_timeout', 600 ) );
+	if ( $timeout <= 0 ) {
+		$timeout = 600;
+	}
 
     $ch = curl_init( 'https://api.openai.com/v1/responses' );
     curl_setopt( $ch, CURLOPT_POST, true );
@@ -1323,10 +1323,10 @@ function rtbcb_handle_openai_responses_job( $job_id, $user_id ) {
         $body_array = [];
     }
 
-    $timeout = intval( get_option( 'rtbcb_responses_timeout', 120 ) );
-    if ( $timeout <= 0 ) {
-        $timeout = 120;
-    }
+	$timeout = intval( get_option( 'rtbcb_responses_timeout', 600 ) );
+	if ( $timeout <= 0 ) {
+		$timeout = 600;
+	}
 
     $response = wp_remote_post(
         'https://api.openai.com/v1/responses',

--- a/public/js/rtbcb-report.js
+++ b/public/js/rtbcb-report.js
@@ -10,9 +10,9 @@ const RTBCB_GPT5_DEFAULTS = {
     text: { verbosity: 'medium' },
     temperature: 0.7,
     store: true,
-    timeout: 180,
-    max_retries: 3,
-    max_retry_time: 60
+	timeout: 600,
+	max_retries: 3,
+	max_retry_time: 600
 };
 
 function estimateTokens(words) {

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -729,7 +729,7 @@ class Real_Treasury_BCB {
         rtbcb_log_memory_usage( 'start' );
 
         // STEP 2: Set longer execution time
-        $timeout    = min( absint( rtbcb_get_api_timeout() ), 300 );
+	$timeout    = min( absint( rtbcb_get_api_timeout() ), 600 );
         $start_time = time();
 
         if ( ! ini_get( 'safe_mode' ) ) {


### PR DESCRIPTION
## Summary
- raise default API timeout and retry window to 600s across configuration and helpers
- extend AJAX request limits for company overview tests and reports to 10 minutes
- adjust admin settings and long-running analysis to respect 600s timeout

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b31d2366148331b4fea72c5d292d44