### PR TITLE
Sanitize API fields and add default structure

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2089,9 +2089,9 @@ return $analysis;
 	private function validate_company_profile( $profile, $user_inputs ) {
 	return [
 	'name'                => $user_inputs['company_name'],
-	'enhanced_description' => sanitize_textarea_field( $profile['enhanced_description'] ?? '' ),
-	'business_model'      => sanitize_textarea_field( $profile['business_model'] ?? '' ),
-	'market_position'     => sanitize_textarea_field( $profile['market_position'] ?? '' ),
+       'enhanced_description' => wp_kses_post( $profile['enhanced_description'] ?? '' ),
+       'business_model'      => wp_kses_post( $profile['business_model'] ?? '' ),
+       'market_position'     => wp_kses_post( $profile['market_position'] ?? '' ),
 	'maturity_level'      => in_array( $profile['maturity_level'] ?? '', [ 'basic', 'developing', 'strategic', 'optimized' ], true )
 	? $profile['maturity_level']
 	: 'basic',
@@ -2101,7 +2101,7 @@ return $analysis;
 	'financial_health'  => sanitize_text_field( $profile['financial_indicators']['financial_health'] ?? 'unknown' ),
 	],
 	'treasury_maturity'   => [
-	'current_state'        => sanitize_textarea_field( $profile['treasury_maturity']['current_state'] ?? '' ),
+       'current_state'        => wp_kses_post( $profile['treasury_maturity']['current_state'] ?? '' ),
 	'sophistication_level' => sanitize_text_field( $profile['treasury_maturity']['sophistication_level'] ?? 'manual' ),
 	'key_gaps'            => array_map( 'sanitize_text_field', $profile['treasury_maturity']['key_gaps'] ?? [] ),
 	'automation_readiness' => sanitize_text_field( $profile['treasury_maturity']['automation_readiness'] ?? 'medium' ),
@@ -2110,7 +2110,7 @@ return $analysis;
 	'primary_challenges'   => array_map( 'sanitize_text_field', $profile['strategic_context']['primary_challenges'] ?? [] ),
 	'growth_objectives'    => array_map( 'sanitize_text_field', $profile['strategic_context']['growth_objectives'] ?? [] ),
 	'competitive_pressures' => array_map( 'sanitize_text_field', $profile['strategic_context']['competitive_pressures'] ?? [] ),
-	'regulatory_environment' => sanitize_textarea_field( $profile['strategic_context']['regulatory_environment'] ?? '' ),
+       'regulatory_environment' => wp_kses_post( $profile['strategic_context']['regulatory_environment'] ?? '' ),
 	],
 	];
 	}
@@ -2141,16 +2141,16 @@ return $analysis;
 	private function validate_industry_context( $context ) {
 	return [
 	'sector_analysis'    => [
-	'market_dynamics'   => sanitize_textarea_field( $context['sector_analysis']['market_dynamics'] ?? '' ),
-	'growth_trends'     => sanitize_textarea_field( $context['sector_analysis']['growth_trends'] ?? '' ),
+       'market_dynamics'   => wp_kses_post( $context['sector_analysis']['market_dynamics'] ?? '' ),
+       'growth_trends'     => wp_kses_post( $context['sector_analysis']['growth_trends'] ?? '' ),
 	'disruption_factors' => array_map( 'sanitize_text_field', $context['sector_analysis']['disruption_factors'] ?? [] ),
 	'technology_adoption' => sanitize_text_field( $context['sector_analysis']['technology_adoption'] ?? 'follower' ),
 	],
 	'benchmarking'       => [
-	'typical_treasury_setup' => sanitize_textarea_field( $context['benchmarking']['typical_treasury_setup'] ?? '' ),
+       'typical_treasury_setup' => wp_kses_post( $context['benchmarking']['typical_treasury_setup'] ?? '' ),
 	'common_pain_points'     => array_map( 'sanitize_text_field', $context['benchmarking']['common_pain_points'] ?? [] ),
 	'technology_penetration' => sanitize_text_field( $context['benchmarking']['technology_penetration'] ?? 'medium' ),
-	'investment_patterns'    => sanitize_textarea_field( $context['benchmarking']['investment_patterns'] ?? '' ),
+       'investment_patterns'    => wp_kses_post( $context['benchmarking']['investment_patterns'] ?? '' ),
 	],
 	'regulatory_landscape' => [
 	'key_regulations'      => array_map( 'sanitize_text_field', $context['regulatory_landscape']['key_regulations'] ?? [] ),
@@ -2172,10 +2172,10 @@ return $analysis;
 	'investment_justification' => sanitize_text_field( $insights['investment_justification'] ?? 'weak' ),
 	'implementation_complexity' => sanitize_text_field( $insights['implementation_complexity'] ?? 'medium' ),
 	'expected_benefits'        => [
-	'efficiency_gains'     => sanitize_textarea_field( $insights['expected_benefits']['efficiency_gains'] ?? '' ),
-	'risk_reduction'       => sanitize_textarea_field( $insights['expected_benefits']['risk_reduction'] ?? '' ),
-	'strategic_value'      => sanitize_textarea_field( $insights['expected_benefits']['strategic_value'] ?? '' ),
-	'competitive_advantage' => sanitize_textarea_field( $insights['expected_benefits']['competitive_advantage'] ?? '' ),
+       'efficiency_gains'     => wp_kses_post( $insights['expected_benefits']['efficiency_gains'] ?? '' ),
+       'risk_reduction'       => wp_kses_post( $insights['expected_benefits']['risk_reduction'] ?? '' ),
+       'strategic_value'      => wp_kses_post( $insights['expected_benefits']['strategic_value'] ?? '' ),
+       'competitive_advantage' => wp_kses_post( $insights['expected_benefits']['competitive_advantage'] ?? '' ),
 	],
 	'critical_success_factors' => array_map( 'sanitize_text_field', $insights['critical_success_factors'] ?? [] ),
 	'potential_obstacles'      => array_map( 'sanitize_text_field', $insights['potential_obstacles'] ?? [] ),

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -267,75 +267,99 @@ class RTBCB_Router {
     * @return array
     */
    private function transform_data_for_template( $business_case_data ) {
+       $defaults = [
+           'company_name'           => '',
+           'base_roi'               => 0,
+           'roi_base'               => 0,
+           'recommended_category'   => '',
+           'category_info'          => [],
+           'executive_summary'      => '',
+           'narrative'              => '',
+           'executive_recommendation' => '',
+           'recommendation'         => '',
+           'payback_months'         => 'N/A',
+           'sensitivity_analysis'   => [],
+           'company_analysis'       => '',
+           'maturity_level'         => 'intermediate',
+           'current_state_analysis' => '',
+           'market_analysis'        => '',
+           'tech_adoption_level'    => 'medium',
+           'operational_analysis'   => [],
+           'risks'                  => [],
+           'confidence'             => 0.85,
+           'processing_time'        => 0,
+       ];
+       $business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
+
        // Get current company data.
        $company      = rtbcb_get_current_company();
-       $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
+       $company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
 
        // Derive recommended category and details from recommendation if not provided.
-       $recommended_category = $business_case_data['recommended_category'] ?? ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' );
-       $category_details     = $business_case_data['category_info'] ?? ( $business_case_data['recommendation']['category_info'] ?? [] );
+       $recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
+       $category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
 
-	// Prepare operational and risk data with fallbacks.
-	$operational_analysis = (array) ( $business_case_data['operational_analysis'] ?? [] );
-	if ( empty( $operational_analysis ) ) {
-	$operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
-	}
-	
-	$implementation_risks = (array) ( $business_case_data['risks'] ?? [] );
-	if ( empty( $implementation_risks ) ) {
-	$implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
-	}
-	
-	// Create structured data format expected by template.
-	$report_data = [
-           'metadata'            => [
-               'company_name'    => $company_name,
-               'analysis_date'   => current_time( 'Y-m-d' ),
-               'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
-               'processing_time' => $business_case_data['processing_time'] ?? 0,
+       // Prepare operational and risk data with fallbacks.
+       $operational_analysis = array_map( 'sanitize_text_field', (array) $business_case_data['operational_analysis'] );
+       if ( empty( $operational_analysis ) ) {
+           $operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
+       }
+
+       $implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
+       if ( empty( $implementation_risks ) ) {
+           $implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
+       }
+
+       // Create structured data format expected by template.
+       $report_data = [
+           'metadata'           => [
+               'company_name'     => $company_name,
+               'analysis_date'    => current_time( 'Y-m-d' ),
+               'confidence_level' => floatval( $business_case_data['confidence'] ),
+               'processing_time'  => intval( $business_case_data['processing_time'] ),
            ],
            'executive_summary'  => [
-               'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
-               'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
-               'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
+               'strategic_positioning'    => wp_kses_post( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
+               'key_value_drivers'       => $this->extract_value_drivers( $business_case_data ),
+               'executive_recommendation' => wp_kses_post( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
+               'business_case_strength'  => $this->determine_business_case_strength( $business_case_data ),
            ],
            'financial_analysis' => [
                'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
                'payback_analysis'   => [
-                   'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
+                   'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
                ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
+               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
            ],
            'company_intelligence' => [
                'enriched_profile' => [
-                   'enhanced_description' => $business_case_data['company_analysis'] ?? '',
-                   'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
+                   'enhanced_description' => wp_kses_post( $business_case_data['company_analysis'] ),
+                   'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
                    'treasury_maturity'    => [
-                       'current_state'    => $business_case_data['current_state_analysis'] ?? '',
+                       'current_state' => wp_kses_post( $business_case_data['current_state_analysis'] ),
                    ],
                ],
                'industry_context' => [
                    'sector_analysis' => [
-                       'market_dynamics' => $business_case_data['market_analysis'] ?? '',
+                       'market_dynamics' => wp_kses_post( $business_case_data['market_analysis'] ),
                    ],
                    'benchmarking'   => [
-                       'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
+                       'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
                    ],
                ],
            ],
-			'technology_strategy' => [
-				'recommended_category' => $recommended_category,
-				'category_details'     => $category_details,
-			],
-			'operational_insights' => $operational_analysis,
-			'risk_analysis'        => [
-				'implementation_risks' => $implementation_risks,
-			],
-	           'action_plan'          => [
-               'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
-               'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),
-               'long_term_objectives'  => $this->extract_long_term_steps( $business_case_data ),
+           'technology_strategy' => [
+               'recommended_category' => $recommended_category,
+               'category_details'     => $category_details,
+           ],
+           'operational_insights' => $operational_analysis,
+           'risk_analysis'        => [
+               'implementation_risks' => $implementation_risks,
+           ],
+           'action_plan'          => [
+               'immediate_steps'      => $this->extract_immediate_steps( $business_case_data ),
+               'short_term_milestones'=> $this->extract_short_term_steps( $business_case_data ),
+               'long_term_objectives' => $this->extract_long_term_steps( $business_case_data ),
            ],
        ];
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1806,77 +1806,101 @@ return $use_comprehensive;
     * @return array
     */
    private function transform_data_for_template( $business_case_data ) {
+       $defaults = [
+           'company_name'           => '',
+           'base_roi'               => 0,
+           'roi_base'               => 0,
+           'recommended_category'   => '',
+           'category_info'          => [],
+           'executive_summary'      => '',
+           'narrative'              => '',
+           'executive_recommendation' => '',
+           'recommendation'         => '',
+           'payback_months'         => 'N/A',
+           'sensitivity_analysis'   => [],
+           'company_analysis'       => '',
+           'maturity_level'         => 'intermediate',
+           'current_state_analysis' => '',
+           'market_analysis'        => '',
+           'tech_adoption_level'    => 'medium',
+           'operational_analysis'   => [],
+           'risks'                  => [],
+           'confidence'             => 0.85,
+           'processing_time'        => 0,
+       ];
+       $business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
+
        // Get current company data.
        $company      = rtbcb_get_current_company();
-       $company_name = $business_case_data['company_name'] ?? $company['name'] ?? __( 'Your Company', 'rtbcb' );
-       $base_roi     = $business_case_data['base_roi'] ?? $business_case_data['roi_base'] ?? 0;
+       $company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
+       $base_roi     = floatval( $business_case_data['base_roi'] ?: $business_case_data['roi_base'] );
        $business_case_data['roi_base'] = $base_roi;
 
        // Derive recommended category and details from recommendation if not provided.
-       $recommended_category = $business_case_data['recommended_category'] ?? ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' );
-       $category_details     = $business_case_data['category_info'] ?? ( $business_case_data['recommendation']['category_info'] ?? [] );
+       $recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
+       $category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
 
-	// Prepare operational and risk data with fallbacks.
-	$operational_analysis = (array) ( $business_case_data['operational_analysis'] ?? [] );
-	if ( empty( $operational_analysis ) ) {
-	$operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
-	}
-	
-	$implementation_risks = (array) ( $business_case_data['risks'] ?? [] );
-	if ( empty( $implementation_risks ) ) {
-	$implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
-	}
-	
-	// Create structured data format expected by template.
-$report_data = [
-           'metadata'            => [
-               'company_name'    => $company_name,
-               'analysis_date'   => current_time( 'Y-m-d' ),
-               'confidence_level'=> $business_case_data['confidence'] ?? 0.85,
-               'processing_time' => $business_case_data['processing_time'] ?? 0,
+       // Prepare operational and risk data with fallbacks.
+       $operational_analysis = array_map( 'sanitize_text_field', (array) $business_case_data['operational_analysis'] );
+       if ( empty( $operational_analysis ) ) {
+           $operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
+       }
+
+       $implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
+       if ( empty( $implementation_risks ) ) {
+           $implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
+       }
+
+       // Create structured data format expected by template.
+       $report_data = [
+           'metadata'           => [
+               'company_name'     => $company_name,
+               'analysis_date'    => current_time( 'Y-m-d' ),
+               'confidence_level' => floatval( $business_case_data['confidence'] ),
+               'processing_time'  => intval( $business_case_data['processing_time'] ),
            ],
            'executive_summary'  => [
-               'strategic_positioning'   => $business_case_data['executive_summary'] ?? $business_case_data['narrative'] ?? '',
-               'key_value_drivers'      => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation'=> $business_case_data['executive_recommendation'] ?? $business_case_data['recommendation'] ?? '',
-               'business_case_strength' => $this->determine_business_case_strength( $business_case_data ),
+               'strategic_positioning'    => wp_kses_post( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
+               'key_value_drivers'       => $this->extract_value_drivers( $business_case_data ),
+               'executive_recommendation' => wp_kses_post( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
+               'business_case_strength'  => $this->determine_business_case_strength( $business_case_data ),
            ],
            'financial_analysis' => [
                'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
                'payback_analysis'   => [
-                   'payback_months' => $business_case_data['payback_months'] ?? 'N/A',
+                   'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
                ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'] ?? [],
+               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
            ],
            'company_intelligence' => [
                'enriched_profile' => [
-                   'enhanced_description' => $business_case_data['company_analysis'] ?? '',
-                   'maturity_level'       => $business_case_data['maturity_level'] ?? 'intermediate',
+                   'enhanced_description' => wp_kses_post( $business_case_data['company_analysis'] ),
+                   'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
                    'treasury_maturity'    => [
-                       'current_state'    => $business_case_data['current_state_analysis'] ?? '',
+                       'current_state' => wp_kses_post( $business_case_data['current_state_analysis'] ),
                    ],
                ],
                'industry_context' => [
                    'sector_analysis' => [
-                       'market_dynamics' => $business_case_data['market_analysis'] ?? '',
+                       'market_dynamics' => wp_kses_post( $business_case_data['market_analysis'] ),
                    ],
                    'benchmarking'   => [
-                       'technology_penetration' => $business_case_data['tech_adoption_level'] ?? 'medium',
+                       'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
                    ],
                ],
            ],
-'technology_strategy' => [
-'recommended_category' => $recommended_category,
-'category_details'     => $category_details,
-],
-'operational_insights' => $operational_analysis,
-'risk_analysis'        => [
-'implementation_risks' => $implementation_risks,
-],
+           'technology_strategy' => [
+               'recommended_category' => $recommended_category,
+               'category_details'     => $category_details,
+           ],
+           'operational_insights' => $operational_analysis,
+           'risk_analysis'        => [
+               'implementation_risks' => $implementation_risks,
+           ],
            'action_plan'          => [
-               'immediate_steps'   => $this->extract_immediate_steps( $business_case_data ),
-               'short_term_milestones' => $this->extract_short_term_steps( $business_case_data ),
-               'long_term_objectives'  => $this->extract_long_term_steps( $business_case_data ),
+               'immediate_steps'      => $this->extract_immediate_steps( $business_case_data ),
+               'short_term_milestones'=> $this->extract_short_term_steps( $business_case_data ),
+               'long_term_objectives' => $this->extract_long_term_steps( $business_case_data ),
            ],
        ];
 


### PR DESCRIPTION
## Summary
- sanitize text-rich API fields with `wp_kses_post` and text fields with `sanitize_text_field`
- merge business case data with defaults using `wp_parse_args` before building report structures

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Call to undefined function add_filter)*
- `phpcs --standard=WordPress --ignore=vendor .` *(fails: Referenced sniff "Universal.NamingConventions.NoReservedKeywordParameterNames" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b37d0aeb9883318046b10c68dafc06