### PR TITLE
Add AI analysis feature flag

### DIFF
--- a/inc/class-rtbcb-settings.php
+++ b/inc/class-rtbcb-settings.php
@@ -26,6 +26,7 @@ class RTBCB_Settings {
         ],
         'bank_fee_reduction'        => [ 'min' => 5, 'max' => 10 ],
         'baseline_bank_fee_multiplier' => 15000,
+        'enable_ai_analysis'        => true,
     ];
 
     /**


### PR DESCRIPTION
## Summary
- add `enable_ai_analysis` default setting
- skip AI enrichment and RAG analysis when AI analysis is disabled

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38523c91883319997ba342a3e26d4