### PR TITLE
Track background job progress with partial status updates

### DIFF
--- a/inc/class-rtbcb-background-job.php
+++ b/inc/class-rtbcb-background-job.php
@@ -16,14 +16,15 @@ class RTBCB_Background_Job {
 	public static function enqueue( $user_inputs ) {
 		$job_id = uniqid( 'rtbcb_job_', true );
 
-		set_transient(
-			$job_id,
-			[
-				'status' => 'queued',
-				'result' => null,
-			],
-			HOUR_IN_SECONDS
-		);
+               set_transient(
+                       $job_id,
+                       [
+                               'status' => 'queued',
+                               'result' => null,
+                               'data'   => [],
+                       ],
+                       HOUR_IN_SECONDS
+               );
 
                 wp_schedule_single_event(
                         time(),
@@ -47,52 +48,76 @@ class RTBCB_Background_Job {
 	 * @return void
 	 */
 	public static function process_job( $job_id, $user_inputs ) {
-		set_transient(
-			$job_id,
-			[
-				'status' => 'processing',
-			],
-			HOUR_IN_SECONDS
-		);
+               self::update_status( $job_id, 'processing' );
 
-		$result = RTBCB_Ajax::process_comprehensive_case( $user_inputs );
+               $result = RTBCB_Ajax::process_comprehensive_case( $user_inputs, $job_id );
 
-		if ( is_wp_error( $result ) ) {
-			set_transient(
-				$job_id,
-				[
-					'status'  => 'error',
-					'message' => $result->get_error_message(),
-				],
-				HOUR_IN_SECONDS
-			);
-		} else {
-			set_transient(
-				$job_id,
-				[
-					'status' => 'completed',
-					'result' => $result,
-				],
-				HOUR_IN_SECONDS
-			);
-		}
-	}
+               if ( is_wp_error( $result ) ) {
+                       self::update_status(
+                               $job_id,
+                               'error',
+                               [ 'message' => $result->get_error_message() ]
+                       );
+               } else {
+                       self::update_status(
+                               $job_id,
+                               'completed',
+                               [ 'result' => $result ]
+                       );
+               }
+       }
 
-	/**
-	 * Get job status data.
-	 *
-	 * @param string $job_id Job identifier.
-	 * @return array|WP_Error Job data or error.
-	 */
-	public static function get_status( $job_id ) {
-		$data = get_transient( $job_id );
+       /**
+        * Update job status and merge payload.
+        *
+        * @param string $job_id  Job identifier.
+        * @param string $state   Job state.
+        * @param array  $payload Optional data to merge.
+        * @return void
+        */
+       public static function update_status( $job_id, $state, $payload = [] ) {
+               $data = get_transient( $job_id );
 
-		if ( false === $data ) {
-			return new WP_Error( 'not_found', __( 'Job not found.', 'rtbcb' ) );
-		}
+               if ( ! is_array( $data ) ) {
+                       $data = [];
+               }
 
-		return $data;
-	}
+               $stored_payload = [];
+               if ( isset( $data['data'] ) && is_array( $data['data'] ) ) {
+                       $stored_payload = $data['data'];
+               }
+
+               if ( is_array( $payload ) && ! empty( $payload ) ) {
+                       $stored_payload = array_merge( $stored_payload, $payload );
+               }
+
+               $data['data']   = $stored_payload;
+               $data['status'] = $state;
+
+               set_transient( $job_id, $data, HOUR_IN_SECONDS );
+       }
+
+       /**
+        * Get job status data.
+        *
+        * @param string $job_id Job identifier.
+        * @return array|WP_Error Job data or error.
+        */
+       public static function get_status( $job_id ) {
+               $data = get_transient( $job_id );
+
+               if ( false === $data ) {
+                       return new WP_Error( 'not_found', __( 'Job not found.', 'rtbcb' ) );
+               }
+
+               $payload = [];
+               if ( isset( $data['data'] ) && is_array( $data['data'] ) ) {
+                       $payload = $data['data'];
+               }
+               unset( $data['data'] );
+
+               return array_merge( $data, $payload );
+       }
 }
 
 add_action( 'rtbcb_process_job', [ 'RTBCB_Background_Job', 'process_job' ], 10, 2 );

--- a/tests/background-job.test.php
+++ b/tests/background-job.test.php
@@ -1,103 +1,106 @@
 <?php
 if ( ! class_exists( 'WP_Error' ) ) {
-    class WP_Error {
-        private $code;
-        private $message;
-        private $data;
-        public function __construct( $code = '', $message = '', $data = [] ) {
-            $this->code    = $code;
-            $this->message = $message;
-            $this->data    = $data;
-        }
-        public function get_error_message() {
-            return $this->message;
-        }
-        public function get_error_code() {
-            return $this->code;
-        }
-        public function get_error_data() {
-            return $this->data;
-        }
-    }
+	class WP_Error {
+		private $code;
+		private $message;
+		private $data;
+		public function __construct( $code = '', $message = '', $data = [] ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+		public function get_error_message() {
+			return $this->message;
+		}
+		public function get_error_code() {
+			return $this->code;
+		}
+		public function get_error_data() {
+			return $this->data;
+		}
+	}
 }
 
 if ( ! function_exists( 'is_wp_error' ) ) {
-    function is_wp_error( $thing ) {
-        return $thing instanceof WP_Error;
-    }
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
 }
 
 if ( ! function_exists( 'set_transient' ) ) {
-    function set_transient( $name, $value, $expiration ) {
-        global $transients, $transient_log;
-        $transients[ $name ]     = $value;
-        $transient_log[ $name ][] = $value;
-        return true;
-    }
+	function set_transient( $name, $value, $expiration ) {
+		global $transients, $transient_log;
+		$transients[ $name ]     = $value;
+		$transient_log[ $name ][] = $value;
+		return true;
+	}
 }
 
 if ( ! function_exists( 'get_transient' ) ) {
-    function get_transient( $name ) {
-        global $transients;
-        return $transients[ $name ] ?? false;
-    }
+	function get_transient( $name ) {
+		global $transients;
+		return $transients[ $name ] ?? false;
+	}
 }
 
 if ( ! function_exists( 'wp_schedule_single_event' ) ) {
-    function wp_schedule_single_event( $timestamp, $hook, $args ) {
-        global $scheduled_events;
-        $scheduled_events[] = [
-            'timestamp' => $timestamp,
-            'hook'      => $hook,
-            'args'      => $args,
-        ];
-    }
+	function wp_schedule_single_event( $timestamp, $hook, $args ) {
+		global $scheduled_events;
+		$scheduled_events[] = [
+			'timestamp' => $timestamp,
+			'hook'      => $hook,
+			'args'      => $args,
+		];
+	}
 }
 
 if ( ! function_exists( 'spawn_cron' ) ) {
-    function spawn_cron() {
-        global $spawned_cron;
-        $spawned_cron = true;
-    }
+	function spawn_cron() {
+		global $spawned_cron;
+		$spawned_cron = true;
+	}
 }
 
 if ( ! function_exists( 'wp_doing_cron' ) ) {
-    function wp_doing_cron() {
-        return false;
-    }
+	function wp_doing_cron() {
+		return false;
+	}
 }
 
 if ( ! function_exists( 'add_action' ) ) {
-    function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {}
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {}
 }
 
 if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
-    define( 'HOUR_IN_SECONDS', 3600 );
+	define( 'HOUR_IN_SECONDS', 3600 );
 }
 
 if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', __DIR__ . '/' );
+	define( 'ABSPATH', __DIR__ . '/' );
 }
 
 if ( ! class_exists( 'RTBCB_Ajax' ) ) {
-    class RTBCB_Ajax {
-        public static $mode = 'success';
-        public static function process_comprehensive_case( $user_inputs ) {
-            if ( 'error' === self::$mode ) {
-                return new WP_Error( 'failed', 'Processing failed.' );
-            }
-            return [ 'result' => 'ok' ];
-        }
-    }
+	class RTBCB_Ajax {
+		public static $mode = 'success';
+		public static function process_comprehensive_case( $user_inputs, $job_id = '' ) {
+			if ( 'error' === self::$mode ) {
+				return new WP_Error( 'failed', 'Processing failed.' );
+			}
+			if ( $job_id ) {
+				RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'basic_roi' => 123 ] );
+			}
+			return [ 'result' => 'ok' ];
+		}
+	}
 }
 
 require_once __DIR__ . '/../inc/class-rtbcb-background-job.php';
 
 function assert_true( $condition, $message ) {
-    if ( ! $condition ) {
-        echo $message . "\n";
-        exit( 1 );
-    }
+	if ( ! $condition ) {
+		echo $message . "\n";
+		exit( 1 );
+	}
 }
 
 // Successful job flow.
@@ -109,14 +112,16 @@ RTBCB_Background_Job::process_job( $job_id, $user_inputs );
 
 global $transient_log;
 $statuses = array_column( $transient_log[ $job_id ], 'status' );
-assert_true( $statuses === [ 'queued', 'processing', 'completed' ], 'Status flow incorrect: ' . json_encode( $statuses ) );
-assert_true( 'completed' === get_transient( $job_id )['status'], 'Job not completed' );
+assert_true( $statuses === [ 'queued', 'processing', 'processing', 'completed' ], 'Status flow incorrect: ' . json_encode( $statuses ) );
+$status = RTBCB_Background_Job::get_status( $job_id );
+assert_true( 123 === $status['basic_roi'], 'Partial data missing' );
+assert_true( 'completed' === $status['status'], 'Job not completed' );
 
 // Error job flow.
 RTBCB_Ajax::$mode = 'error';
 $job_id2          = RTBCB_Background_Job::enqueue( $user_inputs );
 RTBCB_Background_Job::process_job( $job_id2, $user_inputs );
-$status   = get_transient( $job_id2 );
+$status   = RTBCB_Background_Job::get_status( $job_id2 );
 $statuses = array_column( $transient_log[ $job_id2 ], 'status' );
 assert_true( $statuses === [ 'queued', 'processing', 'error' ], 'Error status flow incorrect: ' . json_encode( $statuses ) );
 assert_true( 'error' === $status['status'], 'Job did not error' );


### PR DESCRIPTION
## Summary
- add `update_status()` to merge partial job results into transient storage
- report `enriched_profile`, ROI, category and other progress during `process_comprehensive_case`
- expose accumulated fields via `get_status` and cover with tests

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=test-model bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3852a8834833199db38a58fa2443f