### PR TITLE
docs: add server timeout guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,25 @@ If you encounter `Unchecked runtime.lastError` messages, they typically originat
 - **Database Optimization**: Regular cleanup of old lead data
 - **API Rate Limiting**: Built-in throttling for OpenAI requests
 
+### Server Timeouts
+
+Large reports can take several minutes to generate. Increase server and PHP timeout limits to avoid gateway errors. In nginx, raise `proxy_read_timeout` and `fastcgi_read_timeout`:
+
+```nginx
+location ~ \.php$ {
+    proxy_read_timeout 600;
+    fastcgi_read_timeout 600;
+}
+```
+
+Reload nginx after updating the configuration. For PHP-FPM, set `request_terminate_timeout` to a matching value:
+
+```ini
+request_terminate_timeout = 600
+```
+
+Restart PHP-FPM to apply the change. See [docs/timeout-config.md](docs/timeout-config.md) for full instructions.
+
 ## 🛣️ Roadmap and Future Features
 
 ### Version 2.2 (Coming Soon)


### PR DESCRIPTION
## Summary
- document server timeout settings in README

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `phpcs --standard=WordPress` *(fails: command not found)*
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-5-mini bash tests/run-tests.sh`
- `npx markdownlint README.md` *(fails: could not determine executable to run)*
- `npx markdown-link-check README.md` *(fails: command hung)*

------
https://chatgpt.com/codex/tasks/task_e_68b3265b7df8833190735cdcb3505d2e