### PR TITLE
Validate report sections before rendering

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -21,125 +21,125 @@ class RTBCB_Router {
     public function handle_form_submission( $report_type = 'basic' ) {
         // Nonce verification.
         if (
-            ! isset( $_POST['rtbcb_nonce'] )
-            || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ), 'rtbcb_generate' )
+	  ! isset( $_POST['rtbcb_nonce'] )
+	  || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ), 'rtbcb_generate' )
         ) {
-            wp_send_json_error( [ 'message' => __( 'Nonce verification failed.', 'rtbcb' ) ], 403 );
-            return;
+	  wp_send_json_error( [ 'message' => __( 'Nonce verification failed.', 'rtbcb' ) ], 403 );
+	  return;
         }
 
         try {
-            // Sanitize and validate input.
-            $validator      = new RTBCB_Validator();
-            $validated_data = $validator->validate( $_POST );
+	  // Sanitize and validate input.
+	  $validator      = new RTBCB_Validator();
+	  $validated_data = $validator->validate( $_POST );
 
-            if ( isset( $validated_data['error'] ) ) {
-                wp_send_json_error( [ 'message' => $validated_data['error'] ], 400 );
-                return;
-            }
+	  if ( isset( $validated_data['error'] ) ) {
+	      wp_send_json_error( [ 'message' => $validated_data['error'] ], 400 );
+	      return;
+	  }
 
-            $form_data = $validated_data;
+	  $form_data = $validated_data;
 
-            // Determine report type from request if provided.
-            if ( isset( $_POST['report_type'] ) ) {
-                $report_type = sanitize_text_field( wp_unslash( $_POST['report_type'] ) );
-            }
+	  // Determine report type from request if provided.
+	  if ( isset( $_POST['report_type'] ) ) {
+	      $report_type = sanitize_text_field( wp_unslash( $_POST['report_type'] ) );
+	  }
 
-            // Instantiate necessary classes.
-            $llm = new RTBCB_LLM();
-            $rag = new RTBCB_RAG();
+	  // Instantiate necessary classes.
+	  $llm = new RTBCB_LLM();
+	  $rag = new RTBCB_RAG();
 
-            // Perform calculations.
-            $calculations = RTBCB_Calculator::calculate_roi( $form_data );
+	  // Perform calculations.
+	  $calculations = RTBCB_Calculator::calculate_roi( $form_data );
 
-            // Generate context from RAG.
-            $rag_context = $rag->get_context( $form_data['company_description'] );
+	  // Generate context from RAG.
+	  $rag_context = $rag->get_context( $form_data['company_description'] );
 
-            if ( 'comprehensive' === $report_type ) {
-                // Generate comprehensive business case with LLM.
-                $business_case_data = $llm->generate_comprehensive_business_case( $form_data, $calculations, $rag_context );
-            } else {
-                // Route to the appropriate model.
-                $model = $this->route_model( $form_data, $rag_context );
-                if ( is_wp_error( $model ) ) {
-                    throw new Exception( $model->get_error_message() );
-                }
+	  if ( 'comprehensive' === $report_type ) {
+	      // Generate comprehensive business case with LLM.
+	      $business_case_data = $llm->generate_comprehensive_business_case( $form_data, $calculations, $rag_context );
+	  } else {
+	      // Route to the appropriate model.
+	      $model = $this->route_model( $form_data, $rag_context );
+	      if ( is_wp_error( $model ) ) {
+	          throw new Exception( $model->get_error_message() );
+	      }
 
-                // Generate basic business case with LLM.
-                $business_case_data = $llm->generate_business_case( $form_data, $calculations, $rag_context, $model );
-            }
+	      // Generate basic business case with LLM.
+	      $business_case_data = $llm->generate_business_case( $form_data, $calculations, $rag_context, $model );
+	  }
 
-            // Check for LLM generation errors before proceeding.
-            if ( is_wp_error( $business_case_data ) ) {
-                $error_message = $business_case_data->get_error_message();
-                $error_data    = $business_case_data->get_error_data();
-                $status        = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
+	  // Check for LLM generation errors before proceeding.
+	  if ( is_wp_error( $business_case_data ) ) {
+	      $error_message = $business_case_data->get_error_message();
+	      $error_data    = $business_case_data->get_error_data();
+	      $status        = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
 
-                wp_send_json_error(
-                    [
-                        'message'    => $error_message,
-                        'error_code' => $business_case_data->get_error_code(),
-                    ],
-                    $status
-                );
-                return;
-            }
+	      wp_send_json_error(
+	          [
+	              'message'    => $error_message,
+	              'error_code' => $business_case_data->get_error_code(),
+	          ],
+	          $status
+	      );
+	      return;
+	  }
 
-            // Generate report HTML based on type.
-            $report_html = 'comprehensive' === $report_type ?
-                $this->get_comprehensive_report_html( $business_case_data ) :
-                $this->get_report_html( $business_case_data );
+	  // Generate report HTML based on type.
+	  $report_html = 'comprehensive' === $report_type ?
+	      $this->get_comprehensive_report_html( $business_case_data ) :
+	      $this->get_report_html( $business_case_data );
 
-            // Save the lead.
-            $leads   = new RTBCB_Leads();
-            $lead_id = $leads->save_lead( $form_data, $business_case_data );
+	  // Save the lead.
+	  $leads   = new RTBCB_Leads();
+	  $lead_id = $leads->save_lead( $form_data, $business_case_data );
 
-            // Write report HTML to temporary file in uploads directory.
-            $upload_dir  = wp_upload_dir();
-            $reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
-            if ( ! file_exists( $reports_dir ) ) {
-                wp_mkdir_p( $reports_dir );
-            }
+	  // Write report HTML to temporary file in uploads directory.
+	  $upload_dir  = wp_upload_dir();
+	  $reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
+	  if ( ! file_exists( $reports_dir ) ) {
+	      wp_mkdir_p( $reports_dir );
+	  }
 
-            $filepath = trailingslashit( $reports_dir ) . 'report-' . $lead_id . '.html';
-            file_put_contents( $filepath, $report_html );
+	  $filepath = trailingslashit( $reports_dir ) . 'report-' . $lead_id . '.html';
+	  file_put_contents( $filepath, $report_html );
 
-            // Prepare and send the report email.
-            $to      = sanitize_email( $form_data['email'] );
-            $subject = sprintf(
-                __( 'Your Business Case from %s', 'rtbcb' ),
-                get_bloginfo( 'name' )
-            );
-            $message = __( 'Thank you for using the Business Case Builder. Your report is attached.', 'rtbcb' );
-            wp_mail( $to, $subject, $message, [], [ $filepath ] );
+	  // Prepare and send the report email.
+	  $to      = sanitize_email( $form_data['email'] );
+	  $subject = sprintf(
+	      __( 'Your Business Case from %s', 'rtbcb' ),
+	      get_bloginfo( 'name' )
+	  );
+	  $message = __( 'Thank you for using the Business Case Builder. Your report is attached.', 'rtbcb' );
+	  wp_mail( $to, $subject, $message, [], [ $filepath ] );
 
-            // Clean up temporary file.
-            if ( file_exists( $filepath ) ) {
-                unlink( $filepath );
-            }
+	  // Clean up temporary file.
+	  if ( file_exists( $filepath ) ) {
+	      unlink( $filepath );
+	  }
 
-            // Send success response.
-            wp_send_json_success(
-                [
-                    'message'     => __( 'Business case generated successfully.', 'rtbcb' ),
-                    'report_id'   => $lead_id,
-                    'report_html' => $report_html,
-                ]
-            );
+	  // Send success response.
+	  wp_send_json_success(
+	      [
+	          'message'     => __( 'Business case generated successfully.', 'rtbcb' ),
+	          'report_id'   => $lead_id,
+	          'report_html' => $report_html,
+	      ]
+	  );
         } catch ( Exception $e ) {
-            // Log the detailed error to debug.log.
-            error_log( 'RTBCB Form Submission Error: ' . $e->getMessage() );
+	  // Log the detailed error to debug.log.
+	  error_log( 'RTBCB Form Submission Error: ' . $e->getMessage() );
 
-            // Send a generic error response to the client.
-            wp_send_json_error(
-                [
-                    'message' => sprintf(
-                        __( 'An unexpected error occurred while generating your report. Please check the server logs for more details. Error: %s', 'rtbcb' ),
-                        $e->getMessage()
-                    ),
-                ],
-                500
-            );
+	  // Send a generic error response to the client.
+	  wp_send_json_error(
+	      [
+	          'message' => sprintf(
+	              __( 'An unexpected error occurred while generating your report. Please check the server logs for more details. Error: %s', 'rtbcb' ),
+	              $e->getMessage()
+	          ),
+	      ],
+	      500
+	  );
         }
     }
     /**
@@ -163,21 +163,21 @@ class RTBCB_Router {
         $reasoning = 'Default mini model for basic requests';
 
         if ( $complexity > 0.6 || 'trms' === $category ) {
-            $model     = $premium_model;
-            $reasoning = 'Premium model for high complexity or TRMS category';
+	  $model     = $premium_model;
+	  $reasoning = 'Premium model for high complexity or TRMS category';
         } elseif ( 'tms_lite' === $category && $complexity > 0.4 ) {
-            $model     = $premium_model;
-            $reasoning = 'Premium model for TMS-Lite with moderate complexity';
+	  $model     = $premium_model;
+	  $reasoning = 'Premium model for TMS-Lite with moderate complexity';
         }
 
         // Validate selected model
         if ( empty( $model ) ) {
-            $error = new WP_Error(
-                'rtbcb_missing_model',
-                __( 'No language model configured. Please review the plugin settings.', 'rtbcb' )
-            );
-            error_log( 'RTBCB: ' . $error->get_error_message() );
-            return $error;
+	  $error = new WP_Error(
+	      'rtbcb_missing_model',
+	      __( 'No language model configured. Please review the plugin settings.', 'rtbcb' )
+	  );
+	  error_log( 'RTBCB: ' . $error->get_error_message() );
+	  return $error;
         }
 
         error_log( "RTBCB: Model selected: {$model} (Complexity: {$complexity}, Category: {$category}, Reason: {$reasoning})" );
@@ -201,7 +201,7 @@ class RTBCB_Router {
         $score      += count( $chunks ) * 0.2;
 
         if ( isset( $inputs['company_size'] ) && '>$2B' === $inputs['company_size'] ) {
-            $score += 0.3;
+	  $score += 0.3;
         }
 
         return min( 1.0, $score );
@@ -218,7 +218,7 @@ class RTBCB_Router {
         $template_path = RTBCB_DIR . 'templates/report-template.php';
 
         if ( ! file_exists( $template_path ) ) {
-            return '';
+	  return '';
         }
 
         $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
@@ -241,16 +241,21 @@ class RTBCB_Router {
         $template_path = RTBCB_DIR . 'templates/comprehensive-report-template.php';
 
         if ( file_exists( $template_path ) ) {
-            rtbcb_log_api_debug( 'Router: using comprehensive template', [ 'template_path' => $template_path ] );
+	  rtbcb_log_api_debug( 'Router: using comprehensive template', [ 'template_path' => $template_path ] );
         } else {
-            rtbcb_log_api_debug( 'Router: comprehensive template missing, using basic template', [ 'template_path' => $template_path ] );
-            return $this->get_report_html( $business_case_data );
+	  rtbcb_log_api_debug( 'Router: comprehensive template missing, using basic template', [ 'template_path' => $template_path ] );
+	  return $this->get_report_html( $business_case_data );
         }
 
         $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
 
         // Transform data structure for comprehensive template.
         $report_data = $this->transform_data_for_template( $business_case_data );
+
+        if ( is_wp_error( $report_data ) ) {
+	  rtbcb_log_error( 'Report data validation failed', $report_data->get_error_data() );
+	  $report_data = $report_data->get_error_data()['report_data'] ?? [];
+        }
 
         ob_start();
         include $template_path;
@@ -266,66 +271,98 @@ class RTBCB_Router {
     *
     * @return array
     */
-   private function transform_data_for_template( $business_case_data ) {
-       // Get current company data.
-       $company      = rtbcb_get_current_company();
-       $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
+    private function transform_data_for_template( $business_case_data ) {
+// Define required top-level sections for the report.
+$required_sections = [
+'metadata',
+'executive_summary',
+'financial_analysis',
+'company_intelligence',
+'technology_strategy',
+'operational_insights',
+'risk_analysis',
+'action_plan',
+];
 
-       // Create structured data format expected by template.
-       $report_data = [
-           'metadata'            => [
-               'company_name'    => $company_name,
-               'analysis_date'   => current_time( 'Y-m-d' ),
-               'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
-               'processing_time' => $business_case_data['processing_time'] ?? 0,
-           ],
-           'executive_summary'  => [
-               'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
-               'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
-               'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
-           ],
-           'financial_analysis' => [
-               'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
-               'payback_analysis'   => [
-                   'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
-               ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
-           ],
-           'company_intelligence' => [
-               'enriched_profile' => [
-                   'enhanced_description' => $business_case_data['company_analysis'] ?? '',
-                   'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
-                   'treasury_maturity'    => [
-                       'current_state'    => $business_case_data['current_state_analysis'] ?? '',
-                   ],
-               ],
-               'industry_context' => [
-                   'sector_analysis' => [
-                       'market_dynamics' => $business_case_data['market_analysis'] ?? '',
-                   ],
-                   'benchmarking'   => [
-                       'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
-                   ],
-               ],
-           ],
-           'technology_strategy' => [
-               'recommended_category' => $business_case_data['recommended_category'] ?? 'treasury_management_system',
-               'category_details'     => $business_case_data['category_info'] ?? [],
-           ],
-           'operational_insights' => $business_case_data['operational_analysis'] ?? [],
-           'risk_analysis'        => [
-               'implementation_risks' => $business_case_data['risks'] ?? [],
-           ],
-           'action_plan'          => [
-               'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
-               'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),
-               'long_term_objectives'  => $this->extract_long_term_steps( $business_case_data ),
-           ],
-       ];
+// Get current company data.
+$company      = rtbcb_get_current_company();
+$company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
 
-       return $report_data;
-   }
+// Create structured data format expected by template.
+$report_data = [
+	 'metadata'            => [
+	     'company_name'    => $company_name,
+	     'analysis_date'   => current_time( 'Y-m-d' ),
+	     'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
+	     'processing_time' => $business_case_data['processing_time'] ?? 0,
+	 ],
+	 'executive_summary'  => [
+	     'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
+	     'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
+	     'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
+	     'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
+	 ],
+	 'financial_analysis' => [
+	     'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
+	     'payback_analysis'   => [
+	         'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
+	     ],
+	     'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
+	 ],
+	 'company_intelligence' => [
+	     'enriched_profile' => [
+	         'enhanced_description' => $business_case_data['company_analysis'] ?? '',
+	         'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
+	         'treasury_maturity'    => [
+	             'current_state'    => $business_case_data['current_state_analysis'] ?? '',
+	         ],
+	     ],
+	     'industry_context' => [
+	         'sector_analysis' => [
+	             'market_dynamics' => $business_case_data['market_analysis'] ?? '',
+	         ],
+	         'benchmarking'   => [
+	             'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
+	         ],
+	     ],
+	 ],
+	 'technology_strategy' => [
+	     'recommended_category' => $business_case_data['recommended_category'] ?? 'treasury_management_system',
+	     'category_details'     => $business_case_data['category_info'] ?? [],
+	 ],
+	 'operational_insights' => $business_case_data['operational_analysis'] ?? [],
+	 'risk_analysis'        => [
+	     'implementation_risks' => $business_case_data['risks'] ?? [],
+	 ],
+	  'action_plan'          => [
+	      'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
+	      'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),
+	      'long_term_objectives'  => $this->extract_long_term_steps( $business_case_data ),
+	  ],
+        ];
+$missing_sections = [];
+
+foreach ( $required_sections as $section ) {
+if ( empty( $report_data[ $section ] ) ) {
+$missing_sections[]    = $section;
+rtbcb_log_error( 'Missing report section', [ 'section' => $section ] );
+$report_data[ $section ] = $report_data[ $section ] ?? [];
+}
+}
+
+if ( ! empty( $missing_sections ) ) {
+return new WP_Error(
+'rtbcb_missing_sections',
+__( 'Missing required report sections.', 'rtbcb' ),
+[
+'missing_sections' => $missing_sections,
+'report_data'      => $report_data,
+]
+);
+}
+
+return $report_data;
+    }
 
    /**
     * Extract value drivers from business case data.
@@ -339,17 +376,17 @@ class RTBCB_Router {
 
        // Extract from various possible sources.
        if ( ! empty( $data['value_drivers'] ) ) {
-           $drivers = (array) $data['value_drivers'];
+	 $drivers = (array) $data['value_drivers'];
        } elseif ( ! empty( $data['key_benefits'] ) ) {
-           $drivers = (array) $data['key_benefits'];
+	 $drivers = (array) $data['key_benefits'];
        } else {
-           // Default value drivers.
-           $drivers = [
-               __( 'Automated cash management processes', 'rtbcb' ),
-               __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
-               __( 'Reduced operational risk and errors', 'rtbcb' ),
-               __( 'Improved regulatory compliance', 'rtbcb' ),
-           ];
+	 // Default value drivers.
+	 $drivers = [
+	     __( 'Automated cash management processes', 'rtbcb' ),
+	     __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
+	     __( 'Reduced operational risk and errors', 'rtbcb' ),
+	     __( 'Improved regulatory compliance', 'rtbcb' ),
+	 ];
        }
 
        return array_slice( $drivers, 0, 4 );
@@ -365,33 +402,33 @@ class RTBCB_Router {
    private function format_roi_scenarios( $data ) {
        // Try to get ROI data from various possible locations.
        if ( ! empty( $data['scenarios'] ) ) {
-           return $data['scenarios'];
+	 return $data['scenarios'];
        }
 
        if ( ! empty( $data['roi_scenarios'] ) ) {
-           return $data['roi_scenarios'];
+	 return $data['roi_scenarios'];
        }
 
        // Fallback to default structure.
        return [
-           'conservative' => [
-               'total_annual_benefit' => $data['roi_low'] ?? 0,
-               'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
-           ],
-           'base' => [
-               'total_annual_benefit' => $data['roi_base'] ?? 0,
-               'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
-           ],
-           'optimistic' => [
-               'total_annual_benefit' => $data['roi_high'] ?? 0,
-               'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
-           ],
+	 'conservative' => [
+	     'total_annual_benefit' => $data['roi_low'] ?? 0,
+	     'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
+	     'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
+	     'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
+	 ],
+	 'base' => [
+	     'total_annual_benefit' => $data['roi_base'] ?? 0,
+	     'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
+	     'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
+	     'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
+	 ],
+	 'optimistic' => [
+	     'total_annual_benefit' => $data['roi_high'] ?? 0,
+	     'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
+	     'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
+	     'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
+	 ],
        ];
    }
 
@@ -406,13 +443,13 @@ class RTBCB_Router {
        $base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
 
        if ( $base_roi > 500000 ) {
-           return 'Compelling';
+	 return 'Compelling';
        } elseif ( $base_roi > 200000 ) {
-           return 'Strong';
+	 return 'Strong';
        } elseif ( $base_roi > 50000 ) {
-           return 'Moderate';
+	 return 'Moderate';
        } else {
-           return 'Developing';
+	 return 'Developing';
        }
    }
 
@@ -425,14 +462,14 @@ class RTBCB_Router {
     */
    private function extract_immediate_steps( $data ) {
        if ( ! empty( $data['next_actions'] ) ) {
-           $all_actions = (array) $data['next_actions'];
-           return array_slice( $all_actions, 0, 3 );
+	 $all_actions = (array) $data['next_actions'];
+	 return array_slice( $all_actions, 0, 3 );
        }
 
        return [
-           __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
-           __( 'Form project steering committee', 'rtbcb' ),
-           __( 'Conduct detailed requirements gathering', 'rtbcb' ),
+	 __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
+	 __( 'Form project steering committee', 'rtbcb' ),
+	 __( 'Conduct detailed requirements gathering', 'rtbcb' ),
        ];
    }
 
@@ -445,15 +482,15 @@ class RTBCB_Router {
     */
    private function extract_short_term_steps( $data ) {
        if ( ! empty( $data['implementation_steps'] ) ) {
-           $steps = (array) $data['implementation_steps'];
-           return array_slice( $steps, 0, 4 );
+	 $steps = (array) $data['implementation_steps'];
+	 return array_slice( $steps, 0, 4 );
        }
 
        return [
-           __( 'Issue RFP to qualified vendors', 'rtbcb' ),
-           __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
-           __( 'Negotiate contracts and terms', 'rtbcb' ),
-           __( 'Begin system implementation planning', 'rtbcb' ),
+	 __( 'Issue RFP to qualified vendors', 'rtbcb' ),
+	 __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
+	 __( 'Negotiate contracts and terms', 'rtbcb' ),
+	 __( 'Begin system implementation planning', 'rtbcb' ),
        ];
    }
 
@@ -466,10 +503,10 @@ class RTBCB_Router {
     */
    private function extract_long_term_steps( $data ) {
        return [
-           __( 'Complete system implementation and testing', 'rtbcb' ),
-           __( 'Conduct user training and change management', 'rtbcb' ),
-           __( 'Measure and optimize system performance', 'rtbcb' ),
-           __( 'Expand functionality and integration capabilities', 'rtbcb' ),
+	 __( 'Complete system implementation and testing', 'rtbcb' ),
+	 __( 'Conduct user training and change management', 'rtbcb' ),
+	 __( 'Measure and optimize system performance', 'rtbcb' ),
+	 __( 'Expand functionality and integration capabilities', 'rtbcb' ),
        ];
    }
 }


### PR DESCRIPTION
## Summary
- validate comprehensive report data by defining required sections and logging missing ones
- propagate validation checks to report HTML generation and router

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b37573b14083318d78575704600fa8