### PR TITLE
Sanitize API field assignments and ensure default structure

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2089,9 +2089,9 @@ return $analysis;
 	private function validate_company_profile( $profile, $user_inputs ) {
 	return [
 	'name'                => $user_inputs['company_name'],
-	'enhanced_description' => sanitize_textarea_field( $profile['enhanced_description'] ?? '' ),
-	'business_model'      => sanitize_textarea_field( $profile['business_model'] ?? '' ),
-	'market_position'     => sanitize_textarea_field( $profile['market_position'] ?? '' ),
+'enhanced_description' => wp_kses_post( $profile['enhanced_description'] ?? '' ),
+'business_model'      => wp_kses_post( $profile['business_model'] ?? '' ),
+'market_position'     => wp_kses_post( $profile['market_position'] ?? '' ),
 	'maturity_level'      => in_array( $profile['maturity_level'] ?? '', [ 'basic', 'developing', 'strategic', 'optimized' ], true )
 	? $profile['maturity_level']
 	: 'basic',
@@ -2101,7 +2101,7 @@ return $analysis;
 	'financial_health'  => sanitize_text_field( $profile['financial_indicators']['financial_health'] ?? 'unknown' ),
 	],
 	'treasury_maturity'   => [
-	'current_state'        => sanitize_textarea_field( $profile['treasury_maturity']['current_state'] ?? '' ),
+'current_state'        => wp_kses_post( $profile['treasury_maturity']['current_state'] ?? '' ),
 	'sophistication_level' => sanitize_text_field( $profile['treasury_maturity']['sophistication_level'] ?? 'manual' ),
 	'key_gaps'            => array_map( 'sanitize_text_field', $profile['treasury_maturity']['key_gaps'] ?? [] ),
 	'automation_readiness' => sanitize_text_field( $profile['treasury_maturity']['automation_readiness'] ?? 'medium' ),
@@ -2110,7 +2110,7 @@ return $analysis;
 	'primary_challenges'   => array_map( 'sanitize_text_field', $profile['strategic_context']['primary_challenges'] ?? [] ),
 	'growth_objectives'    => array_map( 'sanitize_text_field', $profile['strategic_context']['growth_objectives'] ?? [] ),
 	'competitive_pressures' => array_map( 'sanitize_text_field', $profile['strategic_context']['competitive_pressures'] ?? [] ),
-	'regulatory_environment' => sanitize_textarea_field( $profile['strategic_context']['regulatory_environment'] ?? '' ),
+'regulatory_environment' => wp_kses_post( $profile['strategic_context']['regulatory_environment'] ?? '' ),
 	],
 	];
 	}
@@ -2141,16 +2141,16 @@ return $analysis;
 	private function validate_industry_context( $context ) {
 	return [
 	'sector_analysis'    => [
-	'market_dynamics'   => sanitize_textarea_field( $context['sector_analysis']['market_dynamics'] ?? '' ),
-	'growth_trends'     => sanitize_textarea_field( $context['sector_analysis']['growth_trends'] ?? '' ),
+'market_dynamics'   => wp_kses_post( $context['sector_analysis']['market_dynamics'] ?? '' ),
+'growth_trends'     => wp_kses_post( $context['sector_analysis']['growth_trends'] ?? '' ),
 	'disruption_factors' => array_map( 'sanitize_text_field', $context['sector_analysis']['disruption_factors'] ?? [] ),
 	'technology_adoption' => sanitize_text_field( $context['sector_analysis']['technology_adoption'] ?? 'follower' ),
 	],
 	'benchmarking'       => [
-	'typical_treasury_setup' => sanitize_textarea_field( $context['benchmarking']['typical_treasury_setup'] ?? '' ),
+'typical_treasury_setup' => wp_kses_post( $context['benchmarking']['typical_treasury_setup'] ?? '' ),
 	'common_pain_points'     => array_map( 'sanitize_text_field', $context['benchmarking']['common_pain_points'] ?? [] ),
 	'technology_penetration' => sanitize_text_field( $context['benchmarking']['technology_penetration'] ?? 'medium' ),
-	'investment_patterns'    => sanitize_textarea_field( $context['benchmarking']['investment_patterns'] ?? '' ),
+'investment_patterns'    => wp_kses_post( $context['benchmarking']['investment_patterns'] ?? '' ),
 	],
 	'regulatory_landscape' => [
 	'key_regulations'      => array_map( 'sanitize_text_field', $context['regulatory_landscape']['key_regulations'] ?? [] ),

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -267,49 +267,72 @@ class RTBCB_Router {
     * @return array
     */
    private function transform_data_for_template( $business_case_data ) {
+       $defaults = [
+               'company_name'          => '',
+               'recommended_category'  => '',
+               'recommendation'        => [],
+               'category_info'         => [],
+               'confidence'            => 0.85,
+               'processing_time'       => 0,
+               'executive_summary'     => '',
+               'narrative'             => '',
+               'executive_recommendation' => '',
+               'payback_months'        => 'N/A',
+               'sensitivity_analysis'  => [],
+               'company_analysis'      => '',
+               'maturity_level'        => 'intermediate',
+               'current_state_analysis' => '',
+               'market_analysis'       => '',
+               'tech_adoption_level'   => 'medium',
+               'operational_analysis'  => [],
+               'risks'                => [],
+       ];
+
+       $business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
+
        // Get current company data.
        $company      = rtbcb_get_current_company();
-       $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
+       $company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
 
        // Derive recommended category and details from recommendation if not provided.
-       $recommended_category = $business_case_data['recommended_category'] ?? ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' );
-       $category_details     = $business_case_data['category_info'] ?? ( $business_case_data['recommendation']['category_info'] ?? [] );
+       $recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
+       $category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
 
        // Create structured data format expected by template.
        $report_data = [
            'metadata'            => [
                'company_name'    => $company_name,
                'analysis_date'   => current_time( 'Y-m-d' ),
-               'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
-               'processing_time' => $business_case_data['processing_time'] ?? 0,
+               'confidence_level'=> $business_case_data['confidence'],
+               'processing_time' => $business_case_data['processing_time'],
            ],
            'executive_summary'  => [
-               'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
+               'strategic_positioning'   => sanitize_text_field( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
                'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
+               'executive_recommendation'=> sanitize_text_field( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
                'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
            ],
            'financial_analysis' => [
                'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
                'payback_analysis'   => [
-                   'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
+                   'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
                ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
+               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
            ],
            'company_intelligence' => [
                'enriched_profile' => [
-                   'enhanced_description' => $business_case_data['company_analysis'] ?? '',
-                   'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
+                   'enhanced_description' => sanitize_text_field( $business_case_data['company_analysis'] ),
+                   'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
                    'treasury_maturity'    => [
-                       'current_state'    => $business_case_data['current_state_analysis'] ?? '',
+                       'current_state'    => sanitize_text_field( $business_case_data['current_state_analysis'] ),
                    ],
                ],
                'industry_context' => [
                    'sector_analysis' => [
-                       'market_dynamics' => $business_case_data['market_analysis'] ?? '',
+                       'market_dynamics' => sanitize_text_field( $business_case_data['market_analysis'] ),
                    ],
                    'benchmarking'   => [
-                       'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
+                       'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
                    ],
                ],
            ],
@@ -317,9 +340,9 @@ class RTBCB_Router {
                'recommended_category' => $recommended_category,
                'category_details'     => $category_details,
            ],
-           'operational_insights' => $business_case_data['operational_analysis'] ?? [],
+           'operational_insights' => $business_case_data['operational_analysis'],
            'risk_analysis'        => [
-               'implementation_risks' => $business_case_data['risks'] ?? [],
+               'implementation_risks' => $business_case_data['risks'],
            ],
            'action_plan'          => [
                'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1732,51 +1732,76 @@ return wp_kses_post( $html );
     * @return array
     */
    private function transform_data_for_template( $business_case_data ) {
+       $defaults = [
+               'company_name'          => '',
+               'recommended_category'  => '',
+               'recommendation'        => [],
+               'category_info'         => [],
+               'confidence'            => 0.85,
+               'processing_time'       => 0,
+               'executive_summary'     => '',
+               'narrative'             => '',
+               'executive_recommendation' => '',
+               'payback_months'        => 'N/A',
+               'sensitivity_analysis'  => [],
+               'company_analysis'      => '',
+               'maturity_level'        => 'intermediate',
+               'current_state_analysis' => '',
+               'market_analysis'       => '',
+               'tech_adoption_level'   => 'medium',
+               'operational_analysis'  => [],
+               'risks'                => [],
+               'base_roi'             => 0,
+               'roi_base'             => 0,
+       ];
+
+       $business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
+
        // Get current company data.
        $company      = rtbcb_get_current_company();
-       $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
-       $base_roi     = $business_case_data['base_roi'] ?? $business_case_data['roi_base'] ?? 0;
+       $company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
+       $base_roi     = $business_case_data['base_roi'] ?: $business_case_data['roi_base'];
        $business_case_data['roi_base'] = $base_roi;
 
        // Derive recommended category and details from recommendation if not provided.
-       $recommended_category = $business_case_data['recommended_category'] ?? ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' );
-       $category_details     = $business_case_data['category_info'] ?? ( $business_case_data['recommendation']['category_info'] ?? [] );
+       $recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
+       $category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
 
        // Create structured data format expected by template.
        $report_data = [
            'metadata'            => [
                'company_name'    => $company_name,
                'analysis_date'   => current_time( 'Y-m-d' ),
-               'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
-               'processing_time' => $business_case_data['processing_time'] ?? 0,
+               'confidence_level'=> $business_case_data['confidence'],
+               'processing_time' => $business_case_data['processing_time'],
            ],
            'executive_summary'  => [
-               'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
+               'strategic_positioning'   => sanitize_text_field( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
                'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
+               'executive_recommendation'=> sanitize_text_field( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
                'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
            ],
            'financial_analysis' => [
                'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
                'payback_analysis'   => [
-                   'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
+                   'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
                ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
+               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
            ],
            'company_intelligence' => [
                'enriched_profile' => [
-                   'enhanced_description' => $business_case_data['company_analysis'] ?? '',
-                   'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
+                   'enhanced_description' => sanitize_text_field( $business_case_data['company_analysis'] ),
+                   'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
                    'treasury_maturity'    => [
-                       'current_state'    => $business_case_data['current_state_analysis'] ?? '',
+                       'current_state'    => sanitize_text_field( $business_case_data['current_state_analysis'] ),
                    ],
                ],
                'industry_context' => [
                    'sector_analysis' => [
-                       'market_dynamics' => $business_case_data['market_analysis'] ?? '',
+                       'market_dynamics' => sanitize_text_field( $business_case_data['market_analysis'] ),
                    ],
                    'benchmarking'   => [
-                       'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
+                       'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
                    ],
                ],
            ],
@@ -1784,9 +1809,9 @@ return wp_kses_post( $html );
                'recommended_category' => $recommended_category,
                'category_details'     => $category_details,
            ],
-           'operational_insights' => $business_case_data['operational_analysis'] ?? [],
+           'operational_insights' => $business_case_data['operational_analysis'],
            'risk_analysis'        => [
-               'implementation_risks' => $business_case_data['risks'] ?? [],
+               'implementation_risks' => $business_case_data['risks'],
            ],
            'action_plan'          => [
                'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),


### PR DESCRIPTION
## Summary
- Sanitize `enhanced_description`, `market_dynamics`, and related text fields before building report data
- Merge API responses with defaults via `wp_parse_args()` to guarantee expected keys

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b37a32736483319cc50d75308b27b9