### PR TITLE
Cast analysis arrays and add fallbacks

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -203,9 +203,29 @@ class RTBCB_Ajax {
 		];
 	}
 
-	private static function structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $request_start ) {
-		return [
-			'metadata' => [
+private static function structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $request_start ) {
+                $current_state_assessment = (array) ( $final_analysis['operational_analysis']['current_state_assessment'] ?? [] );
+                if ( empty( $current_state_assessment ) ) {
+                        $current_state_assessment[] = __( 'No data provided', 'rtbcb' );
+                }
+
+                $process_improvements = (array) ( $final_analysis['operational_analysis']['process_improvements'] ?? [] );
+                if ( empty( $process_improvements ) ) {
+                        $process_improvements[] = __( 'No data provided', 'rtbcb' );
+                }
+
+                $automation_opportunities = (array) ( $final_analysis['operational_analysis']['automation_opportunities'] ?? [] );
+                if ( empty( $automation_opportunities ) ) {
+                        $automation_opportunities[] = __( 'No data provided', 'rtbcb' );
+                }
+
+                $implementation_risks = (array) ( $final_analysis['risk_mitigation']['implementation_risks'] ?? [] );
+                if ( empty( $implementation_risks ) ) {
+                        $implementation_risks[] = __( 'No data provided', 'rtbcb' );
+                }
+
+                return [
+                        'metadata' => [
 				'company_name'   => $user_inputs['company_name'],
 				'analysis_date'  => current_time( 'Y-m-d' ),
 				'analysis_type'  => 'comprehensive_enhanced',
@@ -231,22 +251,22 @@ class RTBCB_Ajax {
 				'payback_analysis'     => $final_analysis['financial_analysis']['payback_analysis'] ?? [],
 				'sensitivity_analysis' => $roi_scenarios['sensitivity_analysis'] ?? [],
 			],
-			'technology_strategy' => [
-				'recommended_category' => $recommendation['recommended'],
-				'category_details'     => $recommendation['category_info'],
-				'implementation_roadmap' => $final_analysis['implementation_roadmap'] ?? [],
-				'vendor_considerations'=> $final_analysis['vendor_considerations'] ?? [],
-			],
-			'operational_insights' => [
-				'current_state_assessment' => $final_analysis['operational_analysis']['current_state_assessment'] ?? [],
-				'process_improvements'     => $final_analysis['operational_analysis']['process_improvements'] ?? [],
-				'automation_opportunities' => $final_analysis['operational_analysis']['automation_opportunities'] ?? [],
-			],
-			'risk_analysis' => [
-				'implementation_risks' => $final_analysis['risk_mitigation']['implementation_risks'] ?? [],
-				'mitigation_strategies' => $final_analysis['risk_mitigation']['mitigation_strategies'] ?? [],
-				'success_factors'      => $final_analysis['risk_mitigation']['success_factors'] ?? [],
-			],
+                       'technology_strategy' => [
+                               'recommended_category' => $recommendation['recommended'],
+                               'category_details'     => $recommendation['category_info'],
+                               'implementation_roadmap' => $final_analysis['implementation_roadmap'] ?? [],
+                               'vendor_considerations'=> $final_analysis['vendor_considerations'] ?? [],
+                       ],
+                       'operational_insights' => [
+                               'current_state_assessment' => $current_state_assessment,
+                               'process_improvements'     => $process_improvements,
+                               'automation_opportunities' => $automation_opportunities,
+                       ],
+                       'risk_analysis' => [
+                               'implementation_risks' => $implementation_risks,
+                               'mitigation_strategies' => (array) ( $final_analysis['risk_mitigation']['mitigation_strategies'] ?? [] ),
+                               'success_factors'      => (array) ( $final_analysis['risk_mitigation']['success_factors'] ?? [] ),
+                       ],
 			'action_plan' => [
 				'immediate_steps'    => $final_analysis['next_steps']['immediate'] ?? [],
 				'short_term_milestones' => $final_analysis['next_steps']['short_term'] ?? [],

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -268,6 +268,16 @@ class RTBCB_Router {
        $company      = rtbcb_get_current_company();
        $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
 
+       $operational_analysis = (array) ( $business_case_data['operational_analysis'] ?? [] );
+       if ( empty( $operational_analysis ) ) {
+               $operational_analysis[] = __( 'No data provided', 'rtbcb' );
+       }
+
+       $risks = (array) ( $business_case_data['risks'] ?? [] );
+       if ( empty( $risks ) ) {
+               $risks[] = __( 'No data provided', 'rtbcb' );
+       }
+
        // Create structured data format expected by template.
        $report_data = [
            'metadata'            => [
@@ -310,9 +320,9 @@ class RTBCB_Router {
                'recommended_category' => $business_case_data['recommended_category'] ?? 'treasury_management_system',
                'category_details'     => $business_case_data['category_info'] ?? [],
            ],
-           'operational_insights' => $business_case_data['operational_analysis'] ?? [],
+           'operational_insights' => $operational_analysis,
            'risk_analysis'        => [
-               'implementation_risks' => $business_case_data['risks'] ?? [],
+               'implementation_risks' => $risks,
            ],
            'action_plan'          => [
                'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1635,6 +1635,16 @@ class Real_Treasury_BCB {
        $company      = rtbcb_get_current_company();
        $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
 
+       $operational_analysis = (array) ( $business_case_data['operational_analysis'] ?? [] );
+       if ( empty( $operational_analysis ) ) {
+               $operational_analysis[] = __( 'No data provided', 'rtbcb' );
+       }
+
+       $risks = (array) ( $business_case_data['risks'] ?? [] );
+       if ( empty( $risks ) ) {
+               $risks[] = __( 'No data provided', 'rtbcb' );
+       }
+
        // Create structured data format expected by template.
        $report_data = [
            'metadata'            => [
@@ -1677,9 +1687,9 @@ class Real_Treasury_BCB {
                'recommended_category' => $business_case_data['recommended_category'] ?? 'treasury_management_system',
                'category_details'     => $business_case_data['category_info'] ?? [],
            ],
-           'operational_insights' => $business_case_data['operational_analysis'] ?? [],
+           'operational_insights' => $operational_analysis,
            'risk_analysis'        => [
-               'implementation_risks' => $business_case_data['risks'] ?? [],
+               'implementation_risks' => $risks,
            ],
            'action_plan'          => [
                'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -21,8 +21,15 @@ $executive_summary    = $report_data['executive_summary'] ?? [];
 $company_intelligence = $report_data['company_intelligence'] ?? [];
 $financial_analysis   = $report_data['financial_analysis'] ?? [];
 $technology_strategy  = $report_data['technology_strategy'] ?? [];
-$operational_insights = $report_data['operational_insights'] ?? [];
-$risk_analysis        = $report_data['risk_analysis'] ?? [];
+$operational_insights = (array) ( $report_data['operational_insights'] ?? [] );
+if ( empty( $operational_insights ) ) {
+	$operational_insights[] = __( 'No data provided', 'rtbcb' );
+}
+
+$risk_analysis        = (array) ( $report_data['risk_analysis'] ?? [] );
+if ( empty( $risk_analysis ) ) {
+	$risk_analysis[] = __( 'No data provided', 'rtbcb' );
+}
 $action_plan          = $report_data['action_plan'] ?? [];
 
 $company_name    = $metadata['company_name'] ?? __( 'Your Company', 'rtbcb' );

--- a/templates/report-template.php
+++ b/templates/report-template.php
@@ -17,10 +17,16 @@ if ( ! defined( 'ABSPATH' ) ) {
         <p><?php echo esc_html( $business_case_data['narrative'] ); ?></p>
     <?php endif; ?>
 
-    <?php if ( ! empty( $business_case_data['risks'] ) ) : ?>
+    <?php
+    $risks = (array) ( $business_case_data['risks'] ?? [] );
+    if ( empty( $risks ) ) {
+	$risks[] = __( 'No data provided', 'rtbcb' );
+    }
+    if ( ! empty( $risks ) ) :
+    ?>
         <h3><?php echo esc_html__( 'Risks', 'rtbcb' ); ?></h3>
         <ul>
-            <?php foreach ( (array) $business_case_data['risks'] as $risk ) : ?>
+            <?php foreach ( $risks as $risk ) : ?>
                 <li><?php echo esc_html( $risk ); ?></li>
             <?php endforeach; ?>
         </ul>


### PR DESCRIPTION
## Summary
- Cast `operational_analysis` and `risks` data to arrays and append a translatable "No data provided" message when empty.
- Updated router, AJAX response builder, and templates to use these normalized arrays.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found; several JS submission tests errored)*
- `phpcs --standard=WordPress real-treasury-business-case-builder.php inc/class-rtbcb-router.php inc/class-rtbcb-ajax.php templates/comprehensive-report-template.php templates/report-template.php` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b374709b548331b9a2179cef6a187d