### PR TITLE
Cast operational and risk arrays and add fallback text

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -203,8 +203,26 @@ class RTBCB_Ajax {
 		];
 	}
 
-	private static function structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $request_start ) {
-		return [
+private static function structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $request_start ) {
+	$operational_analysis = (array) ( $final_analysis['operational_analysis'] ?? [] );
+	$current_state_assessment = (array) ( $operational_analysis['current_state_assessment'] ?? [] );
+	if ( empty( $current_state_assessment ) ) {
+	$current_state_assessment = [ __( 'No data provided', 'rtbcb' ) ];
+	}
+	$process_improvements = (array) ( $operational_analysis['process_improvements'] ?? [] );
+	if ( empty( $process_improvements ) ) {
+	$process_improvements = [ __( 'No data provided', 'rtbcb' ) ];
+	}
+	$automation_opportunities = (array) ( $operational_analysis['automation_opportunities'] ?? [] );
+	if ( empty( $automation_opportunities ) ) {
+	$automation_opportunities = [ __( 'No data provided', 'rtbcb' ) ];
+	}
+	$implementation_risks = (array) ( $final_analysis['risk_mitigation']['implementation_risks'] ?? [] );
+	if ( empty( $implementation_risks ) ) {
+	$implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
+	}
+
+	return [
 			'metadata' => [
 				'company_name'   => $user_inputs['company_name'],
 				'analysis_date'  => current_time( 'Y-m-d' ),
@@ -238,14 +256,14 @@ class RTBCB_Ajax {
 				'vendor_considerations'=> $final_analysis['vendor_considerations'] ?? [],
 			],
 			'operational_insights' => [
-				'current_state_assessment' => $final_analysis['operational_analysis']['current_state_assessment'] ?? [],
-				'process_improvements'     => $final_analysis['operational_analysis']['process_improvements'] ?? [],
-				'automation_opportunities' => $final_analysis['operational_analysis']['automation_opportunities'] ?? [],
+							'current_state_assessment' => $current_state_assessment,
+							'process_improvements'     => $process_improvements,
+							'automation_opportunities' => $automation_opportunities,
 			],
 			'risk_analysis' => [
-				'implementation_risks' => $final_analysis['risk_mitigation']['implementation_risks'] ?? [],
-				'mitigation_strategies' => $final_analysis['risk_mitigation']['mitigation_strategies'] ?? [],
-				'success_factors'      => $final_analysis['risk_mitigation']['success_factors'] ?? [],
+							'implementation_risks' => $implementation_risks,
+							'mitigation_strategies' => $final_analysis['risk_mitigation']['mitigation_strategies'] ?? [],
+							'success_factors'      => $final_analysis['risk_mitigation']['success_factors'] ?? [],
 			],
 			'action_plan' => [
 				'immediate_steps'    => $final_analysis['next_steps']['immediate'] ?? [],

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -275,8 +275,19 @@ class RTBCB_Router {
        $recommended_category = $business_case_data['recommended_category'] ?? ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' );
        $category_details     = $business_case_data['category_info'] ?? ( $business_case_data['recommendation']['category_info'] ?? [] );
 
-       // Create structured data format expected by template.
-       $report_data = [
+	// Prepare operational and risk data with fallbacks.
+	$operational_analysis = (array) ( $business_case_data['operational_analysis'] ?? [] );
+	if ( empty( $operational_analysis ) ) {
+	$operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
+	}
+	
+	$implementation_risks = (array) ( $business_case_data['risks'] ?? [] );
+	if ( empty( $implementation_risks ) ) {
+	$implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
+	}
+	
+	// Create structured data format expected by template.
+	$report_data = [
            'metadata'            => [
                'company_name'    => $company_name,
                'analysis_date'   => current_time( 'Y-m-d' ),
@@ -313,15 +324,15 @@ class RTBCB_Router {
                    ],
                ],
            ],
-           'technology_strategy' => [
-               'recommended_category' => $recommended_category,
-               'category_details'     => $category_details,
-           ],
-           'operational_insights' => $business_case_data['operational_analysis'] ?? [],
-           'risk_analysis'        => [
-               'implementation_risks' => $business_case_data['risks'] ?? [],
-           ],
-           'action_plan'          => [
+			'technology_strategy' => [
+				'recommended_category' => $recommended_category,
+				'category_details'     => $category_details,
+			],
+			'operational_insights' => $operational_analysis,
+			'risk_analysis'        => [
+				'implementation_risks' => $implementation_risks,
+			],
+	           'action_plan'          => [
                'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
                'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),
                'long_term_objectives'  => $this->extract_long_term_steps( $business_case_data ),

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1734,8 +1734,19 @@ return wp_kses_post( $html );
        $recommended_category = $business_case_data['recommended_category'] ?? ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' );
        $category_details     = $business_case_data['category_info'] ?? ( $business_case_data['recommendation']['category_info'] ?? [] );
 
-       // Create structured data format expected by template.
-       $report_data = [
+	// Prepare operational and risk data with fallbacks.
+	$operational_analysis = (array) ( $business_case_data['operational_analysis'] ?? [] );
+	if ( empty( $operational_analysis ) ) {
+	$operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
+	}
+	
+	$implementation_risks = (array) ( $business_case_data['risks'] ?? [] );
+	if ( empty( $implementation_risks ) ) {
+	$implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
+	}
+	
+	// Create structured data format expected by template.
+$report_data = [
            'metadata'            => [
                'company_name'    => $company_name,
                'analysis_date'   => current_time( 'Y-m-d' ),
@@ -1772,14 +1783,14 @@ return wp_kses_post( $html );
                    ],
                ],
            ],
-           'technology_strategy' => [
-               'recommended_category' => $recommended_category,
-               'category_details'     => $category_details,
-           ],
-           'operational_insights' => $business_case_data['operational_analysis'] ?? [],
-           'risk_analysis'        => [
-               'implementation_risks' => $business_case_data['risks'] ?? [],
-           ],
+'technology_strategy' => [
+'recommended_category' => $recommended_category,
+'category_details'     => $category_details,
+],
+'operational_insights' => $operational_analysis,
+'risk_analysis'        => [
+'implementation_risks' => $implementation_risks,
+],
            'action_plan'          => [
                'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
                'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),

--- a/tests/operational-risks-fallback.test.php
+++ b/tests/operational-risks-fallback.test.php
@@ -1,0 +1,77 @@
+<?php
+if ( ! function_exists( '__' ) ) {
+function __( $text, $domain = null ) {
+return $text;
+}
+}
+if ( ! function_exists( 'current_time' ) ) {
+function current_time( $type ) {
+return '2024-01-01';
+}
+}
+if ( ! function_exists( 'rtbcb_get_current_company' ) ) {
+function rtbcb_get_current_company() {
+return [];
+}
+}
+if ( ! function_exists( 'plugin_dir_url' ) ) {
+function plugin_dir_url( $file ) {
+return '';
+}
+}
+if ( ! function_exists( 'plugin_dir_path' ) ) {
+function plugin_dir_path( $file ) {
+return __DIR__ . '/';
+}
+}
+if ( ! function_exists( 'register_activation_hook' ) ) {
+function register_activation_hook() {}
+}
+if ( ! function_exists( 'register_deactivation_hook' ) ) {
+function register_deactivation_hook() {}
+}
+if ( ! function_exists( 'register_uninstall_hook' ) ) {
+function register_uninstall_hook() {}
+}
+if ( ! function_exists( 'add_action' ) ) {
+function add_action() {}
+}
+if ( ! function_exists( 'add_shortcode' ) ) {
+function add_shortcode() {}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+function add_filter() {}
+}
+if ( ! function_exists( 'plugin_basename' ) ) {
+function plugin_basename() {
+return '';
+}
+}
+if ( ! function_exists( 'get_file_data' ) ) {
+function get_file_data() {
+return [];
+}
+}
+
+define( 'ABSPATH', __DIR__ );
+$plugin_code = file_get_contents( __DIR__ . '/../real-treasury-business-case-builder.php' );
+$plugin_code = preg_replace( '/
+?\/\/ Initialize the plugin\s*Real_Treasury_BCB::instance\(\);/', '', $plugin_code );
+eval( '?>' . $plugin_code );
+
+$ref  = new ReflectionClass( 'Real_Treasury_BCB' );
+$plugin = $ref->newInstanceWithoutConstructor();
+$method = $ref->getMethod( 'transform_data_for_template' );
+$method->setAccessible( true );
+
+$result = $method->invoke( $plugin, [] );
+if ( $result['operational_insights'][0] !== 'No data provided' ) {
+echo "Operational fallback failed\n";
+exit( 1 );
+}
+if ( $result['risk_analysis']['implementation_risks'][0] !== 'No data provided' ) {
+echo "Risk fallback failed\n";
+exit( 1 );
+}
+
+echo "operational-risks-fallback.test.php passed\n";


### PR DESCRIPTION
## Summary
- Ensure `operational_analysis` and `risks` data are cast to arrays and provide a "No data provided" fallback
- Apply array casting and fallback handling in AJAX responses and report data transformation
- Add regression test covering operational and risk array fallbacks

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4 bash tests/run-tests.sh`
- `php tests/operational-risks-fallback.test.php`


------
https://chatgpt.com/codex/tasks/task_e_68b379cbbb648331a5763fb2db7fd071