### PR TITLE
Refine ROI workflow with category-aware calculations

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -60,10 +60,10 @@ class RTBCB_Ajax {
 			}
 			$workflow_tracker->complete_step( 'ai_enrichment', $enriched_profile );
 
-			$workflow_tracker->start_step( 'enhanced_roi_calculation' );
-			$enhanced_calculator = new RTBCB_Enhanced_Calculator();
-			$roi_scenarios       = $enhanced_calculator->calculate_enhanced_roi( $user_inputs, $enriched_profile );
-			$workflow_tracker->complete_step( 'enhanced_roi_calculation', $roi_scenarios );
+$workflow_tracker->start_step( 'enhanced_roi_calculation' );
+$category_output = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+$roi_scenarios   = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $category_output );
+$workflow_tracker->complete_step( 'enhanced_roi_calculation', $roi_scenarios );
 
 			$workflow_tracker->start_step( 'intelligent_recommendations' );
 			$intelligent_recommender = new RTBCB_Intelligent_Recommender();

--- a/inc/class-rtbcb-calculator.php
+++ b/inc/class-rtbcb-calculator.php
@@ -19,19 +19,30 @@ class RTBCB_Calculator {
      * @param array $user_inputs User provided inputs.
      * @return array
      */
-    public static function calculate_roi( $user_inputs ) {
-        $settings       = RTBCB_Settings::get_all();
-        $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
-        $category       = $recommendation['category_info'];
-        $industry_mult  = self::get_industry_benchmark( $user_inputs['industry'] ?? '' );
+	public static function calculate_roi( $user_inputs, $category = null ) {
+		$settings      = RTBCB_Settings::get_all();
+		$industry_mult = self::get_industry_benchmark( $user_inputs['industry'] ?? '' );
+		$category      = is_array( $category ) ? $category : [];
 
-        $scenarios = [];
-        foreach ( [ 'conservative', 'base', 'optimistic' ] as $scenario ) {
-            $scenarios[ $scenario ] = self::calculate_scenario( $user_inputs, $settings, $category, $scenario, $industry_mult );
-        }
+		$scenarios = [];
+		foreach ( [ 'conservative', 'base', 'optimistic' ] as $scenario ) {
+		$scenarios[ $scenario ] = self::calculate_scenario( $user_inputs, $settings, $category, $scenario, $industry_mult );
+}
 
-        return $scenarios;
-    }
+		return $scenarios;
+}
+
+/**
+ * Recalculate ROI using category recommendation output.
+ *
+ * @param array $user_inputs     User provided inputs.
+ * @param array $category_output Category recommendation output.
+ * @return array Refined ROI scenarios.
+ */
+	public static function calculate_category_refined_roi( $user_inputs, $category_output ) {
+		$category = $category_output['category_info'] ?? [];
+		return self::calculate_roi( $user_inputs, $category );
+}
 
     /**
      * Calculate ROI for a scenario.

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -51,11 +51,15 @@ class RTBCB_Router {
             $llm = new RTBCB_LLM();
             $rag = new RTBCB_RAG();
 
-            // Perform calculations.
-            $calculations = RTBCB_Calculator::calculate_roi( $form_data );
+// Perform calculations.
+$calculations = RTBCB_Calculator::calculate_roi( $form_data );
 
-            // Generate context from RAG.
-            $rag_context = $rag->get_context( $form_data['company_description'] );
+// Refine ROI using category recommendation.
+$category_output = RTBCB_Category_Recommender::recommend_category( $form_data );
+$calculations    = RTBCB_Calculator::calculate_category_refined_roi( $form_data, $category_output );
+
+// Generate context from RAG.
+$rag_context = $rag->get_context( $form_data['company_description'] );
 
             if ( 'comprehensive' === $report_type ) {
                 // Generate comprehensive business case with LLM.

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -754,18 +754,19 @@ return $use_comprehensive;
 	return;
 	}
 	
-	$scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
-	
-	// Get category recommendation
-	if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
-	wp_send_json_error( [ 'message' => __( 'System error: Recommender not available.', 'rtbcb' ) ], 500 );
-	return;
-	}
-	
-	$recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
-	
-	// Get RAG context if available
-	$rag_context = $this->get_rag_context( $user_inputs, $recommendation );
+$scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
+
+// Get category recommendation and refine ROI
+if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
+wp_send_json_error( [ 'message' => __( 'System error: Recommender not available.', 'rtbcb' ) ], 500 );
+return;
+}
+
+$recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+$scenarios      = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $recommendation );
+
+// Get RAG context if available
+$rag_context = $this->get_rag_context( $user_inputs, $recommendation );
 	
 	// Generate business case analysis
 	$comprehensive_analysis = $this->generate_business_analysis( $user_inputs, $scenarios, $rag_context );

--- a/tests/edge-cases.test.php
+++ b/tests/edge-cases.test.php
@@ -95,8 +95,19 @@ return rtrim( $string, '/\\' ) . '/';
 // Stub plugin classes.
 if ( ! class_exists( 'RTBCB_Calculator' ) ) {
 class RTBCB_Calculator {
-public static function calculate_roi( $data ) {
+public static function calculate_roi( $data, $category = null ) {
 return [ 'roi_base' => 1000 ];
+}
+public static function calculate_category_refined_roi( $data, $category_output ) {
+return self::calculate_roi( $data, $category_output['category_info'] ?? [] );
+}
+}
+}
+
+if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
+class RTBCB_Category_Recommender {
+public static function recommend_category( $inputs ) {
+return [ 'category_info' => [] ];
 }
 }
 }


### PR DESCRIPTION
## Summary
- Allow `RTBCB_Calculator::calculate_roi` to accept an optional category and add `calculate_category_refined_roi`
- Reorder workflow to recommend a category first and then refine ROI
- Update router and AJAX workflow to use new refinement method

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh >/tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68b385202afc8331a098b8a85aec6496