### PR TITLE
Capture company name on lead submissions

### DIFF
--- a/admin/leads-page-enhanced.php
+++ b/admin/leads-page-enhanced.php
@@ -99,6 +99,7 @@ $order   = isset( $order ) ? sanitize_key( $order ) : 'DESC';
                                 <?php endif; ?>
                             </a>
                         </th>
+                        <th class="manage-column column-company-name"><?php esc_html_e( 'Company', 'rtbcb' ); ?></th>
                         <th class="manage-column column-company-size"><?php esc_html_e( 'Company Size', 'rtbcb' ); ?></th>
                         <th class="manage-column column-category"><?php esc_html_e( 'Recommended Category', 'rtbcb' ); ?></th>
                         <th class="manage-column column-roi"><?php esc_html_e( 'Base ROI', 'rtbcb' ); ?></th>
@@ -134,6 +135,13 @@ $order   = isset( $order ) ? sanitize_key( $order ) : 'DESC';
                                     </span>
                                 </div>
                                 <button type="button" class="toggle-row"><span class="screen-reader-text"><?php esc_html_e( 'Show more details', 'rtbcb' ); ?></span></button>
+                            </td>
+                            <td class="column-company-name" data-colname="<?php esc_attr_e( 'Company', 'rtbcb' ); ?>">
+                                <?php if ( ! empty( $lead['company_name'] ) ) : ?>
+                                    <?php echo esc_html( $lead['company_name'] ); ?>
+                                <?php else : ?>
+                                    <span class="rtbcb-no-data"><?php esc_html_e( 'No data', 'rtbcb' ); ?></span>
+                                <?php endif; ?>
                             </td>
                             <td class="column-company-size" data-colname="<?php esc_attr_e( 'Company Size', 'rtbcb' ); ?>">
                                 <span class="rtbcb-company-size-badge rtbcb-size-<?php echo esc_attr( sanitize_title( $lead['company_size'] ) ); ?>">

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -32,6 +32,7 @@ class RTBCB_Leads {
         $sql = "CREATE TABLE " . self::$table_name . " (
             id mediumint(9) NOT NULL AUTO_INCREMENT,
             email varchar(255) NOT NULL,
+            company_name varchar(255) DEFAULT '',
             company_size varchar(50) DEFAULT '',
             industry varchar(50) DEFAULT '',
             hours_reconciliation decimal(5,2) DEFAULT 0,
@@ -79,6 +80,7 @@ class RTBCB_Leads {
                 $simple_sql = "CREATE TABLE IF NOT EXISTS " . self::$table_name . " (
                     id mediumint(9) NOT NULL AUTO_INCREMENT,
                     email varchar(255) NOT NULL,
+                    company_name varchar(255) DEFAULT '',
                     company_size varchar(50) DEFAULT '',
                     industry varchar(50) DEFAULT '',
                     hours_reconciliation decimal(5,2) DEFAULT 0,
@@ -169,6 +171,7 @@ class RTBCB_Leads {
         // Sanitize data with proper validation
         $sanitized_data = [
             'email'                   => sanitize_email( $lead_data['email'] ),
+            'company_name'            => sanitize_text_field( $lead_data['company_name'] ?? '' ),
             'company_size'            => sanitize_text_field( $lead_data['company_size'] ?? '' ),
             'industry'                => sanitize_text_field( $lead_data['industry'] ?? '' ),
             'hours_reconciliation'    => floatval( $lead_data['hours_reconciliation'] ?? 0 ),
@@ -191,6 +194,7 @@ class RTBCB_Leads {
         // Prepare format array to match the sanitized data
         $formats = [
             '%s', // email
+            '%s', // company_name
             '%s', // company_size
             '%s', // industry
             '%f', // hours_reconciliation

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -937,6 +937,7 @@ class Real_Treasury_BCB {
 	try {
 	$lead_data = [
 	'email'                  => $user_inputs['email'],
+	'company_name'           => $user_inputs['company_name'],
 	'company_size'           => $user_inputs['company_size'],
 	'industry'               => $user_inputs['industry'],
 	'hours_reconciliation'   => $user_inputs['hours_reconciliation'],


### PR DESCRIPTION
## Summary
- add `company_name` column to leads database table and persistence logic
- pass `company_name` through lead saving workflow and show it in admin lead list

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`
- `phpcs --standard=WordPress` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b36fb346388331b9a35ef4523fbb6e