### PR TITLE
Add memory usage test for report generation

### DIFF
--- a/tests/report-memory-usage.test.php
+++ b/tests/report-memory-usage.test.php
@@ -1,0 +1,69 @@
+<?php
+if (!defined('ABSPATH')) {
+	define('ABSPATH', __DIR__);
+}
+if (!function_exists('__')) {
+	function __($text, $domain = null) {
+		return $text;
+	}
+}
+if (!function_exists('add_filter')) {
+	function add_filter($tag, $function_to_add, $priority = 10, $accepted_args = 1) {}
+}
+if (!function_exists('apply_filters')) {
+	function apply_filters($tag, $value) {
+		return $value;
+	}
+}
+require_once __DIR__ . '/../inc/helpers.php';
+if (!function_exists('esc_html__')) {
+	function esc_html__($text, $domain = null) {
+		return $text;
+	}
+}
+if (!function_exists('esc_html')) {
+	function esc_html($text) {
+		return $text;
+	}
+}
+if (!function_exists('esc_attr')) {
+function esc_attr($text) {
+return $text;
+}
+}
+if (!function_exists('wp_convert_hr_to_bytes')) {
+	function wp_convert_hr_to_bytes($size) {
+		$size = trim($size);
+		$unit = strtolower(substr($size, -1));
+		$bytes = (int) $size;
+		switch ($unit) {
+			case 'g':
+				$bytes *= 1024 * 1024 * 1024;
+				break;
+			case 'm':
+				$bytes *= 1024 * 1024;
+				break;
+			case 'k':
+				$bytes *= 1024;
+				break;
+		}
+		return $bytes;
+	}
+}
+$business_case_data = [
+	'narrative' => 'Sample report narrative.',
+	'risks' => ['Risk1'],
+	'assumptions_explained' => ['Assumption1'],
+];
+ob_start();
+include __DIR__ . '/../templates/report-template.php';
+ob_end_clean();
+$status = rtbcb_get_memory_status();
+$threshold = getenv('RTBCB_MEMORY_LIMIT');
+$threshold = $threshold ? wp_convert_hr_to_bytes($threshold) : 50 * 1024 * 1024;
+if ($status['current'] > $threshold) {
+	echo 'Memory usage exceeded threshold: ' . $status['current'] . ' > ' . $threshold . "\n";
+	exit(1);
+}
+echo 'Report generation memory usage within threshold: ' . $status['current'] . " bytes\n";
+

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -50,16 +50,19 @@ php tests/openai-api-key-validation.test.php
 echo "11. Rendering comprehensive report template..."
 php tests/render-comprehensive-template.test.php
 
-echo "12. Running report interactivity test..."
+echo "12. Running report memory usage test..."
+php tests/report-memory-usage.test.php
+
+echo "13. Running report interactivity test..."
 node tests/report-interactivity.test.js
 
 # AJAX error handling test (PHPUnit)
-echo "13. Running AJAX error handling tests..."
+echo "14. Running AJAX error handling tests..."
 phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
 phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
 
 # JavaScript tests
-echo "14. Running JavaScript tests..."
+echo "15. Running JavaScript tests..."
 node tests/handle-submit-error.test.js
 node tests/handle-submit-no-ajax-url.test.js
 node tests/render-results-no-narrative.test.js
@@ -75,13 +78,13 @@ npx --yes jest tests/poll-job-show-results.test.js --config '{"testEnvironment":
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then
-    echo "15. Running WordPress coding standards check..."
+    echo "16. Running WordPress coding standards check..."
     phpcs --standard=WordPress --ignore=vendor .
 else
-    echo "15. Skipping WordPress coding standards (phpcs not installed)"
+    echo "16. Skipping WordPress coding standards (phpcs not installed)"
 fi
 
-echo "16. Running project growth path test..."
+echo "17. Running project growth path test..."
 php tests/project-growth-path.test.php
 
 echo "================================================"


### PR DESCRIPTION
## Summary
- add report memory usage test with configurable threshold
- integrate memory usage check into test runner

## Testing
- `bash tests/run-tests.sh` *(phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b373c61c8c83318c06cf71afd8190a