### PR TITLE
Add email and PDF export tests with mock mailer

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -566,7 +566,8 @@ function rtbcb_send_report_email( $form_data, $report_path ) {
 	$subject = __( 'Your Business Case Report', 'rtbcb' );
 	$message = __( 'Please find your business case report attached.', 'rtbcb' );
 
-	wp_mail( $email, $subject, $message, [], [ $report_path ] );
+	$mailer = function_exists( 'apply_filters' ) ? apply_filters( 'rtbcb_mailer', 'wp_mail' ) : 'wp_mail';
+	call_user_func( $mailer, $email, $subject, $message, [], [ $report_path ] );
 }
 
 /**

--- a/tests/email-and-pdf.test.php
+++ b/tests/email-and-pdf.test.php
@@ -1,0 +1,71 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ . '/..' );
+}
+
+if ( ! function_exists( 'sanitize_email' ) ) {
+    function sanitize_email( $email ) {
+        return $email;
+    }
+}
+
+if ( ! function_exists( '__' ) ) {
+    function __( $text, $domain = null ) {
+        return $text;
+    }
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+    $GLOBALS['rtbcb_filters'] = [];
+    function add_filter( $tag, $function_to_add ) {
+        $GLOBALS['rtbcb_filters'][ $tag ] = $function_to_add;
+    }
+    function apply_filters( $tag, $value ) {
+        $args = func_get_args();
+        $tag = array_shift( $args );
+        $value = array_shift( $args );
+        if ( isset( $GLOBALS['rtbcb_filters'][ $tag ] ) ) {
+            $value = call_user_func_array( $GLOBALS['rtbcb_filters'][ $tag ], array_merge( [ $value ], $args ) );
+        }
+        return $value;
+    }
+}
+
+require_once __DIR__ . '/../inc/helpers.php';
+
+$captured = [];
+add_filter( 'rtbcb_mailer', function () use ( &$captured ) {
+    return function ( $to, $subject, $message, $headers, $attachments ) use ( &$captured ) {
+        $captured = [
+            'to' => $to,
+            'subject' => $subject,
+            'attachments' => $attachments,
+        ];
+        return true;
+    };
+} );
+
+$report_path = tempnam( sys_get_temp_dir(), 'rtbcb_report_' );
+file_put_contents( $report_path, 'dummy pdf' );
+
+rtbcb_send_report_email( [ 'email' => 'user@example.com' ], $report_path );
+
+unlink( $report_path );
+
+if ( 'user@example.com' !== $captured['to'] ) {
+    echo "Email recipient mismatch\n";
+    exit( 1 );
+}
+
+if ( 'Your Business Case Report' !== $captured['subject'] ) {
+    echo "Email subject mismatch\n";
+    exit( 1 );
+}
+
+if ( empty( $captured['attachments'] ) || $captured['attachments'][0] !== $report_path ) {
+    echo "Email attachment mismatch\n";
+    exit( 1 );
+}
+
+echo "email-and-pdf.test.php passed\n";

--- a/tests/report-interactivity.test.js
+++ b/tests/report-interactivity.test.js
@@ -37,7 +37,16 @@ global.document = {
     }
 };
 
-global.window = {};
+let printCalled = false;
+global.window = {
+    open() {
+        return {
+            document: { documentElement: { innerHTML: '' } },
+            focus() {},
+            print() { printCalled = true; }
+        };
+    }
+};
 
 global.rtbcbReport = { ajax_url: '', model_capabilities: {}, template_url: '' };
 
@@ -50,5 +59,7 @@ generateProfessionalReport = () => '<!DOCTYPE html><html><body>Report</body></ht
     await generateAndDisplayReport({});
     const exportBtn = container.childNodes.find(node => node.textContent === 'Export to PDF');
     assert.ok(exportBtn, 'Export button not created');
+    exportBtn.onclick();
+    assert.ok(printCalled, 'window.print not triggered');
     console.log('Report interactivity test passed.');
 })();

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -84,5 +84,8 @@ fi
 echo "16. Running project growth path test..."
 php tests/project-growth-path.test.php
 
+echo "17. Running email and PDF test..."
+php tests/email-and-pdf.test.php
+
 echo "================================================"
 echo "Tests complete!"


### PR DESCRIPTION
## Summary
- Allow `rtbcb_send_report_email` to use a filterable mailer for easier testing
- Add `tests/email-and-pdf.test.php` to validate email recipient, subject, and attachment
- Extend front-end test to confirm "Export to PDF" invokes window.print
- Run test suite via `bash tests/run-tests.sh`

## Testing
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b373f5993883319e3011838cb268f1