### PR TITLE
Stream LLM chunks and make raw storage optional

### DIFF
--- a/docs/MEMORY_USAGE.md
+++ b/docs/MEMORY_USAGE.md
@@ -1,0 +1,9 @@
+# MEMORY_USAGE
+
+The plugin reduces memory usage during LLM calls by streaming chunks directly to handlers and
+discarding processed data. Additionally, `rtbcb_parse_gpt5_response()` can skip storing the full raw
+payload unless requested, lowering peak memory.
+
+- The LLM client now processes stream chunks incrementally and logs peak memory after each call.
+- Pass `true` as the second argument to `rtbcb_parse_gpt5_response()` when raw response details are needed.
+- Run `tests/report-memory-usage.test.php` and `tests/parse-gpt5-response-raw-option.test.php` to monitor for regressions.

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -818,7 +818,7 @@ USER,
      * @return array|WP_Error Structured analysis array or error object.
      */
     private function parse_comprehensive_response( $response ) {
-        $parsed_response = rtbcb_parse_gpt5_response( $response );
+        $parsed_response = rtbcb_parse_gpt5_response( $response, true );
         $content         = $parsed_response['output_text'];
         $decoded         = $parsed_response['raw'];
 
@@ -2471,7 +2471,9 @@ return $analysis;
 
         $timeout   = intval( $this->gpt5_config['timeout'] ?? 180 );
         $payload   = wp_json_encode( $body );
-        $streamed  = '';
+        $buffer    = '';
+        $last_event = '';
+        $last_chunk = '';
         $ch        = curl_init( $endpoint );
         curl_setopt( $ch, CURLOPT_HTTPHEADER, [
             'Authorization: Bearer ' . $this->api_key,
@@ -2480,11 +2482,28 @@ return $analysis;
         curl_setopt( $ch, CURLOPT_POST, true );
         curl_setopt( $ch, CURLOPT_POSTFIELDS, $payload );
         curl_setopt( $ch, CURLOPT_TIMEOUT, $timeout );
-        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function ( $curl, $data ) use ( &$streamed, $chunk_handler ) {
-            $streamed .= $data;
+        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function ( $curl, $data ) use ( &$buffer, &$last_event, &$last_chunk, $chunk_handler ) {
+            $last_chunk = $data;
             if ( is_callable( $chunk_handler ) ) {
                 call_user_func( $chunk_handler, $data );
             }
+
+            $buffer .= $data;
+            while ( false !== ( $pos = strpos( $buffer, "\n" ) ) ) {
+                $line   = trim( substr( $buffer, 0, $pos ) );
+                $buffer = substr( $buffer, $pos + 1 );
+                if ( '' === $line ) {
+                    continue;
+                }
+                if ( 0 === strpos( $line, 'data:' ) ) {
+                    $payload_line = trim( substr( $line, strpos( $line, ':' ) + 1 ) );
+                    if ( '[DONE]' === $payload_line ) {
+                        continue;
+                    }
+                    $last_event = $payload_line;
+                }
+            }
+
             return strlen( $data );
         } );
 
@@ -2505,23 +2524,17 @@ return $analysis;
             );
         }
 
-        $last_event = '';
-        $lines      = explode( "\n", $streamed );
-        foreach ( $lines as $line ) {
-            $line = trim( $line );
-            if ( '' === $line ) {
-                continue;
-            }
+        if ( '' !== trim( $buffer ) ) {
+            $line = trim( $buffer );
             if ( 0 === strpos( $line, 'data:' ) ) {
                 $payload_line = trim( substr( $line, strpos( $line, ':' ) + 1 ) );
-                if ( '[DONE]' === $payload_line ) {
-                    continue;
+                if ( '[DONE]' !== $payload_line ) {
+                    $last_event = $payload_line;
                 }
-                $last_event = $payload_line;
             }
         }
 
-        $response_body = $last_event ? $last_event : $streamed;
+        $response_body = $last_event ? $last_event : $last_chunk;
 
         $decoded = json_decode( $response_body, true );
 
@@ -2642,7 +2655,7 @@ return $analysis;
             ? $response
             : [ 'body' => wp_json_encode( is_array( $response ) ? $response : [] ) ];
 
-        $parsed = rtbcb_parse_gpt5_response( $response_for_parser );
+        $parsed = rtbcb_parse_gpt5_response( $response_for_parser, true );
         $content = $parsed['output_text'];
         $usage   = $parsed['raw']['usage'] ?? [];
 
@@ -2650,14 +2663,16 @@ return $analysis;
         $reasoning_tokens  = intval( $usage['reasoning_tokens'] ?? 0 );
         $total_tokens      = intval( $usage['total_tokens'] ?? 0 );
         $response_length   = strlen( $content );
+        $memory            = rtbcb_get_memory_status();
 
         $log_message = sprintf(
-            'RTBCB GPT5 Call: context_size=%d, completion_tokens=%d, reasoning_tokens=%d, total_tokens=%d, response_length=%d',
+            'RTBCB GPT5 Call: context_size=%d, completion_tokens=%d, reasoning_tokens=%d, total_tokens=%d, response_length=%d, peak_memory=%d',
             $context_size,
             $completion_tokens,
             $reasoning_tokens,
             $total_tokens,
-            $response_length
+            $response_length,
+            intval( $memory['peak'] ?? 0 )
         );
 
         if ( ! empty( $error ) ) {
@@ -2822,7 +2837,8 @@ return $analysis;
  * string is not found, it manually walks the `output` chunks, prioritizing
  * message content before reasoning.
  *
- * @param array $response HTTP response array from wp_remote_post().
+ * @param array $response  HTTP response array from wp_remote_post().
+ * @param bool  $store_raw Optional. Include full raw payload. Default false.
  * @return array {
  *     @type string $output_text    Combined output text from the response.
  *     @type array  $reasoning      Reasoning segments provided by the model.
@@ -2831,7 +2847,7 @@ return $analysis;
  *     @type bool   $truncated      Whether the response hit the token limit.
  * }
  */
-function rtbcb_parse_gpt5_response( $response ) {
+function rtbcb_parse_gpt5_response( $response, $store_raw = false ) {
     $body    = wp_remote_retrieve_body( $response );
     $decoded = json_decode( $body, true );
 
@@ -2938,7 +2954,7 @@ function rtbcb_parse_gpt5_response( $response ) {
         'output_text'    => $output_text,
         'reasoning'      => $reasoning,
         'function_calls' => $function_calls,
-        'raw'            => $decoded,
+        'raw'            => $store_raw ? $decoded : [],
         'truncated'      => $truncated,
     ];
 }

--- a/tests/parse-gpt5-response-raw-option.test.php
+++ b/tests/parse-gpt5-response-raw-option.test.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
+
+if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
+	function wp_remote_retrieve_body( $response ) {
+		return $response['body'] ?? '';
+	}
+}
+
+$mock_response = [
+	'body' => json_encode( [ 'output_text' => 'hello world' ] ),
+];
+
+$no_raw = rtbcb_parse_gpt5_response( $mock_response );
+if ( ! empty( $no_raw['raw'] ) ) {
+	echo "Raw payload should be empty by default\n";
+	exit( 1 );
+}
+
+$with_raw = rtbcb_parse_gpt5_response( $mock_response, true );
+if ( empty( $with_raw['raw'] ) ) {
+	echo "Raw payload missing when requested\n";
+	exit( 1 );
+}
+
+echo "parse-gpt5-response-raw-option.test.php passed\n";


### PR DESCRIPTION
## Summary
- Stream OpenAI responses chunk-by-chunk and discard processed data to reduce memory usage
- Allow parsing without retaining raw payload and log peak memory for GPT-5 calls
- Document memory footprint improvements and add regression test for optional raw storage

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit missing, some JS tests passed)*
- `npx markdownlint docs/**/*.md` *(failed: could not determine executable to run)*
- `npx -y markdown-link-check docs/MEMORY_USAGE.md`

------
https://chatgpt.com/codex/tasks/task_e_68b384f6062083318206c448d0477570