### PR TITLE
Remove redundant stylesheet link from comprehensive report template

### DIFF
--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -564,9 +564,6 @@ function rtbcbExportPDF() {
 }
 </script>
 
-<!-- Enhanced CSS Styles -->
-<link rel="stylesheet" href="<?php echo esc_url( RTBCB_URL . 'public/css/enhanced-report.css' ); ?>">
-
 <?php
 // Pass structured data to JavaScript for charts and interactivity
 wp_localize_script( 'rtbcb-report', 'rtbcbReportData', [


### PR DESCRIPTION
## Summary
- remove hardcoded enhanced-report.css link from comprehensive report template
- rely on asset enqueuing to prevent duplicate stylesheet loads

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*
- `phpcs --standard=WordPress templates/comprehensive-report-template.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3737be3a48331afcb1fb5623dcbd7