### PR TITLE
Add tier-based analysis metadata and version-tagged templates

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -102,10 +102,10 @@ class RTBCB_Ajax {
 			self::store_workflow_history( $debug_info, $lead_id, $lead_email );
 
 			return [
-				'report_data'   => $structured_report_data,
-				'workflow_info' => $debug_info,
-				'lead_id'       => $lead_id,
-				'analysis_type' => 'enhanced_comprehensive',
+'report_data'   => $structured_report_data,
+'workflow_info' => $debug_info,
+'lead_id'       => $lead_id,
+'analysis_type' => rtbcb_get_analysis_tier(),
 			];
 		} catch ( Exception $e ) {
 			$workflow_tracker->add_error( 'exception', $e->getMessage() );
@@ -216,11 +216,11 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 
 	return [
 			'metadata' => [
-				'company_name'   => $user_inputs['company_name'],
-				'analysis_date'  => current_time( 'Y-m-d' ),
-				'analysis_type'  => 'comprehensive_enhanced',
-				'confidence_level' => $final_analysis['confidence_level'] ?? 0.85,
-				'processing_time' => microtime( true ) - $request_start,
+'company_name'   => $user_inputs['company_name'],
+'analysis_date'  => current_time( 'Y-m-d' ),
+'analysis_type'  => rtbcb_get_analysis_tier(),
+'confidence_level' => $final_analysis['confidence_level'] ?? 0.85,
+'processing_time' => microtime( true ) - $request_start,
 			],
 			'executive_summary' => [
 				'strategic_positioning'   => $final_analysis['executive_summary']['strategic_positioning'] ?? '',

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -427,7 +427,7 @@ USER,
             'references'     => array_map( 'esc_url_raw', array_filter( (array) $json['references'] ) ),
             'metrics'        => $metrics,
             'generated_at'   => current_time( 'Y-m-d H:i:s' ),
-            'analysis_type'  => 'comprehensive_company_overview',
+            'analysis_type'  => rtbcb_get_analysis_tier(),
         ];
     }
 

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -314,12 +314,13 @@ class RTBCB_Router {
 
        // Create structured data format expected by template.
        $report_data = [
-           'metadata'           => [
-               'company_name'     => $company_name,
-               'analysis_date'    => current_time( 'Y-m-d' ),
-               'confidence_level' => floatval( $business_case_data['confidence'] ),
-               'processing_time'  => intval( $business_case_data['processing_time'] ),
-           ],
+   'metadata'           => [
+       'company_name'     => $company_name,
+       'analysis_date'    => current_time( 'Y-m-d' ),
+       'analysis_type'    => rtbcb_get_analysis_tier(),
+       'confidence_level' => floatval( $business_case_data['confidence'] ),
+       'processing_time'  => intval( $business_case_data['processing_time'] ),
+   ],
            'executive_summary'  => [
                'strategic_positioning'    => wp_kses_post( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
                'key_value_drivers'       => $this->extract_value_drivers( $business_case_data ),

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1726,3 +1726,22 @@ function rtbcb_get_report_allowed_html() {
 	return $allowed;
 }
 
+
+/**
+ * Determine analysis tier based on enabled features.
+ *
+ * @return string Analysis tier.
+ */
+function rtbcb_get_analysis_tier() {
+	$comprehensive = get_option( 'rtbcb_comprehensive_analysis', true );
+	$professional  = get_option( 'rtbcb_professional_reports', true );
+
+	$tier = 'basic';
+	if ( $professional ) {
+		$tier = 'premium';
+	} elseif ( $comprehensive ) {
+		$tier = 'enhanced';
+	}
+
+	return in_array( $tier, RTBCB_ALLOWED_TIERS, true ) ? $tier : 'basic';
+}

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -19,6 +19,7 @@ define( 'RTBCB_VERSION', '2.1.8' );
 define( 'RTBCB_FILE', __FILE__ );
 define( 'RTBCB_URL', plugin_dir_url( RTBCB_FILE ) );
 define( 'RTBCB_DIR', plugin_dir_path( RTBCB_FILE ) );
+define( 'RTBCB_ALLOWED_TIERS', [ 'basic', 'enhanced', 'premium' ] );
 
 /**
  * Enhanced main plugin class.
@@ -810,11 +811,11 @@ return $use_comprehensive;
 	'scenarios'              => $formatted_scenarios,
 	'recommendation'         => $recommendation,
 	'comprehensive_analysis' => $comprehensive_analysis,
-	'report_html'            => $report_html,
-	'lead_id'                => $lead_id,
-	'company_name'           => $user_inputs['company_name'],
-	'analysis_type'          => 'comprehensive_enhanced',
-	'memory_info'            => rtbcb_get_memory_status(),
+'report_html'            => $report_html,
+'lead_id'                => $lead_id,
+'company_name'           => $user_inputs['company_name'],
+'analysis_type'          => rtbcb_get_analysis_tier(),
+'memory_info'            => rtbcb_get_memory_status(),
 	];
 	
 	wp_send_json_success( $response_data );
@@ -1660,18 +1661,18 @@ return $use_comprehensive;
 
             // Prepare final response
             $response_data = [
-                'scenarios'              => $formatted_scenarios,
-                'recommendation'         => $recommendation,
-                'comprehensive_analysis' => $comprehensive_analysis,
-                'narrative'              => $comprehensive_analysis,
-                'rag_context'            => $rag_context,
-                'report_html'            => $report_html,
-                'lead_id'                => $lead_id,
-                'company_name'           => $user_inputs['company_name'],
-                'analysis_type'          => 'comprehensive',
-                'api_used'               => ! empty( get_option( 'rtbcb_openai_api_key' ) ),
-                'fallback_used'          => isset( $comprehensive_analysis['enhanced_fallback'] ),
-                'memory_info'            => rtbcb_get_memory_status(),
+'scenarios'              => $formatted_scenarios,
+'recommendation'         => $recommendation,
+'comprehensive_analysis' => $comprehensive_analysis,
+'narrative'              => $comprehensive_analysis,
+'rag_context'            => $rag_context,
+'report_html'            => $report_html,
+'lead_id'                => $lead_id,
+'company_name'           => $user_inputs['company_name'],
+'analysis_type'          => rtbcb_get_analysis_tier(),
+'api_used'               => ! empty( get_option( 'rtbcb_openai_api_key' ) ),
+'fallback_used'          => isset( $comprehensive_analysis['enhanced_fallback'] ),
+'memory_info'            => rtbcb_get_memory_status(),
             ];
 
             rtbcb_log_memory_usage( 'before_response' );

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -30,6 +30,9 @@ $company_name    = $metadata['company_name'] ?? __( 'Your Company', 'rtbcb' );
 $analysis_date   = $metadata['analysis_date'] ?? current_time( 'Y-m-d' );
 $confidence_level = round( ( $metadata['confidence_level'] ?? 0.85 ) * 100 );
 $processing_time = $metadata['processing_time'] ?? 0;
+$analysis_tier  = $metadata['analysis_type'] ?? 'basic';
+$is_enhanced    = in_array( $analysis_tier, [ 'enhanced', 'premium' ], true );
+$is_premium     = 'premium' === $analysis_tier;
 ?>
 
 <div class="rtbcb-enhanced-report" data-company="<?php echo esc_attr( $company_name ); ?>">
@@ -63,12 +66,17 @@ $processing_time = $metadata['processing_time'] ?? 0;
 						<span class="rtbcb-meta-label"><?php echo esc_html__( 'Processing Time', 'rtbcb' ); ?></span>
 						<span class="rtbcb-meta-value"><?php echo esc_html( round( $processing_time, 1 ) ); ?>s</span>
 					</div>
-					<div class="rtbcb-meta-item">
-						<span class="rtbcb-meta-icon">📊</span>
-						<span class="rtbcb-meta-label"><?php echo esc_html__( 'Analysis Type', 'rtbcb' ); ?></span>
-						<span class="rtbcb-meta-value"><?php echo esc_html__( 'Comprehensive Enhanced', 'rtbcb' ); ?></span>
-					</div>
-				</div>
+                                       <div class="rtbcb-meta-item">
+                                               <span class="rtbcb-meta-icon">📊</span>
+                                               <span class="rtbcb-meta-label"><?php echo esc_html__( 'Analysis Type', 'rtbcb' ); ?></span>
+                                               <span class="rtbcb-meta-value"><?php echo esc_html( ucfirst( $analysis_tier ) ); ?></span>
+                                       </div>
+                                       <div class="rtbcb-meta-item">
+                                               <span class="rtbcb-meta-icon">🏷️</span>
+                                               <span class="rtbcb-meta-label"><?php echo esc_html__( 'Version', 'rtbcb' ); ?></span>
+                                               <span class="rtbcb-meta-value"><?php echo esc_html( RTBCB_VERSION ); ?></span>
+                                       </div>
+                               </div>
 			</div>
 
 			<!-- Key Metrics Dashboard -->
@@ -338,8 +346,8 @@ $processing_time = $metadata['processing_time'] ?? 0;
 	</div>
 	<?php endif; ?>
 
-	<!-- Action Plan Section with Timeline -->
-	<?php if ( ! empty( $action_plan ) ) : ?>
+       <!-- Action Plan Section with Timeline -->
+       <?php if ( $is_enhanced && ! empty( $action_plan ) ) : ?>
 	<div class="rtbcb-section-enhanced rtbcb-action-plan">
 		<div class="rtbcb-section-header-enhanced">
 			<h2 class="rtbcb-section-title">
@@ -399,24 +407,28 @@ $processing_time = $metadata['processing_time'] ?? 0;
 	</div>
 <?php endif; ?>
 
-	<!-- Supporting Context Section -->
-	<?php if ( ! empty( $rag_context ) ) : ?>
-	<div class="rtbcb-section-enhanced rtbcb-supporting-context">
-		<div class="rtbcb-section-header-enhanced">
-			<h2 class="rtbcb-section-title">
-				<span class="rtbcb-section-icon">📚</span>
-				<?php echo esc_html__( 'Supporting Context', 'rtbcb' ); ?>
-			</h2>
-		</div>
-		<div class="rtbcb-section-content">
-			<ul class="rtbcb-context-list">
-				<?php foreach ( (array) $rag_context as $context_item ) : ?>
-					<li><?php echo esc_html( $context_item ); ?></li>
-				<?php endforeach; ?>
-			</ul>
-		</div>
-	</div>
-	<?php endif; ?>
+       <!-- Supporting Context Section -->
+       <?php if ( $is_premium ) : ?>
+       <div class="rtbcb-section-enhanced rtbcb-supporting-context">
+               <div class="rtbcb-section-header-enhanced">
+                        <h2 class="rtbcb-section-title">
+                                <span class="rtbcb-section-icon">📚</span>
+                                <?php echo esc_html__( 'Supporting Context', 'rtbcb' ); ?>
+                        </h2>
+               </div>
+               <div class="rtbcb-section-content">
+                        <?php if ( ! empty( $rag_context ) ) : ?>
+                                <ul class="rtbcb-context-list">
+                                        <?php foreach ( (array) $rag_context as $context_item ) : ?>
+                                                <li><?php echo esc_html( $context_item ); ?></li>
+                                        <?php endforeach; ?>
+                                </ul>
+                        <?php else : ?>
+                                <p><?php echo esc_html__( 'No additional supporting context available.', 'rtbcb' ); ?></p>
+                        <?php endif; ?>
+               </div>
+       </div>
+       <?php endif; ?>
 
 	<!-- Enhanced Report Footer -->
 	<div class="rtbcb-report-footer-enhanced">

--- a/templates/report-template.php
+++ b/templates/report-template.php
@@ -10,16 +10,17 @@
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
-
-$rag_context = $business_case_data['rag_context'] ?? [];
+$rag_context    = $business_case_data['rag_context'] ?? [];
+$analysis_tier = $business_case_data['metadata']['analysis_type'] ?? 'basic';
 ?>
 <div class="rtbcb-report">
     <h2><?php echo esc_html__( 'Business Case Report', 'rtbcb' ); ?></h2>
+    <div class="rtbcb-version-tag"><?php echo esc_html( RTBCB_VERSION ); ?></div>
     <?php if ( ! empty( $business_case_data['narrative'] ) ) : ?>
         <p><?php echo esc_html( $business_case_data['narrative'] ); ?></p>
     <?php endif; ?>
 
-    <?php if ( ! empty( $business_case_data['risks'] ) ) : ?>
+    <?php if ( in_array( $analysis_tier, [ 'enhanced', 'premium' ], true ) && ! empty( $business_case_data['risks'] ) ) : ?>
         <h3><?php echo esc_html__( 'Risks', 'rtbcb' ); ?></h3>
         <ul>
             <?php foreach ( (array) $business_case_data['risks'] as $risk ) : ?>
@@ -28,7 +29,7 @@ $rag_context = $business_case_data['rag_context'] ?? [];
         </ul>
     <?php endif; ?>
 
-    <?php if ( ! empty( $business_case_data['assumptions_explained'] ) ) : ?>
+    <?php if ( in_array( $analysis_tier, [ 'enhanced', 'premium' ], true ) && ! empty( $business_case_data['assumptions_explained'] ) ) : ?>
         <h3><?php echo esc_html__( 'Assumptions', 'rtbcb' ); ?></h3>
         <ul>
             <?php foreach ( (array) $business_case_data['assumptions_explained'] as $assumption ) : ?>
@@ -37,7 +38,7 @@ $rag_context = $business_case_data['rag_context'] ?? [];
         </ul>
     <?php endif; ?>
 
-    <?php if ( ! empty( $business_case_data['citations'] ) ) : ?>
+    <?php if ( 'premium' === $analysis_tier && ! empty( $business_case_data['citations'] ) ) : ?>
         <h3><?php echo esc_html__( 'Citations', 'rtbcb' ); ?></h3>
         <ol>
             <?php foreach ( (array) $business_case_data['citations'] as $citation ) : ?>
@@ -56,7 +57,7 @@ $rag_context = $business_case_data['rag_context'] ?? [];
         </ol>
     <?php endif; ?>
 
-    <?php if ( ! empty( $business_case_data['next_actions'] ) ) : ?>
+    <?php if ( 'premium' === $analysis_tier && ! empty( $business_case_data['next_actions'] ) ) : ?>
         <h3><?php echo esc_html__( 'Next Actions', 'rtbcb' ); ?></h3>
         <ul>
             <?php foreach ( (array) $business_case_data['next_actions'] as $action ) : ?>
@@ -73,14 +74,16 @@ $rag_context = $business_case_data['rag_context'] ?? [];
         <p><?php echo esc_html__( 'Recommended Category:', 'rtbcb' ) . ' ' . esc_html( $business_case_data['recommended_category'] ); ?></p>
     <?php endif; ?>
 
-	<h3><?php echo esc_html__( 'Context', 'rtbcb' ); ?></h3>
-	<?php if ( ! empty( $rag_context ) ) : ?>
+    <?php if ( 'premium' === $analysis_tier ) : ?>
+        <h3><?php echo esc_html__( 'Context', 'rtbcb' ); ?></h3>
+        <?php if ( ! empty( $rag_context ) ) : ?>
 		<ul>
 			<?php foreach ( (array) $rag_context as $context_item ) : ?>
 				<li><?php echo esc_html( $context_item ); ?></li>
 			<?php endforeach; ?>
 		</ul>
-	<?php else : ?>
-		<p><?php echo esc_html__( 'No additional context available.', 'rtbcb' ); ?></p>
-	<?php endif; ?>
+        <?php else : ?>
+                <p><?php echo esc_html__( 'No additional context available.', 'rtbcb' ); ?></p>
+        <?php endif; ?>
+    <?php endif; ?>
 </div>


### PR DESCRIPTION
## Summary
- Define allowed tiers and helper to derive analysis type
- Populate metadata and responses with tier-based analysis_type
- Display plugin version and tier-driven sections in report templates

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`
- `phpcs --standard=WordPress` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38534f6c88331b121879ac0fe25ea