### PR TITLE
Optimize RAG search with embedding norm index

### DIFF
--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -220,14 +220,17 @@ class RTBCB_RAG {
         $query_norm = $this->calculate_embedding_norm( $query_embedding );
         $limit      = max( $top_k * 10, $top_k );
 
-        $rows = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT type, ref_id, embedding, metadata FROM {$table_name} ORDER BY ABS( embedding_norm - %f ) ASC LIMIT %d",
-                $query_norm,
-                $limit
-            ),
-            ARRAY_A
-        );
+		$range = 1;
+		$rows  = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT type, ref_id, embedding, metadata FROM {$table_name} WHERE embedding_norm BETWEEN %f AND %f ORDER BY ABS( embedding_norm - %f ) ASC LIMIT %d",
+				$query_norm - $range,
+				$query_norm + $range,
+				$query_norm,
+				$limit
+			),
+			ARRAY_A
+		);
 
         $scores = [];
         foreach ( $rows as $row ) {


### PR DESCRIPTION
## Summary
- add `embedding_norm_idx` to RAG index table and bump DB version
- ensure upgrades add the new index automatically
- narrow cosine similarity query using bounded `embedding_norm`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`
- `phpcs --standard=WordPress` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b384f34f6083319ef0072964ad1a0e