### PR TITLE
Fix bulk lead deletion in Lead Management page

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -71,7 +71,7 @@ class RTBCB_Admin {
         $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
         if ( strpos( $hook, 'rtbcb' ) === false && strpos( $page, 'rtbcb' ) === false ) {
             return;
-        }
+	}
 
         wp_enqueue_script( 'chart-js', RTBCB_URL . 'public/js/chart.min.js', [], '3.9.1', true );
         wp_enqueue_script( 
@@ -110,7 +110,7 @@ class RTBCB_Admin {
                         ],
                 ]
             );
-        }
+	}
 
         $company_data = [];
         if ( function_exists( 'rtbcb_get_current_company' ) ) {
@@ -561,8 +561,14 @@ class RTBCB_Admin {
             wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
         }
 
-        $action = sanitize_text_field( wp_unslash( $_POST['action'] ?? '' ) );
-        $lead_ids = array_map( 'intval', wp_unslash( $_POST['lead_ids'] ?? [] ) );
+	$bulk_action = sanitize_text_field( wp_unslash( $_POST['bulk_action'] ?? '' ) );
+	$lead_ids_raw = wp_unslash( $_POST['lead_ids'] ?? [] );
+
+	if ( is_string( $lead_ids_raw ) ) {
+		$lead_ids_raw = json_decode( $lead_ids_raw, true );
+	}
+
+	$lead_ids = array_map( 'intval', (array) $lead_ids_raw );
 
         if ( empty( $lead_ids ) ) {
             wp_send_json_error( [ 'message' => __( 'No leads selected.', 'rtbcb' ) ] );
@@ -572,7 +578,7 @@ class RTBCB_Admin {
         $table_name = $wpdb->prefix . 'rtbcb_leads';
         $placeholders = implode( ',', array_fill( 0, count( $lead_ids ), '%d' ) );
 
-        switch ( $action ) {
+	switch ( $bulk_action ) {
             case 'delete':
                 $result = $wpdb->query( 
                     $wpdb->prepare( 

--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -805,7 +805,7 @@ jQuery(document).ready(function($) {
                             action: 'rtbcb_bulk_action_leads',
                             nonce: window.rtbcbAdmin.nonce,
                             bulk_action: action,
-                            lead_ids: JSON.stringify(ids)
+                            lead_ids: ids
                         }
                     });
                     if (response.success) {


### PR DESCRIPTION
## Summary
- ensure bulk lead actions read `bulk_action` param and decode ID arrays on the server
- send raw lead ID arrays from the admin UI instead of JSON strings

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b33bbad6e083318e1b89040f9d34eb