### PR TITLE
Defer RAG context retrieval

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -709,13 +709,18 @@ USER,
      * call or response parsing fails.
      *
      * @param array $user_inputs    Sanitized user inputs.
-     * @param array $roi_data       ROI calculation data.
-     * @param array $context_chunks Optional context strings for the prompt.
+     * @param array          $roi_data       ROI calculation data.
+     * @param callable|array $context_chunks Optional context provider or strings.
      *
      * @return array|WP_Error Comprehensive analysis array or error object.
      */
     public function generate_comprehensive_business_case( $user_inputs, $roi_data, $context_chunks = [] ) {
         $this->current_inputs = $user_inputs;
+
+        if ( is_callable( $context_chunks ) ) {
+            $use_rag       = function_exists( 'apply_filters' ) ? apply_filters( 'rtbcb_use_rag', true ) : true;
+            $context_chunks = $use_rag ? call_user_func( $context_chunks ) : [];
+        }
 
         if ( empty( $this->api_key ) ) {
             return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );

--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
@@ -76,7 +76,10 @@ if ( ! function_exists( 'rtbcb_log_memory_usage' ) ) {
 if ( ! class_exists( 'RTBCB_LLM' ) ) {
     class RTBCB_LLM {
         public static $mode = 'generic';
-        public function generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context ) {
+        public function generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_loader ) {
+            if ( is_callable( $rag_loader ) ) {
+                $rag_loader();
+            }
             if ( 'no_api_key' === self::$mode ) {
                 return new WP_Error( 'no_api_key', 'OpenAI API key not configured.' );
             }

--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
@@ -55,7 +55,10 @@ if ( ! function_exists( 'rtbcb_is_openai_configuration_error' ) ) {
 if ( ! class_exists( 'RTBCB_LLM' ) ) {
     class RTBCB_LLM {
         public static $mode = 'ok';
-        public function generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context ) {
+        public function generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_loader ) {
+            if ( is_callable( $rag_loader ) ) {
+                $rag_loader();
+            }
             if ( 'fatal_config' === self::$mode ) {
                 throw new Error( 'Missing API key' );
             }

--- a/tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
+++ b/tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
@@ -51,7 +51,10 @@ function rtbcb_log_error( $message, $details = '' ) {
 }
 
 class RTBCB_LLM {
-public function generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context ) {
+public function generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_loader ) {
+if ( is_callable( $rag_loader ) ) {
+$rag_loader();
+}
 return $this->call_openai_with_retry( '', '', 0 );
 }
 
@@ -61,7 +64,7 @@ return new WP_Error( 'llm_timeout', 'Request timed out' );
 }
 
 class Real_Treasury_BCB {
-private function generate_business_analysis( $user_inputs, $scenarios, $rag_context ) {
+private function generate_business_analysis( $user_inputs, $scenarios, $rag_loader ) {
 if ( ! class_exists( 'RTBCB_LLM' ) ) {
 return new WP_Error( 'llm_unavailable', __( 'AI analysis service unavailable.', 'rtbcb' ) );
 }
@@ -72,7 +75,7 @@ return $this->generate_fallback_analysis( $user_inputs, $scenarios );
 
 try {
 $llm    = new RTBCB_LLM();
-$result = $llm->generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context );
+$result = $llm->generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_loader );
 
 if ( is_wp_error( $result ) ) {
 return $this->generate_fallback_analysis( $user_inputs, $scenarios );
@@ -130,7 +133,7 @@ $method->setAccessible( true );
 $user_inputs = [ 'company_name' => 'Test Co' ];
 $scenarios   = [ 'base' => [ 'total_annual_benefit' => 1000 ] ];
 
-$result = $method->invoke( $plugin, $user_inputs, $scenarios, [] );
+$result = $method->invoke( $plugin, $user_inputs, $scenarios, function() { return []; } );
 
 $this->assertIsArray( $result );
 $this->assertArrayHasKey( 'enhanced_fallback', $result );

--- a/tests/edge-cases.test.php
+++ b/tests/edge-cases.test.php
@@ -107,7 +107,10 @@ public function generate_business_case( $form_data, $calculations, $rag_context,
 return [ 'roi_base' => 1000 ];
 }
 
-public function generate_comprehensive_business_case( $form_data, $calculations, $rag_context ) {
+public function generate_comprehensive_business_case( $form_data, $calculations, $rag_loader ) {
+if ( is_callable( $rag_loader ) ) {
+$rag_loader();
+}
 return [ 'roi_base' => 1000 ];
 }
 }


### PR DESCRIPTION
## Summary
- Load RAG context lazily via a deadline-aware closure
- Pass callable to LLM and generate analysis only when context is required
- Allow LLM to invoke context provider after checking a filter

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4 bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b384ee9a148331bb964cdb5d3ebbe8