### PR TITLE
Add report data validation and error handling

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -249,6 +249,15 @@ class RTBCB_Router {
        // Transform data structure for comprehensive template.
        $report_data = $this->transform_data_for_template( $business_case_data );
 
+       if ( is_wp_error( $report_data ) ) {
+       $error_data = $report_data->get_error_data();
+       rtbcb_log_error(
+       'Report data validation failed',
+       [ 'missing_keys' => $error_data['missing_keys'] ?? [] ]
+       );
+       $report_data = $error_data['report_data'] ?? [];
+       }
+
        ob_start();
        include $template_path;
        $html = ob_get_clean();
@@ -268,58 +277,91 @@ class RTBCB_Router {
        $company      = rtbcb_get_current_company();
        $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
 
+       // Required top-level keys.
+       $required_keys = [
+       'metadata',
+       'executive_summary',
+       'financial_analysis',
+       'company_intelligence',
+       'technology_strategy',
+       'operational_insights',
+       'risk_analysis',
+       'action_plan',
+       ];
+
        // Create structured data format expected by template.
        $report_data = [
-           'metadata'            => [
-               'company_name'    => $company_name,
-               'analysis_date'   => current_time( 'Y-m-d' ),
-               'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
-               'processing_time' => $business_case_data['processing_time'] ?? 0,
-           ],
-           'executive_summary'  => [
-               'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
-               'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
-               'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
-           ],
-           'financial_analysis' => [
-               'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
-               'payback_analysis'   => [
-                   'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
-               ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
-           ],
-           'company_intelligence' => [
-               'enriched_profile' => [
-                   'enhanced_description' => $business_case_data['company_analysis'] ?? '',
-                   'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
-                   'treasury_maturity'    => [
-                       'current_state'    => $business_case_data['current_state_analysis'] ?? '',
-                   ],
-               ],
-               'industry_context' => [
-                   'sector_analysis' => [
-                       'market_dynamics' => $business_case_data['market_analysis'] ?? '',
-                   ],
-                   'benchmarking'   => [
-                       'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
-                   ],
-               ],
-           ],
-           'technology_strategy' => [
-               'recommended_category' => $business_case_data['recommended_category'] ?? 'treasury_management_system',
-               'category_details'     => $business_case_data['category_info'] ?? [],
-           ],
-           'operational_insights' => $business_case_data['operational_analysis'] ?? [],
-           'risk_analysis'        => [
-               'implementation_risks' => $business_case_data['risks'] ?? [],
-           ],
-           'action_plan'          => [
-               'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
-               'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),
-               'long_term_objectives'  => $this->extract_long_term_steps( $business_case_data ),
-           ],
+       'metadata'            => [
+       'company_name'    => $company_name,
+       'analysis_date'   => current_time( 'Y-m-d' ),
+       'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
+       'processing_time' => $business_case_data['processing_time'] ?? 0,
+       ],
+       'executive_summary'  => [
+       'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
+       'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
+       'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
+       'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
+       ],
+       'financial_analysis' => [
+       'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
+       'payback_analysis'   => [
+       'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
+       ],
+       'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
+       ],
+       'company_intelligence' => [
+       'enriched_profile' => [
+       'enhanced_description' => $business_case_data['company_analysis'] ?? '',
+       'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
+       'treasury_maturity'    => [
+       'current_state'    => $business_case_data['current_state_analysis'] ?? '',
+       ],
+       ],
+       'industry_context' => [
+       'sector_analysis' => [
+       'market_dynamics' => $business_case_data['market_analysis'] ?? '',
+       ],
+       'benchmarking'   => [
+       'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
+       ],
+       ],
+       ],
+       'technology_strategy' => [
+       'recommended_category' => $business_case_data['recommended_category'] ?? 'treasury_management_system',
+       'category_details'     => $business_case_data['category_info'] ?? [],
+       ],
+       'operational_insights' => $business_case_data['operational_analysis'] ?? [],
+       'risk_analysis'        => [
+       'implementation_risks' => $business_case_data['risks'] ?? [],
+       ],
+       'action_plan'          => [
+       'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
+       'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),
+       'long_term_objectives'  => $this->extract_long_term_steps( $business_case_data ),
+       ],
        ];
+
+       $missing_keys = [];
+
+       foreach ( $required_keys as $key ) {
+       if ( empty( $report_data[ $key ] ) ) {
+       $missing_keys[]       = $key;
+       rtbcb_log_error( 'Missing report section: ' . $key );
+       $report_data[ $key ]  = $report_data[ $key ] ?? [];
+       }
+       }
+
+       if ( ! empty( $missing_keys ) ) {
+       return new WP_Error(
+       'rtbcb_missing_report_data',
+       __( 'Missing required report sections', 'rtbcb' ),
+       [
+       'missing_keys' => $missing_keys,
+       'report_data'  => $report_data,
+       ]
+       );
+       }
 
        return $report_data;
    }

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1615,13 +1615,23 @@ class Real_Treasury_BCB {
 		return '';
 		}
 		$business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
-		// Transform data structure for template.
-		$report_data = $this->transform_data_for_template( $business_case_data );
-		ob_start();
-		include $template_path;
-		$html = ob_get_clean();
-		return wp_kses_post( $html );
-		}
+               // Transform data structure for template.
+               $report_data = $this->transform_data_for_template( $business_case_data );
+
+               if ( is_wp_error( $report_data ) ) {
+               $error_data = $report_data->get_error_data();
+               rtbcb_log_error(
+               'Report data validation failed',
+               [ 'missing_keys' => $error_data['missing_keys'] ?? [] ]
+               );
+               $report_data = $error_data['report_data'] ?? [];
+               }
+
+               ob_start();
+               include $template_path;
+               $html = ob_get_clean();
+               return wp_kses_post( $html );
+               }
 
    /**
     * Transform LLM response data into the structure expected by comprehensive template.
@@ -1635,58 +1645,91 @@ class Real_Treasury_BCB {
        $company      = rtbcb_get_current_company();
        $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
 
+       // Required top-level keys.
+       $required_keys = [
+       'metadata',
+       'executive_summary',
+       'financial_analysis',
+       'company_intelligence',
+       'technology_strategy',
+       'operational_insights',
+       'risk_analysis',
+       'action_plan',
+       ];
+
        // Create structured data format expected by template.
        $report_data = [
-           'metadata'            => [
-               'company_name'    => $company_name,
-               'analysis_date'   => current_time( 'Y-m-d' ),
-               'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
-               'processing_time' => $business_case_data['processing_time'] ?? 0,
-           ],
-           'executive_summary'  => [
-               'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
-               'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
-               'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
-           ],
-           'financial_analysis' => [
-               'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
-               'payback_analysis'   => [
-                   'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
-               ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
-           ],
-           'company_intelligence' => [
-               'enriched_profile' => [
-                   'enhanced_description' => $business_case_data['company_analysis'] ?? '',
-                   'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
-                   'treasury_maturity'    => [
-                       'current_state'    => $business_case_data['current_state_analysis'] ?? '',
-                   ],
-               ],
-               'industry_context' => [
-                   'sector_analysis' => [
-                       'market_dynamics' => $business_case_data['market_analysis'] ?? '',
-                   ],
-                   'benchmarking'   => [
-                       'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
-                   ],
-               ],
-           ],
-           'technology_strategy' => [
-               'recommended_category' => $business_case_data['recommended_category'] ?? 'treasury_management_system',
-               'category_details'     => $business_case_data['category_info'] ?? [],
-           ],
-           'operational_insights' => $business_case_data['operational_analysis'] ?? [],
-           'risk_analysis'        => [
-               'implementation_risks' => $business_case_data['risks'] ?? [],
-           ],
-           'action_plan'          => [
-               'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
-               'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),
-               'long_term_objectives'  => $this->extract_long_term_steps( $business_case_data ),
-           ],
+       'metadata'            => [
+       'company_name'    => $company_name,
+       'analysis_date'   => current_time( 'Y-m-d' ),
+       'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
+       'processing_time' => $business_case_data['processing_time'] ?? 0,
+       ],
+       'executive_summary'  => [
+       'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
+       'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
+       'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
+       'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
+       ],
+       'financial_analysis' => [
+       'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
+       'payback_analysis'   => [
+       'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
+       ],
+       'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
+       ],
+       'company_intelligence' => [
+       'enriched_profile' => [
+       'enhanced_description' => $business_case_data['company_analysis'] ?? '',
+       'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
+       'treasury_maturity'    => [
+       'current_state'    => $business_case_data['current_state_analysis'] ?? '',
+       ],
+       ],
+       'industry_context' => [
+       'sector_analysis' => [
+       'market_dynamics' => $business_case_data['market_analysis'] ?? '',
+       ],
+       'benchmarking'   => [
+       'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
+       ],
+       ],
+       ],
+       'technology_strategy' => [
+       'recommended_category' => $business_case_data['recommended_category'] ?? 'treasury_management_system',
+       'category_details'     => $business_case_data['category_info'] ?? [],
+       ],
+       'operational_insights' => $business_case_data['operational_analysis'] ?? [],
+       'risk_analysis'        => [
+       'implementation_risks' => $business_case_data['risks'] ?? [],
+       ],
+       'action_plan'          => [
+       'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
+       'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),
+       'long_term_objectives'  => $this->extract_long_term_steps( $business_case_data ),
+       ],
        ];
+
+       $missing_keys = [];
+
+       foreach ( $required_keys as $key ) {
+       if ( empty( $report_data[ $key ] ) ) {
+       $missing_keys[]       = $key;
+       rtbcb_log_error( 'Missing report section: ' . $key );
+       $report_data[ $key ]  = $report_data[ $key ] ?? [];
+       }
+       }
+
+       if ( ! empty( $missing_keys ) ) {
+       return new WP_Error(
+       'rtbcb_missing_report_data',
+       __( 'Missing required report sections', 'rtbcb' ),
+       [
+       'missing_keys' => $missing_keys,
+       'report_data'  => $report_data,
+       ]
+       );
+       }
 
        return $report_data;
    }


### PR DESCRIPTION
## Summary
- validate report sections before rendering
- log and default missing sections when transforming report data
- surface report data validation errors in HTML generation

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*
- `phpcs --standard=WordPress real-treasury-business-case-builder.php inc/class-rtbcb-router.php` *(fails: phpcs: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b37342b38883319f6b972245b83bc0