### PR TITLE
Respect API timeout in LLM retry logic

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2308,11 +2308,11 @@ return $analysis;
 	 */
 	private function call_openai_with_retry( $model, $prompt, $max_output_tokens = null, $max_retries = null, $chunk_handler = null ) {
 	        $max_retries     = $max_retries ?? intval( $this->gpt5_config['max_retries'] );
-        $base_timeout    = intval( $this->gpt5_config['timeout'] ?? 180 );
-        $current_timeout = $base_timeout;
-        $current_tokens  = $max_output_tokens;
-        $max_retry_time  = intval( $this->gpt5_config['max_retry_time'] ?? 60 );
-        $start_time      = microtime( true );
+	        $base_timeout    = intval( $this->gpt5_config['timeout'] ?? 180 );
+	        $current_timeout = $base_timeout;
+	        $current_tokens  = $max_output_tokens;
+	        $max_retry_time  = max( $base_timeout, intval( $this->gpt5_config['max_retry_time'] ?? $base_timeout ) );
+	        $start_time      = microtime( true );
 
         for ( $attempt = 1; $attempt <= $max_retries; $attempt++ ) {
             $elapsed = microtime( true ) - $start_time;

--- a/inc/config.php
+++ b/inc/config.php
@@ -44,7 +44,7 @@ function rtbcb_get_gpt5_config( $overrides = [] ) {
         'store'             => true,
         'timeout'           => function_exists( 'rtbcb_get_api_timeout' ) ? rtbcb_get_api_timeout() : (int) get_option( 'rtbcb_gpt5_timeout', 180 ),
         'max_retries'       => 2,
-        'max_retry_time'    => 60,
+        'max_retry_time'    => function_exists( 'rtbcb_get_api_timeout' ) ? rtbcb_get_api_timeout() : (int) get_option( 'rtbcb_gpt5_timeout', 180 ),
         'reasoning_effort'  => 'medium',
         'text_verbosity'    => 'medium',
     ];

--- a/public/js/rtbcb-report.js
+++ b/public/js/rtbcb-report.js
@@ -16,7 +16,7 @@ const RTBCB_GPT5_DEFAULTS = {
     store: true,
     timeout: RTBCB_API_TIMEOUT,
     max_retries: 3,
-    max_retry_time: 60
+    max_retry_time: RTBCB_API_TIMEOUT
 };
 
 function estimateTokens(words) {


### PR DESCRIPTION
## Summary
- derive GPT-5 retry window from configured API timeout
- ensure retry logic never uses a shorter window than the base timeout
- sync front-end report generator's retry limit with API timeout

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4o bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b32972391083319bbfed820e472e44