### PR TITLE
Sanitize LLM fields and ensure default structure

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2087,33 +2087,62 @@ return $analysis;
 	 * @return array Validated profile data.
 	 */
 	private function validate_company_profile( $profile, $user_inputs ) {
-	return [
-	'name'                => $user_inputs['company_name'],
-	'enhanced_description' => sanitize_textarea_field( $profile['enhanced_description'] ?? '' ),
-	'business_model'      => sanitize_textarea_field( $profile['business_model'] ?? '' ),
-	'market_position'     => sanitize_textarea_field( $profile['market_position'] ?? '' ),
-	'maturity_level'      => in_array( $profile['maturity_level'] ?? '', [ 'basic', 'developing', 'strategic', 'optimized' ], true )
-	? $profile['maturity_level']
-	: 'basic',
-	'financial_indicators' => [
-	'estimated_revenue' => floatval( $profile['financial_indicators']['estimated_revenue'] ?? 0 ),
-	'growth_stage'      => sanitize_text_field( $profile['financial_indicators']['growth_stage'] ?? 'unknown' ),
-	'financial_health'  => sanitize_text_field( $profile['financial_indicators']['financial_health'] ?? 'unknown' ),
-	],
-	'treasury_maturity'   => [
-	'current_state'        => sanitize_textarea_field( $profile['treasury_maturity']['current_state'] ?? '' ),
-	'sophistication_level' => sanitize_text_field( $profile['treasury_maturity']['sophistication_level'] ?? 'manual' ),
-	'key_gaps'            => array_map( 'sanitize_text_field', $profile['treasury_maturity']['key_gaps'] ?? [] ),
-	'automation_readiness' => sanitize_text_field( $profile['treasury_maturity']['automation_readiness'] ?? 'medium' ),
-	],
-	'strategic_context'   => [
-	'primary_challenges'   => array_map( 'sanitize_text_field', $profile['strategic_context']['primary_challenges'] ?? [] ),
-	'growth_objectives'    => array_map( 'sanitize_text_field', $profile['strategic_context']['growth_objectives'] ?? [] ),
-	'competitive_pressures' => array_map( 'sanitize_text_field', $profile['strategic_context']['competitive_pressures'] ?? [] ),
-	'regulatory_environment' => sanitize_textarea_field( $profile['strategic_context']['regulatory_environment'] ?? '' ),
-	],
-	];
-	}
+       $defaults = [
+       'enhanced_description' => '',
+       'business_model'      => '',
+       'market_position'     => '',
+       'maturity_level'      => 'basic',
+       'financial_indicators' => [
+       'estimated_revenue' => 0,
+       'growth_stage'      => 'unknown',
+       'financial_health'  => 'unknown',
+       ],
+       'treasury_maturity'   => [
+       'current_state'        => '',
+       'sophistication_level' => 'manual',
+       'key_gaps'            => [],
+       'automation_readiness' => 'medium',
+       ],
+       'strategic_context'   => [
+       'primary_challenges'   => [],
+       'growth_objectives'    => [],
+       'competitive_pressures' => [],
+       'regulatory_environment' => '',
+       ],
+       ];
+
+       $profile                 = wp_parse_args( $profile, $defaults );
+       $profile['financial_indicators'] = wp_parse_args( $profile['financial_indicators'], $defaults['financial_indicators'] );
+       $profile['treasury_maturity']    = wp_parse_args( $profile['treasury_maturity'], $defaults['treasury_maturity'] );
+       $profile['strategic_context']    = wp_parse_args( $profile['strategic_context'], $defaults['strategic_context'] );
+
+       return [
+       'name'                => $user_inputs['company_name'],
+       'enhanced_description' => wp_kses_post( $profile['enhanced_description'] ),
+       'business_model'      => wp_kses_post( $profile['business_model'] ),
+       'market_position'     => wp_kses_post( $profile['market_position'] ),
+       'maturity_level'      => in_array( $profile['maturity_level'], [ 'basic', 'developing', 'strategic', 'optimized' ], true )
+       ? $profile['maturity_level']
+       : 'basic',
+       'financial_indicators' => [
+       'estimated_revenue' => floatval( $profile['financial_indicators']['estimated_revenue'] ),
+       'growth_stage'      => sanitize_text_field( $profile['financial_indicators']['growth_stage'] ),
+       'financial_health'  => sanitize_text_field( $profile['financial_indicators']['financial_health'] ),
+       ],
+       'treasury_maturity'   => [
+       'current_state'        => wp_kses_post( $profile['treasury_maturity']['current_state'] ),
+       'sophistication_level' => sanitize_text_field( $profile['treasury_maturity']['sophistication_level'] ),
+       'key_gaps'            => array_map( 'sanitize_text_field', $profile['treasury_maturity']['key_gaps'] ),
+       'automation_readiness' => sanitize_text_field( $profile['treasury_maturity']['automation_readiness'] ),
+       ],
+       'strategic_context'   => [
+       'primary_challenges'   => array_map( 'sanitize_text_field', $profile['strategic_context']['primary_challenges'] ),
+       'growth_objectives'    => array_map( 'sanitize_text_field', $profile['strategic_context']['growth_objectives'] ),
+       'competitive_pressures' => array_map( 'sanitize_text_field', $profile['strategic_context']['competitive_pressures'] ),
+       'regulatory_environment' => wp_kses_post( $profile['strategic_context']['regulatory_environment'] ),
+       ],
+       ];
+       }
 	
 	/**
 	 * Safe JSON encoding with error handling.
@@ -2139,26 +2168,51 @@ return $analysis;
 	 * @return array Validated context.
 	 */
 	private function validate_industry_context( $context ) {
-	return [
-	'sector_analysis'    => [
-	'market_dynamics'   => sanitize_textarea_field( $context['sector_analysis']['market_dynamics'] ?? '' ),
-	'growth_trends'     => sanitize_textarea_field( $context['sector_analysis']['growth_trends'] ?? '' ),
-	'disruption_factors' => array_map( 'sanitize_text_field', $context['sector_analysis']['disruption_factors'] ?? [] ),
-	'technology_adoption' => sanitize_text_field( $context['sector_analysis']['technology_adoption'] ?? 'follower' ),
-	],
-	'benchmarking'       => [
-	'typical_treasury_setup' => sanitize_textarea_field( $context['benchmarking']['typical_treasury_setup'] ?? '' ),
-	'common_pain_points'     => array_map( 'sanitize_text_field', $context['benchmarking']['common_pain_points'] ?? [] ),
-	'technology_penetration' => sanitize_text_field( $context['benchmarking']['technology_penetration'] ?? 'medium' ),
-	'investment_patterns'    => sanitize_textarea_field( $context['benchmarking']['investment_patterns'] ?? '' ),
-	],
-	'regulatory_landscape' => [
-	'key_regulations'      => array_map( 'sanitize_text_field', $context['regulatory_landscape']['key_regulations'] ?? [] ),
-	'compliance_complexity' => sanitize_text_field( $context['regulatory_landscape']['compliance_complexity'] ?? 'medium' ),
-	'upcoming_changes'     => array_map( 'sanitize_text_field', $context['regulatory_landscape']['upcoming_changes'] ?? [] ),
-	],
-	];
-	}
+       $defaults = [
+       'sector_analysis'    => [
+       'market_dynamics'   => '',
+       'growth_trends'     => '',
+       'disruption_factors' => [],
+       'technology_adoption' => 'follower',
+       ],
+       'benchmarking'       => [
+       'typical_treasury_setup' => '',
+       'common_pain_points'     => [],
+       'technology_penetration' => 'medium',
+       'investment_patterns'    => '',
+       ],
+       'regulatory_landscape' => [
+       'key_regulations'      => [],
+       'compliance_complexity' => 'medium',
+       'upcoming_changes'     => [],
+       ],
+       ];
+
+       $context                        = wp_parse_args( $context, $defaults );
+       $context['sector_analysis']     = wp_parse_args( $context['sector_analysis'], $defaults['sector_analysis'] );
+       $context['benchmarking']        = wp_parse_args( $context['benchmarking'], $defaults['benchmarking'] );
+       $context['regulatory_landscape'] = wp_parse_args( $context['regulatory_landscape'], $defaults['regulatory_landscape'] );
+
+       return [
+       'sector_analysis'    => [
+       'market_dynamics'   => wp_kses_post( $context['sector_analysis']['market_dynamics'] ),
+       'growth_trends'     => wp_kses_post( $context['sector_analysis']['growth_trends'] ),
+       'disruption_factors' => array_map( 'sanitize_text_field', $context['sector_analysis']['disruption_factors'] ),
+       'technology_adoption' => sanitize_text_field( $context['sector_analysis']['technology_adoption'] ),
+       ],
+       'benchmarking'       => [
+       'typical_treasury_setup' => wp_kses_post( $context['benchmarking']['typical_treasury_setup'] ),
+       'common_pain_points'     => array_map( 'sanitize_text_field', $context['benchmarking']['common_pain_points'] ),
+       'technology_penetration' => sanitize_text_field( $context['benchmarking']['technology_penetration'] ),
+       'investment_patterns'    => wp_kses_post( $context['benchmarking']['investment_patterns'] ),
+       ],
+       'regulatory_landscape' => [
+       'key_regulations'      => array_map( 'sanitize_text_field', $context['regulatory_landscape']['key_regulations'] ),
+       'compliance_complexity' => sanitize_text_field( $context['regulatory_landscape']['compliance_complexity'] ),
+       'upcoming_changes'     => array_map( 'sanitize_text_field', $context['regulatory_landscape']['upcoming_changes'] ),
+       ],
+       ];
+       }
 	
 	/**
 	 * Validate strategic insights data.

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -265,54 +265,86 @@ class RTBCB_Router {
     */
    private function transform_data_for_template( $business_case_data ) {
        // Get current company data.
-       $company      = rtbcb_get_current_company();
-       $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
+       $company  = rtbcb_get_current_company();
+       $defaults = [
+           'company_name'            => $company['name'] ?? __( 'Your Company', 'rtbcb' ),
+           'confidence'              => 0.85,
+           'processing_time'         => 0,
+           'executive_summary'       => '',
+           'narrative'               => '',
+           'executive_recommendation'=> '',
+           'recommendation'          => '',
+           'payback_months'          => 'N/A',
+           'sensitivity_analysis'    => [],
+           'company_analysis'        => '',
+           'maturity_level'          => 'intermediate',
+           'current_state_analysis'  => '',
+           'market_analysis'         => '',
+           'tech_adoption_level'     => 'medium',
+           'recommended_category'    => 'treasury_management_system',
+           'category_info'           => [],
+           'operational_analysis'    => [],
+           'risks'                   => [],
+       ];
+       $business_case_data = wp_parse_args( $business_case_data, $defaults );
+
+       $business_case_data['company_name']            = sanitize_text_field( $business_case_data['company_name'] );
+       $business_case_data['company_analysis']        = wp_kses_post( $business_case_data['company_analysis'] );
+       $business_case_data['current_state_analysis']  = wp_kses_post( $business_case_data['current_state_analysis'] );
+       $business_case_data['market_analysis']         = wp_kses_post( $business_case_data['market_analysis'] );
+       $business_case_data['executive_summary']       = wp_kses_post( $business_case_data['executive_summary'] );
+       $business_case_data['narrative']               = wp_kses_post( $business_case_data['narrative'] );
+       $business_case_data['executive_recommendation']= wp_kses_post( $business_case_data['executive_recommendation'] );
+       $business_case_data['recommendation']          = wp_kses_post( $business_case_data['recommendation'] );
+       $business_case_data['maturity_level']          = sanitize_text_field( $business_case_data['maturity_level'] );
+       $business_case_data['tech_adoption_level']     = sanitize_text_field( $business_case_data['tech_adoption_level'] );
+       $business_case_data['recommended_category']    = sanitize_text_field( $business_case_data['recommended_category'] );
 
        // Create structured data format expected by template.
        $report_data = [
            'metadata'            => [
-               'company_name'    => $company_name,
+               'company_name'    => $business_case_data['company_name'],
                'analysis_date'   => current_time( 'Y-m-d' ),
-               'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
-               'processing_time' => $business_case_data['processing_time'] ?? 0,
+               'confidence_level'=> $business_case_data['confidence'],
+               'processing_time' => $business_case_data['processing_time'],
            ],
            'executive_summary'  => [
-               'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
+               'strategic_positioning'   => $business_case_data['executive_summary'] ?: $business_case_data['narrative'],
                'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
+               'executive_recommendation'=> $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'],
                'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
            ],
            'financial_analysis' => [
                'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
                'payback_analysis'   => [
-                   'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
+                   'payback_months' => $business_case_data['payback_months'],
                ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
+               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
            ],
            'company_intelligence' => [
                'enriched_profile' => [
-                   'enhanced_description' => $business_case_data['company_analysis'] ?? '',
-                   'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
+                   'enhanced_description' => $business_case_data['company_analysis'],
+                   'maturity_level'       => $business_case_data['maturity_level'],
                    'treasury_maturity'    => [
-                       'current_state'    => $business_case_data['current_state_analysis'] ?? '',
+                       'current_state'    => $business_case_data['current_state_analysis'],
                    ],
                ],
                'industry_context' => [
                    'sector_analysis' => [
-                       'market_dynamics' => $business_case_data['market_analysis'] ?? '',
+                       'market_dynamics' => $business_case_data['market_analysis'],
                    ],
                    'benchmarking'   => [
-                       'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
+                       'technology_penetration' => $business_case_data['tech_adoption_level'],
                    ],
                ],
            ],
            'technology_strategy' => [
-               'recommended_category' => $business_case_data['recommended_category'] ?? 'treasury_management_system',
-               'category_details'     => $business_case_data['category_info'] ?? [],
+               'recommended_category' => $business_case_data['recommended_category'],
+               'category_details'     => $business_case_data['category_info'],
            ],
-           'operational_insights' => $business_case_data['operational_analysis'] ?? [],
+           'operational_insights' => $business_case_data['operational_analysis'],
            'risk_analysis'        => [
-               'implementation_risks' => $business_case_data['risks'] ?? [],
+               'implementation_risks' => $business_case_data['risks'],
            ],
            'action_plan'          => [
                'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1632,54 +1632,86 @@ class Real_Treasury_BCB {
     */
    private function transform_data_for_template( $business_case_data ) {
        // Get current company data.
-       $company      = rtbcb_get_current_company();
-       $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
+       $company   = rtbcb_get_current_company();
+       $defaults  = [
+           'company_name'            => $company['name'] ?? __( 'Your Company', 'rtbcb' ),
+           'confidence'              => 0.85,
+           'processing_time'         => 0,
+           'executive_summary'       => '',
+           'narrative'               => '',
+           'executive_recommendation'=> '',
+           'recommendation'          => '',
+           'payback_months'          => 'N/A',
+           'sensitivity_analysis'    => [],
+           'company_analysis'        => '',
+           'maturity_level'          => 'intermediate',
+           'current_state_analysis'  => '',
+           'market_analysis'         => '',
+           'tech_adoption_level'     => 'medium',
+           'recommended_category'    => 'treasury_management_system',
+           'category_info'           => [],
+           'operational_analysis'    => [],
+           'risks'                   => [],
+       ];
+       $business_case_data = wp_parse_args( $business_case_data, $defaults );
+
+       $business_case_data['company_name']            = sanitize_text_field( $business_case_data['company_name'] );
+       $business_case_data['company_analysis']        = wp_kses_post( $business_case_data['company_analysis'] );
+       $business_case_data['current_state_analysis']  = wp_kses_post( $business_case_data['current_state_analysis'] );
+       $business_case_data['market_analysis']         = wp_kses_post( $business_case_data['market_analysis'] );
+       $business_case_data['executive_summary']       = wp_kses_post( $business_case_data['executive_summary'] );
+       $business_case_data['narrative']               = wp_kses_post( $business_case_data['narrative'] );
+       $business_case_data['executive_recommendation']= wp_kses_post( $business_case_data['executive_recommendation'] );
+       $business_case_data['recommendation']          = wp_kses_post( $business_case_data['recommendation'] );
+       $business_case_data['maturity_level']          = sanitize_text_field( $business_case_data['maturity_level'] );
+       $business_case_data['tech_adoption_level']     = sanitize_text_field( $business_case_data['tech_adoption_level'] );
+       $business_case_data['recommended_category']    = sanitize_text_field( $business_case_data['recommended_category'] );
 
        // Create structured data format expected by template.
        $report_data = [
            'metadata'            => [
-               'company_name'    => $company_name,
+               'company_name'    => $business_case_data['company_name'],
                'analysis_date'   => current_time( 'Y-m-d' ),
-               'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
-               'processing_time' => $business_case_data['processing_time'] ?? 0,
+               'confidence_level'=> $business_case_data['confidence'],
+               'processing_time' => $business_case_data['processing_time'],
            ],
            'executive_summary'  => [
-               'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
+               'strategic_positioning'   => $business_case_data['executive_summary'] ?: $business_case_data['narrative'],
                'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
+               'executive_recommendation'=> $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'],
                'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
            ],
            'financial_analysis' => [
                'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
                'payback_analysis'   => [
-                   'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
+                   'payback_months' => $business_case_data['payback_months'],
                ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
+               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
            ],
            'company_intelligence' => [
                'enriched_profile' => [
-                   'enhanced_description' => $business_case_data['company_analysis'] ?? '',
-                   'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
+                   'enhanced_description' => $business_case_data['company_analysis'],
+                   'maturity_level'       => $business_case_data['maturity_level'],
                    'treasury_maturity'    => [
-                       'current_state'    => $business_case_data['current_state_analysis'] ?? '',
+                       'current_state'    => $business_case_data['current_state_analysis'],
                    ],
                ],
                'industry_context' => [
                    'sector_analysis' => [
-                       'market_dynamics' => $business_case_data['market_analysis'] ?? '',
+                       'market_dynamics' => $business_case_data['market_analysis'],
                    ],
                    'benchmarking'   => [
-                       'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
+                       'technology_penetration' => $business_case_data['tech_adoption_level'],
                    ],
                ],
            ],
            'technology_strategy' => [
-               'recommended_category' => $business_case_data['recommended_category'] ?? 'treasury_management_system',
-               'category_details'     => $business_case_data['category_info'] ?? [],
+               'recommended_category' => $business_case_data['recommended_category'],
+               'category_details'     => $business_case_data['category_info'],
            ],
-           'operational_insights' => $business_case_data['operational_analysis'] ?? [],
+           'operational_insights' => $business_case_data['operational_analysis'],
            'risk_analysis'        => [
-               'implementation_risks' => $business_case_data['risks'] ?? [],
+               'implementation_risks' => $business_case_data['risks'],
            ],
            'action_plan'          => [
                'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),


### PR DESCRIPTION
## Summary
- sanitize API text like enhanced_description and market_dynamics using `wp_kses_post`
- merge incoming data with default structures via `wp_parse_args` to ensure keys exist

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` (phpunit missing)


------
https://chatgpt.com/codex/tasks/task_e_68b374776bbc83319350903947350fbb