### PR TITLE
feat: log lead context

### DIFF
--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -19,6 +19,8 @@ defined( 'ABSPATH' ) || exit;
             <thead>
                 <tr>
                     <th><?php esc_html_e( 'ID', 'rtbcb' ); ?></th>
+                    <th><?php esc_html_e( 'Email', 'rtbcb' ); ?></th>
+                    <th><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></th>
                     <th><?php esc_html_e( 'Request', 'rtbcb' ); ?></th>
                     <th><?php esc_html_e( 'Tokens', 'rtbcb' ); ?></th>
                     <th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
@@ -41,6 +43,8 @@ defined( 'ABSPATH' ) || exit;
                     ?>
                     <tr data-id="<?php echo esc_attr( $log['id'] ); ?>" data-request="<?php echo esc_attr( $log['request_json'] ); ?>" data-response="<?php echo esc_attr( $log['response_json'] ); ?>">
                         <td><?php echo esc_html( $log['id'] ); ?></td>
+                        <td><?php echo esc_html( $log['user_email'] ); ?></td>
+                        <td><?php echo esc_html( $log['company_name'] ); ?></td>
                         <td><?php echo esc_html( $summary ); ?></td>
                         <td><?php echo esc_html( $log['total_tokens'] ); ?></td>
                         <td><?php echo esc_html( $status ); ?></td>
@@ -57,7 +61,7 @@ defined( 'ABSPATH' ) || exit;
                     <?php endforeach; ?>
                 <?php else : ?>
                     <tr>
-                        <td colspan="6"><?php esc_html_e( 'No logs found.', 'rtbcb' ); ?></td>
+                        <td colspan="8"><?php esc_html_e( 'No logs found.', 'rtbcb' ); ?></td>
                     </tr>
                 <?php endif; ?>
             </tbody>

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2536,7 +2536,10 @@ return $analysis;
             if ( ! is_array( $decoded ) ) {
                 $decoded = [];
             }
-            RTBCB_API_Log::save_log( $body, $decoded, get_current_user_id() );
+            $company      = rtbcb_get_current_company();
+            $user_email   = $this->current_inputs['email'] ?? ( $company['email'] ?? '' );
+            $company_name = $this->current_inputs['company_name'] ?? ( $company['name'] ?? '' );
+            RTBCB_API_Log::save_log( $body, $decoded, get_current_user_id(), $user_email, $company_name );
         }
 
         if ( $http_code >= 400 ) {


### PR DESCRIPTION
## Summary
- track lead email and company name in API logs
- surface lead context in admin log viewer

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b36fad62f883318d05cadd4e9272a4