### PR TITLE
Show workflow step statuses per lead in visualizer

### DIFF
--- a/admin/js/workflow-visualizer.js
+++ b/admin/js/workflow-visualizer.js
@@ -1,58 +1,76 @@
 jQuery(function($) {
-function loadHistory() {
-$.post(rtbcbWorkflow.ajax_url, {
-action: 'rtbcb_get_workflow_history',
-nonce: rtbcbWorkflow.nonce
-}).done(function(response) {
-    if (response.success) {
-        var history = response.data.history || [];
-        var html = '';
-        history.forEach(function(item, index) {
-            if (item.prompts && item.prompts.length) {
-                html += '<h3>Execution ' + (index + 1) + '</h3><ul>';
-                item.prompts.forEach(function(p) {
-                    var txt = '';
-                    if (p.instructions) {
-                        txt += p.instructions + "\n";
-                    }
-                    txt += p.input;
-                    html += '<li><pre>' + $('<div>').text(txt).html() + '</pre></li>';
-                });
-                html += '</ul>';
-            }
-        });
-        if (!html) {
-            html = '<p>' + rtbcbWorkflow.strings.no_history + '</p>';
+    function renderHistory(history) {
+        var $container = $('#rtbcb-workflow-history-container');
+        $container.empty();
+        if (!history.length) {
+            $container.append($('<p>').text(rtbcbWorkflow.strings.no_history));
+            return;
         }
-        $('#rtbcb-workflow-history-container').html(html);
-        alert(rtbcbWorkflow.strings.refresh_success);
-    } else {
-        alert(rtbcbWorkflow.strings.error);
+        var stepNames = [];
+        history.forEach(function(item) {
+            (item.steps || []).forEach(function(step) {
+                if (stepNames.indexOf(step.name) === -1) {
+                    stepNames.push(step.name);
+                }
+            });
+        });
+        var $table = $('<table></table>');
+        var $headRow = $('<tr></tr>').append($('<th>').text(rtbcbWorkflow.strings.lead_label));
+        stepNames.forEach(function(name) {
+            $headRow.append($('<th>').text(name));
+        });
+        $table.append($('<thead></thead>').append($headRow));
+        var $tbody = $('<tbody></tbody>');
+        history.forEach(function(item) {
+            var leadLabel = item.lead.email || item.lead.id || '';
+            var $row = $('<tr></tr>').append($('<td>').text(leadLabel));
+            stepNames.forEach(function(name) {
+                var match = (item.steps || []).find(function(s) { return s.name === name; });
+                var status = match ? match.status : '';
+                $row.append($('<td>').text(status));
+            });
+            $tbody.append($row);
+        });
+        $table.append($tbody);
+        $container.append($table);
     }
-}).fail(function() {
-alert(rtbcbWorkflow.strings.error);
-});
-}
 
-$('#rtbcb-refresh-workflow').on('click', function() {
-loadHistory();
-});
+    function loadHistory() {
+        $.post(rtbcbWorkflow.ajax_url, {
+            action: 'rtbcb_get_workflow_history',
+            nonce: rtbcbWorkflow.nonce
+        }).done(function(response) {
+            if (response.success) {
+                var history = response.data.history || [];
+                renderHistory(history);
+                alert(rtbcbWorkflow.strings.refresh_success);
+            } else {
+                alert(rtbcbWorkflow.strings.error);
+            }
+        }).fail(function() {
+            alert(rtbcbWorkflow.strings.error);
+        });
+    }
 
-$('#rtbcb-clear-workflow').on('click', function() {
-$.post(rtbcbWorkflow.ajax_url, {
-action: 'rtbcb_clear_workflow_history',
-nonce: rtbcbWorkflow.nonce
-}).done(function(response) {
-if (response.success) {
-$('#rtbcb-workflow-history-container').empty();
-alert(rtbcbWorkflow.strings.clear_success);
-} else {
-alert(rtbcbWorkflow.strings.error);
-}
-}).fail(function() {
-alert(rtbcbWorkflow.strings.error);
-});
-});
+    $('#rtbcb-refresh-workflow').on('click', function() {
+        loadHistory();
+    });
 
-loadHistory();
+    $('#rtbcb-clear-workflow').on('click', function() {
+        $.post(rtbcbWorkflow.ajax_url, {
+            action: 'rtbcb_clear_workflow_history',
+            nonce: rtbcbWorkflow.nonce
+        }).done(function(response) {
+            if (response.success) {
+                $('#rtbcb-workflow-history-container').empty();
+                alert(rtbcbWorkflow.strings.clear_success);
+            } else {
+                alert(rtbcbWorkflow.strings.error);
+            }
+        }).fail(function() {
+            alert(rtbcbWorkflow.strings.error);
+        });
+    });
+
+    loadHistory();
 });

--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -91,10 +91,14 @@ class RTBCB_Ajax {
 			$structured_report_data = self::structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $request_start );
 			$workflow_tracker->complete_step( 'data_structuring', $structured_report_data );
 
-			$lead_id = self::save_lead_data_async( $user_inputs, $structured_report_data );
+$lead_id = self::save_lead_data_async( $user_inputs, $structured_report_data );
 
-			$debug_info = $workflow_tracker->get_debug_info();
-			self::store_workflow_history( $debug_info );
+$debug_info          = $workflow_tracker->get_debug_info();
+$debug_info['lead'] = [
+'id'    => $lead_id,
+'email' => $user_inputs['email'] ?? '',
+];
+self::store_workflow_history( $debug_info );
 
 			return [
 				'report_data'   => $structured_report_data,


### PR DESCRIPTION
## Summary
- Render workflow history in a table showing each lead and the status of each workflow step
- Return sanitized lead metadata and step summaries from ajax_get_workflow_history
- Track lead id and email when storing workflow history

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3466dd7908331891ca486ea4d0f44