### PR TITLE
Sanitize report HTML with custom allowlist

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -227,7 +227,9 @@ class RTBCB_Router {
         include $template_path;
         $html = ob_get_clean();
 
-        return wp_kses_post( $html );
+        $allowed_html = rtbcb_get_report_allowed_html();
+
+        return wp_kses( $html, $allowed_html );
     }
 
    /**
@@ -253,7 +255,9 @@ class RTBCB_Router {
        include $template_path;
        $html = ob_get_clean();
 
-       return wp_kses_post( $html );
+       $allowed_html = rtbcb_get_report_allowed_html();
+
+       return wp_kses( $html, $allowed_html );
    }
 
    /**

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -61,9 +61,43 @@ function rtbcb_has_openai_api_key() {
  * @return bool True if the error appears configuration related.
  */
 function rtbcb_is_openai_configuration_error( $e ) {
-	$message = strtolower( $e->getMessage() );
+        $message = strtolower( $e->getMessage() );
 
-	return false !== strpos( $message, 'api key' ) || false !== strpos( $message, 'model' );
+        return false !== strpos( $message, 'api key' ) || false !== strpos( $message, 'model' );
+}
+
+/**
+ * Get allowed HTML tags for report templates.
+ *
+ * Adds interactive elements and data attributes to the default allowlist.
+ *
+ * @return array Allowed HTML tags.
+ */
+function rtbcb_get_report_allowed_html() {
+        $allowed_html = wp_kses_allowed_html( 'post' );
+
+        foreach ( $allowed_html as $tag => $attrs ) {
+                $allowed_html[ $tag ]['data-*'] = true;
+        }
+
+        $allowed_html['canvas'] = [
+                'id'     => true,
+                'class'  => true,
+                'style'  => true,
+                'width'  => true,
+                'height' => true,
+                'data-*' => true,
+        ];
+
+        $allowed_html['button'] = [
+                'id'     => true,
+                'class'  => true,
+                'style'  => true,
+                'type'   => true,
+                'data-*' => true,
+        ];
+
+        return $allowed_html;
 }
 
 /**

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1616,12 +1616,13 @@ class Real_Treasury_BCB {
 		}
 		$business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
 		// Transform data structure for template.
-		$report_data = $this->transform_data_for_template( $business_case_data );
-		ob_start();
-		include $template_path;
-		$html = ob_get_clean();
-		return wp_kses_post( $html );
-		}
+                $report_data = $this->transform_data_for_template( $business_case_data );
+                ob_start();
+                include $template_path;
+                $html = ob_get_clean();
+                $allowed_html = rtbcb_get_report_allowed_html();
+                return wp_kses( $html, $allowed_html );
+                }
 
    /**
     * Transform LLM response data into the structure expected by comprehensive template.


### PR DESCRIPTION
## Summary
- add reusable report HTML allowlist helper
- sanitize report templates via `wp_kses` and custom allowlist for interactive elements

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh >/tmp/unit.log && tail -n 20 /tmp/unit.log`
- `phpcs --standard=WordPress real-treasury-business-case-builder.php inc/class-rtbcb-router.php inc/helpers.php >/tmp/phpcs.log && tail -n 20 /tmp/phpcs.log` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3739a3cd48331b5ddb33eb80c9f4b