### PR TITLE
Expose job report data at top level

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -134,6 +134,23 @@ class RTBCB_Ajax {
 			return;
 		}
 
+		if (
+			'completed' === ( $status['status'] ?? '' ) &&
+			! empty( $status['result']['report_data'] )
+		) {
+			$result                = $status['result'];
+			$status['report_data'] = $result['report_data'];
+			if ( is_array( $result ) ) {
+				foreach ( $result as $key => $value ) {
+					if ( 'report_data' === $key ) {
+						continue;
+					}
+					$status[ $key ] = $value;
+				}
+			}
+			unset( $status['result'] );
+		}
+
 		wp_send_json_success( $status );
 	}
 


### PR DESCRIPTION
## Summary
- Flatten job status results so completed jobs expose `report_data` and related fields at the top level.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b33c6cd2cc8331bc664bb7108e4286