### PR TITLE
Add validator unit tests and run via phpunit

### DIFF
--- a/inc/class-rtbcb-validator.php
+++ b/inc/class-rtbcb-validator.php
@@ -38,7 +38,29 @@ class RTBCB_Validator {
             }
         }
 
+        if ( ! rtbcb_is_business_email( $sanitized['email'] ) ) {
+            return [
+                'error' => __( 'Please use your business email address.', 'rtbcb' ),
+            ];
+        }
+
+        $length_limits = [
+            'company_name' => 255,
+            'email'        => 254,
+        ];
+
+        foreach ( $length_limits as $field => $limit ) {
+            if ( isset( $sanitized[ $field ] ) && strlen( $sanitized[ $field ] ) > $limit ) {
+                return [
+                    'error' => sprintf(
+                        __( '%s cannot exceed %d characters.', 'rtbcb' ),
+                        ucwords( str_replace( '_', ' ', $field ) ),
+                        $limit
+                    ),
+                ];
+            }
+        }
+
         return $sanitized;
     }
 }
-

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit>
+  <testsuites>
+    <testsuite name="validator">
+      <file>tests/validator.test.php</file>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -84,5 +84,8 @@ fi
 echo "16. Running project growth path test..."
 php tests/project-growth-path.test.php
 
+echo "17. Running validator tests..."
+phpunit -c phpunit.xml
+
 echo "================================================"
 echo "Tests complete!"

--- a/tests/validator.test.php
+++ b/tests/validator.test.php
@@ -1,0 +1,84 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+define( 'ABSPATH', __DIR__ . '/../' );
+
+if ( ! function_exists( 'add_filter' ) ) {
+    function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+        // No-op for testing.
+    }
+}
+
+if ( ! function_exists( '__' ) ) {
+    function __( $text, $domain = null ) {
+        return $text;
+    }
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $text ) {
+        return is_string( $text ) ? trim( $text ) : '';
+    }
+}
+
+if ( ! function_exists( 'sanitize_email' ) ) {
+    function sanitize_email( $email ) {
+        return filter_var( $email, FILTER_SANITIZE_EMAIL );
+    }
+}
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+    function wp_unslash( $value ) {
+        return $value;
+    }
+}
+
+require_once __DIR__ . '/../inc/helpers.php';
+require_once __DIR__ . '/../inc/class-rtbcb-validator.php';
+
+final class RTBCB_ValidatorTest extends TestCase {
+    public function test_missing_required_fields() {
+        $validator = new RTBCB_Validator();
+
+        $result = $validator->validate( [ 'email' => 'user@corp.com', 'company_size' => '100-500' ] );
+        $this->assertSame( 'Company name is required.', $result['error'] );
+
+        $result = $validator->validate( [ 'company_name' => 'Acme', 'company_size' => '100-500' ] );
+        $this->assertSame( 'Email is required.', $result['error'] );
+
+        $result = $validator->validate( [ 'company_name' => 'Acme', 'email' => 'user@corp.com' ] );
+        $this->assertSame( 'Company size is required.', $result['error'] );
+    }
+
+    public function test_email_domain_validation() {
+        $validator = new RTBCB_Validator();
+        $result = $validator->validate( [
+            'company_name' => 'Acme',
+            'email'        => 'user@gmail.com',
+            'company_size' => '100-500',
+        ] );
+        $this->assertSame( 'Please use your business email address.', $result['error'] );
+
+        $this->assertTrue( rtbcb_is_business_email( 'user@company.com' ) );
+        $this->assertFalse( rtbcb_is_business_email( 'user@yahoo.com' ) );
+    }
+
+    public function test_field_length_constraints() {
+        $validator = new RTBCB_Validator();
+        $long_name = str_repeat( 'a', 256 );
+        $result = $validator->validate( [
+            'company_name' => $long_name,
+            'email'        => 'user@corp.com',
+            'company_size' => '100-500',
+        ] );
+        $this->assertSame( 'Company Name cannot exceed 255 characters.', $result['error'] );
+
+        $long_email = str_repeat( 'a', 250 ) . '@example.com';
+        $result = $validator->validate( [
+            'company_name' => 'Acme',
+            'email'        => $long_email,
+            'company_size' => '100-500',
+        ] );
+        $this->assertSame( 'Email cannot exceed 254 characters.', $result['error'] );
+    }
+}


### PR DESCRIPTION
## Summary
- enhance validator with business email and field length checks
- add PHPUnit tests for validator edge cases
- run validator tests in test script

## Testing
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b373e602148331829b583eb8dcca6d