### PR TITLE
Include company name and ROI in fallback analysis

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -915,15 +915,17 @@ class Real_Treasury_BCB {
 	__( 'User adoption and change management challenges', 'rtbcb' ),
 	__( 'Integration complexity with existing systems', 'rtbcb' ),
 	],
-	'next_actions'      => [
-	__( 'Secure executive sponsorship and project funding', 'rtbcb' ),
-	__( 'Conduct detailed requirements analysis', 'rtbcb' ),
-	__( 'Evaluate treasury technology vendors', 'rtbcb' ),
-	__( 'Develop implementation roadmap and timeline', 'rtbcb' ),
-	],
-	'confidence'        => 0.75,
-	'enhanced_fallback' => true,
-	];
+        'next_actions'      => [
+        __( 'Secure executive sponsorship and project funding', 'rtbcb' ),
+        __( 'Conduct detailed requirements analysis', 'rtbcb' ),
+        __( 'Evaluate treasury technology vendors', 'rtbcb' ),
+        __( 'Develop implementation roadmap and timeline', 'rtbcb' ),
+        ],
+       'company_name'      => $company_name,
+       'base_roi'          => $base_roi,
+        'confidence'        => 0.75,
+        'enhanced_fallback' => true,
+        ];
 	}
 	
 	/**
@@ -1634,6 +1636,8 @@ class Real_Treasury_BCB {
        // Get current company data.
        $company      = rtbcb_get_current_company();
        $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
+       $base_roi     = $business_case_data['base_roi'] ?? $business_case_data['roi_base'] ?? 0;
+       $business_case_data['roi_base'] = $base_roi;
 
        // Create structured data format expected by template.
        $report_data = [


### PR DESCRIPTION
## Summary
- propagate company name and base ROI into fallback analysis response
- ensure template transformation maps and utilizes new fallback fields

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: `phpunit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68b373b8cd2c8331a52172659cd3ad2a