### PR TITLE
Ensure workflow history is deleted in AJAX handler

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -1831,13 +1831,17 @@ class RTBCB_Admin {
 		] );
 	}
 
-	public function ajax_clear_workflow_history() {
-		check_ajax_referer( 'rtbcb_workflow_visualizer', 'nonce' );
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error( __( 'Insufficient permissions', 'rtbcb' ) );
+		public function ajax_clear_workflow_history() {
+			check_ajax_referer( 'rtbcb_workflow_visualizer', 'nonce' );
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_send_json_error( __( 'Insufficient permissions', 'rtbcb' ) );
+			}
+			$cleared = delete_option( 'rtbcb_workflow_history' );
+			if ( ! $cleared ) {
+				wp_send_json_error( __( 'Failed to clear workflow history', 'rtbcb' ) );
+			}
+			wp_send_json_success( __( 'Workflow history cleared', 'rtbcb' ) );
 		}
-		wp_send_json_success();
-	}
 
        private function get_workflow_history_from_logs() {
                $history = get_option( 'rtbcb_workflow_history', [] );


### PR DESCRIPTION
## Summary
- Clear `rtbcb_workflow_history` option before returning success
- Add error handling if option deletion fails

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b34668bc0083319f6a4716b965907a