### PR TITLE
Use custom kses allowlist for report HTML

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -226,8 +226,33 @@ class RTBCB_Router {
         ob_start();
         include $template_path;
         $html = ob_get_clean();
+        $allowed_html = wp_kses_allowed_html( 'post' );
 
-        return wp_kses_post( $html );
+        $allowed_html['canvas'] = [
+                'id'     => true,
+                'class'  => true,
+                'height' => true,
+                'width'  => true,
+                'style'  => true,
+        ];
+
+        $allowed_html['button'] = [
+                'id'      => true,
+                'class'   => true,
+                'type'    => true,
+                'name'    => true,
+                'value'   => true,
+                'onclick' => true,
+                'style'   => true,
+        ];
+
+        foreach ( $allowed_html as $tag => $attributes ) {
+                if ( is_array( $attributes ) ) {
+                        $allowed_html[ $tag ]['data-*'] = true;
+                }
+        }
+
+        return wp_kses( $html, $allowed_html );
     }
 
    /**
@@ -255,8 +280,33 @@ class RTBCB_Router {
         ob_start();
         include $template_path;
         $html = ob_get_clean();
+        $allowed_html = wp_kses_allowed_html( 'post' );
 
-        return wp_kses_post( $html );
+        $allowed_html['canvas'] = [
+                'id'     => true,
+                'class'  => true,
+                'height' => true,
+                'width'  => true,
+                'style'  => true,
+        ];
+
+        $allowed_html['button'] = [
+                'id'      => true,
+                'class'   => true,
+                'type'    => true,
+                'name'    => true,
+                'value'   => true,
+                'onclick' => true,
+                'style'   => true,
+        ];
+
+        foreach ( $allowed_html as $tag => $attributes ) {
+                if ( is_array( $attributes ) ) {
+                        $allowed_html[ $tag ]['data-*'] = true;
+                }
+        }
+
+        return wp_kses( $html, $allowed_html );
     }
 
    /**

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1718,7 +1718,33 @@ $report_data = $this->transform_data_for_template( $business_case_data );
 ob_start();
 include $template_path;
 $html = ob_get_clean();
-return wp_kses_post( $html );
+        $allowed_html = wp_kses_allowed_html( 'post' );
+
+        $allowed_html['canvas'] = [
+                'id'     => true,
+                'class'  => true,
+                'height' => true,
+                'width'  => true,
+                'style'  => true,
+        ];
+
+        $allowed_html['button'] = [
+                'id'      => true,
+                'class'   => true,
+                'type'    => true,
+                'name'    => true,
+                'value'   => true,
+                'onclick' => true,
+                'style'   => true,
+        ];
+
+        foreach ( $allowed_html as $tag => $attributes ) {
+                if ( is_array( $attributes ) ) {
+                        $allowed_html[ $tag ]['data-*'] = true;
+                }
+        }
+
+        return wp_kses( $html, $allowed_html );
                }
 
    /**


### PR DESCRIPTION
## Summary
- sanitize report templates with wp_kses using a custom allowlist
- permit canvas, button, and data-* attributes so interactive elements survive

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b377abd3f88331a3690c136ccd443e