### PR TITLE
Trigger cron immediately after job enqueue

### DIFF
--- a/inc/class-rtbcb-background-job.php
+++ b/inc/class-rtbcb-background-job.php
@@ -25,14 +25,19 @@ class RTBCB_Background_Job {
 			HOUR_IN_SECONDS
 		);
 
-		wp_schedule_single_event(
-			time(),
-			'rtbcb_process_job',
-			[ $job_id, $user_inputs ]
-		);
+                wp_schedule_single_event(
+                        time(),
+                        'rtbcb_process_job',
+                        [ $job_id, $user_inputs ]
+                );
 
-		return $job_id;
-	}
+		// Trigger cron immediately in a non-blocking way.
+		if ( function_exists( 'spawn_cron' ) && ! wp_doing_cron() ) {
+			spawn_cron();
+		}
+
+                return $job_id;
+        }
 
 	/**
 	 * Process a queued job.


### PR DESCRIPTION
## Summary
- trigger WordPress cron right after scheduling background jobs so they begin processing without delay

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b35cca244083319c2ec8a3a06a496c