### PR TITLE
Display workflow step statuses per lead

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -102,12 +102,15 @@ class RTBCB_Admin {
                 [
                     'ajax_url' => admin_url( 'admin-ajax.php' ),
                     'nonce'    => wp_create_nonce( 'rtbcb_workflow_visualizer' ),
-                        'strings'  => [
-                                'refresh_success' => __( 'Workflow history refreshed', 'rtbcb' ),
-                                'clear_success'   => __( 'Workflow history cleared', 'rtbcb' ),
-                                'error'           => __( 'An error occurred', 'rtbcb' ),
-                                'no_history'      => __( 'No workflow history available.', 'rtbcb' ),
-                        ],
+					'strings'  => [
+						'refresh_success' => __( 'Workflow history refreshed', 'rtbcb' ),
+						'clear_success'   => __( 'Workflow history cleared', 'rtbcb' ),
+						'error'           => __( 'An error occurred', 'rtbcb' ),
+						'no_history'      => __( 'No workflow history available.', 'rtbcb' ),
+						'lead'            => __( 'Lead', 'rtbcb' ),
+						'unknown_lead'    => __( 'Unknown Lead', 'rtbcb' ),
+						'not_run'         => __( 'Not run', 'rtbcb' ),
+					],
                 ]
             );
 	}
@@ -1818,18 +1821,42 @@ class RTBCB_Admin {
 	public function ajax_get_workflow_history() {
 		check_ajax_referer( 'rtbcb_workflow_visualizer', 'nonce' );
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error( __( 'Insufficient permissions', 'rtbcb' ) );
+		wp_send_json_error( __( 'Insufficient permissions', 'rtbcb' ) );
 		}
-		$history = $this->get_workflow_history_from_logs();
-		wp_send_json_success( [
-			'history' => $history,
-			'summary' => [
-				'total_executions' => count( $history ),
-				'avg_duration' => $this->calculate_average_duration( $history ),
-				'success_rate' => $this->calculate_success_rate( $history ),
-			],
-		] );
-	}
+		$raw_history = $this->get_workflow_history_from_logs();
+		$history     = array_map(
+		function ( $entry ) {
+		$lead_id = isset( $entry['lead_id'] ) ? intval( $entry['lead_id'] ) : 0;
+		$email   = isset( $entry['lead_email'] ) ? sanitize_email( $entry['lead_email'] ) : '';
+		$steps   = [];
+		if ( isset( $entry['steps'] ) && is_array( $entry['steps'] ) ) {
+		foreach ( $entry['steps'] as $step ) {
+		$steps[] = [
+		'name'   => sanitize_text_field( $step['name'] ?? '' ),
+		'status' => sanitize_text_field( $step['status'] ?? '' ),
+		];
+		}
+		}
+		return [
+		'lead_id' => $lead_id,
+		'email'   => $email,
+		'steps'   => $steps,
+		];
+		},
+		$raw_history
+		);
+		
+		wp_send_json_success(
+		[
+		'history' => $history,
+		'summary' => [
+		'total_executions' => count( $raw_history ),
+		'avg_duration'     => $this->calculate_average_duration( $raw_history ),
+		'success_rate'     => $this->calculate_success_rate( $raw_history ),
+		],
+		]
+		);
+}
 
 	public function ajax_clear_workflow_history() {
 		check_ajax_referer( 'rtbcb_workflow_visualizer', 'nonce' );


### PR DESCRIPTION
## Summary
- track lead identifiers in workflow history and expose sanitized step data
- show workflow steps per lead in a new visualizer table
- localize workflow visualizer strings and sanitize AJAX output

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b3466dd7908331891ca486ea4d0f44