### PR TITLE
Ensure wizard script receives localized AJAX data

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -412,16 +412,8 @@ class Real_Treasury_BCB {
             false
         );
 
-        wp_enqueue_script(
-            'rtbcb-script',
-            RTBCB_URL . 'public/js/rtbcb.js',
-            [ 'jquery', 'rtbcb-wizard', 'dompurify' ],
-            RTBCB_VERSION,
-            true
-        );
-
         wp_localize_script(
-            'rtbcb-script',
+            'rtbcb-wizard',
             'rtbcbAjax',
             [
                 'ajax_url'    => admin_url( 'admin-ajax.php' ),
@@ -447,6 +439,14 @@ class Real_Treasury_BCB {
                     'professional_reports'   => get_option( 'rtbcb_professional_reports', true ),
                 ],
             ]
+        );
+
+        wp_enqueue_script(
+            'rtbcb-script',
+            RTBCB_URL . 'public/js/rtbcb.js',
+            [ 'jquery', 'rtbcb-wizard', 'dompurify' ],
+            RTBCB_VERSION,
+            true
         );
 
         wp_enqueue_script(


### PR DESCRIPTION
## Summary
- Localize `rtbcbAjax` for `rtbcb-wizard` so the wizard initializes with the correct AJAX URL and nonce
- Enqueue the main script after localization to guarantee the object is defined before wizard code runs

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit missing)*
- `phpcs --standard=WordPress` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3216965f88331802e6155fc4359fb