### PR TITLE
Handle empty operational analysis and risk arrays

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -203,56 +203,73 @@ class RTBCB_Ajax {
 		];
 	}
 
-	private static function structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $request_start ) {
-		return [
-			'metadata' => [
-				'company_name'   => $user_inputs['company_name'],
-				'analysis_date'  => current_time( 'Y-m-d' ),
-				'analysis_type'  => 'comprehensive_enhanced',
-				'confidence_level' => $final_analysis['confidence_level'] ?? 0.85,
-				'processing_time' => microtime( true ) - $request_start,
-			],
-			'executive_summary' => [
-				'strategic_positioning'   => $final_analysis['executive_summary']['strategic_positioning'] ?? '',
-				'business_case_strength'  => self::calculate_business_case_strength( $roi_scenarios, $recommendation ),
-				'key_value_drivers'       => $final_analysis['executive_summary']['key_value_drivers'] ?? [],
-				'executive_recommendation' => $final_analysis['executive_summary']['executive_recommendation'] ?? '',
-				'confidence_level'        => $final_analysis['executive_summary']['confidence_level'] ?? 0.85,
-			],
-			'company_intelligence' => [
-				'enriched_profile'    => $enriched_profile['company_profile'],
-				'industry_context'    => $enriched_profile['industry_context'],
-				'maturity_assessment' => $enriched_profile['maturity_assessment'] ?? [],
-				'competitive_position'=> $enriched_profile['competitive_position'] ?? [],
-			],
-			'financial_analysis' => [
-				'roi_scenarios'        => self::format_roi_scenarios( $roi_scenarios ),
-				'investment_breakdown' => $final_analysis['financial_analysis']['investment_breakdown'] ?? [],
-				'payback_analysis'     => $final_analysis['financial_analysis']['payback_analysis'] ?? [],
-				'sensitivity_analysis' => $roi_scenarios['sensitivity_analysis'] ?? [],
-			],
-			'technology_strategy' => [
-				'recommended_category' => $recommendation['recommended'],
-				'category_details'     => $recommendation['category_info'],
-				'implementation_roadmap' => $final_analysis['implementation_roadmap'] ?? [],
-				'vendor_considerations'=> $final_analysis['vendor_considerations'] ?? [],
-			],
-			'operational_insights' => [
-				'current_state_assessment' => $final_analysis['operational_analysis']['current_state_assessment'] ?? [],
-				'process_improvements'     => $final_analysis['operational_analysis']['process_improvements'] ?? [],
-				'automation_opportunities' => $final_analysis['operational_analysis']['automation_opportunities'] ?? [],
-			],
-			'risk_analysis' => [
-				'implementation_risks' => $final_analysis['risk_mitigation']['implementation_risks'] ?? [],
-				'mitigation_strategies' => $final_analysis['risk_mitigation']['mitigation_strategies'] ?? [],
-				'success_factors'      => $final_analysis['risk_mitigation']['success_factors'] ?? [],
-			],
-			'action_plan' => [
-				'immediate_steps'    => $final_analysis['next_steps']['immediate'] ?? [],
-				'short_term_milestones' => $final_analysis['next_steps']['short_term'] ?? [],
-				'long_term_objectives'  => $final_analysis['next_steps']['long_term'] ?? [],
-			],
-		];
+	  private static function structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $request_start ) {
+	$current_state_assessment = (array) ( $final_analysis['operational_analysis']['current_state_assessment'] ?? [] );
+	if ( empty( $current_state_assessment ) ) {
+	    $current_state_assessment[] = __( 'No data provided', 'rtbcb' );
+	}
+	$process_improvements = (array) ( $final_analysis['operational_analysis']['process_improvements'] ?? [] );
+	if ( empty( $process_improvements ) ) {
+	    $process_improvements[] = __( 'No data provided', 'rtbcb' );
+	}
+	$automation_opportunities = (array) ( $final_analysis['operational_analysis']['automation_opportunities'] ?? [] );
+	if ( empty( $automation_opportunities ) ) {
+	    $automation_opportunities[] = __( 'No data provided', 'rtbcb' );
+	}
+	$implementation_risks = (array) ( $final_analysis['risk_mitigation']['implementation_risks'] ?? [] );
+	if ( empty( $implementation_risks ) ) {
+	    $implementation_risks[] = __( 'No data provided', 'rtbcb' );
+	}
+
+	return [
+	    'metadata' => [
+	        'company_name'   => $user_inputs['company_name'],
+	        'analysis_date'  => current_time( 'Y-m-d' ),
+	        'analysis_type'  => 'comprehensive_enhanced',
+	        'confidence_level' => $final_analysis['confidence_level'] ?? 0.85,
+	        'processing_time' => microtime( true ) - $request_start,
+	    ],
+	    'executive_summary' => [
+	        'strategic_positioning'   => $final_analysis['executive_summary']['strategic_positioning'] ?? '',
+	        'business_case_strength'  => self::calculate_business_case_strength( $roi_scenarios, $recommendation ),
+	        'key_value_drivers'       => $final_analysis['executive_summary']['key_value_drivers'] ?? [],
+	        'executive_recommendation' => $final_analysis['executive_summary']['executive_recommendation'] ?? '',
+	        'confidence_level'        => $final_analysis['executive_summary']['confidence_level'] ?? 0.85,
+	    ],
+	    'company_intelligence' => [
+	        'enriched_profile'    => $enriched_profile['company_profile'],
+	        'industry_context'    => $enriched_profile['industry_context'],
+	        'maturity_assessment' => $enriched_profile['maturity_assessment'] ?? [],
+	        'competitive_position'=> $enriched_profile['competitive_position'] ?? [],
+	    ],
+	    'financial_analysis' => [
+	        'roi_scenarios'        => self::format_roi_scenarios( $roi_scenarios ),
+	        'investment_breakdown' => $final_analysis['financial_analysis']['investment_breakdown'] ?? [],
+	        'payback_analysis'     => $final_analysis['financial_analysis']['payback_analysis'] ?? [],
+	        'sensitivity_analysis' => $roi_scenarios['sensitivity_analysis'] ?? [],
+	    ],
+	    'technology_strategy' => [
+	        'recommended_category' => $recommendation['recommended'],
+	        'category_details'     => $recommendation['category_info'],
+	        'implementation_roadmap' => $final_analysis['implementation_roadmap'] ?? [],
+	        'vendor_considerations'=> $final_analysis['vendor_considerations'] ?? [],
+	    ],
+	    'operational_insights' => [
+	        'current_state_assessment' => $current_state_assessment,
+	        'process_improvements'     => $process_improvements,
+	        'automation_opportunities' => $automation_opportunities,
+	    ],
+	    'risk_analysis' => [
+	        'implementation_risks' => $implementation_risks,
+	        'mitigation_strategies' => (array) ( $final_analysis['risk_mitigation']['mitigation_strategies'] ?? [] ),
+	        'success_factors'      => (array) ( $final_analysis['risk_mitigation']['success_factors'] ?? [] ),
+	    ],
+	    'action_plan' => [
+	        'immediate_steps'    => $final_analysis['next_steps']['immediate'] ?? [],
+	        'short_term_milestones' => $final_analysis['next_steps']['short_term'] ?? [],
+	        'long_term_objectives'  => $final_analysis['next_steps']['long_term'] ?? [],
+	    ],
+	];
 	}
 
 	private static function build_rag_search_query( $user_inputs, $enriched_profile ) {

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -19,128 +19,128 @@ class RTBCB_Router {
      * @return void
      */
     public function handle_form_submission( $report_type = 'basic' ) {
-        // Nonce verification.
-        if (
-            ! isset( $_POST['rtbcb_nonce'] )
-            || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ), 'rtbcb_generate' )
-        ) {
-            wp_send_json_error( [ 'message' => __( 'Nonce verification failed.', 'rtbcb' ) ], 403 );
-            return;
-        }
+	  // Nonce verification.
+	  if (
+	      ! isset( $_POST['rtbcb_nonce'] )
+	      || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ), 'rtbcb_generate' )
+	  ) {
+	      wp_send_json_error( [ 'message' => __( 'Nonce verification failed.', 'rtbcb' ) ], 403 );
+	      return;
+	  }
 
-        try {
-            // Sanitize and validate input.
-            $validator      = new RTBCB_Validator();
-            $validated_data = $validator->validate( $_POST );
+	  try {
+	      // Sanitize and validate input.
+	      $validator      = new RTBCB_Validator();
+	      $validated_data = $validator->validate( $_POST );
 
-            if ( isset( $validated_data['error'] ) ) {
-                wp_send_json_error( [ 'message' => $validated_data['error'] ], 400 );
-                return;
-            }
+	      if ( isset( $validated_data['error'] ) ) {
+	          wp_send_json_error( [ 'message' => $validated_data['error'] ], 400 );
+	          return;
+	      }
 
-            $form_data = $validated_data;
+	      $form_data = $validated_data;
 
-            // Determine report type from request if provided.
-            if ( isset( $_POST['report_type'] ) ) {
-                $report_type = sanitize_text_field( wp_unslash( $_POST['report_type'] ) );
-            }
+	      // Determine report type from request if provided.
+	      if ( isset( $_POST['report_type'] ) ) {
+	          $report_type = sanitize_text_field( wp_unslash( $_POST['report_type'] ) );
+	      }
 
-            // Instantiate necessary classes.
-            $llm = new RTBCB_LLM();
-            $rag = new RTBCB_RAG();
+	      // Instantiate necessary classes.
+	      $llm = new RTBCB_LLM();
+	      $rag = new RTBCB_RAG();
 
-            // Perform calculations.
-            $calculations = RTBCB_Calculator::calculate_roi( $form_data );
+	      // Perform calculations.
+	      $calculations = RTBCB_Calculator::calculate_roi( $form_data );
 
-            // Generate context from RAG.
-            $rag_context = $rag->get_context( $form_data['company_description'] );
+	      // Generate context from RAG.
+	      $rag_context = $rag->get_context( $form_data['company_description'] );
 
-            if ( 'comprehensive' === $report_type ) {
-                // Generate comprehensive business case with LLM.
-                $business_case_data = $llm->generate_comprehensive_business_case( $form_data, $calculations, $rag_context );
-            } else {
-                // Route to the appropriate model.
-                $model = $this->route_model( $form_data, $rag_context );
-                if ( is_wp_error( $model ) ) {
-                    throw new Exception( $model->get_error_message() );
-                }
+	      if ( 'comprehensive' === $report_type ) {
+	          // Generate comprehensive business case with LLM.
+	          $business_case_data = $llm->generate_comprehensive_business_case( $form_data, $calculations, $rag_context );
+	      } else {
+	          // Route to the appropriate model.
+	          $model = $this->route_model( $form_data, $rag_context );
+	          if ( is_wp_error( $model ) ) {
+	              throw new Exception( $model->get_error_message() );
+	          }
 
-                // Generate basic business case with LLM.
-                $business_case_data = $llm->generate_business_case( $form_data, $calculations, $rag_context, $model );
-            }
+	          // Generate basic business case with LLM.
+	          $business_case_data = $llm->generate_business_case( $form_data, $calculations, $rag_context, $model );
+	      }
 
-            // Check for LLM generation errors before proceeding.
-            if ( is_wp_error( $business_case_data ) ) {
-                $error_message = $business_case_data->get_error_message();
-                $error_data    = $business_case_data->get_error_data();
-                $status        = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
+	      // Check for LLM generation errors before proceeding.
+	      if ( is_wp_error( $business_case_data ) ) {
+	          $error_message = $business_case_data->get_error_message();
+	          $error_data    = $business_case_data->get_error_data();
+	          $status        = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
 
-                wp_send_json_error(
-                    [
-                        'message'    => $error_message,
-                        'error_code' => $business_case_data->get_error_code(),
-                    ],
-                    $status
-                );
-                return;
-            }
+	          wp_send_json_error(
+	              [
+	                  'message'    => $error_message,
+	                  'error_code' => $business_case_data->get_error_code(),
+	              ],
+	              $status
+	          );
+	          return;
+	      }
 
-            // Generate report HTML based on type.
-            $report_html = 'comprehensive' === $report_type ?
-                $this->get_comprehensive_report_html( $business_case_data ) :
-                $this->get_report_html( $business_case_data );
+	      // Generate report HTML based on type.
+	      $report_html = 'comprehensive' === $report_type ?
+	          $this->get_comprehensive_report_html( $business_case_data ) :
+	          $this->get_report_html( $business_case_data );
 
-            // Save the lead.
-            $leads   = new RTBCB_Leads();
-            $lead_id = $leads->save_lead( $form_data, $business_case_data );
+	      // Save the lead.
+	      $leads   = new RTBCB_Leads();
+	      $lead_id = $leads->save_lead( $form_data, $business_case_data );
 
-            // Write report HTML to temporary file in uploads directory.
-            $upload_dir  = wp_upload_dir();
-            $reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
-            if ( ! file_exists( $reports_dir ) ) {
-                wp_mkdir_p( $reports_dir );
-            }
+	      // Write report HTML to temporary file in uploads directory.
+	      $upload_dir  = wp_upload_dir();
+	      $reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
+	      if ( ! file_exists( $reports_dir ) ) {
+	          wp_mkdir_p( $reports_dir );
+	      }
 
-            $filepath = trailingslashit( $reports_dir ) . 'report-' . $lead_id . '.html';
-            file_put_contents( $filepath, $report_html );
+	      $filepath = trailingslashit( $reports_dir ) . 'report-' . $lead_id . '.html';
+	      file_put_contents( $filepath, $report_html );
 
-            // Prepare and send the report email.
-            $to      = sanitize_email( $form_data['email'] );
-            $subject = sprintf(
-                __( 'Your Business Case from %s', 'rtbcb' ),
-                get_bloginfo( 'name' )
-            );
-            $message = __( 'Thank you for using the Business Case Builder. Your report is attached.', 'rtbcb' );
-            wp_mail( $to, $subject, $message, [], [ $filepath ] );
+	      // Prepare and send the report email.
+	      $to      = sanitize_email( $form_data['email'] );
+	      $subject = sprintf(
+	          __( 'Your Business Case from %s', 'rtbcb' ),
+	          get_bloginfo( 'name' )
+	      );
+	      $message = __( 'Thank you for using the Business Case Builder. Your report is attached.', 'rtbcb' );
+	      wp_mail( $to, $subject, $message, [], [ $filepath ] );
 
-            // Clean up temporary file.
-            if ( file_exists( $filepath ) ) {
-                unlink( $filepath );
-            }
+	      // Clean up temporary file.
+	      if ( file_exists( $filepath ) ) {
+	          unlink( $filepath );
+	      }
 
-            // Send success response.
-            wp_send_json_success(
-                [
-                    'message'     => __( 'Business case generated successfully.', 'rtbcb' ),
-                    'report_id'   => $lead_id,
-                    'report_html' => $report_html,
-                ]
-            );
-        } catch ( Exception $e ) {
-            // Log the detailed error to debug.log.
-            error_log( 'RTBCB Form Submission Error: ' . $e->getMessage() );
+	      // Send success response.
+	      wp_send_json_success(
+	          [
+	              'message'     => __( 'Business case generated successfully.', 'rtbcb' ),
+	              'report_id'   => $lead_id,
+	              'report_html' => $report_html,
+	          ]
+	      );
+	  } catch ( Exception $e ) {
+	      // Log the detailed error to debug.log.
+	      error_log( 'RTBCB Form Submission Error: ' . $e->getMessage() );
 
-            // Send a generic error response to the client.
-            wp_send_json_error(
-                [
-                    'message' => sprintf(
-                        __( 'An unexpected error occurred while generating your report. Please check the server logs for more details. Error: %s', 'rtbcb' ),
-                        $e->getMessage()
-                    ),
-                ],
-                500
-            );
-        }
+	      // Send a generic error response to the client.
+	      wp_send_json_error(
+	          [
+	              'message' => sprintf(
+	                  __( 'An unexpected error occurred while generating your report. Please check the server logs for more details. Error: %s', 'rtbcb' ),
+	                  $e->getMessage()
+	              ),
+	          ],
+	          500
+	      );
+	  }
     }
     /**
      * Route to the appropriate LLM model.
@@ -151,38 +151,38 @@ class RTBCB_Router {
      * @return string|WP_Error Model name or error if no model configured.
      */
     public function route_model( $inputs, $chunks ) {
-        $complexity = $this->calculate_complexity( $inputs, $chunks );
-        $category   = RTBCB_Category_Recommender::recommend_category( $inputs )['recommended'];
+	  $complexity = $this->calculate_complexity( $inputs, $chunks );
+	  $category   = RTBCB_Category_Recommender::recommend_category( $inputs )['recommended'];
 
-        // Get available models
-        $mini_model    = get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) );
-        $premium_model = get_option( 'rtbcb_premium_model', rtbcb_get_default_model( 'premium' ) );
+	  // Get available models
+	  $mini_model    = get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) );
+	  $premium_model = get_option( 'rtbcb_premium_model', rtbcb_get_default_model( 'premium' ) );
 
-        // Start with mini model as default
-        $model     = $mini_model;
-        $reasoning = 'Default mini model for basic requests';
+	  // Start with mini model as default
+	  $model     = $mini_model;
+	  $reasoning = 'Default mini model for basic requests';
 
-        if ( $complexity > 0.6 || 'trms' === $category ) {
-            $model     = $premium_model;
-            $reasoning = 'Premium model for high complexity or TRMS category';
-        } elseif ( 'tms_lite' === $category && $complexity > 0.4 ) {
-            $model     = $premium_model;
-            $reasoning = 'Premium model for TMS-Lite with moderate complexity';
-        }
+	  if ( $complexity > 0.6 || 'trms' === $category ) {
+	      $model     = $premium_model;
+	      $reasoning = 'Premium model for high complexity or TRMS category';
+	  } elseif ( 'tms_lite' === $category && $complexity > 0.4 ) {
+	      $model     = $premium_model;
+	      $reasoning = 'Premium model for TMS-Lite with moderate complexity';
+	  }
 
-        // Validate selected model
-        if ( empty( $model ) ) {
-            $error = new WP_Error(
-                'rtbcb_missing_model',
-                __( 'No language model configured. Please review the plugin settings.', 'rtbcb' )
-            );
-            error_log( 'RTBCB: ' . $error->get_error_message() );
-            return $error;
-        }
+	  // Validate selected model
+	  if ( empty( $model ) ) {
+	      $error = new WP_Error(
+	          'rtbcb_missing_model',
+	          __( 'No language model configured. Please review the plugin settings.', 'rtbcb' )
+	      );
+	      error_log( 'RTBCB: ' . $error->get_error_message() );
+	      return $error;
+	  }
 
-        error_log( "RTBCB: Model selected: {$model} (Complexity: {$complexity}, Category: {$category}, Reason: {$reasoning})" );
+	  error_log( "RTBCB: Model selected: {$model} (Complexity: {$complexity}, Category: {$category}, Reason: {$reasoning})" );
 
-        return $model;
+	  return $model;
     }
 
     /**
@@ -194,17 +194,17 @@ class RTBCB_Router {
      * @return float Complexity score between 0 and 1.
      */
     private function calculate_complexity( $inputs, $chunks ) {
-        $score = 0;
+	  $score = 0;
 
-        $pain_points = isset( $inputs['pain_points'] ) ? (array) $inputs['pain_points'] : [];
-        $score      += count( $pain_points ) * 0.1;
-        $score      += count( $chunks ) * 0.2;
+	  $pain_points = isset( $inputs['pain_points'] ) ? (array) $inputs['pain_points'] : [];
+	  $score      += count( $pain_points ) * 0.1;
+	  $score      += count( $chunks ) * 0.2;
 
-        if ( isset( $inputs['company_size'] ) && '>$2B' === $inputs['company_size'] ) {
-            $score += 0.3;
-        }
+	  if ( isset( $inputs['company_size'] ) && '>$2B' === $inputs['company_size'] ) {
+	      $score += 0.3;
+	  }
 
-        return min( 1.0, $score );
+	  return min( 1.0, $score );
     }
 
     /**
@@ -215,19 +215,19 @@ class RTBCB_Router {
      * @return string Report HTML.
      */
     public function get_report_html( $business_case_data ) {
-        $template_path = RTBCB_DIR . 'templates/report-template.php';
+	  $template_path = RTBCB_DIR . 'templates/report-template.php';
 
-        if ( ! file_exists( $template_path ) ) {
-            return '';
-        }
+	  if ( ! file_exists( $template_path ) ) {
+	      return '';
+	  }
 
-        $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
+	  $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
 
-        ob_start();
-        include $template_path;
-        $html = ob_get_clean();
+	  ob_start();
+	  include $template_path;
+	  $html = ob_get_clean();
 
-        return wp_kses_post( $html );
+	  return wp_kses_post( $html );
     }
 
    /**
@@ -238,25 +238,25 @@ class RTBCB_Router {
     * @return string
     */
     private function get_comprehensive_report_html( $business_case_data ) {
-        $template_path = RTBCB_DIR . 'templates/comprehensive-report-template.php';
+	  $template_path = RTBCB_DIR . 'templates/comprehensive-report-template.php';
 
-        if ( file_exists( $template_path ) ) {
-            rtbcb_log_api_debug( 'Router: using comprehensive template', [ 'template_path' => $template_path ] );
-        } else {
-            rtbcb_log_api_debug( 'Router: comprehensive template missing, using basic template', [ 'template_path' => $template_path ] );
-            return $this->get_report_html( $business_case_data );
-        }
+	  if ( file_exists( $template_path ) ) {
+	      rtbcb_log_api_debug( 'Router: using comprehensive template', [ 'template_path' => $template_path ] );
+	  } else {
+	      rtbcb_log_api_debug( 'Router: comprehensive template missing, using basic template', [ 'template_path' => $template_path ] );
+	      return $this->get_report_html( $business_case_data );
+	  }
 
-        $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
+	  $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
 
-        // Transform data structure for comprehensive template.
-        $report_data = $this->transform_data_for_template( $business_case_data );
+	  // Transform data structure for comprehensive template.
+	  $report_data = $this->transform_data_for_template( $business_case_data );
 
-        ob_start();
-        include $template_path;
-        $html = ob_get_clean();
+	  ob_start();
+	  include $template_path;
+	  $html = ob_get_clean();
 
-        return wp_kses_post( $html );
+	  return wp_kses_post( $html );
     }
 
    /**
@@ -267,68 +267,78 @@ class RTBCB_Router {
     * @return array
     */
    private function transform_data_for_template( $business_case_data ) {
-       // Get current company data.
-       $company      = rtbcb_get_current_company();
-       $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
+	 // Get current company data.
+	 $company      = rtbcb_get_current_company();
+	 $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
 
-       // Derive recommended category and details from recommendation if not provided.
-       $recommended_category = $business_case_data['recommended_category'] ?? ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' );
-       $category_details     = $business_case_data['category_info'] ?? ( $business_case_data['recommendation']['category_info'] ?? [] );
+	 // Derive recommended category and details from recommendation if not provided.
+	 $recommended_category = $business_case_data['recommended_category'] ?? ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' );
+	 $category_details     = $business_case_data['category_info'] ?? ( $business_case_data['recommendation']['category_info'] ?? [] );
 
-       // Create structured data format expected by template.
-       $report_data = [
-           'metadata'            => [
-               'company_name'    => $company_name,
-               'analysis_date'   => current_time( 'Y-m-d' ),
-               'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
-               'processing_time' => $business_case_data['processing_time'] ?? 0,
-           ],
-           'executive_summary'  => [
-               'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
-               'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
-               'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
-           ],
-           'financial_analysis' => [
-               'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
-               'payback_analysis'   => [
-                   'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
-               ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
-           ],
-           'company_intelligence' => [
-               'enriched_profile' => [
-                   'enhanced_description' => $business_case_data['company_analysis'] ?? '',
-                   'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
-                   'treasury_maturity'    => [
-                       'current_state'    => $business_case_data['current_state_analysis'] ?? '',
-                   ],
-               ],
-               'industry_context' => [
-                   'sector_analysis' => [
-                       'market_dynamics' => $business_case_data['market_analysis'] ?? '',
-                   ],
-                   'benchmarking'   => [
-                       'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
-                   ],
-               ],
-           ],
-           'technology_strategy' => [
-               'recommended_category' => $recommended_category,
-               'category_details'     => $category_details,
-           ],
-           'operational_insights' => $business_case_data['operational_analysis'] ?? [],
-           'risk_analysis'        => [
-               'implementation_risks' => $business_case_data['risks'] ?? [],
-           ],
-           'action_plan'          => [
-               'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
-               'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),
-               'long_term_objectives'  => $this->extract_long_term_steps( $business_case_data ),
-           ],
-       ];
+	$operational_analysis = (array) ( $business_case_data['operational_analysis'] ?? [] );
+	if ( empty( $operational_analysis ) ) {
+	    $operational_analysis[] = __( 'No data provided', 'rtbcb' );
+	}
 
-       return $report_data;
+	$risks = (array) ( $business_case_data['risks'] ?? [] );
+	if ( empty( $risks ) ) {
+	    $risks[] = __( 'No data provided', 'rtbcb' );
+	}
+
+	// Create structured data format expected by template.
+	$report_data = [
+	     'metadata'            => [
+	         'company_name'    => $company_name,
+	         'analysis_date'   => current_time( 'Y-m-d' ),
+	         'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
+	         'processing_time' => $business_case_data['processing_time'] ?? 0,
+	     ],
+	     'executive_summary'  => [
+	         'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
+	         'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
+	         'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
+	         'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
+	     ],
+	     'financial_analysis' => [
+	         'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
+	         'payback_analysis'   => [
+	             'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
+	         ],
+	         'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
+	     ],
+	     'company_intelligence' => [
+	         'enriched_profile' => [
+	             'enhanced_description' => $business_case_data['company_analysis'] ?? '',
+	             'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
+	             'treasury_maturity'    => [
+	                 'current_state'    => $business_case_data['current_state_analysis'] ?? '',
+	             ],
+	         ],
+	         'industry_context' => [
+	             'sector_analysis' => [
+	                 'market_dynamics' => $business_case_data['market_analysis'] ?? '',
+	             ],
+	             'benchmarking'   => [
+	                 'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
+	             ],
+	         ],
+	     ],
+	    'technology_strategy' => [
+	        'recommended_category' => $recommended_category,
+	        'category_details'     => $category_details,
+	    ],
+	    'operational_insights' => $operational_analysis,
+	    'risk_analysis'        => [
+	        'implementation_risks' => $risks,
+	    ],
+	    'action_plan'          => [
+	        'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
+	        'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),
+	        'long_term_objectives'  => $this->extract_long_term_steps( $business_case_data ),
+	    ],
+	];
+
+	 return $report_data;
    }
 
    /**
@@ -339,24 +349,24 @@ class RTBCB_Router {
     * @return array
     */
    private function extract_value_drivers( $data ) {
-       $drivers = [];
+	 $drivers = [];
 
-       // Extract from various possible sources.
-       if ( ! empty( $data['value_drivers'] ) ) {
-           $drivers = (array) $data['value_drivers'];
-       } elseif ( ! empty( $data['key_benefits'] ) ) {
-           $drivers = (array) $data['key_benefits'];
-       } else {
-           // Default value drivers.
-           $drivers = [
-               __( 'Automated cash management processes', 'rtbcb' ),
-               __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
-               __( 'Reduced operational risk and errors', 'rtbcb' ),
-               __( 'Improved regulatory compliance', 'rtbcb' ),
-           ];
-       }
+	 // Extract from various possible sources.
+	 if ( ! empty( $data['value_drivers'] ) ) {
+	     $drivers = (array) $data['value_drivers'];
+	 } elseif ( ! empty( $data['key_benefits'] ) ) {
+	     $drivers = (array) $data['key_benefits'];
+	 } else {
+	     // Default value drivers.
+	     $drivers = [
+	         __( 'Automated cash management processes', 'rtbcb' ),
+	         __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
+	         __( 'Reduced operational risk and errors', 'rtbcb' ),
+	         __( 'Improved regulatory compliance', 'rtbcb' ),
+	     ];
+	 }
 
-       return array_slice( $drivers, 0, 4 );
+	 return array_slice( $drivers, 0, 4 );
    }
 
    /**
@@ -367,36 +377,36 @@ class RTBCB_Router {
     * @return array
     */
    private function format_roi_scenarios( $data ) {
-       // Try to get ROI data from various possible locations.
-       if ( ! empty( $data['scenarios'] ) ) {
-           return $data['scenarios'];
-       }
+	 // Try to get ROI data from various possible locations.
+	 if ( ! empty( $data['scenarios'] ) ) {
+	     return $data['scenarios'];
+	 }
 
-       if ( ! empty( $data['roi_scenarios'] ) ) {
-           return $data['roi_scenarios'];
-       }
+	 if ( ! empty( $data['roi_scenarios'] ) ) {
+	     return $data['roi_scenarios'];
+	 }
 
-       // Fallback to default structure.
-       return [
-           'conservative' => [
-               'total_annual_benefit' => $data['roi_low'] ?? 0,
-               'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
-           ],
-           'base' => [
-               'total_annual_benefit' => $data['roi_base'] ?? 0,
-               'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
-           ],
-           'optimistic' => [
-               'total_annual_benefit' => $data['roi_high'] ?? 0,
-               'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
-           ],
-       ];
+	 // Fallback to default structure.
+	 return [
+	     'conservative' => [
+	         'total_annual_benefit' => $data['roi_low'] ?? 0,
+	         'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
+	         'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
+	         'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
+	     ],
+	     'base' => [
+	         'total_annual_benefit' => $data['roi_base'] ?? 0,
+	         'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
+	         'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
+	         'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
+	     ],
+	     'optimistic' => [
+	         'total_annual_benefit' => $data['roi_high'] ?? 0,
+	         'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
+	         'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
+	         'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
+	     ],
+	 ];
    }
 
    /**
@@ -407,17 +417,17 @@ class RTBCB_Router {
     * @return string
     */
    private function determine_business_case_strength( $data ) {
-       $base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
+	 $base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
 
-       if ( $base_roi > 500000 ) {
-           return 'Compelling';
-       } elseif ( $base_roi > 200000 ) {
-           return 'Strong';
-       } elseif ( $base_roi > 50000 ) {
-           return 'Moderate';
-       } else {
-           return 'Developing';
-       }
+	 if ( $base_roi > 500000 ) {
+	     return 'Compelling';
+	 } elseif ( $base_roi > 200000 ) {
+	     return 'Strong';
+	 } elseif ( $base_roi > 50000 ) {
+	     return 'Moderate';
+	 } else {
+	     return 'Developing';
+	 }
    }
 
    /**
@@ -428,16 +438,16 @@ class RTBCB_Router {
     * @return array
     */
    private function extract_immediate_steps( $data ) {
-       if ( ! empty( $data['next_actions'] ) ) {
-           $all_actions = (array) $data['next_actions'];
-           return array_slice( $all_actions, 0, 3 );
-       }
+	 if ( ! empty( $data['next_actions'] ) ) {
+	     $all_actions = (array) $data['next_actions'];
+	     return array_slice( $all_actions, 0, 3 );
+	 }
 
-       return [
-           __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
-           __( 'Form project steering committee', 'rtbcb' ),
-           __( 'Conduct detailed requirements gathering', 'rtbcb' ),
-       ];
+	 return [
+	     __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
+	     __( 'Form project steering committee', 'rtbcb' ),
+	     __( 'Conduct detailed requirements gathering', 'rtbcb' ),
+	 ];
    }
 
    /**
@@ -448,17 +458,17 @@ class RTBCB_Router {
     * @return array
     */
    private function extract_short_term_steps( $data ) {
-       if ( ! empty( $data['implementation_steps'] ) ) {
-           $steps = (array) $data['implementation_steps'];
-           return array_slice( $steps, 0, 4 );
-       }
+	 if ( ! empty( $data['implementation_steps'] ) ) {
+	     $steps = (array) $data['implementation_steps'];
+	     return array_slice( $steps, 0, 4 );
+	 }
 
-       return [
-           __( 'Issue RFP to qualified vendors', 'rtbcb' ),
-           __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
-           __( 'Negotiate contracts and terms', 'rtbcb' ),
-           __( 'Begin system implementation planning', 'rtbcb' ),
-       ];
+	 return [
+	     __( 'Issue RFP to qualified vendors', 'rtbcb' ),
+	     __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
+	     __( 'Negotiate contracts and terms', 'rtbcb' ),
+	     __( 'Begin system implementation planning', 'rtbcb' ),
+	 ];
    }
 
    /**
@@ -469,12 +479,12 @@ class RTBCB_Router {
     * @return array
     */
    private function extract_long_term_steps( $data ) {
-       return [
-           __( 'Complete system implementation and testing', 'rtbcb' ),
-           __( 'Conduct user training and change management', 'rtbcb' ),
-           __( 'Measure and optimize system performance', 'rtbcb' ),
-           __( 'Expand functionality and integration capabilities', 'rtbcb' ),
-       ];
+	 return [
+	     __( 'Complete system implementation and testing', 'rtbcb' ),
+	     __( 'Conduct user training and change management', 'rtbcb' ),
+	     __( 'Measure and optimize system performance', 'rtbcb' ),
+	     __( 'Expand functionality and integration capabilities', 'rtbcb' ),
+	 ];
    }
 }
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -51,28 +51,28 @@ class Real_Treasury_BCB {
      * @return Real_Treasury_BCB
      */
     public static function instance() {
-        if ( null === self::$instance ) {
-            self::$instance = new self();
-        }
+	  if ( null === self::$instance ) {
+	      self::$instance = new self();
+	  }
 
-        return self::$instance;
+	  return self::$instance;
     }
 
     /**
      * Constructor.
      */
     private function __construct() {
-        $this->plugin_data = get_file_data( RTBCB_FILE, [
-            'Name'        => 'Plugin Name',
-            'Version'     => 'Version',
-            'Description' => 'Description',
-            'Author'      => 'Author',
-            'RequiresWP'  => 'Requires at least',
-            'RequiresPHP' => 'Requires PHP',
-        ] );
+	  $this->plugin_data = get_file_data( RTBCB_FILE, [
+	      'Name'        => 'Plugin Name',
+	      'Version'     => 'Version',
+	      'Description' => 'Description',
+	      'Author'      => 'Author',
+	      'RequiresWP'  => 'Requires at least',
+	      'RequiresPHP' => 'Requires PHP',
+	  ] );
 
-        $this->init_hooks();
-        $this->includes();
+	  $this->init_hooks();
+	  $this->includes();
     }
 
     /**
@@ -81,25 +81,25 @@ class Real_Treasury_BCB {
      * @return void
      */
     private function init_hooks() {
-        register_activation_hook( RTBCB_FILE, [ $this, 'activate' ] );
-        register_deactivation_hook( RTBCB_FILE, [ $this, 'deactivate' ] );
-        register_uninstall_hook( RTBCB_FILE, [ __CLASS__, 'uninstall' ] );
+	  register_activation_hook( RTBCB_FILE, [ $this, 'activate' ] );
+	  register_deactivation_hook( RTBCB_FILE, [ $this, 'deactivate' ] );
+	  register_uninstall_hook( RTBCB_FILE, [ __CLASS__, 'uninstall' ] );
 
-        add_action( 'init', [ $this, 'init' ] );
-        add_action( 'plugins_loaded', [ $this, 'plugins_loaded' ] );
-        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+	  add_action( 'init', [ $this, 'init' ] );
+	  add_action( 'plugins_loaded', [ $this, 'plugins_loaded' ] );
+	  add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 
-        // Shortcode
-        add_shortcode( 'rt_business_case_builder', [ $this, 'shortcode_handler' ] );
+	  // Shortcode
+	  add_shortcode( 'rt_business_case_builder', [ $this, 'shortcode_handler' ] );
 
-        // Portal integration hooks
-        add_action( 'rt_portal_data_changed', [ $this, 'handle_portal_data_change' ] );
+	  // Portal integration hooks
+	  add_action( 'rt_portal_data_changed', [ $this, 'handle_portal_data_change' ] );
 
-        // Admin notices
-        add_action( 'admin_notices', [ $this, 'admin_notices' ] );
+	  // Admin notices
+	  add_action( 'admin_notices', [ $this, 'admin_notices' ] );
 
-        // Plugin action links
-        add_filter( 'plugin_action_links_' . plugin_basename( RTBCB_FILE ), [ $this, 'plugin_action_links' ] );
+	  // Plugin action links
+	  add_filter( 'plugin_action_links_' . plugin_basename( RTBCB_FILE ), [ $this, 'plugin_action_links' ] );
 
 		// AJAX handlers - Use the enhanced version
 		add_action( 'wp_ajax_rtbcb_generate_case', [ $this, 'ajax_generate_comprehensive_case_enhanced' ] );
@@ -137,33 +137,33 @@ class Real_Treasury_BCB {
      * @return void
      */
     private function includes() {
-        // Core classes
-        require_once RTBCB_DIR . 'inc/helpers.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-settings.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-calculator.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-router.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-llm.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-rag.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-leads.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-api-log.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-db.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-category-recommender.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-tests.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-maturity-model.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-validator.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-api-tester.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-workflow-tracker.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-enhanced-calculator.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-intelligent-recommender.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-background-job.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-ajax.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-logger.php';
+	  // Core classes
+	  require_once RTBCB_DIR . 'inc/helpers.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-settings.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-calculator.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-router.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-llm.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-rag.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-leads.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-api-log.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-db.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-category-recommender.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-tests.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-maturity-model.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-validator.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-api-tester.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-workflow-tracker.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-enhanced-calculator.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-intelligent-recommender.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-background-job.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-ajax.php';
+	  require_once RTBCB_DIR . 'inc/class-rtbcb-logger.php';
 
-        // Admin functionality
-        if ( is_admin() ) {
-            require_once RTBCB_DIR . 'admin/class-rtbcb-admin.php';
-            new RTBCB_Admin();
-        }
+	  // Admin functionality
+	  if ( is_admin() ) {
+	      require_once RTBCB_DIR . 'admin/class-rtbcb-admin.php';
+	      new RTBCB_Admin();
+	  }
     }
 
     /**
@@ -172,12 +172,12 @@ class Real_Treasury_BCB {
      * @return void
      */
     public function init() {
-        // Load text domain
-        load_plugin_textdomain( 'rtbcb', false, dirname( plugin_basename( RTBCB_FILE ) ) . '/languages' );
+	  // Load text domain
+	  load_plugin_textdomain( 'rtbcb', false, dirname( plugin_basename( RTBCB_FILE ) ) . '/languages' );
 
-        // Initialize components that need early loading
-        $this->maybe_upgrade();
-        $this->setup_capabilities();
+	  // Initialize components that need early loading
+	  $this->maybe_upgrade();
+	  $this->setup_capabilities();
     }
 
     /**
@@ -186,19 +186,19 @@ class Real_Treasury_BCB {
      * @return void
      */
     public function plugins_loaded() {
-        // Check compatibility
-        if ( ! $this->check_compatibility() ) {
-            return;
-        }
+	  // Check compatibility
+	  if ( ! $this->check_compatibility() ) {
+	      return;
+	  }
 
-        // Initialize database tables and data
-        $this->init_database();
+	  // Initialize database tables and data
+	  $this->init_database();
 
-        // Setup cron jobs
-        $this->setup_cron_jobs();
+	  // Setup cron jobs
+	  $this->setup_cron_jobs();
 
-        // Fire action for other plugins to hook into
-        do_action( 'rtbcb_loaded' );
+	  // Fire action for other plugins to hook into
+	  do_action( 'rtbcb_loaded' );
     }
 
     /**
@@ -207,35 +207,35 @@ class Real_Treasury_BCB {
      * @return bool
      */
     private function check_compatibility() {
-        // Check PHP version
-        if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
-            add_action( 'admin_notices', function() {
-                echo '<div class="notice notice-error"><p>';
-                printf(
-                    esc_html__( 'Real Treasury Business Case Builder requires PHP %1$s or higher. You are running %2$s.', 'rtbcb' ),
-                    '7.4',
-                    PHP_VERSION
-                );
-                echo '</p></div>';
-            } );
-            return false;
-        }
+	  // Check PHP version
+	  if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
+	      add_action( 'admin_notices', function() {
+	          echo '<div class="notice notice-error"><p>';
+	          printf(
+	              esc_html__( 'Real Treasury Business Case Builder requires PHP %1$s or higher. You are running %2$s.', 'rtbcb' ),
+	              '7.4',
+	              PHP_VERSION
+	          );
+	          echo '</p></div>';
+	      } );
+	      return false;
+	  }
 
-        // Check WordPress version
-        if ( version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ) {
-            add_action( 'admin_notices', function() {
-                echo '<div class="notice notice-error"><p>';
-                printf(
-                    esc_html__( 'Real Treasury Business Case Builder requires WordPress %1$s or higher. You are running %2$s.', 'rtbcb' ),
-                    '5.0',
-                    get_bloginfo( 'version' )
-                );
-                echo '</p></div>';
-            } );
-            return false;
-        }
+	  // Check WordPress version
+	  if ( version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ) {
+	      add_action( 'admin_notices', function() {
+	          echo '<div class="notice notice-error"><p>';
+	          printf(
+	              esc_html__( 'Real Treasury Business Case Builder requires WordPress %1$s or higher. You are running %2$s.', 'rtbcb' ),
+	              '5.0',
+	              get_bloginfo( 'version' )
+	          );
+	          echo '</p></div>';
+	      } );
+	      return false;
+	  }
 
-        return true;
+	  return true;
     }
 
     /**
@@ -244,13 +244,13 @@ class Real_Treasury_BCB {
      * @return void
      */
     private function init_database() {
-        // Initialize database and tables
-        RTBCB_DB::init();
+	  // Initialize database and tables
+	  RTBCB_DB::init();
 
-        // Initialize RAG database if needed
-        if ( class_exists( 'RTBCB_RAG' ) ) {
-            new RTBCB_RAG();
-        }
+	  // Initialize RAG database if needed
+	  if ( class_exists( 'RTBCB_RAG' ) ) {
+	      new RTBCB_RAG();
+	  }
     }
 
     /**
@@ -259,12 +259,12 @@ class Real_Treasury_BCB {
      * @return void
      */
     private function setup_capabilities() {
-        $admin = get_role( 'administrator' );
-        if ( $admin ) {
-            $admin->add_cap( 'manage_rtbcb' );
-            $admin->add_cap( 'view_rtbcb_leads' );
-            $admin->add_cap( 'export_rtbcb_data' );
-        }
+	  $admin = get_role( 'administrator' );
+	  if ( $admin ) {
+	      $admin->add_cap( 'manage_rtbcb' );
+	      $admin->add_cap( 'view_rtbcb_leads' );
+	      $admin->add_cap( 'export_rtbcb_data' );
+	  }
     }
 
     /**
@@ -273,19 +273,19 @@ class Real_Treasury_BCB {
      * @return void
      */
     private function setup_cron_jobs() {
-        // Schedule RAG index rebuilds
-        if ( ! wp_next_scheduled( 'rtbcb_rebuild_rag_index' ) ) {
-            wp_schedule_event( time(), 'daily', 'rtbcb_rebuild_rag_index' );
-        }
+	  // Schedule RAG index rebuilds
+	  if ( ! wp_next_scheduled( 'rtbcb_rebuild_rag_index' ) ) {
+	      wp_schedule_event( time(), 'daily', 'rtbcb_rebuild_rag_index' );
+	  }
 
-        add_action( 'rtbcb_rebuild_rag_index', [ $this, 'scheduled_rag_rebuild' ] );
+	  add_action( 'rtbcb_rebuild_rag_index', [ $this, 'scheduled_rag_rebuild' ] );
 
-        // Schedule data cleanup
-        if ( ! wp_next_scheduled( 'rtbcb_cleanup_data' ) ) {
-            wp_schedule_event( time(), 'weekly', 'rtbcb_cleanup_data' );
-        }
+	  // Schedule data cleanup
+	  if ( ! wp_next_scheduled( 'rtbcb_cleanup_data' ) ) {
+	      wp_schedule_event( time(), 'weekly', 'rtbcb_cleanup_data' );
+	  }
 
-        add_action( 'rtbcb_cleanup_data', [ $this, 'scheduled_data_cleanup' ] );
+	  add_action( 'rtbcb_cleanup_data', [ $this, 'scheduled_data_cleanup' ] );
     }
 
     /**
@@ -294,12 +294,12 @@ class Real_Treasury_BCB {
      * @return void
      */
     private function maybe_upgrade() {
-        $current_version = get_option( 'rtbcb_version', '1.0.0' );
+	  $current_version = get_option( 'rtbcb_version', '1.0.0' );
 
-        if ( version_compare( $current_version, RTBCB_VERSION, '<' ) ) {
-            $this->upgrade_plugin( $current_version );
-            update_option( 'rtbcb_version', RTBCB_VERSION );
-        }
+	  if ( version_compare( $current_version, RTBCB_VERSION, '<' ) ) {
+	      $this->upgrade_plugin( $current_version );
+	      update_option( 'rtbcb_version', RTBCB_VERSION );
+	  }
     }
 
     /**
@@ -309,32 +309,32 @@ class Real_Treasury_BCB {
      * @return void
      */
     private function upgrade_plugin( $from_version ) {
-        // Upgrade from 1.x to 2.x
-        if ( version_compare( $from_version, '2.0.0', '<' ) ) {
-            $this->migrate_v1_settings();
-            $this->init_database();
-            $this->set_default_options();
-        }
+	  // Upgrade from 1.x to 2.x
+	  if ( version_compare( $from_version, '2.0.0', '<' ) ) {
+	      $this->migrate_v1_settings();
+	      $this->init_database();
+	      $this->set_default_options();
+	  }
 
-        // Add new options introduced in 2.1.0
-        if ( version_compare( $from_version, '2.1.0', '<' ) ) {
-            $new_options = [
-                'rtbcb_advanced_model'        => 'gpt-5-mini',
-                'rtbcb_comprehensive_analysis' => true,
-            ];
+	  // Add new options introduced in 2.1.0
+	  if ( version_compare( $from_version, '2.1.0', '<' ) ) {
+	      $new_options = [
+	          'rtbcb_advanced_model'        => 'gpt-5-mini',
+	          'rtbcb_comprehensive_analysis' => true,
+	      ];
 
-            foreach ( $new_options as $option => $value ) {
-                if ( get_option( $option ) === false ) {
-                    add_option( $option, $value );
-                }
-            }
-        }
+	      foreach ( $new_options as $option => $value ) {
+	          if ( get_option( $option ) === false ) {
+	              add_option( $option, $value );
+	          }
+	      }
+	  }
 
-        // Clear any caches
-        wp_cache_flush();
+	  // Clear any caches
+	  wp_cache_flush();
 
-        // Log upgrade
-        error_log( "RTBCB: Upgraded from version {$from_version} to " . RTBCB_VERSION );
+	  // Log upgrade
+	  error_log( "RTBCB: Upgraded from version {$from_version} to " . RTBCB_VERSION );
     }
 
     /**
@@ -343,18 +343,18 @@ class Real_Treasury_BCB {
      * @return void
      */
     private function migrate_v1_settings() {
-        // Migration logic for old settings format
-        $old_settings = get_option( 'rtbcb_old_settings', [] );
+	  // Migration logic for old settings format
+	  $old_settings = get_option( 'rtbcb_old_settings', [] );
 
-        if ( ! empty( $old_settings ) ) {
-            // Convert old format to new format
-            foreach ( $old_settings as $key => $value ) {
-                update_option( 'rtbcb_' . $key, $value );
-            }
+	  if ( ! empty( $old_settings ) ) {
+	      // Convert old format to new format
+	      foreach ( $old_settings as $key => $value ) {
+	          update_option( 'rtbcb_' . $key, $value );
+	      }
 
-            // Remove old settings
-            delete_option( 'rtbcb_old_settings' );
-        }
+	      // Remove old settings
+	      delete_option( 'rtbcb_old_settings' );
+	  }
     }
 
     /**
@@ -363,21 +363,21 @@ class Real_Treasury_BCB {
      * @return void
      */
     private function set_default_options() {
-        $defaults = [
-            'rtbcb_mini_model'         => rtbcb_get_default_model( 'mini' ),
-            'rtbcb_premium_model'      => rtbcb_get_default_model( 'premium' ),
-            'rtbcb_advanced_model'     => rtbcb_get_default_model( 'advanced' ),
-            'rtbcb_embedding_model'    => rtbcb_get_default_model( 'embedding' ),
-            'rtbcb_labor_cost_per_hour'=> 100,
-            'rtbcb_bank_fee_baseline'  => 15000,
-            'rtbcb_comprehensive_analysis' => true,
-        ];
+	  $defaults = [
+	      'rtbcb_mini_model'         => rtbcb_get_default_model( 'mini' ),
+	      'rtbcb_premium_model'      => rtbcb_get_default_model( 'premium' ),
+	      'rtbcb_advanced_model'     => rtbcb_get_default_model( 'advanced' ),
+	      'rtbcb_embedding_model'    => rtbcb_get_default_model( 'embedding' ),
+	      'rtbcb_labor_cost_per_hour'=> 100,
+	      'rtbcb_bank_fee_baseline'  => 15000,
+	      'rtbcb_comprehensive_analysis' => true,
+	  ];
 
-        foreach ( $defaults as $option => $value ) {
-            if ( get_option( $option ) === false ) {
-                add_option( $option, $value );
-            }
-        }
+	  foreach ( $defaults as $option => $value ) {
+	      if ( get_option( $option ) === false ) {
+	          add_option( $option, $value );
+	      }
+	  }
     }
 
     /**
@@ -563,12 +563,12 @@ class Real_Treasury_BCB {
 		return false;
 	}
 
-               /**
-                * Determine if comprehensive template should be used.
-                *
-                * @return bool
-                */
-               private function should_use_comprehensive_template() {
+	         /**
+	          * Determine if comprehensive template should be used.
+	          *
+	          * @return bool
+	          */
+	         private function should_use_comprehensive_template() {
 $comprehensive_enabled = get_option( 'rtbcb_comprehensive_analysis', true );
 
 $template_path  = RTBCB_DIR . 'templates/comprehensive-report-template.php';
@@ -600,27 +600,27 @@ return $use_comprehensive;
      * @return string
      */
     public function shortcode_handler( $atts = [] ) {
-        // Parse attributes
-        $atts = shortcode_atts( [
-            'style'    => 'default',
-            'title'    => __( 'Treasury Tech Business Case Builder', 'rtbcb' ),
-            'subtitle' => __( 'Generate a data-driven business case for your treasury technology investment.', 'rtbcb' ),
-        ], $atts, 'rt_business_case_builder' );
+	  // Parse attributes
+	  $atts = shortcode_atts( [
+	      'style'    => 'default',
+	      'title'    => __( 'Treasury Tech Business Case Builder', 'rtbcb' ),
+	      'subtitle' => __( 'Generate a data-driven business case for your treasury technology investment.', 'rtbcb' ),
+	  ], $atts, 'rt_business_case_builder' );
 
-        // Start output buffering
-        ob_start();
+	  // Start output buffering
+	  ob_start();
 
-        // Pass attributes to template
-        $template_args = [
-            'style'    => sanitize_text_field( $atts['style'] ),
-            'title'    => sanitize_text_field( $atts['title'] ),
-            'subtitle' => sanitize_text_field( $atts['subtitle'] ),
-        ];
+	  // Pass attributes to template
+	  $template_args = [
+	      'style'    => sanitize_text_field( $atts['style'] ),
+	      'title'    => sanitize_text_field( $atts['title'] ),
+	      'subtitle' => sanitize_text_field( $atts['subtitle'] ),
+	  ];
 
-        // Load template
-        $this->load_template( 'business-case-form', $template_args );
+	  // Load template
+	  $this->load_template( 'business-case-form', $template_args );
 
-        return ob_get_clean();
+	  return ob_get_clean();
     }
 
     /**
@@ -631,15 +631,15 @@ return $use_comprehensive;
      * @return void
      */
     private function load_template( $template, $args = [] ) {
-        $template_path = RTBCB_DIR . "templates/{$template}.php";
+	  $template_path = RTBCB_DIR . "templates/{$template}.php";
 
-        if ( file_exists( $template_path ) ) {
-            // Extract arguments to variables
-            extract( $args );
-            include $template_path;
-        } else {
-            echo '<div class="rtbcb-error">' . esc_html__( 'Template not found.', 'rtbcb' ) . '</div>';
-        }
+	  if ( file_exists( $template_path ) ) {
+	      // Extract arguments to variables
+	      extract( $args );
+	      include $template_path;
+	  } else {
+	      echo '<div class="rtbcb-error">' . esc_html__( 'Template not found.', 'rtbcb' ) . '</div>';
+	  }
     }
 
     /**
@@ -648,13 +648,13 @@ return $use_comprehensive;
      * @return void
      */
     public function handle_portal_data_change() {
-        // Rebuild RAG index when portal data changes
-        if ( class_exists( 'RTBCB_RAG' ) ) {
-            wp_schedule_single_event( time() + 60, 'rtbcb_rebuild_rag_index' );
-        }
+	  // Rebuild RAG index when portal data changes
+	  if ( class_exists( 'RTBCB_RAG' ) ) {
+	      wp_schedule_single_event( time() + 60, 'rtbcb_rebuild_rag_index' );
+	  }
 
-        // Log the event
-        error_log( 'RTBCB: Portal data change detected, RAG index rebuild scheduled' );
+	  // Log the event
+	  error_log( 'RTBCB: Portal data change detected, RAG index rebuild scheduled' );
     }
 
     /**
@@ -663,17 +663,17 @@ return $use_comprehensive;
      * @return void
      */
     public function scheduled_rag_rebuild() {
-        if ( ! class_exists( 'RTBCB_RAG' ) ) {
-            return;
-        }
+	  if ( ! class_exists( 'RTBCB_RAG' ) ) {
+	      return;
+	  }
 
-        try {
-            $rag = new RTBCB_RAG();
-            $rag->rebuild_index();
-            error_log( 'RTBCB: Scheduled RAG index rebuild completed successfully' );
-        } catch ( Exception $e ) {
-            error_log( 'RTBCB: Scheduled RAG index rebuild failed: ' . $e->getMessage() );
-        }
+	  try {
+	      $rag = new RTBCB_RAG();
+	      $rag->rebuild_index();
+	      error_log( 'RTBCB: Scheduled RAG index rebuild completed successfully' );
+	  } catch ( Exception $e ) {
+	      error_log( 'RTBCB: Scheduled RAG index rebuild failed: ' . $e->getMessage() );
+	  }
     }
 
     /**
@@ -682,41 +682,41 @@ return $use_comprehensive;
      * @return void
      */
     public function scheduled_data_cleanup() {
-        global $wpdb;
+	  global $wpdb;
 
-        // Clean up old temporary files
-        $upload_dir = wp_get_upload_dir();
-        $temp_dir = $upload_dir['basedir'] . '/rtbcb-temp';
+	  // Clean up old temporary files
+	  $upload_dir = wp_get_upload_dir();
+	  $temp_dir = $upload_dir['basedir'] . '/rtbcb-temp';
 
-        if ( is_dir( $temp_dir ) ) {
-            $files = glob( $temp_dir . '/*' );
-            $old_time = time() - ( 7 * DAY_IN_SECONDS ); // 7 days old
+	  if ( is_dir( $temp_dir ) ) {
+	      $files = glob( $temp_dir . '/*' );
+	      $old_time = time() - ( 7 * DAY_IN_SECONDS ); // 7 days old
 
-            foreach ( $files as $file ) {
-                if ( is_file( $file ) && filemtime( $file ) < $old_time ) {
-                    unlink( $file );
-                }
-            }
-        }
+	      foreach ( $files as $file ) {
+	          if ( is_file( $file ) && filemtime( $file ) < $old_time ) {
+	              unlink( $file );
+	          }
+	      }
+	  }
 
-        // Clean up old lead data (optional, configurable)
-        $retention_days = apply_filters( 'rtbcb_lead_retention_days', 0 ); // 0 = keep forever
+	  // Clean up old lead data (optional, configurable)
+	  $retention_days = apply_filters( 'rtbcb_lead_retention_days', 0 ); // 0 = keep forever
 
-        if ( $retention_days > 0 ) {
-            $cutoff_date = date( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
-            $table_name = $wpdb->prefix . 'rtbcb_leads';
+	  if ( $retention_days > 0 ) {
+	      $cutoff_date = date( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
+	      $table_name = $wpdb->prefix . 'rtbcb_leads';
 
-            $deleted = $wpdb->query(
-                $wpdb->prepare(
-                    "DELETE FROM {$table_name} WHERE created_at < %s",
-                    $cutoff_date
-                )
-            );
+	      $deleted = $wpdb->query(
+	          $wpdb->prepare(
+	              "DELETE FROM {$table_name} WHERE created_at < %s",
+	              $cutoff_date
+	          )
+	      );
 
-            if ( $deleted > 0 ) {
-                error_log( "RTBCB: Cleaned up {$deleted} old lead records" );
-            }
-        }
+	      if ( $deleted > 0 ) {
+	          error_log( "RTBCB: Cleaned up {$deleted} old lead records" );
+	      }
+	  }
     }
 
 
@@ -886,36 +886,36 @@ return $use_comprehensive;
 	}
 	
 	try {
-        $rag          = new RTBCB_RAG();
-        $search_query = implode(
-            ' ',
-            array_merge(
-                [ $user_inputs['company_name'], $user_inputs['industry'] ],
-                $user_inputs['pain_points'],
-                [ $recommendation['recommended'] ?? '' ]
-            )
-        );
+	  $rag          = new RTBCB_RAG();
+	  $search_query = implode(
+	      ' ',
+	      array_merge(
+	          [ $user_inputs['company_name'], $user_inputs['industry'] ],
+	          $user_inputs['pain_points'],
+	          [ $recommendation['recommended'] ?? '' ]
+	      )
+	  );
 
-        $results   = $rag->search_similar( $search_query, 3 );
-        $sanitized = [];
+	  $results   = $rag->search_similar( $search_query, 3 );
+	  $sanitized = [];
 
-        foreach ( $results as $result ) {
-            $text = '';
+	  foreach ( $results as $result ) {
+	      $text = '';
 
-            if ( is_array( $result ) && isset( $result['metadata'] ) ) {
-                $metadata = $result['metadata'];
-                $text     = is_array( $metadata ) ? wp_json_encode( $metadata ) : (string) $metadata;
-            } elseif ( is_scalar( $result ) ) {
-                $text = (string) $result;
-            } else {
-                $text = wp_json_encode( $result );
-            }
+	      if ( is_array( $result ) && isset( $result['metadata'] ) ) {
+	          $metadata = $result['metadata'];
+	          $text     = is_array( $metadata ) ? wp_json_encode( $metadata ) : (string) $metadata;
+	      } elseif ( is_scalar( $result ) ) {
+	          $text = (string) $result;
+	      } else {
+	          $text = wp_json_encode( $result );
+	      }
 
-            $text        = sanitize_text_field( (string) $text );
-            $sanitized[] = mb_substr( $text, 0, 1000 );
-        }
+	      $text        = sanitize_text_field( (string) $text );
+	      $sanitized[] = mb_substr( $text, 0, 1000 );
+	  }
 
-        return $sanitized;
+	  return $sanitized;
 	} catch ( Exception $e ) {
 	rtbcb_log_error( 'RAG search failed', $e->getMessage() );
 	return [];
@@ -925,39 +925,39 @@ return $use_comprehensive;
 	/**
 	 * Generate comprehensive business analysis using LLM.
 	 */
-        private function generate_business_analysis( $user_inputs, $scenarios, $rag_context ) {
-        if ( ! class_exists( 'RTBCB_LLM' ) ) {
-        return new WP_Error( 'llm_unavailable', __( 'AI analysis service unavailable.', 'rtbcb' ) );
-        }
+	  private function generate_business_analysis( $user_inputs, $scenarios, $rag_context ) {
+	  if ( ! class_exists( 'RTBCB_LLM' ) ) {
+	  return new WP_Error( 'llm_unavailable', __( 'AI analysis service unavailable.', 'rtbcb' ) );
+	  }
 
-        if ( ! rtbcb_has_openai_api_key() ) {
-        // Return fallback analysis instead of failing.
-        return $this->generate_fallback_analysis( $user_inputs, $scenarios );
-        }
+	  if ( ! rtbcb_has_openai_api_key() ) {
+	  // Return fallback analysis instead of failing.
+	  return $this->generate_fallback_analysis( $user_inputs, $scenarios );
+	  }
 
-        try {
-        $llm    = new RTBCB_LLM();
-        $result = $llm->generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context );
+	  try {
+	  $llm    = new RTBCB_LLM();
+	  $result = $llm->generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context );
 
-        if ( is_wp_error( $result ) ) {
-        // Fall back to structured analysis.
-        return $this->generate_fallback_analysis( $user_inputs, $scenarios );
-        }
+	  if ( is_wp_error( $result ) ) {
+	  // Fall back to structured analysis.
+	  return $this->generate_fallback_analysis( $user_inputs, $scenarios );
+	  }
 
-        $required_keys = [ 'executive_summary', 'financial_analysis', 'industry_analysis', 'implementation_roadmap', 'risk_mitigation', 'next_steps' ];
-        $missing_keys  = array_diff( $required_keys, array_keys( $result ) );
+	  $required_keys = [ 'executive_summary', 'financial_analysis', 'industry_analysis', 'implementation_roadmap', 'risk_mitigation', 'next_steps' ];
+	  $missing_keys  = array_diff( $required_keys, array_keys( $result ) );
 
-        if ( ! empty( $missing_keys ) ) {
-        rtbcb_log_error( 'LLM missing required sections', [ 'missing' => $missing_keys ] );
-        return $this->generate_fallback_analysis( $user_inputs, $scenarios );
-        }
+	  if ( ! empty( $missing_keys ) ) {
+	  rtbcb_log_error( 'LLM missing required sections', [ 'missing' => $missing_keys ] );
+	  return $this->generate_fallback_analysis( $user_inputs, $scenarios );
+	  }
 
-        return $result;
-        } catch ( Exception $e ) {
-        rtbcb_log_error( 'LLM analysis failed', $e->getMessage() );
-        return $this->generate_fallback_analysis( $user_inputs, $scenarios );
-        }
-        }
+	  return $result;
+	  } catch ( Exception $e ) {
+	  rtbcb_log_error( 'LLM analysis failed', $e->getMessage() );
+	  return $this->generate_fallback_analysis( $user_inputs, $scenarios );
+	  }
+	  }
 	
 	/**
 	 * Generate fallback analysis when LLM is unavailable.
@@ -986,17 +986,17 @@ return $use_comprehensive;
 	__( 'User adoption and change management challenges', 'rtbcb' ),
 	__( 'Integration complexity with existing systems', 'rtbcb' ),
 	],
-        'next_actions'      => [
-        __( 'Secure executive sponsorship and project funding', 'rtbcb' ),
-        __( 'Conduct detailed requirements analysis', 'rtbcb' ),
-        __( 'Evaluate treasury technology vendors', 'rtbcb' ),
-        __( 'Develop implementation roadmap and timeline', 'rtbcb' ),
-        ],
-       'company_name'      => $company_name,
-       'base_roi'          => $base_roi,
-        'confidence'        => 0.75,
-        'enhanced_fallback' => true,
-        ];
+	  'next_actions'      => [
+	  __( 'Secure executive sponsorship and project funding', 'rtbcb' ),
+	  __( 'Conduct detailed requirements analysis', 'rtbcb' ),
+	  __( 'Evaluate treasury technology vendors', 'rtbcb' ),
+	  __( 'Develop implementation roadmap and timeline', 'rtbcb' ),
+	  ],
+	 'company_name'      => $company_name,
+	 'base_roi'          => $base_roi,
+	  'confidence'        => 0.75,
+	  'enhanced_fallback' => true,
+	  ];
 	}
 	
 	/**
@@ -1063,61 +1063,61 @@ return $use_comprehensive;
      * Debug wrapper for comprehensive case generation AJAX handler.
      */
     public function ajax_generate_comprehensive_case_debug() {
-        error_log( 'RTBCB: Enter ajax_generate_comprehensive_case_debug' );
+	  error_log( 'RTBCB: Enter ajax_generate_comprehensive_case_debug' );
 
-        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-            ini_set( 'display_errors', '1' );
-        }
+	  if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+	      ini_set( 'display_errors', '1' );
+	  }
 
-        $post_keys = implode( ', ', array_keys( $_POST ) );
-        error_log( 'RTBCB: POST keys: ' . $post_keys );
+	  $post_keys = implode( ', ', array_keys( $_POST ) );
+	  error_log( 'RTBCB: POST keys: ' . $post_keys );
 
-        $nonce_present = isset( $_POST['rtbcb_nonce'] );
-        error_log( 'RTBCB: nonce present: ' . ( $nonce_present ? 'yes' : 'no' ) );
+	  $nonce_present = isset( $_POST['rtbcb_nonce'] );
+	  error_log( 'RTBCB: nonce present: ' . ( $nonce_present ? 'yes' : 'no' ) );
 
-        $nonce_valid = check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false );
-        error_log( 'RTBCB: nonce verification: ' . ( $nonce_valid ? 'passed' : 'failed' ) );
+	  $nonce_valid = check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false );
+	  error_log( 'RTBCB: nonce verification: ' . ( $nonce_valid ? 'passed' : 'failed' ) );
 
-        if ( ! $nonce_valid ) {
-            wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
-        }
+	  if ( ! $nonce_valid ) {
+	      wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
+	  }
 
-        $company = rtbcb_get_current_company();
-        if ( empty( $company ) ) {
-            wp_send_json_error( __( 'No company data found. Please run the company overview first.', 'rtbcb' ), 400 );
-        }
+	  $company = rtbcb_get_current_company();
+	  if ( empty( $company ) ) {
+	      wp_send_json_error( __( 'No company data found. Please run the company overview first.', 'rtbcb' ), 400 );
+	  }
 
-        $required_classes = [ 'RTBCB_Calculator', 'RTBCB_DB' ];
-        $missing_classes  = [];
-        foreach ( $required_classes as $class ) {
-            $exists = class_exists( $class );
-            error_log( 'RTBCB: class ' . $class . ' exists: ' . ( $exists ? 'yes' : 'no' ) );
-            if ( ! $exists ) {
-                $missing_classes[] = $class;
-            }
-        }
+	  $required_classes = [ 'RTBCB_Calculator', 'RTBCB_DB' ];
+	  $missing_classes  = [];
+	  foreach ( $required_classes as $class ) {
+	      $exists = class_exists( $class );
+	      error_log( 'RTBCB: class ' . $class . ' exists: ' . ( $exists ? 'yes' : 'no' ) );
+	      if ( ! $exists ) {
+	          $missing_classes[] = $class;
+	      }
+	  }
 
-        if ( ! empty( $missing_classes ) ) {
-            wp_send_json_error( __( 'Required components missing.', 'rtbcb' ), 500 );
-        }
+	  if ( ! empty( $missing_classes ) ) {
+	      wp_send_json_error( __( 'Required components missing.', 'rtbcb' ), 500 );
+	  }
 
-        rtbcb_setup_ajax_logging();
-        rtbcb_increase_memory_limit();
-        if ( ! ini_get( 'safe_mode' ) ) {
-            set_time_limit( 300 );
-        }
+	  rtbcb_setup_ajax_logging();
+	  rtbcb_increase_memory_limit();
+	  if ( ! ini_get( 'safe_mode' ) ) {
+	      set_time_limit( 300 );
+	  }
 
-        try {
-            RTBCB_Ajax::generate_comprehensive_case();
-        } catch ( Exception $e ) {
-            error_log( 'RTBCB Exception: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );
-            wp_send_json_error( __( 'An error occurred. Please try again later.', 'rtbcb' ), 500 );
-        } catch ( Error $e ) {
-            error_log( 'RTBCB Error: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );
-            wp_send_json_error( __( 'An error occurred. Please try again later.', 'rtbcb' ), 500 );
-        }
+	  try {
+	      RTBCB_Ajax::generate_comprehensive_case();
+	  } catch ( Exception $e ) {
+	      error_log( 'RTBCB Exception: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );
+	      wp_send_json_error( __( 'An error occurred. Please try again later.', 'rtbcb' ), 500 );
+	  } catch ( Error $e ) {
+	      error_log( 'RTBCB Error: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );
+	      wp_send_json_error( __( 'An error occurred. Please try again later.', 'rtbcb' ), 500 );
+	  }
 
-        error_log( 'RTBCB: Exit ajax_generate_comprehensive_case_debug' );
+	  error_log( 'RTBCB: Exit ajax_generate_comprehensive_case_debug' );
     }
 
 
@@ -1125,145 +1125,145 @@ return $use_comprehensive;
      * Enhanced AJAX handler with memory management
      */
     public function ajax_generate_comprehensive_case_legacy() {
-        $request_start   = microtime( true );
-        $request_payload = rtbcb_recursive_sanitize_text_field( wp_unslash( $_POST ) );
-        register_shutdown_function( [ 'RTBCB_Logger', 'log_shutdown' ], $request_start, $request_payload );
+	  $request_start   = microtime( true );
+	  $request_payload = rtbcb_recursive_sanitize_text_field( wp_unslash( $_POST ) );
+	  register_shutdown_function( [ 'RTBCB_Logger', 'log_shutdown' ], $request_start, $request_payload );
 
-        rtbcb_setup_ajax_logging();
+	  rtbcb_setup_ajax_logging();
 
-        // STEP 1: Increase memory limit and log initial state
-        rtbcb_increase_memory_limit();
-        rtbcb_log_memory_usage( 'start' );
+	  // STEP 1: Increase memory limit and log initial state
+	  rtbcb_increase_memory_limit();
+	  rtbcb_log_memory_usage( 'start' );
 
-        // STEP 2: Set longer execution time
-        $timeout    = absint( rtbcb_get_api_timeout() );
-        $start_time = time();
+	  // STEP 2: Set longer execution time
+	  $timeout    = absint( rtbcb_get_api_timeout() );
+	  $start_time = time();
 
-        if ( ! ini_get( 'safe_mode' ) ) {
-            if ( $timeout <= 0 ) {
-                wp_send_json_error(
-                    [ 'message' => __( 'Request timed out; please retry.', 'rtbcb' ) ],
-                    504
-                );
-                return;
-            }
-            set_time_limit( $timeout );
-        }
+	  if ( ! ini_get( 'safe_mode' ) ) {
+	      if ( $timeout <= 0 ) {
+	          wp_send_json_error(
+	              [ 'message' => __( 'Request timed out; please retry.', 'rtbcb' ) ],
+	              504
+	          );
+	          return;
+	      }
+	      set_time_limit( $timeout );
+	  }
 
-        // Clear any buffered output before sending JSON responses.
-        $buffer_content = ob_get_level() ? ob_get_clean() : '';
-        if ( '' !== $buffer_content ) {
-            rtbcb_log_api_debug( 'Output buffer not empty before JSON response', $buffer_content );
-        }
+	  // Clear any buffered output before sending JSON responses.
+	  $buffer_content = ob_get_level() ? ob_get_clean() : '';
+	  if ( '' !== $buffer_content ) {
+	      rtbcb_log_api_debug( 'Output buffer not empty before JSON response', $buffer_content );
+	  }
 
-        try {
-            // Verify nonce
-            if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
-                rtbcb_log_error( 'Nonce verification failed', $_POST );
-                wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
-                return;
-            }
+	  try {
+	      // Verify nonce
+	      if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
+	          rtbcb_log_error( 'Nonce verification failed', $_POST );
+	          wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
+	          return;
+	      }
 
-            $company_name = sanitize_text_field( wp_unslash( $_POST['company_name'] ?? '' ) );
-            $company_size = sanitize_text_field( wp_unslash( $_POST['company_size'] ?? '' ) );
-            $industry     = sanitize_text_field( wp_unslash( $_POST['industry'] ?? '' ) );
+	      $company_name = sanitize_text_field( wp_unslash( $_POST['company_name'] ?? '' ) );
+	      $company_size = sanitize_text_field( wp_unslash( $_POST['company_size'] ?? '' ) );
+	      $industry     = sanitize_text_field( wp_unslash( $_POST['industry'] ?? '' ) );
 
-            $company = rtbcb_get_current_company();
-            if ( empty( $company ) ) {
-                if ( $company_name && $company_size && $industry ) {
-                    $company = [
-                        'name'     => $company_name,
-                        'size'     => $company_size,
-                        'industry' => $industry,
-                    ];
-                    update_option( 'rtbcb_current_company', $company );
-                } else {
-                    if ( empty( $company_name ) ) {
-                        wp_send_json_error( __( 'Please enter your company name.', 'rtbcb' ), 400 );
-                        return;
-                    }
+	      $company = rtbcb_get_current_company();
+	      if ( empty( $company ) ) {
+	          if ( $company_name && $company_size && $industry ) {
+	              $company = [
+	                  'name'     => $company_name,
+	                  'size'     => $company_size,
+	                  'industry' => $industry,
+	              ];
+	              update_option( 'rtbcb_current_company', $company );
+	          } else {
+	              if ( empty( $company_name ) ) {
+	                  wp_send_json_error( __( 'Please enter your company name.', 'rtbcb' ), 400 );
+	                  return;
+	              }
 
-                    if ( empty( $company_size ) ) {
-                        wp_send_json_error( __( 'Please select your company size.', 'rtbcb' ), 400 );
-                        return;
-                    }
+	              if ( empty( $company_size ) ) {
+	                  wp_send_json_error( __( 'Please select your company size.', 'rtbcb' ), 400 );
+	                  return;
+	              }
 
-                    if ( empty( $industry ) ) {
-                        wp_send_json_error( __( 'Please select your industry.', 'rtbcb' ), 400 );
-                        return;
-                    }
-                }
-            }
+	              if ( empty( $industry ) ) {
+	                  wp_send_json_error( __( 'Please select your industry.', 'rtbcb' ), 400 );
+	                  return;
+	              }
+	          }
+	      }
 
-            rtbcb_log_memory_usage( 'after_nonce_verification' );
+	      rtbcb_log_memory_usage( 'after_nonce_verification' );
 
-            // Collect and validate form data
-            $hours_reconciliation_raw   = isset( $_POST['hours_reconciliation'] ) ? wp_unslash( $_POST['hours_reconciliation'] ) : null;
-            $hours_cash_positioning_raw = isset( $_POST['hours_cash_positioning'] ) ? wp_unslash( $_POST['hours_cash_positioning'] ) : null;
-            $num_banks_raw              = isset( $_POST['num_banks'] ) ? wp_unslash( $_POST['num_banks'] ) : null;
-            $ftes_raw                   = isset( $_POST['ftes'] ) ? wp_unslash( $_POST['ftes'] ) : null;
+	      // Collect and validate form data
+	      $hours_reconciliation_raw   = isset( $_POST['hours_reconciliation'] ) ? wp_unslash( $_POST['hours_reconciliation'] ) : null;
+	      $hours_cash_positioning_raw = isset( $_POST['hours_cash_positioning'] ) ? wp_unslash( $_POST['hours_cash_positioning'] ) : null;
+	      $num_banks_raw              = isset( $_POST['num_banks'] ) ? wp_unslash( $_POST['num_banks'] ) : null;
+	      $ftes_raw                   = isset( $_POST['ftes'] ) ? wp_unslash( $_POST['ftes'] ) : null;
 
-            if ( ! is_numeric( $hours_reconciliation_raw ) ) {
-                wp_send_json_error( __( 'Please enter your weekly reconciliation hours.', 'rtbcb' ), 400 );
-                return;
-            }
-            if ( ! is_numeric( $hours_cash_positioning_raw ) ) {
-                wp_send_json_error( __( 'Please enter your weekly cash positioning hours.', 'rtbcb' ), 400 );
-                return;
-            }
-            if ( ! is_numeric( $num_banks_raw ) ) {
-                wp_send_json_error( __( 'Please enter the number of banking relationships.', 'rtbcb' ), 400 );
-                return;
-            }
-            if ( ! is_numeric( $ftes_raw ) ) {
-                wp_send_json_error( __( 'Please enter your treasury team size.', 'rtbcb' ), 400 );
-                return;
-            }
+	      if ( ! is_numeric( $hours_reconciliation_raw ) ) {
+	          wp_send_json_error( __( 'Please enter your weekly reconciliation hours.', 'rtbcb' ), 400 );
+	          return;
+	      }
+	      if ( ! is_numeric( $hours_cash_positioning_raw ) ) {
+	          wp_send_json_error( __( 'Please enter your weekly cash positioning hours.', 'rtbcb' ), 400 );
+	          return;
+	      }
+	      if ( ! is_numeric( $num_banks_raw ) ) {
+	          wp_send_json_error( __( 'Please enter the number of banking relationships.', 'rtbcb' ), 400 );
+	          return;
+	      }
+	      if ( ! is_numeric( $ftes_raw ) ) {
+	          wp_send_json_error( __( 'Please enter your treasury team size.', 'rtbcb' ), 400 );
+	          return;
+	      }
 
-            $user_inputs = [
-                'email'                  => sanitize_email( wp_unslash( $_POST['email'] ?? '' ) ),
-                'company_name'           => $company_name,
-                'company_size'           => $company_size,
-                'industry'               => $industry,
-                'job_title'              => sanitize_text_field( wp_unslash( $_POST['job_title'] ?? '' ) ),
-                'hours_reconciliation'   => floatval( $hours_reconciliation_raw ),
-                'hours_cash_positioning' => floatval( $hours_cash_positioning_raw ),
-                'num_banks'              => intval( $num_banks_raw ),
-                'ftes'                   => floatval( $ftes_raw ),
-                'pain_points'            => array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['pain_points'] ?? [] ) ),
-                'business_objective'     => sanitize_text_field( wp_unslash( $_POST['business_objective'] ?? '' ) ),
-                'implementation_timeline'=> sanitize_text_field( wp_unslash( $_POST['implementation_timeline'] ?? '' ) ),
-                'budget_range'           => sanitize_text_field( wp_unslash( $_POST['budget_range'] ?? '' ) ),
-            ];
+	      $user_inputs = [
+	          'email'                  => sanitize_email( wp_unslash( $_POST['email'] ?? '' ) ),
+	          'company_name'           => $company_name,
+	          'company_size'           => $company_size,
+	          'industry'               => $industry,
+	          'job_title'              => sanitize_text_field( wp_unslash( $_POST['job_title'] ?? '' ) ),
+	          'hours_reconciliation'   => floatval( $hours_reconciliation_raw ),
+	          'hours_cash_positioning' => floatval( $hours_cash_positioning_raw ),
+	          'num_banks'              => intval( $num_banks_raw ),
+	          'ftes'                   => floatval( $ftes_raw ),
+	          'pain_points'            => array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['pain_points'] ?? [] ) ),
+	          'business_objective'     => sanitize_text_field( wp_unslash( $_POST['business_objective'] ?? '' ) ),
+	          'implementation_timeline'=> sanitize_text_field( wp_unslash( $_POST['implementation_timeline'] ?? '' ) ),
+	          'budget_range'           => sanitize_text_field( wp_unslash( $_POST['budget_range'] ?? '' ) ),
+	      ];
 
-            rtbcb_log_api_debug( 'Collected user inputs', $user_inputs );
+	      rtbcb_log_api_debug( 'Collected user inputs', $user_inputs );
 
-            rtbcb_log_api_debug( 'Validating user inputs' );
+	      rtbcb_log_api_debug( 'Validating user inputs' );
 
-            // Validate required fields
-            if ( empty( $user_inputs['email'] ) || ! is_email( $user_inputs['email'] ) ) {
-                rtbcb_log_error( 'Invalid email address', $user_inputs );
-                wp_send_json_error( __( 'Please enter a valid email address.', 'rtbcb' ), 400 );
-                return;
-            }
+	      // Validate required fields
+	      if ( empty( $user_inputs['email'] ) || ! is_email( $user_inputs['email'] ) ) {
+	          rtbcb_log_error( 'Invalid email address', $user_inputs );
+	          wp_send_json_error( __( 'Please enter a valid email address.', 'rtbcb' ), 400 );
+	          return;
+	      }
 
-            if ( empty( $user_inputs['company_name'] ) ) {
-                rtbcb_log_error( 'Missing company name', $user_inputs );
-                wp_send_json_error( __( 'Please enter your company name.', 'rtbcb' ), 400 );
-                return;
-            }
+	      if ( empty( $user_inputs['company_name'] ) ) {
+	          rtbcb_log_error( 'Missing company name', $user_inputs );
+	          wp_send_json_error( __( 'Please enter your company name.', 'rtbcb' ), 400 );
+	          return;
+	      }
 
-            if ( empty( $user_inputs['company_size'] ) ) {
-                rtbcb_log_error( 'Missing company size', $user_inputs );
-                wp_send_json_error( __( 'Please select your company size.', 'rtbcb' ), 400 );
-                return;
-            }
+	      if ( empty( $user_inputs['company_size'] ) ) {
+	          rtbcb_log_error( 'Missing company size', $user_inputs );
+	          wp_send_json_error( __( 'Please select your company size.', 'rtbcb' ), 400 );
+	          return;
+	      }
 
-            if ( empty( $user_inputs['industry'] ) ) {
-                rtbcb_log_error( 'Missing industry', $user_inputs );
-                wp_send_json_error( __( 'Please select your industry.', 'rtbcb' ), 400 );
-                return;
-            }
+	      if ( empty( $user_inputs['industry'] ) ) {
+	          rtbcb_log_error( 'Missing industry', $user_inputs );
+	          wp_send_json_error( __( 'Please select your industry.', 'rtbcb' ), 400 );
+	          return;
+	      }
 
 			if ( $user_inputs['hours_reconciliation'] < 0 ) {
 				rtbcb_log_error( 'Invalid reconciliation hours', $user_inputs );
@@ -1271,23 +1271,23 @@ return $use_comprehensive;
 				return;
 			}
 
-            if ( $user_inputs['hours_cash_positioning'] <= 0 ) {
-                rtbcb_log_error( 'Invalid cash positioning hours', $user_inputs );
-                wp_send_json_error( __( 'Please enter your weekly cash positioning hours.', 'rtbcb' ), 400 );
-                return;
-            }
+	      if ( $user_inputs['hours_cash_positioning'] <= 0 ) {
+	          rtbcb_log_error( 'Invalid cash positioning hours', $user_inputs );
+	          wp_send_json_error( __( 'Please enter your weekly cash positioning hours.', 'rtbcb' ), 400 );
+	          return;
+	      }
 
-            if ( $user_inputs['num_banks'] <= 0 ) {
-                rtbcb_log_error( 'Invalid number of banks', $user_inputs );
-                wp_send_json_error( __( 'Please enter the number of banking relationships.', 'rtbcb' ), 400 );
-                return;
-            }
+	      if ( $user_inputs['num_banks'] <= 0 ) {
+	          rtbcb_log_error( 'Invalid number of banks', $user_inputs );
+	          wp_send_json_error( __( 'Please enter the number of banking relationships.', 'rtbcb' ), 400 );
+	          return;
+	      }
 
-            if ( $user_inputs['ftes'] <= 0 ) {
-                rtbcb_log_error( 'Invalid treasury team size', $user_inputs );
-                wp_send_json_error( __( 'Please enter your treasury team size.', 'rtbcb' ), 400 );
-                return;
-            }
+	      if ( $user_inputs['ftes'] <= 0 ) {
+	          rtbcb_log_error( 'Invalid treasury team size', $user_inputs );
+	          wp_send_json_error( __( 'Please enter your treasury team size.', 'rtbcb' ), 400 );
+	          return;
+	      }
 
 			if ( empty( $user_inputs['business_objective'] ) ) {
 				rtbcb_log_error( 'Missing business objective', $user_inputs );
@@ -1295,382 +1295,382 @@ return $use_comprehensive;
 				return;
 			}
 
-            if ( empty( $user_inputs['implementation_timeline'] ) ) {
-                rtbcb_log_error( 'Missing implementation timeline', $user_inputs );
-                wp_send_json_error( __( 'Please select an implementation timeline.', 'rtbcb' ), 400 );
-                return;
-            }
+	      if ( empty( $user_inputs['implementation_timeline'] ) ) {
+	          rtbcb_log_error( 'Missing implementation timeline', $user_inputs );
+	          wp_send_json_error( __( 'Please select an implementation timeline.', 'rtbcb' ), 400 );
+	          return;
+	      }
 
-            if ( empty( $user_inputs['budget_range'] ) ) {
-                rtbcb_log_error( 'Missing budget range', $user_inputs );
-                wp_send_json_error( __( 'Please select a budget range.', 'rtbcb' ), 400 );
-                return;
-            }
+	      if ( empty( $user_inputs['budget_range'] ) ) {
+	          rtbcb_log_error( 'Missing budget range', $user_inputs );
+	          wp_send_json_error( __( 'Please select a budget range.', 'rtbcb' ), 400 );
+	          return;
+	      }
 
-            rtbcb_log_api_debug( 'Validation passed', $user_inputs );
-            rtbcb_log_memory_usage( 'after_validation' );
+	      rtbcb_log_api_debug( 'Validation passed', $user_inputs );
+	      rtbcb_log_memory_usage( 'after_validation' );
 
-            // Calculate ROI scenarios
-            if ( ! class_exists( 'RTBCB_Calculator' ) ) {
-                rtbcb_log_error( 'Calculator class not found' );
-                wp_send_json_error( __( 'System error: Calculator not available.', 'rtbcb' ), 500 );
-                return;
-            }
+	      // Calculate ROI scenarios
+	      if ( ! class_exists( 'RTBCB_Calculator' ) ) {
+	          rtbcb_log_error( 'Calculator class not found' );
+	          wp_send_json_error( __( 'System error: Calculator not available.', 'rtbcb' ), 500 );
+	          return;
+	      }
 
-            rtbcb_log_api_debug( 'Starting ROI calculation' );
-            $scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
-            rtbcb_log_api_debug( 'ROI scenarios calculated', $scenarios );
-            rtbcb_log_memory_usage( 'after_roi_calculation' );
+	      rtbcb_log_api_debug( 'Starting ROI calculation' );
+	      $scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
+	      rtbcb_log_api_debug( 'ROI scenarios calculated', $scenarios );
+	      rtbcb_log_memory_usage( 'after_roi_calculation' );
 
-            // Get category recommendation
-            if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
-                rtbcb_log_error( 'Category Recommender class not found' );
-                wp_send_json_error( __( 'System error: Recommender not available.', 'rtbcb' ), 500 );
-                return;
-            }
+	      // Get category recommendation
+	      if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
+	          rtbcb_log_error( 'Category Recommender class not found' );
+	          wp_send_json_error( __( 'System error: Recommender not available.', 'rtbcb' ), 500 );
+	          return;
+	      }
 
-            rtbcb_log_api_debug( 'Running category recommendation' );
-            $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
-            rtbcb_log_api_debug( 'Category recommendation result', $recommendation );
-            rtbcb_log_memory_usage( 'after_category_recommendation' );
+	      rtbcb_log_api_debug( 'Running category recommendation' );
+	      $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+	      rtbcb_log_api_debug( 'Category recommendation result', $recommendation );
+	      rtbcb_log_memory_usage( 'after_category_recommendation' );
 
-            // Get RAG context (with memory monitoring)
-            $rag_context = [];
-            if ( class_exists( 'RTBCB_RAG' ) ) {
-                try {
-                    $rag = new RTBCB_RAG();
-                    $search_query = implode(
-                        ' ',
-                        array_merge(
-                            [ $user_inputs['company_name'], $user_inputs['industry'] ],
-                            $user_inputs['pain_points'],
-                            [ $recommendation['recommended'] ?? '' ]
-                        )
-                    );
-                    rtbcb_log_api_debug( 'Performing RAG search', [ 'query' => $search_query ] );
-                    $rag_context = $rag->search_similar( $search_query, 3 );
-                    rtbcb_log_api_debug( 'RAG search results', $rag_context );
-                    rtbcb_log_memory_usage( 'after_rag_search' );
-                } catch ( Exception $e ) {
-                    rtbcb_log_error( 'RAG search failed', $e->getMessage() );
-                } catch ( Error $e ) {
-                    rtbcb_log_error( 'RAG search fatal error', $e->getMessage() );
-                }
-            }
+	      // Get RAG context (with memory monitoring)
+	      $rag_context = [];
+	      if ( class_exists( 'RTBCB_RAG' ) ) {
+	          try {
+	              $rag = new RTBCB_RAG();
+	              $search_query = implode(
+	                  ' ',
+	                  array_merge(
+	                      [ $user_inputs['company_name'], $user_inputs['industry'] ],
+	                      $user_inputs['pain_points'],
+	                      [ $recommendation['recommended'] ?? '' ]
+	                  )
+	              );
+	              rtbcb_log_api_debug( 'Performing RAG search', [ 'query' => $search_query ] );
+	              $rag_context = $rag->search_similar( $search_query, 3 );
+	              rtbcb_log_api_debug( 'RAG search results', $rag_context );
+	              rtbcb_log_memory_usage( 'after_rag_search' );
+	          } catch ( Exception $e ) {
+	              rtbcb_log_error( 'RAG search failed', $e->getMessage() );
+	          } catch ( Error $e ) {
+	              rtbcb_log_error( 'RAG search fatal error', $e->getMessage() );
+	          }
+	      }
 
-            // Generate business case with memory optimization
-            $comprehensive_analysis = null;
-            if ( class_exists( 'RTBCB_LLM' ) ) {
-                try {
-                    if ( function_exists( 'gc_collect_cycles' ) ) {
-                        gc_collect_cycles();
-                    }
+	      // Generate business case with memory optimization
+	      $comprehensive_analysis = null;
+	      if ( class_exists( 'RTBCB_LLM' ) ) {
+	          try {
+	              if ( function_exists( 'gc_collect_cycles' ) ) {
+	                  gc_collect_cycles();
+	              }
 
-                    rtbcb_log_memory_usage( 'before_llm_generation' );
+	              rtbcb_log_memory_usage( 'before_llm_generation' );
 
-                    if ( ! rtbcb_has_openai_api_key() ) {
-                        $error_code = 'E_API_KEY_MISSING';
-                        rtbcb_log_error( $error_code . ': ' . __( 'OpenAI API key not configured.', 'rtbcb' ) );
-                        wp_send_json_error(
-                            [
-                                'message'    => __( 'OpenAI API key not configured.', 'rtbcb' ),
-                                'error_code' => $error_code,
-                            ],
-                            500
-                        );
-                        return;
-                    }
+	              if ( ! rtbcb_has_openai_api_key() ) {
+	                  $error_code = 'E_API_KEY_MISSING';
+	                  rtbcb_log_error( $error_code . ': ' . __( 'OpenAI API key not configured.', 'rtbcb' ) );
+	                  wp_send_json_error(
+	                      [
+	                          'message'    => __( 'OpenAI API key not configured.', 'rtbcb' ),
+	                          'error_code' => $error_code,
+	                      ],
+	                      500
+	                  );
+	                  return;
+	              }
 
-                    $api_key = rtbcb_get_openai_api_key();
-                    if ( class_exists( 'RTBCB_API_Tester' ) ) {
-                        $connection_test = RTBCB_API_Tester::test_connection( $api_key );
-                        if ( empty( $connection_test['success'] ) ) {
-                            $error_code = 'E_API_TEST_FAILURE';
-                            rtbcb_log_error( $error_code . ': ' . $connection_test['message'] );
-                            wp_send_json_error(
-                                [
-                                    'message'    => $connection_test['message'],
-                                    'details'    => $connection_test['details'] ?? '',
-                                    'error_code' => $error_code,
-                                ],
-                                500
-                            );
-                            return;
-                        }
-                    }
+	              $api_key = rtbcb_get_openai_api_key();
+	              if ( class_exists( 'RTBCB_API_Tester' ) ) {
+	                  $connection_test = RTBCB_API_Tester::test_connection( $api_key );
+	                  if ( empty( $connection_test['success'] ) ) {
+	                      $error_code = 'E_API_TEST_FAILURE';
+	                      rtbcb_log_error( $error_code . ': ' . $connection_test['message'] );
+	                      wp_send_json_error(
+	                          [
+	                              'message'    => $connection_test['message'],
+	                              'details'    => $connection_test['details'] ?? '',
+	                              'error_code' => $error_code,
+	                          ],
+	                          500
+	                      );
+	                      return;
+	                  }
+	              }
 
-                    // Short-circuit if the remaining time is insufficient for LLM processing.
-                    if ( ( time() - $start_time ) > ( $timeout - 5 ) ) {
-                        wp_send_json_error(
-                            [ 'message' => __( 'Request timed out; please retry.', 'rtbcb' ) ],
-                            504
-                        );
-                        return;
-                    }
+	              // Short-circuit if the remaining time is insufficient for LLM processing.
+	              if ( ( time() - $start_time ) > ( $timeout - 5 ) ) {
+	                  wp_send_json_error(
+	                      [ 'message' => __( 'Request timed out; please retry.', 'rtbcb' ) ],
+	                      504
+	                  );
+	                  return;
+	              }
 
-                    // Consider offloading this LLM call to a background task and polling for completion to
-                    // avoid keeping the HTTP connection open.
-                    rtbcb_log_api_debug( 'Calling LLM for comprehensive business case' );
-                    $llm = new RTBCB_LLM();
-                    $comprehensive_analysis = $llm->generate_comprehensive_business_case(
-                        $user_inputs,
-                        $scenarios,
-                        $rag_context
-                    );
+	              // Consider offloading this LLM call to a background task and polling for completion to
+	              // avoid keeping the HTTP connection open.
+	              rtbcb_log_api_debug( 'Calling LLM for comprehensive business case' );
+	              $llm = new RTBCB_LLM();
+	              $comprehensive_analysis = $llm->generate_comprehensive_business_case(
+	                  $user_inputs,
+	                  $scenarios,
+	                  $rag_context
+	              );
 
-                    rtbcb_log_memory_usage( 'after_llm_generation' );
+	              rtbcb_log_memory_usage( 'after_llm_generation' );
 
-                    if ( is_wp_error( $comprehensive_analysis ) ) {
-                        $error_message  = $comprehensive_analysis->get_error_message();
-                        $llm_error_code = method_exists( $comprehensive_analysis, 'get_error_code' ) ? $comprehensive_analysis->get_error_code() : '';
-                        $error_data     = $comprehensive_analysis->get_error_data();
-                        $status         = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
+	              if ( is_wp_error( $comprehensive_analysis ) ) {
+	                  $error_message  = $comprehensive_analysis->get_error_message();
+	                  $llm_error_code = method_exists( $comprehensive_analysis, 'get_error_code' ) ? $comprehensive_analysis->get_error_code() : '';
+	                  $error_data     = $comprehensive_analysis->get_error_data();
+	                  $status         = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
 
-                        if ( 'llm_http_status' === $llm_error_code ) {
-                            rtbcb_log_error( 'E_LLM_HTTP_STATUS: ' . $error_message, [ 'status' => $status ] );
-                            wp_send_json_error(
-                                [
-                                    'message'    => $error_message,
-                                    'error_code' => 'E_LLM_HTTP_STATUS',
-                                ],
-                                $status
-                            );
-                            return;
-                        }
+	                  if ( 'llm_http_status' === $llm_error_code ) {
+	                      rtbcb_log_error( 'E_LLM_HTTP_STATUS: ' . $error_message, [ 'status' => $status ] );
+	                      wp_send_json_error(
+	                          [
+	                              'message'    => $error_message,
+	                              'error_code' => 'E_LLM_HTTP_STATUS',
+	                          ],
+	                          $status
+	                      );
+	                      return;
+	                  }
 
-                        $error_code      = 'no_api_key' === $llm_error_code ? 'E_NO_API_KEY' : 'E_LLM_WP_ERROR';
-                        rtbcb_log_error( $error_code . ': ' . $error_message, [ 'wp_error_code' => $llm_error_code ] );
-                        $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
-                        $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
-                        if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
-                            $response_message = $error_message . ' ' . $guidance;
-                        }
-                        wp_send_json_error(
-                            [
-                                'message'    => $response_message,
-                                'error_code' => $error_code,
-                            ],
-                            500
-                        );
-                        return;
-                    }
+	                  $error_code      = 'no_api_key' === $llm_error_code ? 'E_NO_API_KEY' : 'E_LLM_WP_ERROR';
+	                  rtbcb_log_error( $error_code . ': ' . $error_message, [ 'wp_error_code' => $llm_error_code ] );
+	                  $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
+	                  $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
+	                  if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+	                      $response_message = $error_message . ' ' . $guidance;
+	                  }
+	                  wp_send_json_error(
+	                      [
+	                          'message'    => $response_message,
+	                          'error_code' => $error_code,
+	                      ],
+	                      500
+	                  );
+	                  return;
+	              }
 
-                    if ( isset( $comprehensive_analysis['error'] ) ) {
-                        $error_code = 'E_LLM_RESPONSE_ERROR';
-                        rtbcb_log_error( $error_code . ': ' . $comprehensive_analysis['error'] );
-                        $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
-                        $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
-                        if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
-                            $response_message = $comprehensive_analysis['error'] . ' ' . $guidance;
-                        }
-                        wp_send_json_error(
-                            [
-                                'message'    => $response_message,
-                                'error_code' => $error_code,
-                            ],
-                            500
-                        );
-                        return;
-                    }
-                    $required_sections = [ 'executive_summary', 'financial_analysis', 'industry_analysis', 'implementation_roadmap', 'risk_mitigation', 'next_steps' ];
-                    $missing_sections  = array_diff( $required_sections, array_keys( $comprehensive_analysis ) );
+	              if ( isset( $comprehensive_analysis['error'] ) ) {
+	                  $error_code = 'E_LLM_RESPONSE_ERROR';
+	                  rtbcb_log_error( $error_code . ': ' . $comprehensive_analysis['error'] );
+	                  $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
+	                  $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
+	                  if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+	                      $response_message = $comprehensive_analysis['error'] . ' ' . $guidance;
+	                  }
+	                  wp_send_json_error(
+	                      [
+	                          'message'    => $response_message,
+	                          'error_code' => $error_code,
+	                      ],
+	                      500
+	                  );
+	                  return;
+	              }
+	              $required_sections = [ 'executive_summary', 'financial_analysis', 'industry_analysis', 'implementation_roadmap', 'risk_mitigation', 'next_steps' ];
+	              $missing_sections  = array_diff( $required_sections, array_keys( $comprehensive_analysis ) );
 
-                    if ( ! empty( $missing_sections ) ) {
-                        rtbcb_log_error( 'LLM missing required sections', [ 'missing' => $missing_sections ] );
-                        $comprehensive_analysis = $this->generate_fallback_analysis( $user_inputs, $scenarios );
-                    } else {
-                        rtbcb_log_api_debug( 'LLM generation succeeded' );
-                    }
-                } catch ( Exception $e ) {
-                    $error_code = 'E_LLM_EXCEPTION';
-                    rtbcb_log_error( $error_code . ': ' . $e->getMessage() );
-                    $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
-                    $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
-                    if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
-                        $response_message = $e->getMessage() . ' ' . $guidance;
-                    }
-                    wp_send_json_error(
-                        [
-                            'message'    => $response_message,
-                            'error_code' => $error_code,
-                        ],
-                        500
-                    );
-                    return;
-                } catch ( Error $e ) {
-                    // Developers: check server logs for E_LLM_FATAL stack trace.
-                    $error_code    = 'E_LLM_FATAL';
-                    $error_message = $e->getMessage();
+	              if ( ! empty( $missing_sections ) ) {
+	                  rtbcb_log_error( 'LLM missing required sections', [ 'missing' => $missing_sections ] );
+	                  $comprehensive_analysis = $this->generate_fallback_analysis( $user_inputs, $scenarios );
+	              } else {
+	                  rtbcb_log_api_debug( 'LLM generation succeeded' );
+	              }
+	          } catch ( Exception $e ) {
+	              $error_code = 'E_LLM_EXCEPTION';
+	              rtbcb_log_error( $error_code . ': ' . $e->getMessage() );
+	              $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
+	              $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
+	              if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+	                  $response_message = $e->getMessage() . ' ' . $guidance;
+	              }
+	              wp_send_json_error(
+	                  [
+	                      'message'    => $response_message,
+	                      'error_code' => $error_code,
+	                  ],
+	                  500
+	              );
+	              return;
+	          } catch ( Error $e ) {
+	              // Developers: check server logs for E_LLM_FATAL stack trace.
+	              $error_code    = 'E_LLM_FATAL';
+	              $error_message = $e->getMessage();
 
-                    rtbcb_log_error( $error_code . ': ' . $error_message, $e->getTraceAsString() );
+	              rtbcb_log_error( $error_code . ': ' . $error_message, $e->getTraceAsString() );
 
-                    if ( rtbcb_is_openai_configuration_error( $e ) ) {
-                        $guidance          = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
-                        $sanitized_message = esc_html( $error_message );
-                        $response_message  = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
+	              if ( rtbcb_is_openai_configuration_error( $e ) ) {
+	                  $guidance          = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
+	                  $sanitized_message = esc_html( $error_message );
+	                  $response_message  = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
 
-                        if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
-                            $response_message = $sanitized_message . ' ' . $guidance;
-                        } elseif ( current_user_can( 'manage_options' ) ) {
-                            $response_message .= ' ' . $sanitized_message;
-                        }
-                    } else {
-                        $response_message = __( 'Internal error. Please try again later.', 'rtbcb' );
-                    }
+	                  if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+	                      $response_message = $sanitized_message . ' ' . $guidance;
+	                  } elseif ( current_user_can( 'manage_options' ) ) {
+	                      $response_message .= ' ' . $sanitized_message;
+	                  }
+	              } else {
+	                  $response_message = __( 'Internal error. Please try again later.', 'rtbcb' );
+	              }
 
-                        wp_send_json_error(
-                            [
-                                'message'    => $response_message,
-                                'error_code' => $error_code,
-                            ],
-                            500
-                        );
-                        return;
-                    }
-                }
+	                  wp_send_json_error(
+	                      [
+	                          'message'    => $response_message,
+	                          'error_code' => $error_code,
+	                      ],
+	                      500
+	                  );
+	                  return;
+	              }
+	          }
 
-            if ( empty( $comprehensive_analysis ) ) {
-                $error_code = 'E_LLM_EMPTY';
-                rtbcb_log_error( $error_code . ': LLM returned empty analysis', $user_inputs );
-                $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
-                $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
-                if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
-                    $response_message = __( 'LLM returned empty analysis.', 'rtbcb' ) . ' ' . $guidance;
-                }
-                wp_send_json_error(
-                    [
-                        'message'    => $response_message,
-                        'error_code' => $error_code,
-                    ],
-                    500
-                );
-                return;
-            }
+	      if ( empty( $comprehensive_analysis ) ) {
+	          $error_code = 'E_LLM_EMPTY';
+	          rtbcb_log_error( $error_code . ': LLM returned empty analysis', $user_inputs );
+	          $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
+	          $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
+	          if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+	              $response_message = __( 'LLM returned empty analysis.', 'rtbcb' ) . ' ' . $guidance;
+	          }
+	          wp_send_json_error(
+	              [
+	                  'message'    => $response_message,
+	                  'error_code' => $error_code,
+	              ],
+	              500
+	          );
+	          return;
+	      }
 
-            if ( empty( $comprehensive_analysis['company_name'] ) ) {
-                $comprehensive_analysis['company_name'] = $user_inputs['company_name'];
-            }
+	      if ( empty( $comprehensive_analysis['company_name'] ) ) {
+	          $comprehensive_analysis['company_name'] = $user_inputs['company_name'];
+	      }
 
-            // Format scenarios
-            $formatted_scenarios = [
-                'low'  => [
-                    'total_annual_benefit' => $scenarios['conservative']['total_annual_benefit'] ?? 0,
-                    'labor_savings'        => $scenarios['conservative']['labor_savings'] ?? 0,
-                    'fee_savings'          => $scenarios['conservative']['fee_savings'] ?? 0,
-                    'error_reduction'      => $scenarios['conservative']['error_reduction'] ?? 0,
-                ],
-                'base' => [
-                    'total_annual_benefit' => $scenarios['base']['total_annual_benefit'] ?? 0,
-                    'labor_savings'        => $scenarios['base']['labor_savings'] ?? 0,
-                    'fee_savings'          => $scenarios['base']['fee_savings'] ?? 0,
-                    'error_reduction'      => $scenarios['base']['error_reduction'] ?? 0,
-                ],
-                'high' => [
-                    'total_annual_benefit' => $scenarios['optimistic']['total_annual_benefit'] ?? 0,
-                    'labor_savings'        => $scenarios['optimistic']['labor_savings'] ?? 0,
-                    'fee_savings'          => $scenarios['optimistic']['fee_savings'] ?? 0,
-                    'error_reduction'      => $scenarios['optimistic']['error_reduction'] ?? 0,
-                ],
-            ];
+	      // Format scenarios
+	      $formatted_scenarios = [
+	          'low'  => [
+	              'total_annual_benefit' => $scenarios['conservative']['total_annual_benefit'] ?? 0,
+	              'labor_savings'        => $scenarios['conservative']['labor_savings'] ?? 0,
+	              'fee_savings'          => $scenarios['conservative']['fee_savings'] ?? 0,
+	              'error_reduction'      => $scenarios['conservative']['error_reduction'] ?? 0,
+	          ],
+	          'base' => [
+	              'total_annual_benefit' => $scenarios['base']['total_annual_benefit'] ?? 0,
+	              'labor_savings'        => $scenarios['base']['labor_savings'] ?? 0,
+	              'fee_savings'          => $scenarios['base']['fee_savings'] ?? 0,
+	              'error_reduction'      => $scenarios['base']['error_reduction'] ?? 0,
+	          ],
+	          'high' => [
+	              'total_annual_benefit' => $scenarios['optimistic']['total_annual_benefit'] ?? 0,
+	              'labor_savings'        => $scenarios['optimistic']['labor_savings'] ?? 0,
+	              'fee_savings'          => $scenarios['optimistic']['fee_savings'] ?? 0,
+	              'error_reduction'      => $scenarios['optimistic']['error_reduction'] ?? 0,
+	          ],
+	      ];
 
-            rtbcb_log_memory_usage( 'after_scenario_formatting' );
+	      rtbcb_log_memory_usage( 'after_scenario_formatting' );
 
-            // Generate HTML report
-            $report_html = '';
-            try {
-                $report_html = $this->get_comprehensive_report_html( $comprehensive_analysis );
-                if ( empty( $report_html ) ) {
-                    rtbcb_log_error( 'Report HTML generation returned empty', $comprehensive_analysis );
-                    wp_send_json_error(
-                        [ 'message' => __( 'Failed to render business case report.', 'rtbcb' ) ],
-                        500
-                    );
-                    return;
-                }
-                rtbcb_log_memory_usage( 'after_report_generation' );
-            } catch ( Exception $e ) {
-                rtbcb_log_error( 'Report generation failed', $e->getMessage() );
-                wp_send_json_error(
-                    [ 'message' => __( 'Failed to render business case report.', 'rtbcb' ) ],
-                    500
-                );
-                return;
-            }
+	      // Generate HTML report
+	      $report_html = '';
+	      try {
+	          $report_html = $this->get_comprehensive_report_html( $comprehensive_analysis );
+	          if ( empty( $report_html ) ) {
+	              rtbcb_log_error( 'Report HTML generation returned empty', $comprehensive_analysis );
+	              wp_send_json_error(
+	                  [ 'message' => __( 'Failed to render business case report.', 'rtbcb' ) ],
+	                  500
+	              );
+	              return;
+	          }
+	          rtbcb_log_memory_usage( 'after_report_generation' );
+	      } catch ( Exception $e ) {
+	          rtbcb_log_error( 'Report generation failed', $e->getMessage() );
+	          wp_send_json_error(
+	              [ 'message' => __( 'Failed to render business case report.', 'rtbcb' ) ],
+	              500
+	          );
+	          return;
+	      }
 
-            // Save lead data (non-blocking)
-            $lead_id = null;
-            if ( class_exists( 'RTBCB_Leads' ) ) {
-                try {
-                    $lead_data = [
-                        'email'                  => $user_inputs['email'],
-                        'company_size'           => $user_inputs['company_size'],
-                        'industry'               => $user_inputs['industry'],
-                        'hours_reconciliation'   => $user_inputs['hours_reconciliation'],
-                        'hours_cash_positioning' => $user_inputs['hours_cash_positioning'],
-                        'num_banks'              => $user_inputs['num_banks'],
-                        'ftes'                   => $user_inputs['ftes'],
-                        'pain_points'            => $user_inputs['pain_points'],
-                        'recommended_category'   => $recommendation['recommended'] ?? '',
-                        'roi_low'                => $formatted_scenarios['low']['total_annual_benefit'],
-                        'roi_base'               => $formatted_scenarios['base']['total_annual_benefit'],
-                        'roi_high'               => $formatted_scenarios['high']['total_annual_benefit'],
-                        'report_html'            => $report_html,
-                    ];
+	      // Save lead data (non-blocking)
+	      $lead_id = null;
+	      if ( class_exists( 'RTBCB_Leads' ) ) {
+	          try {
+	              $lead_data = [
+	                  'email'                  => $user_inputs['email'],
+	                  'company_size'           => $user_inputs['company_size'],
+	                  'industry'               => $user_inputs['industry'],
+	                  'hours_reconciliation'   => $user_inputs['hours_reconciliation'],
+	                  'hours_cash_positioning' => $user_inputs['hours_cash_positioning'],
+	                  'num_banks'              => $user_inputs['num_banks'],
+	                  'ftes'                   => $user_inputs['ftes'],
+	                  'pain_points'            => $user_inputs['pain_points'],
+	                  'recommended_category'   => $recommendation['recommended'] ?? '',
+	                  'roi_low'                => $formatted_scenarios['low']['total_annual_benefit'],
+	                  'roi_base'               => $formatted_scenarios['base']['total_annual_benefit'],
+	                  'roi_high'               => $formatted_scenarios['high']['total_annual_benefit'],
+	                  'report_html'            => $report_html,
+	              ];
 
-                    $lead_id = RTBCB_Leads::save_lead( $lead_data );
-                    if ( false === $lead_id ) {
-                        rtbcb_log_error( 'Failed to save lead', $lead_data );
-                    }
-                    rtbcb_log_memory_usage( 'after_lead_save' );
-                } catch ( Throwable $e ) {
-                    rtbcb_log_error( 'Failed to save lead', $e->getMessage() );
-                }
-            }
+	              $lead_id = RTBCB_Leads::save_lead( $lead_data );
+	              if ( false === $lead_id ) {
+	                  rtbcb_log_error( 'Failed to save lead', $lead_data );
+	              }
+	              rtbcb_log_memory_usage( 'after_lead_save' );
+	          } catch ( Throwable $e ) {
+	              rtbcb_log_error( 'Failed to save lead', $e->getMessage() );
+	          }
+	      }
 
-            // Prepare final response
-            $response_data = [
-                'scenarios'              => $formatted_scenarios,
-                'recommendation'         => $recommendation,
-                'comprehensive_analysis' => $comprehensive_analysis,
-                'narrative'              => $comprehensive_analysis,
-                'rag_context'            => $rag_context,
-                'report_html'            => $report_html,
-                'lead_id'                => $lead_id,
-                'company_name'           => $user_inputs['company_name'],
-                'analysis_type'          => 'comprehensive',
-                'api_used'               => ! empty( get_option( 'rtbcb_openai_api_key' ) ),
-                'fallback_used'          => isset( $comprehensive_analysis['enhanced_fallback'] ),
-                'memory_info'            => rtbcb_get_memory_status(),
-            ];
+	      // Prepare final response
+	      $response_data = [
+	          'scenarios'              => $formatted_scenarios,
+	          'recommendation'         => $recommendation,
+	          'comprehensive_analysis' => $comprehensive_analysis,
+	          'narrative'              => $comprehensive_analysis,
+	          'rag_context'            => $rag_context,
+	          'report_html'            => $report_html,
+	          'lead_id'                => $lead_id,
+	          'company_name'           => $user_inputs['company_name'],
+	          'analysis_type'          => 'comprehensive',
+	          'api_used'               => ! empty( get_option( 'rtbcb_openai_api_key' ) ),
+	          'fallback_used'          => isset( $comprehensive_analysis['enhanced_fallback'] ),
+	          'memory_info'            => rtbcb_get_memory_status(),
+	      ];
 
-            rtbcb_log_memory_usage( 'before_response' );
+	      rtbcb_log_memory_usage( 'before_response' );
 
-            wp_send_json_success( $response_data );
-            return;
+	      wp_send_json_success( $response_data );
+	      return;
 
-        } catch ( Exception $e ) {
-            rtbcb_log_memory_usage( 'exception_occurred' );
-            rtbcb_log_error(
-                'Ajax exception',
-                $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
-            );
-            wp_send_json_error(
-                [ 'message' => __( 'An error occurred while generating your business case. Please try again.', 'rtbcb' ) ],
-                500
-            );
-            return;
-        } catch ( Error $e ) {
-            rtbcb_log_memory_usage( 'fatal_error_occurred' );
-            rtbcb_log_error(
-                'Ajax fatal error',
-                $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
-            );
-            wp_send_json_error(
-                [ 'message' => __( 'A system error occurred. Please contact support.', 'rtbcb' ) ],
-                500
-            );
-            return;
-        }
+	  } catch ( Exception $e ) {
+	      rtbcb_log_memory_usage( 'exception_occurred' );
+	      rtbcb_log_error(
+	          'Ajax exception',
+	          $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
+	      );
+	      wp_send_json_error(
+	          [ 'message' => __( 'An error occurred while generating your business case. Please try again.', 'rtbcb' ) ],
+	          500
+	      );
+	      return;
+	  } catch ( Error $e ) {
+	      rtbcb_log_memory_usage( 'fatal_error_occurred' );
+	      rtbcb_log_error(
+	          'Ajax fatal error',
+	          $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
+	      );
+	      wp_send_json_error(
+	          [ 'message' => __( 'A system error occurred. Please contact support.', 'rtbcb' ) ],
+	          500
+	      );
+	      return;
+	  }
     }
    /**
     * Generate comprehensive report HTML from template with proper data transformation.
@@ -1679,7 +1679,7 @@ return $use_comprehensive;
     *
     * @return string
     */
-               private function get_comprehensive_report_html( $business_case_data ) {
+	         private function get_comprehensive_report_html( $business_case_data ) {
 $use_comprehensive = $this->should_use_comprehensive_template();
 
 if ( $use_comprehensive ) {
@@ -1714,7 +1714,7 @@ ob_start();
 include $template_path;
 $html = ob_get_clean();
 return wp_kses_post( $html );
-               }
+	         }
 
    /**
     * Transform LLM response data into the structure expected by comprehensive template.
@@ -1724,70 +1724,80 @@ return wp_kses_post( $html );
     * @return array
     */
    private function transform_data_for_template( $business_case_data ) {
-       // Get current company data.
-       $company      = rtbcb_get_current_company();
-       $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
-       $base_roi     = $business_case_data['base_roi'] ?? $business_case_data['roi_base'] ?? 0;
-       $business_case_data['roi_base'] = $base_roi;
+	 // Get current company data.
+	 $company      = rtbcb_get_current_company();
+	 $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
+	 $base_roi     = $business_case_data['base_roi'] ?? $business_case_data['roi_base'] ?? 0;
+	 $business_case_data['roi_base'] = $base_roi;
 
-       // Derive recommended category and details from recommendation if not provided.
-       $recommended_category = $business_case_data['recommended_category'] ?? ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' );
-       $category_details     = $business_case_data['category_info'] ?? ( $business_case_data['recommendation']['category_info'] ?? [] );
+	 // Derive recommended category and details from recommendation if not provided.
+	 $recommended_category = $business_case_data['recommended_category'] ?? ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' );
+	 $category_details     = $business_case_data['category_info'] ?? ( $business_case_data['recommendation']['category_info'] ?? [] );
 
-       // Create structured data format expected by template.
-       $report_data = [
-           'metadata'            => [
-               'company_name'    => $company_name,
-               'analysis_date'   => current_time( 'Y-m-d' ),
-               'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
-               'processing_time' => $business_case_data['processing_time'] ?? 0,
-           ],
-           'executive_summary'  => [
-               'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
-               'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
-               'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
-           ],
-           'financial_analysis' => [
-               'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
-               'payback_analysis'   => [
-                   'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
-               ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
-           ],
-           'company_intelligence' => [
-               'enriched_profile' => [
-                   'enhanced_description' => $business_case_data['company_analysis'] ?? '',
-                   'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
-                   'treasury_maturity'    => [
-                       'current_state'    => $business_case_data['current_state_analysis'] ?? '',
-                   ],
-               ],
-               'industry_context' => [
-                   'sector_analysis' => [
-                       'market_dynamics' => $business_case_data['market_analysis'] ?? '',
-                   ],
-                   'benchmarking'   => [
-                       'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
-                   ],
-               ],
-           ],
-           'technology_strategy' => [
-               'recommended_category' => $recommended_category,
-               'category_details'     => $category_details,
-           ],
-           'operational_insights' => $business_case_data['operational_analysis'] ?? [],
-           'risk_analysis'        => [
-               'implementation_risks' => $business_case_data['risks'] ?? [],
-           ],
-           'action_plan'          => [
-               'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
-               'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),
-               'long_term_objectives'  => $this->extract_long_term_steps( $business_case_data ),
-           ],
-       ];
+	$operational_analysis = (array) ( $business_case_data['operational_analysis'] ?? [] );
+	if ( empty( $operational_analysis ) ) {
+	    $operational_analysis[] = __( 'No data provided', 'rtbcb' );
+	}
 
-       return $report_data;
+	$risks = (array) ( $business_case_data['risks'] ?? [] );
+	if ( empty( $risks ) ) {
+	    $risks[] = __( 'No data provided', 'rtbcb' );
+	}
+
+	// Create structured data format expected by template.
+	$report_data = [
+	     'metadata'            => [
+	         'company_name'    => $company_name,
+	         'analysis_date'   => current_time( 'Y-m-d' ),
+	         'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
+	         'processing_time' => $business_case_data['processing_time'] ?? 0,
+	     ],
+	     'executive_summary'  => [
+	         'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
+	         'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
+	         'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
+	         'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
+	     ],
+	     'financial_analysis' => [
+	         'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
+	         'payback_analysis'   => [
+	             'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
+	         ],
+	         'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
+	     ],
+	     'company_intelligence' => [
+	         'enriched_profile' => [
+	             'enhanced_description' => $business_case_data['company_analysis'] ?? '',
+	             'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
+	             'treasury_maturity'    => [
+	                 'current_state'    => $business_case_data['current_state_analysis'] ?? '',
+	             ],
+	         ],
+	         'industry_context' => [
+	             'sector_analysis' => [
+	                 'market_dynamics' => $business_case_data['market_analysis'] ?? '',
+	             ],
+	             'benchmarking'   => [
+	                 'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
+	             ],
+	         ],
+	     ],
+	    'technology_strategy' => [
+	        'recommended_category' => $recommended_category,
+	        'category_details'     => $category_details,
+	    ],
+	    'operational_insights' => $operational_analysis,
+	    'risk_analysis'        => [
+	        'implementation_risks' => $risks,
+	    ],
+	    'action_plan'          => [
+	        'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
+	        'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),
+	        'long_term_objectives'  => $this->extract_long_term_steps( $business_case_data ),
+	    ],
+	];
+
+	 return $report_data;
    }
 
    /**
@@ -1798,24 +1808,24 @@ return wp_kses_post( $html );
     * @return array
     */
    private function extract_value_drivers( $data ) {
-       $drivers = [];
+	 $drivers = [];
 
-       // Extract from various possible sources.
-       if ( ! empty( $data['value_drivers'] ) ) {
-           $drivers = (array) $data['value_drivers'];
-       } elseif ( ! empty( $data['key_benefits'] ) ) {
-           $drivers = (array) $data['key_benefits'];
-       } else {
-           // Default value drivers.
-           $drivers = [
-               __( 'Automated cash management processes', 'rtbcb' ),
-               __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
-               __( 'Reduced operational risk and errors', 'rtbcb' ),
-               __( 'Improved regulatory compliance', 'rtbcb' ),
-           ];
-       }
+	 // Extract from various possible sources.
+	 if ( ! empty( $data['value_drivers'] ) ) {
+	     $drivers = (array) $data['value_drivers'];
+	 } elseif ( ! empty( $data['key_benefits'] ) ) {
+	     $drivers = (array) $data['key_benefits'];
+	 } else {
+	     // Default value drivers.
+	     $drivers = [
+	         __( 'Automated cash management processes', 'rtbcb' ),
+	         __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
+	         __( 'Reduced operational risk and errors', 'rtbcb' ),
+	         __( 'Improved regulatory compliance', 'rtbcb' ),
+	     ];
+	 }
 
-       return array_slice( $drivers, 0, 4 );
+	 return array_slice( $drivers, 0, 4 );
    }
 
    /**
@@ -1826,36 +1836,36 @@ return wp_kses_post( $html );
     * @return array
     */
    private function format_roi_scenarios( $data ) {
-       // Try to get ROI data from various possible locations.
-       if ( ! empty( $data['scenarios'] ) ) {
-           return $data['scenarios'];
-       }
+	 // Try to get ROI data from various possible locations.
+	 if ( ! empty( $data['scenarios'] ) ) {
+	     return $data['scenarios'];
+	 }
 
-       if ( ! empty( $data['roi_scenarios'] ) ) {
-           return $data['roi_scenarios'];
-       }
+	 if ( ! empty( $data['roi_scenarios'] ) ) {
+	     return $data['roi_scenarios'];
+	 }
 
-       // Fallback to default structure.
-       return [
-           'conservative' => [
-               'total_annual_benefit' => $data['roi_low'] ?? 0,
-               'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
-           ],
-           'base' => [
-               'total_annual_benefit' => $data['roi_base'] ?? 0,
-               'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
-           ],
-           'optimistic' => [
-               'total_annual_benefit' => $data['roi_high'] ?? 0,
-               'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
-           ],
-       ];
+	 // Fallback to default structure.
+	 return [
+	     'conservative' => [
+	         'total_annual_benefit' => $data['roi_low'] ?? 0,
+	         'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
+	         'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
+	         'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
+	     ],
+	     'base' => [
+	         'total_annual_benefit' => $data['roi_base'] ?? 0,
+	         'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
+	         'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
+	         'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
+	     ],
+	     'optimistic' => [
+	         'total_annual_benefit' => $data['roi_high'] ?? 0,
+	         'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
+	         'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
+	         'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
+	     ],
+	 ];
    }
 
    /**
@@ -1866,17 +1876,17 @@ return wp_kses_post( $html );
     * @return string
     */
    private function determine_business_case_strength( $data ) {
-       $base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
+	 $base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
 
-       if ( $base_roi > 500000 ) {
-           return 'Compelling';
-       } elseif ( $base_roi > 200000 ) {
-           return 'Strong';
-       } elseif ( $base_roi > 50000 ) {
-           return 'Moderate';
-       } else {
-           return 'Developing';
-       }
+	 if ( $base_roi > 500000 ) {
+	     return 'Compelling';
+	 } elseif ( $base_roi > 200000 ) {
+	     return 'Strong';
+	 } elseif ( $base_roi > 50000 ) {
+	     return 'Moderate';
+	 } else {
+	     return 'Developing';
+	 }
    }
 
    /**
@@ -1887,16 +1897,16 @@ return wp_kses_post( $html );
     * @return array
     */
    private function extract_immediate_steps( $data ) {
-       if ( ! empty( $data['next_actions'] ) ) {
-           $all_actions = (array) $data['next_actions'];
-           return array_slice( $all_actions, 0, 3 );
-       }
+	 if ( ! empty( $data['next_actions'] ) ) {
+	     $all_actions = (array) $data['next_actions'];
+	     return array_slice( $all_actions, 0, 3 );
+	 }
 
-       return [
-           __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
-           __( 'Form project steering committee', 'rtbcb' ),
-           __( 'Conduct detailed requirements gathering', 'rtbcb' ),
-       ];
+	 return [
+	     __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
+	     __( 'Form project steering committee', 'rtbcb' ),
+	     __( 'Conduct detailed requirements gathering', 'rtbcb' ),
+	 ];
    }
 
    /**
@@ -1907,17 +1917,17 @@ return wp_kses_post( $html );
     * @return array
     */
    private function extract_short_term_steps( $data ) {
-       if ( ! empty( $data['implementation_steps'] ) ) {
-           $steps = (array) $data['implementation_steps'];
-           return array_slice( $steps, 0, 4 );
-       }
+	 if ( ! empty( $data['implementation_steps'] ) ) {
+	     $steps = (array) $data['implementation_steps'];
+	     return array_slice( $steps, 0, 4 );
+	 }
 
-       return [
-           __( 'Issue RFP to qualified vendors', 'rtbcb' ),
-           __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
-           __( 'Negotiate contracts and terms', 'rtbcb' ),
-           __( 'Begin system implementation planning', 'rtbcb' ),
-       ];
+	 return [
+	     __( 'Issue RFP to qualified vendors', 'rtbcb' ),
+	     __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
+	     __( 'Negotiate contracts and terms', 'rtbcb' ),
+	     __( 'Begin system implementation planning', 'rtbcb' ),
+	 ];
    }
 
    /**
@@ -1928,43 +1938,43 @@ return wp_kses_post( $html );
     * @return array
     */
    private function extract_long_term_steps( $data ) {
-       return [
-           __( 'Complete system implementation and testing', 'rtbcb' ),
-           __( 'Conduct user training and change management', 'rtbcb' ),
-           __( 'Measure and optimize system performance', 'rtbcb' ),
-           __( 'Expand functionality and integration capabilities', 'rtbcb' ),
-       ];
+	 return [
+	     __( 'Complete system implementation and testing', 'rtbcb' ),
+	     __( 'Conduct user training and change management', 'rtbcb' ),
+	     __( 'Measure and optimize system performance', 'rtbcb' ),
+	     __( 'Expand functionality and integration capabilities', 'rtbcb' ),
+	 ];
    }
 
     public function admin_notices() {
-        // Check if API key is configured
-        if ( current_user_can( 'manage_options' ) && empty( get_option( 'rtbcb_openai_api_key' ) ) ) {
-            $settings_url = admin_url( 'admin.php?page=rtbcb-settings' );
-            echo '<div class="notice notice-warning is-dismissible">';
-            echo '<p>';
-            printf(
-                wp_kses(
-                    __( '<strong>Real Treasury Business Case Builder:</strong> Please <a href="%s">configure your OpenAI API key</a> to enable business case generation.', 'rtbcb' ),
-                    [ 'strong' => [], 'a' => [ 'href' => [] ] ]
-                ),
-                esc_url( $settings_url )
-            );
-            echo '</p>';
-            echo '</div>';
-        }
+	  // Check if API key is configured
+	  if ( current_user_can( 'manage_options' ) && empty( get_option( 'rtbcb_openai_api_key' ) ) ) {
+	      $settings_url = admin_url( 'admin.php?page=rtbcb-settings' );
+	      echo '<div class="notice notice-warning is-dismissible">';
+	      echo '<p>';
+	      printf(
+	          wp_kses(
+	              __( '<strong>Real Treasury Business Case Builder:</strong> Please <a href="%s">configure your OpenAI API key</a> to enable business case generation.', 'rtbcb' ),
+	              [ 'strong' => [], 'a' => [ 'href' => [] ] ]
+	          ),
+	          esc_url( $settings_url )
+	      );
+	      echo '</p>';
+	      echo '</div>';
+	  }
 
-        // Show upgrade notice if applicable
-        if ( get_transient( 'rtbcb_show_upgrade_notice' ) ) {
-            echo '<div class="notice notice-success is-dismissible">';
-            echo '<p>';
-            printf(
-                esc_html__( 'Real Treasury Business Case Builder has been upgraded to version %s with new features including PDF reports, analytics, and enhanced lead tracking!', 'rtbcb' ),
-                RTBCB_VERSION
-            );
-            echo '</p>';
-            echo '</div>';
-            delete_transient( 'rtbcb_show_upgrade_notice' );
-        }
+	  // Show upgrade notice if applicable
+	  if ( get_transient( 'rtbcb_show_upgrade_notice' ) ) {
+	      echo '<div class="notice notice-success is-dismissible">';
+	      echo '<p>';
+	      printf(
+	          esc_html__( 'Real Treasury Business Case Builder has been upgraded to version %s with new features including PDF reports, analytics, and enhanced lead tracking!', 'rtbcb' ),
+	          RTBCB_VERSION
+	      );
+	      echo '</p>';
+	      echo '</div>';
+	      delete_transient( 'rtbcb_show_upgrade_notice' );
+	  }
     }
 
     /**
@@ -1974,20 +1984,20 @@ return wp_kses_post( $html );
      * @return array Modified links.
      */
     public function plugin_action_links( $links ) {
-        $custom_links = [
-            'settings' => sprintf(
-                '<a href="%s">%s</a>',
-                admin_url( 'admin.php?page=rtbcb-settings' ),
-                __( 'Settings', 'rtbcb' )
-            ),
-            'dashboard' => sprintf(
-                '<a href="%s">%s</a>',
-                admin_url( 'admin.php?page=rtbcb-dashboard' ),
-                __( 'Dashboard', 'rtbcb' )
-            ),
-        ];
+	  $custom_links = [
+	      'settings' => sprintf(
+	          '<a href="%s">%s</a>',
+	          admin_url( 'admin.php?page=rtbcb-settings' ),
+	          __( 'Settings', 'rtbcb' )
+	      ),
+	      'dashboard' => sprintf(
+	          '<a href="%s">%s</a>',
+	          admin_url( 'admin.php?page=rtbcb-dashboard' ),
+	          __( 'Dashboard', 'rtbcb' )
+	      ),
+	  ];
 
-        return array_merge( $custom_links, $links );
+	  return array_merge( $custom_links, $links );
     }
 
     /**
@@ -1996,25 +2006,25 @@ return wp_kses_post( $html );
      * @return void
      */
     public function activate() {
-        // Create database tables
-        $this->init_database();
+	  // Create database tables
+	  $this->init_database();
 
-        // Set default options
-        $this->set_default_options();
+	  // Set default options
+	  $this->set_default_options();
 
-        // Setup capabilities
-        $this->setup_capabilities();
+	  // Setup capabilities
+	  $this->setup_capabilities();
 
-        // Schedule cron jobs
-        $this->setup_cron_jobs();
+	  // Schedule cron jobs
+	  $this->setup_cron_jobs();
 
-        // Set activation flag
-        set_transient( 'rtbcb_show_upgrade_notice', true, 30 );
+	  // Set activation flag
+	  set_transient( 'rtbcb_show_upgrade_notice', true, 30 );
 
-        // Flush rewrite rules
-        flush_rewrite_rules();
+	  // Flush rewrite rules
+	  flush_rewrite_rules();
 
-        error_log( 'RTBCB: Plugin activated successfully' );
+	  error_log( 'RTBCB: Plugin activated successfully' );
     }
 
     /**
@@ -2023,14 +2033,14 @@ return wp_kses_post( $html );
      * @return void
      */
     public function deactivate() {
-        // Clear scheduled events
-        wp_clear_scheduled_hook( 'rtbcb_rebuild_rag_index' );
-        wp_clear_scheduled_hook( 'rtbcb_cleanup_data' );
+	  // Clear scheduled events
+	  wp_clear_scheduled_hook( 'rtbcb_rebuild_rag_index' );
+	  wp_clear_scheduled_hook( 'rtbcb_cleanup_data' );
 
-        // Flush rewrite rules
-        flush_rewrite_rules();
+	  // Flush rewrite rules
+	  flush_rewrite_rules();
 
-        error_log( 'RTBCB: Plugin deactivated' );
+	  error_log( 'RTBCB: Plugin deactivated' );
     }
 
     /**
@@ -2039,69 +2049,69 @@ return wp_kses_post( $html );
      * @return void
      */
     public static function uninstall() {
-        global $wpdb;
+	  global $wpdb;
 
-        // Remove database tables
-        $tables = [
-            $wpdb->prefix . 'rtbcb_leads',
-            $wpdb->prefix . 'rtbcb_rag_index',
-        ];
+	  // Remove database tables
+	  $tables = [
+	      $wpdb->prefix . 'rtbcb_leads',
+	      $wpdb->prefix . 'rtbcb_rag_index',
+	  ];
 
-        foreach ( $tables as $table ) {
-            $wpdb->query( "DROP TABLE IF EXISTS {$table}" );
-        }
+	  foreach ( $tables as $table ) {
+	      $wpdb->query( "DROP TABLE IF EXISTS {$table}" );
+	  }
 
-        // Remove options
-        $options = [
-            'rtbcb_version',
-            'rtbcb_db_version',
-            'rtbcb_openai_api_key',
-            'rtbcb_mini_model',
-            'rtbcb_premium_model',
-            'rtbcb_embedding_model',
-            'rtbcb_labor_cost_per_hour',
-            'rtbcb_bank_fee_baseline',
-            'rtbcb_pdf_enabled',
-            'rtbcb_last_indexed',
-            'rtbcb_settings',
-            'rtbcb_contact_form_id',
-        ];
+	  // Remove options
+	  $options = [
+	      'rtbcb_version',
+	      'rtbcb_db_version',
+	      'rtbcb_openai_api_key',
+	      'rtbcb_mini_model',
+	      'rtbcb_premium_model',
+	      'rtbcb_embedding_model',
+	      'rtbcb_labor_cost_per_hour',
+	      'rtbcb_bank_fee_baseline',
+	      'rtbcb_pdf_enabled',
+	      'rtbcb_last_indexed',
+	      'rtbcb_settings',
+	      'rtbcb_contact_form_id',
+	  ];
 
-        foreach ( $options as $option ) {
-            delete_option( $option );
-        }
+	  foreach ( $options as $option ) {
+	      delete_option( $option );
+	  }
 
-        // Remove user capabilities
-        $roles = wp_roles();
-        foreach ( $roles->roles as $role_name => $role_info ) {
-            $role = get_role( $role_name );
-            if ( $role ) {
-                $role->remove_cap( 'manage_rtbcb' );
-                $role->remove_cap( 'view_rtbcb_leads' );
-                $role->remove_cap( 'export_rtbcb_data' );
-            }
-        }
+	  // Remove user capabilities
+	  $roles = wp_roles();
+	  foreach ( $roles->roles as $role_name => $role_info ) {
+	      $role = get_role( $role_name );
+	      if ( $role ) {
+	          $role->remove_cap( 'manage_rtbcb' );
+	          $role->remove_cap( 'view_rtbcb_leads' );
+	          $role->remove_cap( 'export_rtbcb_data' );
+	      }
+	  }
 
-        // Remove uploaded files
-        $upload_dir = wp_get_upload_dir();
-        $plugin_dirs = [
-            $upload_dir['basedir'] . '/rtbcb-reports',
-            $upload_dir['basedir'] . '/rtbcb-temp',
-        ];
+	  // Remove uploaded files
+	  $upload_dir = wp_get_upload_dir();
+	  $plugin_dirs = [
+	      $upload_dir['basedir'] . '/rtbcb-reports',
+	      $upload_dir['basedir'] . '/rtbcb-temp',
+	  ];
 
-        foreach ( $plugin_dirs as $dir ) {
-            if ( is_dir( $dir ) ) {
-                $files = glob( $dir . '/*' );
-                foreach ( $files as $file ) {
-                    if ( is_file( $file ) ) {
-                        unlink( $file );
-                    }
-                }
-                rmdir( $dir );
-            }
-        }
+	  foreach ( $plugin_dirs as $dir ) {
+	      if ( is_dir( $dir ) ) {
+	          $files = glob( $dir . '/*' );
+	          foreach ( $files as $file ) {
+	              if ( is_file( $file ) ) {
+	                  unlink( $file );
+	              }
+	          }
+	          rmdir( $dir );
+	      }
+	  }
 
-        error_log( 'RTBCB: Plugin uninstalled and data cleaned up' );
+	  error_log( 'RTBCB: Plugin uninstalled and data cleaned up' );
     }
 
     /**
@@ -2111,10 +2121,10 @@ return wp_kses_post( $html );
      * @return mixed
      */
     public function get_plugin_data( $key = null ) {
-        if ( $key ) {
-            return $this->plugin_data[ $key ] ?? null;
-        }
-        return $this->plugin_data;
+	  if ( $key ) {
+	      return $this->plugin_data[ $key ] ?? null;
+	  }
+	  return $this->plugin_data;
     }
 
     /**
@@ -2123,27 +2133,27 @@ return wp_kses_post( $html );
      * @return void
      */
     public function debug_ajax_handler() {
-        $nonce       = isset( $_POST['rtbcb_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ) : '';
-        $nonce_valid = wp_verify_nonce( $nonce, 'rtbcb_debug' );
+	  $nonce       = isset( $_POST['rtbcb_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ) : '';
+	  $nonce_valid = wp_verify_nonce( $nonce, 'rtbcb_debug' );
 
-        $post_keys = array_map( 'sanitize_key', array_keys( $_POST ) );
-        $api_key   = get_option( 'rtbcb_openai_api_key', '' );
+	  $post_keys = array_map( 'sanitize_key', array_keys( $_POST ) );
+	  $api_key   = get_option( 'rtbcb_openai_api_key', '' );
 
-        global $wpdb;
-        $table_name   = $wpdb->prefix . 'rtbcb_leads';
-        $table_exists = ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name );
+	  global $wpdb;
+	  $table_name   = $wpdb->prefix . 'rtbcb_leads';
+	  $table_exists = ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name );
 
-        $diagnostics = [
-            'wp_functions'     => function_exists( 'add_action' ) && function_exists( 'wp_send_json_success' ),
-            'required_classes' => class_exists( 'RTBCB_Calculator' ) && class_exists( 'RTBCB_DB' ),
-            'nonce_valid'      => $nonce_valid,
-            'post_keys'        => $post_keys,
-            'api_key_present'  => ! empty( $api_key ),
-            'db_table_exists'  => $table_exists,
-            'memory_usage'     => size_format( memory_get_usage( true ) ),
-        ];
+	  $diagnostics = [
+	      'wp_functions'     => function_exists( 'add_action' ) && function_exists( 'wp_send_json_success' ),
+	      'required_classes' => class_exists( 'RTBCB_Calculator' ) && class_exists( 'RTBCB_DB' ),
+	      'nonce_valid'      => $nonce_valid,
+	      'post_keys'        => $post_keys,
+	      'api_key_present'  => ! empty( $api_key ),
+	      'db_table_exists'  => $table_exists,
+	      'memory_usage'     => size_format( memory_get_usage( true ) ),
+	  ];
 
-        wp_send_json_success( $diagnostics );
+	  wp_send_json_success( $diagnostics );
     }
 
     /**
@@ -2152,34 +2162,34 @@ return wp_kses_post( $html );
      * @return void
      */
     public function ajax_generate_case_simple() {
-        if ( ! check_ajax_referer( 'rtbcb_simple', 'rtbcb_nonce', false ) ) {
-            wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
-        }
+	  if ( ! check_ajax_referer( 'rtbcb_simple', 'rtbcb_nonce', false ) ) {
+	      wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
+	  }
 
-        $investment_raw = wp_unslash( $_POST['investment'] ?? '' );
-        $returns_raw    = wp_unslash( $_POST['returns'] ?? '' );
+	  $investment_raw = wp_unslash( $_POST['investment'] ?? '' );
+	  $returns_raw    = wp_unslash( $_POST['returns'] ?? '' );
 
-        if ( ! is_numeric( $investment_raw ) || ! is_numeric( $returns_raw ) ) {
-            wp_send_json_error( __( 'Invalid values provided.', 'rtbcb' ), 400 );
-        }
+	  if ( ! is_numeric( $investment_raw ) || ! is_numeric( $returns_raw ) ) {
+	      wp_send_json_error( __( 'Invalid values provided.', 'rtbcb' ), 400 );
+	  }
 
-        $investment = floatval( $investment_raw );
-        $returns    = floatval( $returns_raw );
+	  $investment = floatval( $investment_raw );
+	  $returns    = floatval( $returns_raw );
 
-        if ( $investment <= 0 || $returns <= 0 ) {
-            wp_send_json_error( __( 'Invalid values provided.', 'rtbcb' ), 400 );
-        }
+	  if ( $investment <= 0 || $returns <= 0 ) {
+	      wp_send_json_error( __( 'Invalid values provided.', 'rtbcb' ), 400 );
+	  }
 
-        $roi = 0;
-        if ( $investment > 0 ) {
-            $roi = ( ( $returns - $investment ) / $investment ) * 100;
-        }
+	  $roi = 0;
+	  if ( $investment > 0 ) {
+	      $roi = ( ( $returns - $investment ) / $investment ) * 100;
+	  }
 
-        wp_send_json_success(
-            [
-                'roi' => round( $roi, 2 ),
-            ]
-        );
+	  wp_send_json_success(
+	      [
+	          'roi' => round( $roi, 2 ),
+	      ]
+	  );
     }
 
 		/**
@@ -2227,8 +2237,8 @@ if ( ! function_exists( 'rtbcb_get_leads_count' ) ) {
      * @return int
      */
     function rtbcb_get_leads_count() {
-        $stats = RTBCB_Leads::get_statistics();
-        return intval( $stats['total_leads'] ?? 0 );
+	  $stats = RTBCB_Leads::get_statistics();
+	  return intval( $stats['total_leads'] ?? 0 );
     }
 }
 
@@ -2239,8 +2249,8 @@ if ( ! function_exists( 'rtbcb_get_average_roi' ) ) {
      * @return float
      */
     function rtbcb_get_average_roi() {
-        $stats = RTBCB_Leads::get_statistics();
-        return floatval( $stats['average_roi']['avg_base'] ?? 0 );
+	  $stats = RTBCB_Leads::get_statistics();
+	  return floatval( $stats['average_roi']['avg_base'] ?? 0 );
     }
 }
 
@@ -2251,7 +2261,7 @@ if ( ! function_exists( 'rtbcb_is_configured' ) ) {
      * @return bool
      */
     function rtbcb_is_configured() {
-        return ! empty( get_option( 'rtbcb_openai_api_key' ) );
+	  return ! empty( get_option( 'rtbcb_openai_api_key' ) );
     }
 }
 
@@ -2270,23 +2280,23 @@ add_action( 'wp_ajax_rtbcb_company_overview_simple', 'rtbcb_handle_company_overv
  */
 function rtbcb_handle_company_overview_simple() {
     if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_company_overview' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
-        return;
+	  wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
+	  return;
     }
 
     $company_name = isset( $_POST['company_name'] ) ? sanitize_text_field( wp_unslash( $_POST['company_name'] ) ) : '';
 
     if ( empty( $company_name ) ) {
-        wp_send_json_error( [ 'message' => __( 'Company name required', 'rtbcb' ) ] );
-        return;
+	  wp_send_json_error( [ 'message' => __( 'Company name required', 'rtbcb' ) ] );
+	  return;
     }
 
     wp_send_json_success(
-        [
-            'message'         => sprintf( __( 'Processing started for %s', 'rtbcb' ), $company_name ),
-            'status'          => 'processing',
-            'simple_analysis' => rtbcb_get_simple_company_info( $company_name ),
-        ]
+	  [
+	      'message'         => sprintf( __( 'Processing started for %s', 'rtbcb' ), $company_name ),
+	      'status'          => 'processing',
+	      'simple_analysis' => rtbcb_get_simple_company_info( $company_name ),
+	  ]
     );
 }
 
@@ -2298,17 +2308,17 @@ function rtbcb_handle_company_overview_simple() {
  */
 function rtbcb_get_simple_company_info( $company_name ) {
     return [
-        'analysis'        => sprintf( __( 'Analysis requested for %s. This is a placeholder response to test the connection without LLM calls.', 'rtbcb' ), $company_name ),
-        'recommendations' => [
-            __( 'Implement treasury management system', 'rtbcb' ),
-            __( 'Automate cash forecasting', 'rtbcb' ),
-            __( 'Improve bank connectivity', 'rtbcb' ),
-        ],
-        'references'      => [
-            esc_url_raw( 'https://www.afponline.org' ),
-            esc_url_raw( 'https://www.treasury.gov' ),
-        ],
-        'generated_at'    => current_time( 'Y-m-d H:i:s' ),
+	  'analysis'        => sprintf( __( 'Analysis requested for %s. This is a placeholder response to test the connection without LLM calls.', 'rtbcb' ), $company_name ),
+	  'recommendations' => [
+	      __( 'Implement treasury management system', 'rtbcb' ),
+	      __( 'Automate cash forecasting', 'rtbcb' ),
+	      __( 'Improve bank connectivity', 'rtbcb' ),
+	  ],
+	  'references'      => [
+	      esc_url_raw( 'https://www.afponline.org' ),
+	      esc_url_raw( 'https://www.treasury.gov' ),
+	  ],
+	  'generated_at'    => current_time( 'Y-m-d H:i:s' ),
     ];
 }
 
@@ -2319,13 +2329,13 @@ function rtbcb_get_simple_company_info( $company_name ) {
  */
 function rtbcb_ajax_generate_company_overview() {
     if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_company_overview' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
-        return;
+	  wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
+	  return;
     }
 
     if ( ! current_user_can( 'manage_options' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        return;
+	  wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+	  return;
     }
 
     $company_name = isset( $_POST['company_name'] ) ? sanitize_text_field( wp_unslash( $_POST['company_name'] ) ) : '';
@@ -2333,8 +2343,8 @@ function rtbcb_ajax_generate_company_overview() {
     $industry     = isset( $_POST['industry'] ) ? sanitize_text_field( wp_unslash( $_POST['industry'] ) ) : '';
 
     if ( empty( $company_name ) ) {
-        wp_send_json_error( [ 'message' => __( 'Company name is required.', 'rtbcb' ) ] );
-        return;
+	  wp_send_json_error( [ 'message' => __( 'Company name is required.', 'rtbcb' ) ] );
+	  return;
     }
 
     // Increase timeout for comprehensive analysis
@@ -2344,54 +2354,54 @@ function rtbcb_ajax_generate_company_overview() {
     $start_time = microtime( true );
 
     try {
-        $overview = rtbcb_test_generate_company_overview( $company_name );
+	  $overview = rtbcb_test_generate_company_overview( $company_name );
 
-        if ( is_wp_error( $overview ) ) {
-            wp_send_json_error( [
-                'message' => sanitize_text_field( $overview->get_error_message() ),
-            ] );
-            return;
-        }
+	  if ( is_wp_error( $overview ) ) {
+	      wp_send_json_error( [
+	          'message' => sanitize_text_field( $overview->get_error_message() ),
+	      ] );
+	      return;
+	  }
 
-        $analysis        = $overview['analysis'] ?? '';
-        $recommendations = array_map( 'sanitize_text_field', $overview['recommendations'] ?? [] );
-        $references      = array_map( 'esc_url_raw', $overview['references'] ?? [] );
+	  $analysis        = $overview['analysis'] ?? '';
+	  $recommendations = array_map( 'sanitize_text_field', $overview['recommendations'] ?? [] );
+	  $references      = array_map( 'esc_url_raw', $overview['references'] ?? [] );
 
-        $word_count   = str_word_count( wp_strip_all_tags( $analysis ) );
-        $elapsed_time = microtime( true ) - $start_time;
-        $timestamp    = current_time( 'mysql' );
+	  $word_count   = str_word_count( wp_strip_all_tags( $analysis ) );
+	  $elapsed_time = microtime( true ) - $start_time;
+	  $timestamp    = current_time( 'mysql' );
 
-        $company_data = [
-            'name'            => $company_name,
-            'summary'         => sanitize_textarea_field( wp_strip_all_tags( $analysis ) ),
-            'size'            => $company_size,
-            'industry'        => $industry,
-            'recommendations' => $recommendations,
-            'references'      => $references,
-            'word_count'      => intval( $word_count ),
-            'generated_at'    => $timestamp,
-        ];
+	  $company_data = [
+	      'name'            => $company_name,
+	      'summary'         => sanitize_textarea_field( wp_strip_all_tags( $analysis ) ),
+	      'size'            => $company_size,
+	      'industry'        => $industry,
+	      'recommendations' => $recommendations,
+	      'references'      => $references,
+	      'word_count'      => intval( $word_count ),
+	      'generated_at'    => $timestamp,
+	  ];
 
-        update_option( 'rtbcb_current_company', $company_data );
+	  update_option( 'rtbcb_current_company', $company_data );
 
-        wp_send_json_success(
-            [
-                'overview'        => wp_kses_post( $analysis ),
-                'company_name'    => $company_name,
-                'recommendations' => $recommendations,
-                'references'      => $references,
-                'word_count'      => intval( $word_count ),
-                'elapsed_time'    => round( $elapsed_time, 2 ),
-                'generated_at'    => $timestamp,
-            ]
-        );
+	  wp_send_json_success(
+	      [
+	          'overview'        => wp_kses_post( $analysis ),
+	          'company_name'    => $company_name,
+	          'recommendations' => $recommendations,
+	          'references'      => $references,
+	          'word_count'      => intval( $word_count ),
+	          'elapsed_time'    => round( $elapsed_time, 2 ),
+	          'generated_at'    => $timestamp,
+	      ]
+	  );
     } catch ( Exception $e ) {
-        error_log( 'RTBCB Company Overview Error: ' . $e->getMessage() );
-        wp_send_json_error(
-            [
-                'message' => __( 'An error occurred while generating the overview. Please try again.', 'rtbcb' ),
-            ]
-        );
+	  error_log( 'RTBCB Company Overview Error: ' . $e->getMessage() );
+	  wp_send_json_error(
+	      [
+	          'message' => __( 'An error occurred while generating the overview. Please try again.', 'rtbcb' ),
+	      ]
+	  );
     }
 }
 
@@ -2402,13 +2412,13 @@ function rtbcb_ajax_generate_company_overview() {
  */
 function rtbcb_ajax_clear_current_company() {
     if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_company_overview' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
-        return;
+	  wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
+	  return;
     }
 
     if ( ! current_user_can( 'manage_options' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        return;
+	  wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+	  return;
     }
 
     rtbcb_clear_current_company();
@@ -2423,58 +2433,58 @@ function rtbcb_ajax_clear_current_company() {
  */
 function rtbcb_ajax_generate_real_treasury_overview() {
     if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_real_treasury_overview' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
-        return;
+	  wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
+	  return;
     }
 
     if ( ! current_user_can( 'manage_options' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        return;
+	  wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+	  return;
     }
 
     $company = rtbcb_get_current_company();
     if ( empty( $company ) ) {
-        wp_send_json_error( [ 'message' => __( 'No company data found. Please run the company overview first.', 'rtbcb' ) ] );
-        return;
+	  wp_send_json_error( [ 'message' => __( 'No company data found. Please run the company overview first.', 'rtbcb' ) ] );
+	  return;
     }
 
     $include_portal = isset( $_POST['include_portal'] ) ? rest_sanitize_boolean( wp_unslash( $_POST['include_portal'] ) ) : false;
     $categories     = [];
     if ( isset( $_POST['vendor_categories'] ) ) {
-        $categories = array_filter( array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['vendor_categories'] ) ) );
+	  $categories = array_filter( array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['vendor_categories'] ) ) );
     }
 
     $start_time = microtime( true );
 
     try {
-        $overview = rtbcb_test_generate_real_treasury_overview( $include_portal, $categories );
+	  $overview = rtbcb_test_generate_real_treasury_overview( $include_portal, $categories );
 
-        if ( is_wp_error( $overview ) ) {
-            wp_send_json_error( [ 'message' => sanitize_text_field( $overview->get_error_message() ) ] );
-            return;
-        }
+	  if ( is_wp_error( $overview ) ) {
+	      wp_send_json_error( [ 'message' => sanitize_text_field( $overview->get_error_message() ) ] );
+	      return;
+	  }
 
-        $word_count   = str_word_count( wp_strip_all_tags( $overview ) );
-        $elapsed_time = microtime( true ) - $start_time;
-        $timestamp    = current_time( 'mysql' );
+	  $word_count   = str_word_count( wp_strip_all_tags( $overview ) );
+	  $elapsed_time = microtime( true ) - $start_time;
+	  $timestamp    = current_time( 'mysql' );
 
-        wp_send_json_success(
-            [
-                'overview'       => wp_kses_post( $overview ),
-                'include_portal' => $include_portal,
-                'categories'     => $categories,
-                'word_count'     => intval( $word_count ),
-                'elapsed_time'   => round( $elapsed_time, 2 ),
-                'generated_at'   => $timestamp,
-            ]
-        );
+	  wp_send_json_success(
+	      [
+	          'overview'       => wp_kses_post( $overview ),
+	          'include_portal' => $include_portal,
+	          'categories'     => $categories,
+	          'word_count'     => intval( $word_count ),
+	          'elapsed_time'   => round( $elapsed_time, 2 ),
+	          'generated_at'   => $timestamp,
+	      ]
+	  );
     } catch ( Exception $e ) {
-        error_log( 'RTBCB Real Treasury Overview Error: ' . $e->getMessage() );
-        wp_send_json_error(
-            [
-                'message' => __( 'An error occurred while generating the overview. Please try again.', 'rtbcb' ),
-            ]
-        );
+	  error_log( 'RTBCB Real Treasury Overview Error: ' . $e->getMessage() );
+	  wp_send_json_error(
+	      [
+	          'message' => __( 'An error occurred while generating the overview. Please try again.', 'rtbcb' ),
+	      ]
+	  );
     }
 }
 
@@ -2485,38 +2495,38 @@ function rtbcb_ajax_generate_real_treasury_overview() {
  */
 function rtbcb_ajax_generate_category_recommendation() {
     if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_category_recommendation' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
-        return;
+	  wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
+	  return;
     }
 
     if ( ! current_user_can( 'manage_options' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        return;
+	  wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+	  return;
     }
 
     $company = rtbcb_get_current_company();
     if ( empty( $company ) ) {
-        wp_send_json_error( [ 'message' => __( 'No company data found. Please run the company overview first.', 'rtbcb' ) ] );
-        return;
+	  wp_send_json_error( [ 'message' => __( 'No company data found. Please run the company overview first.', 'rtbcb' ) ] );
+	  return;
     }
 
     $extra_requirements = isset( $_POST['extra_requirements'] ) ? sanitize_textarea_field( wp_unslash( $_POST['extra_requirements'] ) ) : '';
 
     $analysis = [
-        'company_overview'    => sanitize_textarea_field( get_option( 'rtbcb_company_overview', '' ) ),
-        'industry_insights'   => sanitize_textarea_field( get_option( 'rtbcb_industry_insights', '' ) ),
-        'maturity_model'      => sanitize_textarea_field( get_option( 'rtbcb_maturity_model', '' ) ),
-        'rag_market_analysis' => get_option( 'rtbcb_rag_market_analysis', [] ),
-        'value_proposition'   => sanitize_textarea_field( get_option( 'rtbcb_value_proposition', '' ) ),
-        'treasury_challenges' => sanitize_textarea_field( get_option( 'rtbcb_treasury_challenges', '' ) ),
-        'extra_requirements'  => $extra_requirements,
+	  'company_overview'    => sanitize_textarea_field( get_option( 'rtbcb_company_overview', '' ) ),
+	  'industry_insights'   => sanitize_textarea_field( get_option( 'rtbcb_industry_insights', '' ) ),
+	  'maturity_model'      => sanitize_textarea_field( get_option( 'rtbcb_maturity_model', '' ) ),
+	  'rag_market_analysis' => get_option( 'rtbcb_rag_market_analysis', [] ),
+	  'value_proposition'   => sanitize_textarea_field( get_option( 'rtbcb_value_proposition', '' ) ),
+	  'treasury_challenges' => sanitize_textarea_field( get_option( 'rtbcb_treasury_challenges', '' ) ),
+	  'extra_requirements'  => $extra_requirements,
     ];
 
     try {
-        $recommendation = rtbcb_test_generate_category_recommendation( $analysis );
-        wp_send_json_success( $recommendation );
+	  $recommendation = rtbcb_test_generate_category_recommendation( $analysis );
+	  wp_send_json_success( $recommendation );
     } catch ( Exception $e ) {
-        wp_send_json_error( [ 'message' => __( 'An error occurred while generating the recommendation.', 'rtbcb' ) ] );
+	  wp_send_json_error( [ 'message' => __( 'An error occurred while generating the recommendation.', 'rtbcb' ) ] );
     }
 }
 
@@ -2534,30 +2544,30 @@ add_action( 'admin_enqueue_scripts', 'rtbcb_enqueue_recommended_category_scripts
 function rtbcb_enqueue_company_overview_scripts( $hook ) {
     $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
     if ( strpos( $hook, 'rtbcb' ) !== false && ( strpos( $hook, 'company-overview' ) !== false || 'rtbcb-test-dashboard' === $page ) ) {
-        wp_enqueue_script(
-            'rtbcb-test-utils',
-            plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
-            [ 'jquery' ],
-            '1.0.0',
-            true
-        );
-        wp_enqueue_script(
-            'rtbcb-company-overview',
-            plugin_dir_url( __FILE__ ) . 'admin/js/company-overview.js',
-            [ 'jquery', 'rtbcb-test-utils' ],
-            '1.0.0',
-            true
-        );
+	  wp_enqueue_script(
+	      'rtbcb-test-utils',
+	      plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
+	      [ 'jquery' ],
+	      '1.0.0',
+	      true
+	  );
+	  wp_enqueue_script(
+	      'rtbcb-company-overview',
+	      plugin_dir_url( __FILE__ ) . 'admin/js/company-overview.js',
+	      [ 'jquery', 'rtbcb-test-utils' ],
+	      '1.0.0',
+	      true
+	  );
 
-        wp_localize_script(
-            'rtbcb-company-overview',
-            'rtbcb_ajax',
-            [
-                'ajax_url' => admin_url( 'admin-ajax.php' ),
-                'nonce'    => wp_create_nonce( 'rtbcb_test_company_overview' ),
-                'timeout'  => rtbcb_get_api_timeout() * 1000,
-            ]
-        );
+	  wp_localize_script(
+	      'rtbcb-company-overview',
+	      'rtbcb_ajax',
+	      [
+	          'ajax_url' => admin_url( 'admin-ajax.php' ),
+	          'nonce'    => wp_create_nonce( 'rtbcb_test_company_overview' ),
+	          'timeout'  => rtbcb_get_api_timeout() * 1000,
+	      ]
+	  );
     }
 }
 
@@ -2570,29 +2580,29 @@ function rtbcb_enqueue_company_overview_scripts( $hook ) {
 function rtbcb_enqueue_real_treasury_overview_scripts( $hook ) {
     $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
     if ( strpos( $hook, 'rtbcb' ) !== false && ( strpos( $hook, 'real-treasury-overview' ) !== false || 'rtbcb-test-dashboard' === $page ) ) {
-        wp_enqueue_script(
-            'rtbcb-test-utils',
-            plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
-            [ 'jquery' ],
-            '1.0.0',
-            true
-        );
-        wp_enqueue_script(
-            'rtbcb-real-treasury-overview',
-            plugin_dir_url( __FILE__ ) . 'admin/js/real-treasury-overview.js',
-            [ 'jquery', 'rtbcb-test-utils' ],
-            '1.0.0',
-            true
-        );
+	  wp_enqueue_script(
+	      'rtbcb-test-utils',
+	      plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
+	      [ 'jquery' ],
+	      '1.0.0',
+	      true
+	  );
+	  wp_enqueue_script(
+	      'rtbcb-real-treasury-overview',
+	      plugin_dir_url( __FILE__ ) . 'admin/js/real-treasury-overview.js',
+	      [ 'jquery', 'rtbcb-test-utils' ],
+	      '1.0.0',
+	      true
+	  );
 
-        wp_localize_script(
-            'rtbcb-real-treasury-overview',
-            'rtbcb_ajax',
-            [
-                'ajax_url' => admin_url( 'admin-ajax.php' ),
-                'nonce'    => wp_create_nonce( 'rtbcb_test_real_treasury_overview' ),
-            ]
-        );
+	  wp_localize_script(
+	      'rtbcb-real-treasury-overview',
+	      'rtbcb_ajax',
+	      [
+	          'ajax_url' => admin_url( 'admin-ajax.php' ),
+	          'nonce'    => wp_create_nonce( 'rtbcb_test_real_treasury_overview' ),
+	      ]
+	  );
     }
 }
 
@@ -2606,29 +2616,29 @@ function rtbcb_enqueue_recommended_category_scripts( $hook ) {
     $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
 
     if ( false !== strpos( $page, 'recommended-category' ) || 'rtbcb-test-dashboard' === $page ) {
-        wp_enqueue_script(
-            'rtbcb-test-utils',
-            plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
-            [ 'jquery' ],
-            '1.0.0',
-            true
-        );
-        wp_enqueue_script(
-            'rtbcb-recommended-category',
-            plugin_dir_url( __FILE__ ) . 'admin/js/recommended-category.js',
-            [ 'jquery', 'rtbcb-test-utils' ],
-            '1.0.0',
-            true
-        );
+	  wp_enqueue_script(
+	      'rtbcb-test-utils',
+	      plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
+	      [ 'jquery' ],
+	      '1.0.0',
+	      true
+	  );
+	  wp_enqueue_script(
+	      'rtbcb-recommended-category',
+	      plugin_dir_url( __FILE__ ) . 'admin/js/recommended-category.js',
+	      [ 'jquery', 'rtbcb-test-utils' ],
+	      '1.0.0',
+	      true
+	  );
 
-        wp_localize_script(
-            'rtbcb-recommended-category',
-            'rtbcb_ajax',
-            [
-                'ajax_url' => admin_url( 'admin-ajax.php' ),
-                'nonce'    => wp_create_nonce( 'rtbcb_test_category_recommendation' ),
-            ]
-        );
+	  wp_localize_script(
+	      'rtbcb-recommended-category',
+	      'rtbcb_ajax',
+	      [
+	          'ajax_url' => admin_url( 'admin-ajax.php' ),
+	          'nonce'    => wp_create_nonce( 'rtbcb_test_category_recommendation' ),
+	      ]
+	  );
     }
 }
 

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -21,8 +21,16 @@ $executive_summary    = $report_data['executive_summary'] ?? [];
 $company_intelligence = $report_data['company_intelligence'] ?? [];
 $financial_analysis   = $report_data['financial_analysis'] ?? [];
 $technology_strategy  = $report_data['technology_strategy'] ?? [];
-$operational_insights = $report_data['operational_insights'] ?? [];
-$risk_analysis        = $report_data['risk_analysis'] ?? [];
+$operational_insights = (array) ( $report_data['operational_insights'] ?? [] );
+if ( empty( $operational_insights ) ) {
+	$operational_insights[] = __( 'No data provided', 'rtbcb' );
+}
+$risk_analysis = $report_data['risk_analysis'] ?? [];
+$implementation_risks = (array) ( $risk_analysis['implementation_risks'] ?? [] );
+if ( empty( $implementation_risks ) ) {
+	$implementation_risks[] = __( 'No data provided', 'rtbcb' );
+}
+$risk_analysis['implementation_risks'] = $implementation_risks;
 $action_plan          = $report_data['action_plan'] ?? [];
 $rag_context          = $report_data['rag_context'] ?? [];
 


### PR DESCRIPTION
## Summary
- Cast `operational_analysis` and `risks` values to arrays and provide "No data provided" fallback.
- Apply the same fallback handling in AJAX responses and router output.
- Ensure templates display a fallback entry when risk or operational data is missing.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b379cbbb648331a5763fb2db7fd071