### PR TITLE
Add lead storage integration test

### DIFF
--- a/tests/lead-storage.test.php
+++ b/tests/lead-storage.test.php
@@ -1,0 +1,227 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+$temp_root = sys_get_temp_dir() . '/wp-' . uniqid();
+mkdir( $temp_root . '/wp-admin/includes', 0777, true );
+file_put_contents( $temp_root . '/wp-admin/includes/upgrade.php', "<?php\nfunction dbDelta( \$sql ) {\n\tglobal \$wpdb;\n\t\$wpdb->query( \$sql );\n\treturn true;\n}\n" );
+define( 'ABSPATH', $temp_root . '/' );
+}
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! defined( 'DB_NAME' ) ) {
+define( 'DB_NAME', 'testdb' );
+}
+
+if ( ! defined( 'ARRAY_A' ) ) {
+define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+function add_action( $hook, $callback ) {}
+}
+
+if ( ! function_exists( 'is_email' ) ) {
+function is_email( $email ) {
+return (bool) filter_var( $email, FILTER_VALIDATE_EMAIL );
+}
+}
+
+if ( ! function_exists( 'sanitize_email' ) ) {
+function sanitize_email( $email ) {
+return filter_var( $email, FILTER_SANITIZE_EMAIL );
+}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+function sanitize_text_field( $text ) {
+$text = is_scalar( $text ) ? (string) $text : '';
+$text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
+return trim( $text );
+}
+}
+
+if ( ! function_exists( 'maybe_serialize' ) ) {
+function maybe_serialize( $data ) {
+return ( is_array( $data ) || is_object( $data ) ) ? serialize( $data ) : $data;
+}
+}
+
+if ( ! function_exists( 'maybe_unserialize' ) ) {
+function maybe_unserialize( $data ) {
+$unser = @unserialize( $data );
+return false === $unser && 'b:0;' !== $data ? $data : $unser;
+}
+}
+
+if ( ! function_exists( 'wp_kses_post' ) ) {
+function wp_kses_post( $data ) {
+return $data;
+}
+}
+
+if ( ! function_exists( '__' ) ) {
+function __( $text, $domain = null ) {
+return $text;
+}
+}
+
+class WPDB_Memory {
+    public $prefix = '';
+    public $insert_id = 0;
+    public $last_error = '';
+    private $dbh;
+
+public function __construct() {
+$this->dbh = new SQLite3( ':memory:' );
+}
+
+public function get_charset_collate() {
+return '';
+}
+
+public function query( $sql ) {
+return $this->dbh->exec( $sql );
+}
+
+public function prepare( $query, ...$args ) {
+$escaped = array_map( function ( $arg ) {
+if ( is_string( $arg ) ) {
+return "'" . str_replace( "'", "''", $arg ) . "'";
+}
+return $arg;
+}, $args );
+return vsprintf( $query, $escaped );
+}
+
+public function get_var( $sql ) {
+if ( false !== strpos( $sql, 'information_schema.tables' ) ) {
+return 1;
+}
+$result = $this->dbh->query( $sql );
+if ( $result instanceof SQLite3Result ) {
+$row = $result->fetchArray( SQLITE3_NUM );
+return $row[0] ?? null;
+}
+return null;
+}
+
+public function get_row( $sql, $output = ARRAY_A ) {
+$result = $this->dbh->query( $sql );
+if ( $result instanceof SQLite3Result ) {
+$row = $result->fetchArray( SQLITE3_ASSOC );
+return $row ?: null;
+}
+return null;
+}
+
+public function insert( $table, $data, $format ) {
+$cols  = array_keys( $data );
+$vals  = [];
+foreach ( $cols as $i => $col ) {
+$fmt  = $format[ $i ];
+$val  = $data[ $col ];
+$vals[] = '%s' === $fmt ? "'" . str_replace( "'", "''", $val ) . "'" : $val;
+}
+        $sql = "INSERT INTO $table (" . implode( ',', $cols ) . ") VALUES (" . implode( ',', $vals ) . ")";
+        $ok  = $this->dbh->exec( $sql );
+        if ( $ok ) {
+            $this->insert_id = $this->dbh->lastInsertRowID();
+            return 1;
+        }
+        $this->last_error = $this->dbh->lastErrorMsg();
+        return false;
+}
+
+public function update( $table, $data, $where, $format, $where_format ) {
+$sets = [];
+foreach ( $data as $col => $val ) {
+$fmt    = array_shift( $format );
+$sets[] = '%s' === $fmt ? "$col = '" . str_replace( "'", "''", $val ) . "'" : "$col = $val";
+}
+$where_col = key( $where );
+$where_val = current( $where );
+$where_fmt = $where_format[0];
+$where_sql = '%s' === $where_fmt ? "'" . str_replace( "'", "''", $where_val ) . "'" : $where_val;
+$sql       = "UPDATE $table SET " . implode( ', ', $sets ) . " WHERE $where_col = $where_sql";
+        $ok = $this->dbh->exec( $sql );
+        if ( ! $ok ) {
+            $this->last_error = $this->dbh->lastErrorMsg();
+        }
+        return $ok;
+}
+
+public function last_error() {
+return $this->dbh->lastErrorMsg();
+}
+}
+
+global $wpdb;
+$wpdb = new WPDB_Memory();
+
+require_once __DIR__ . '/../inc/class-rtbcb-leads.php';
+
+$reflect = new ReflectionClass( 'RTBCB_Leads' );
+$prop    = $reflect->getProperty( 'table_name' );
+$prop->setAccessible( true );
+$prop->setValue( null, $wpdb->prefix . 'rtbcb_leads' );
+
+$wpdb->query( 'CREATE TABLE rtbcb_leads (
+id INTEGER PRIMARY KEY AUTOINCREMENT,
+email TEXT UNIQUE,
+company_name TEXT,
+company_size TEXT,
+industry TEXT,
+hours_reconciliation REAL,
+hours_cash_positioning REAL,
+num_banks INTEGER,
+ftes REAL,
+pain_points TEXT,
+recommended_category TEXT,
+roi_low REAL,
+roi_base REAL,
+roi_high REAL,
+report_html TEXT,
+ip_address TEXT,
+user_agent TEXT,
+utm_source TEXT,
+utm_medium TEXT,
+utm_campaign TEXT,
+created_at TEXT,
+updated_at TEXT
+)' );
+
+$_SERVER['REMOTE_ADDR']     = '127.0.0.1';
+$_SERVER['HTTP_USER_AGENT'] = 'test-agent';
+
+$lead_data = [
+'email'         => 'test@example.com',
+'company_size'  => '100-500',
+'pain_points'   => [ 'delays', 'errors' ],
+'roi_low'       => 1000,
+'roi_base'      => 2000,
+'roi_high'      => 3000,
+];
+
+$lead_id = RTBCB_Leads::save_lead( $lead_data );
+if ( ! $lead_id ) {
+echo "Failed to save lead\n";
+exit( 1 );
+}
+
+$retrieved = RTBCB_Leads::get_lead_by_email( 'test@example.com' );
+if ( '100-500' !== ( $retrieved['company_size'] ?? '' ) ) {
+echo "Company size mismatch\n";
+exit( 1 );
+}
+
+if ( [ 'delays', 'errors' ] !== ( $retrieved['pain_points'] ?? [] ) ) {
+echo "Pain points mismatch\n";
+exit( 1 );
+}
+
+if ( 1000.0 !== (float) ( $retrieved['roi_low'] ?? 0 ) || 2000.0 !== (float) ( $retrieved['roi_base'] ?? 0 ) || 3000.0 !== (float) ( $retrieved['roi_high'] ?? 0 ) ) {
+echo "ROI mismatch\n";
+exit( 1 );
+}
+
+echo "lead-storage.test.php passed\n";

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -50,23 +50,27 @@ php tests/reasoning-first-output.test.php
 echo "10. Running OpenAI API key validation test..."
 php tests/openai-api-key-validation.test.php
 
-echo "11. Rendering comprehensive report template..."
+# Lead storage test
+echo "11. Running lead storage test..."
+php tests/lead-storage.test.php
+
+echo "12. Rendering comprehensive report template..."
 php tests/render-comprehensive-template.test.php
 
-echo "12. Running report memory usage test..."
+echo "13. Running report memory usage test..."
 php tests/report-memory-usage.test.php
 
-echo "13. Running report interactivity test..."
+echo "14. Running report interactivity test..."
 node tests/report-interactivity.test.js
 
 # AJAX error handling test (PHPUnit)
-echo "14. Running AJAX error handling tests..."
+echo "15. Running AJAX error handling tests..."
 phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
 phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
 phpunit tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
 
 # JavaScript tests
-echo "15. Running JavaScript tests..."
+echo "16. Running JavaScript tests..."
 node tests/handle-submit-error.test.js
 node tests/handle-submit-no-ajax-url.test.js
 node tests/render-results-no-narrative.test.js
@@ -83,16 +87,16 @@ npx --yes jest tests/poll-job-show-results.test.js --config '{"testEnvironment":
 
 # WordPress coding standards (if installed)
 if command -v phpcs &> /dev/null; then
-    echo "16. Running WordPress coding standards check..."
+    echo "17. Running WordPress coding standards check..."
     phpcs --standard=WordPress --ignore=vendor .
 else
-    echo "16. Skipping WordPress coding standards (phpcs not installed)"
+    echo "17. Skipping WordPress coding standards (phpcs not installed)"
 fi
 
-echo "17. Running project growth path test..."
+echo "18. Running project growth path test..."
 php tests/project-growth-path.test.php
 
-echo "17. Running validator tests..."
+echo "19. Running validator tests..."
 phpunit -c phpunit.xml
 
 echo "================================================"


### PR DESCRIPTION
## Summary
- add lead-storage.test.php to verify RTBCB_Leads persistence using an in-memory database
- run new test as part of test suite

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit not installed; JS warnings present but suite completed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3781b18408331b3e812922f03bb51