### PR TITLE
Add error handling tests and validation

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -164,24 +164,16 @@ class RTBCB_Ajax {
 		wp_send_json_success( $status );
 	}
 
-	private static function collect_and_validate_user_inputs() {
-		$user_inputs = [
-			'email'                  => sanitize_email( wp_unslash( $_POST['email'] ?? '' ) ),
-			'company_name'           => sanitize_text_field( wp_unslash( $_POST['company_name'] ?? '' ) ),
-			'company_size'           => sanitize_text_field( wp_unslash( $_POST['company_size'] ?? '' ) ),
-			'industry'               => sanitize_text_field( wp_unslash( $_POST['industry'] ?? '' ) ),
-			'hours_reconciliation'   => floatval( wp_unslash( $_POST['hours_reconciliation'] ?? 0 ) ),
-			'hours_cash_positioning' => floatval( wp_unslash( $_POST['hours_cash_positioning'] ?? 0 ) ),
-			'num_banks'              => intval( wp_unslash( $_POST['num_banks'] ?? 0 ) ),
-			'ftes'                   => floatval( wp_unslash( $_POST['ftes'] ?? 0 ) ),
-			'pain_points'            => array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['pain_points'] ?? [] ) ),
-			'business_objective'     => sanitize_text_field( wp_unslash( $_POST['business_objective'] ?? '' ) ),
-			'implementation_timeline'=> sanitize_text_field( wp_unslash( $_POST['implementation_timeline'] ?? '' ) ),
-			'budget_range'           => sanitize_text_field( wp_unslash( $_POST['budget_range'] ?? '' ) ),
-		];
+       private static function collect_and_validate_user_inputs() {
+               $validator = new RTBCB_Validator();
+               $validated = $validator->validate( $_POST );
 
-		return $user_inputs;
-	}
+               if ( isset( $validated['error'] ) ) {
+                       return new WP_Error( 'validation_error', $validated['error'] );
+               }
+
+               return $validated;
+       }
 
 	private static function create_fallback_profile( $user_inputs ) {
 		return [

--- a/inc/class-rtbcb-validator.php
+++ b/inc/class-rtbcb-validator.php
@@ -38,6 +38,24 @@ class RTBCB_Validator {
             }
         }
 
+       $numeric_fields = [
+               'hours_reconciliation',
+               'hours_cash_positioning',
+               'num_banks',
+               'ftes',
+       ];
+
+       foreach ( $numeric_fields as $field ) {
+               if ( isset( $data[ $field ] ) && '' !== $data[ $field ] && ! is_numeric( $data[ $field ] ) ) {
+                       return [
+                               'error' => sprintf(
+                                       __( '%s must be a numeric value.', 'rtbcb' ),
+                                       ucwords( str_replace( '_', ' ', $field ) )
+                               ),
+                       ];
+               }
+       }
+
         if ( ! rtbcb_is_business_email( $sanitized['email'] ) ) {
             return [
                 'error' => __( 'Please use your business email address.', 'rtbcb' ),

--- a/tests/report-error-handling.test.php
+++ b/tests/report-error-handling.test.php
@@ -1,0 +1,254 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+define( 'ABSPATH', __DIR__ . '/../' );
+
+if ( ! class_exists( 'WP_Error' ) ) {
+class WP_Error {
+private $code;
+private $message;
+private $data;
+public function __construct( $code = '', $message = '', $data = [] ) {
+$this->code   = $code;
+$this->message = $message;
+$this->data    = $data;
+}
+public function get_error_message() {
+return $this->message;
+}
+public function get_error_code() {
+return $this->code;
+}
+public function get_error_data() {
+return $this->data;
+}
+}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+function is_wp_error( $thing ) {
+return $thing instanceof WP_Error;
+}
+}
+
+if ( ! function_exists( '__' ) ) {
+function __( $text, $domain = null ) {
+return $text;
+}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+function sanitize_text_field( $text ) {
+return is_string( $text ) ? trim( $text ) : '';
+}
+}
+
+if ( ! function_exists( 'sanitize_email' ) ) {
+function sanitize_email( $email ) {
+return filter_var( $email, FILTER_SANITIZE_EMAIL );
+}
+}
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+function wp_unslash( $value ) {
+return $value;
+}
+}
+
+if ( ! function_exists( 'check_ajax_referer' ) ) {
+function check_ajax_referer( $action, $query_arg = false, $die = true ) {
+return true;
+}
+}
+
+if ( ! function_exists( 'wp_verify_nonce' ) ) {
+function wp_verify_nonce( $nonce, $action ) {
+return true;
+}
+}
+
+class RTBCB_JSON_Error extends Exception {
+public $data;
+public $status;
+public function __construct( $data, $status ) {
+parent::__construct();
+$this->data   = $data;
+$this->status = $status;
+}
+}
+
+if ( ! function_exists( 'wp_send_json_error' ) ) {
+function wp_send_json_error( $data = null, $status_code = null ) {
+throw new RTBCB_JSON_Error(
+[
+'success' => false,
+'data'    => $data,
+],
+$status_code
+);
+}
+}
+
+if ( ! function_exists( 'wp_send_json_success' ) ) {
+function wp_send_json_success( $data = null ) {
+// No-op for tests.
+}
+}
+
+class RTBCB_Background_Job {
+public static function enqueue( $user_inputs ) {
+return 123;
+}
+}
+
+require_once __DIR__ . '/../inc/helpers.php';
+require_once __DIR__ . '/../inc/class-rtbcb-validator.php';
+require_once __DIR__ . '/../inc/class-rtbcb-ajax.php';
+require_once __DIR__ . '/../inc/class-rtbcb-router.php';
+
+final class Report_Error_Handling_Test extends TestCase {
+protected function setUp(): void {
+$_POST = [];
+}
+
+public function test_ajax_missing_required_fields() {
+$_POST = [
+'email'        => 'user@corp.com',
+'company_size' => '100-500',
+];
+
+try {
+RTBCB_Ajax::generate_comprehensive_case();
+$this->fail( 'Expected RTBCB_JSON_Error not thrown.' );
+} catch ( RTBCB_JSON_Error $e ) {
+$this->assertSame( 400, $e->status );
+$this->assertSame(
+[
+'success' => false,
+'data'    => 'Company name is required.',
+],
+$e->data
+);
+}
+}
+
+public function test_ajax_invalid_email() {
+$_POST = [
+'company_name' => 'Acme',
+'company_size' => '100-500',
+'email'        => 'user@gmail.com',
+];
+
+try {
+RTBCB_Ajax::generate_comprehensive_case();
+$this->fail( 'Expected RTBCB_JSON_Error not thrown.' );
+} catch ( RTBCB_JSON_Error $e ) {
+$this->assertSame( 400, $e->status );
+$this->assertSame(
+[
+'success' => false,
+'data'    => 'Please use your business email address.',
+],
+$e->data
+);
+}
+}
+
+public function test_ajax_malformed_numeric() {
+$_POST = [
+'company_name'         => 'Acme',
+'company_size'         => '100-500',
+'email'                => 'user@corp.com',
+'hours_reconciliation' => 'notanumber',
+];
+
+try {
+RTBCB_Ajax::generate_comprehensive_case();
+$this->fail( 'Expected RTBCB_JSON_Error not thrown.' );
+} catch ( RTBCB_JSON_Error $e ) {
+$this->assertSame( 400, $e->status );
+$this->assertSame(
+[
+'success' => false,
+'data'    => 'Hours Reconciliation must be a numeric value.',
+],
+$e->data
+);
+}
+}
+
+public function test_router_missing_required_fields() {
+$_POST = [
+'rtbcb_nonce' => 'nonce',
+'email'       => 'user@corp.com',
+];
+
+$router = new RTBCB_Router();
+
+try {
+$router->handle_form_submission();
+$this->fail( 'Expected RTBCB_JSON_Error not thrown.' );
+} catch ( RTBCB_JSON_Error $e ) {
+$this->assertSame( 400, $e->status );
+$this->assertSame(
+[
+'success' => false,
+'data'    => [ 'message' => 'Company name is required.' ],
+],
+$e->data
+);
+}
+}
+
+public function test_router_invalid_email() {
+$_POST = [
+'rtbcb_nonce'  => 'nonce',
+'company_name' => 'Acme',
+'company_size' => '100-500',
+'email'        => 'user@yahoo.com',
+];
+
+$router = new RTBCB_Router();
+
+try {
+$router->handle_form_submission();
+$this->fail( 'Expected RTBCB_JSON_Error not thrown.' );
+} catch ( RTBCB_JSON_Error $e ) {
+$this->assertSame( 400, $e->status );
+$this->assertSame(
+[
+'success' => false,
+'data'    => [ 'message' => 'Please use your business email address.' ],
+],
+$e->data
+);
+}
+}
+
+public function test_router_malformed_numeric() {
+$_POST = [
+'rtbcb_nonce'            => 'nonce',
+'company_name'          => 'Acme',
+'company_size'          => '100-500',
+'email'                 => 'user@corp.com',
+'hours_cash_positioning' => 'abc',
+];
+
+$router = new RTBCB_Router();
+
+try {
+$router->handle_form_submission();
+$this->fail( 'Expected RTBCB_JSON_Error not thrown.' );
+} catch ( RTBCB_JSON_Error $e ) {
+$this->assertSame( 400, $e->status );
+$this->assertSame(
+[
+'success' => false,
+'data'    => [ 'message' => 'Hours Cash Positioning must be a numeric value.' ],
+],
+$e->data
+);
+}
+}
+}
+

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -64,6 +64,7 @@ echo "14. Running AJAX error handling tests..."
 phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
 phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
 phpunit tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
+phpunit tests/report-error-handling.test.php
 
 # JavaScript tests
 echo "15. Running JavaScript tests..."


### PR DESCRIPTION
## Summary
- validate AJAX requests via RTBCB_Validator and return WP_Error on invalid data
- extend validator with numeric field checking
- add tests covering malformed payloads for AJAX and router handlers
- run new test from test runner

## Testing
- `bash tests/run-tests.sh` (phpunit permission denied)


------
https://chatgpt.com/codex/tasks/task_e_68b3783da46483318c9cbe2969b2d474