### PR TITLE
feat: track background job progress and cleanup

### DIFF
--- a/inc/class-rtbcb-background-job.php
+++ b/inc/class-rtbcb-background-job.php
@@ -6,7 +6,25 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package RealTreasuryBusinessCaseBuilder
  */
+
 class RTBCB_Background_Job {
+/**
+ * Update job status data.
+ *
+ * @param string $job_id Job identifier.
+ * @param string $status  New status.
+ * @param array  $extra   Extra data such as step, message, percent, or result.
+ * @return void
+ */
+public static function update_status( $job_id, $status, $extra = [] ) {
+$current = get_transient( $job_id );
+if ( ! is_array( $current ) ) {
+$current = [];
+}
+
+$new_data = array_merge( $current, $extra, [ 'status' => $status ] );
+set_transient( $job_id, $new_data, HOUR_IN_SECONDS );
+}
 	/**
 	 * Enqueue a case generation job.
 	 *
@@ -16,14 +34,13 @@ class RTBCB_Background_Job {
 	public static function enqueue( $user_inputs ) {
 		$job_id = uniqid( 'rtbcb_job_', true );
 
-		set_transient(
-			$job_id,
-			[
-				'status' => 'queued',
-				'result' => null,
-			],
-			HOUR_IN_SECONDS
-		);
+self::update_status(
+$job_id,
+'queued',
+[
+'result' => null,
+]
+);
 
                 wp_schedule_single_event(
                         time(),
@@ -47,35 +64,54 @@ class RTBCB_Background_Job {
 	 * @return void
 	 */
 	public static function process_job( $job_id, $user_inputs ) {
-		set_transient(
-			$job_id,
-			[
-				'status' => 'processing',
-			],
-			HOUR_IN_SECONDS
-		);
+self::update_status( $job_id, 'processing' );
 
-		$result = RTBCB_Ajax::process_comprehensive_case( $user_inputs );
+add_action(
+'rtbcb_workflow_step_completed',
+function ( $step ) use ( $job_id ) {
+$map = [
+'ai_enrichment'             => 20,
+'enhanced_roi_calculation'  => 40,
+'intelligent_recommendations' => 60,
+'hybrid_rag_analysis'       => 80,
+'data_structuring'          => 90,
+];
+if ( isset( $map[ $step ] ) ) {
+self::update_status(
+$job_id,
+'processing',
+[
+'step'    => $step,
+'percent' => $map[ $step ],
+]
+);
+}
+},
+10,
+1
+);
 
-		if ( is_wp_error( $result ) ) {
-			set_transient(
-				$job_id,
-				[
-					'status'  => 'error',
-					'message' => $result->get_error_message(),
-				],
-				HOUR_IN_SECONDS
-			);
-		} else {
-			set_transient(
-				$job_id,
-				[
-					'status' => 'completed',
-					'result' => $result,
-				],
-				HOUR_IN_SECONDS
-			);
-		}
+$result = RTBCB_Ajax::process_comprehensive_case( $user_inputs );
+
+if ( is_wp_error( $result ) ) {
+self::update_status(
+$job_id,
+'error',
+[
+'message' => $result->get_error_message(),
+'percent' => 100,
+]
+);
+} else {
+self::update_status(
+$job_id,
+'completed',
+[
+'result'  => $result,
+'percent' => 100,
+]
+);
+}
 	}
 
 	/**
@@ -91,8 +127,39 @@ class RTBCB_Background_Job {
 			return new WP_Error( 'not_found', __( 'Job not found.', 'rtbcb' ) );
 		}
 
-		return $data;
-	}
+return $data;
+}
+
+/**
+ * Cleanup completed or expired job transients.
+ *
+ * @return void
+ */
+public static function cleanup() {
+global $wpdb;
+
+if ( isset( $wpdb ) ) {
+$like         = $wpdb->esc_like( '_transient_rtbcb_job_' ) . '%';
+$option_names = $wpdb->get_col( "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE '{$like}' OR option_name LIKE '_transient_timeout_rtbcb_job_%'" );
+foreach ( $option_names as $option_name ) {
+$job_id = str_replace( [ '_transient_', '_transient_timeout_' ], '', $option_name );
+$data   = get_transient( $job_id );
+if ( false === $data || in_array( $data['status'] ?? '', [ 'completed', 'error' ], true ) ) {
+delete_transient( $job_id );
+}
+}
+} elseif ( isset( $GLOBALS['transients'] ) && is_array( $GLOBALS['transients'] ) ) {
+foreach ( array_keys( $GLOBALS['transients'] ) as $job_id ) {
+if ( 0 === strpos( $job_id, 'rtbcb_job_' ) ) {
+$data = $GLOBALS['transients'][ $job_id ];
+if ( ! is_array( $data ) || in_array( $data['status'] ?? '', [ 'completed', 'error' ], true ) ) {
+unset( $GLOBALS['transients'][ $job_id ] );
+}
+}
+}
+}
+}
 }
 
 add_action( 'rtbcb_process_job', [ 'RTBCB_Background_Job', 'process_job' ], 10, 2 );
+add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );

--- a/inc/class-rtbcb-workflow-tracker.php
+++ b/inc/class-rtbcb-workflow-tracker.php
@@ -103,6 +103,8 @@ $this->ai_calls++;
 $this->steps[]     = $this->current_step;
 $this->current_step = null;
 
+do_action( 'rtbcb_workflow_step_completed', $step_name );
+
 error_log( 'RTBCB Workflow: Completed step ' . $step_name . ' in ' . round( $this->steps[ count( $this->steps ) - 1 ]['duration'], 2 ) . 's' );
 }
 }

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -280,13 +280,20 @@ class Real_Treasury_BCB {
 
         add_action( 'rtbcb_rebuild_rag_index', [ $this, 'scheduled_rag_rebuild' ] );
 
-        // Schedule data cleanup
-        if ( ! wp_next_scheduled( 'rtbcb_cleanup_data' ) ) {
-            wp_schedule_event( time(), 'weekly', 'rtbcb_cleanup_data' );
-        }
+// Schedule data cleanup
+if ( ! wp_next_scheduled( 'rtbcb_cleanup_data' ) ) {
+wp_schedule_event( time(), 'weekly', 'rtbcb_cleanup_data' );
+}
 
-        add_action( 'rtbcb_cleanup_data', [ $this, 'scheduled_data_cleanup' ] );
-    }
+add_action( 'rtbcb_cleanup_data', [ $this, 'scheduled_data_cleanup' ] );
+
+// Schedule background job cleanup
+if ( ! wp_next_scheduled( 'rtbcb_cleanup_jobs' ) ) {
+wp_schedule_event( time(), 'hourly', 'rtbcb_cleanup_jobs' );
+}
+
+add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
+}
 
     /**
      * Handle version upgrades.


### PR DESCRIPTION
## Summary
- add RTBCB_Background_Job::update_status to record job progress and percent completion
- expose workflow step completion and update job status per major phase
- add hourly cleanup of completed/expired job transients and schedule on plugin load

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b384aa6bf48331a08b1805d420e6b7