### PR TITLE
Handle missing recommendation data in template transform

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -268,6 +268,10 @@ class RTBCB_Router {
        $company      = rtbcb_get_current_company();
        $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
 
+       // Derive recommended category and details from recommendation if not provided.
+       $recommended_category = $business_case_data['recommended_category'] ?? ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' );
+       $category_details     = $business_case_data['category_info'] ?? ( $business_case_data['recommendation']['category_info'] ?? [] );
+
        // Create structured data format expected by template.
        $report_data = [
            'metadata'            => [
@@ -307,8 +311,8 @@ class RTBCB_Router {
                ],
            ],
            'technology_strategy' => [
-               'recommended_category' => $business_case_data['recommended_category'] ?? 'treasury_management_system',
-               'category_details'     => $business_case_data['category_info'] ?? [],
+               'recommended_category' => $recommended_category,
+               'category_details'     => $category_details,
            ],
            'operational_insights' => $business_case_data['operational_analysis'] ?? [],
            'risk_analysis'        => [

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1635,6 +1635,10 @@ class Real_Treasury_BCB {
        $company      = rtbcb_get_current_company();
        $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
 
+       // Derive recommended category and details from recommendation if not provided.
+       $recommended_category = $business_case_data['recommended_category'] ?? ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' );
+       $category_details     = $business_case_data['category_info'] ?? ( $business_case_data['recommendation']['category_info'] ?? [] );
+
        // Create structured data format expected by template.
        $report_data = [
            'metadata'            => [
@@ -1674,8 +1678,8 @@ class Real_Treasury_BCB {
                ],
            ],
            'technology_strategy' => [
-               'recommended_category' => $business_case_data['recommended_category'] ?? 'treasury_management_system',
-               'category_details'     => $business_case_data['category_info'] ?? [],
+               'recommended_category' => $recommended_category,
+               'category_details'     => $category_details,
            ],
            'operational_insights' => $business_case_data['operational_analysis'] ?? [],
            'risk_analysis'        => [


### PR DESCRIPTION
## Summary
- Derive recommended category from recommendation data when not explicitly provided
- Ensure technology strategy includes category details from recommendation info

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b3746d74e08331879303baecaace15