### PR TITLE
Track lead metadata in workflow history

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -1870,10 +1870,25 @@ class RTBCB_Admin {
 			wp_send_json_success( __( 'Workflow history cleared', 'rtbcb' ) );
 		}
 
-       private function get_workflow_history_from_logs() {
-               $history = get_option( 'rtbcb_workflow_history', [] );
-               return is_array( $history ) ? $history : [];
-       }
+		/**
+		 * Retrieve workflow history with lead metadata.
+		 *
+		 * @return array Workflow history entries.
+		 */
+		private function get_workflow_history_from_logs() {
+			$history = get_option( 'rtbcb_workflow_history', [] );
+			if ( ! is_array( $history ) ) {
+			return [];
+			}
+			return array_map(
+				function ( $entry ) {
+				$entry['lead_id']    = isset( $entry['lead_id'] ) ? intval( $entry['lead_id'] ) : 0;
+				$entry['lead_email'] = isset( $entry['lead_email'] ) ? sanitize_email( $entry['lead_email'] ) : '';
+				return $entry;
+			},
+			$history
+			);
+		}
 
 	private function calculate_average_duration( $history ) {
 		if ( empty( $history ) ) {

--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -91,12 +91,15 @@ class RTBCB_Ajax {
 			$structured_report_data = self::structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $request_start );
 			$workflow_tracker->complete_step( 'data_structuring', $structured_report_data );
 
-					$lead_id = self::save_lead_data_async( $user_inputs, $structured_report_data );
-
-					$debug_info              = $workflow_tracker->get_debug_info();
-					$debug_info['lead_id']    = $lead_id;
-					$debug_info['lead_email'] = $user_inputs['email'];
-					self::store_workflow_history( $debug_info, $lead_id, $user_inputs['email'] );
+			$lead_id    = self::save_lead_data_async( $user_inputs, $structured_report_data );
+			$lead_email = ! empty( $user_inputs['email'] ) ? sanitize_email( $user_inputs['email'] ) : '';
+			
+			$debug_info           = $workflow_tracker->get_debug_info();
+			$debug_info['lead_id'] = $lead_id;
+			if ( $lead_email ) {
+			$debug_info['lead_email'] = $lead_email;
+			}
+			self::store_workflow_history( $debug_info, $lead_id, $lead_email );
 
 			return [
 				'report_data'   => $structured_report_data,
@@ -107,10 +110,13 @@ class RTBCB_Ajax {
 		} catch ( Exception $e ) {
 			$workflow_tracker->add_error( 'exception', $e->getMessage() );
 			rtbcb_log_error( 'Ajax exception in new workflow', $e->getMessage() );
-					$debug_info              = $workflow_tracker->get_debug_info();
-					$debug_info['lead_id']    = isset( $lead_id ) ? $lead_id : null;
-					$debug_info['lead_email'] = $user_inputs['email'];
-					self::store_workflow_history( $debug_info, isset( $lead_id ) ? $lead_id : null, $user_inputs['email'] );
+			$debug_info           = $workflow_tracker->get_debug_info();
+			$lead_email           = ! empty( $user_inputs['email'] ) ? sanitize_email( $user_inputs['email'] ) : '';
+			$debug_info['lead_id'] = isset( $lead_id ) ? $lead_id : null;
+			if ( $lead_email ) {
+			$debug_info['lead_email'] = $lead_email;
+			}
+			self::store_workflow_history( $debug_info, isset( $lead_id ) ? $lead_id : null, $lead_email );
 			return new WP_Error( 'generation_failed', __( 'An error occurred while generating your business case. Please try again.', 'rtbcb' ) );
 		}
 	}
@@ -290,18 +296,28 @@ class RTBCB_Ajax {
 		return $roi_scenarios;
 	}
 
+/**
+	 * Store workflow history and associated lead metadata.
+	 *
+	 * @param array     $debug_info  Workflow debug information.
+	 * @param int|null  $lead_id     Lead ID.
+	 * @param string    $lead_email  Lead email address.
+	 * @return void
+	 */
 	private static function store_workflow_history( $debug_info, $lead_id = null, $lead_email = '' ) {
-		       $history = get_option( 'rtbcb_workflow_history', [] );
-		       if ( ! is_array( $history ) ) {
-		               $history = [];
-		       }
-		       $debug_info['lead_id']    = $lead_id ? intval( $lead_id ) : null;
-		       $debug_info['lead_email'] = sanitize_email( $lead_email );
-		       $history[]                = $debug_info;
-		       if ( count( $history ) > 20 ) {
-		               $history = array_slice( $history, -20 );
-		       }
-		       update_option( 'rtbcb_workflow_history', $history, false );
+		$history = get_option( 'rtbcb_workflow_history', [] );
+		if ( ! is_array( $history ) ) {
+		$history = [];
+		}
+		$debug_info['lead_id'] = $lead_id ? intval( $lead_id ) : null;
+		if ( ! empty( $lead_email ) ) {
+		$debug_info['lead_email'] = sanitize_email( $lead_email );
+		}
+		$history[] = $debug_info;
+		if ( count( $history ) > 20 ) {
+		$history = array_slice( $history, -20 );
+		}
+		update_option( 'rtbcb_workflow_history', $history, false );
 	}
 }
 


### PR DESCRIPTION
## Summary
- Append `lead_id` and sanitized email to workflow debug info and persist in history
- Store lead metadata in workflow history records
- Return sanitized lead metadata from admin workflow history retrieval

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b348d1024c83319effeb503ea0524b