### PR TITLE
Refactor leads table schema and add indexed upgrade routine

### DIFF
--- a/inc/class-rtbcb-db.php
+++ b/inc/class-rtbcb-db.php
@@ -14,7 +14,7 @@ class RTBCB_DB {
     /**
      * Current database version.
      */
-    const DB_VERSION = '2.0.0';
+    const DB_VERSION = '2.1.0';
 
     /**
      * Initialize database and handle upgrades.
@@ -22,8 +22,6 @@ class RTBCB_DB {
      * @return void
      */
     public static function init() {
-        self::create_tables();
-
         $current = get_option( 'rtbcb_db_version', '1.0.0' );
 
         if ( version_compare( $current, self::DB_VERSION, '<' ) ) {
@@ -31,7 +29,7 @@ class RTBCB_DB {
             update_option( 'rtbcb_db_version', self::DB_VERSION );
         }
 
-        // Ensure required tables exist.
+        // Ensure required tables exist after upgrades.
         RTBCB_Leads::init();
         if ( class_exists( 'RTBCB_API_Log' ) ) {
             RTBCB_API_Log::init();
@@ -47,8 +45,12 @@ class RTBCB_DB {
      * @return void
      */
     private static function upgrade( $from_version ) {
-        // Run table creation/migration for leads.
-        RTBCB_Leads::init();
+        if ( version_compare( $from_version, '2.1.0', '<' ) ) {
+            RTBCB_Leads::upgrade_schema();
+        } else {
+            RTBCB_Leads::init();
+        }
+
         if ( class_exists( 'RTBCB_API_Log' ) ) {
             RTBCB_API_Log::init();
         }
@@ -60,31 +62,6 @@ class RTBCB_DB {
 
         // Log the upgrade.
         error_log( 'RTBCB: Database upgraded from version ' . $from_version . ' to ' . self::DB_VERSION );
-    }
-
-    /**
-     * Create required database tables.
-     *
-     * @return void
-     */
-    private static function create_tables() {
-        global $wpdb;
-
-        $charset_collate = $wpdb->get_charset_collate();
-
-        // Create leads table.
-        $table_name = $wpdb->prefix . 'rtbcb_leads';
-        $sql        = "CREATE TABLE {$table_name} (
-            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-            email varchar(255) NOT NULL,
-            company_size varchar(50),
-            industry varchar(100),
-            created_at datetime DEFAULT CURRENT_TIMESTAMP,
-            PRIMARY KEY (id)
-        ) {$charset_collate};";
-
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        dbDelta( $sql );
     }
 
     /**

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -101,7 +101,9 @@ class RTBCB_Leads {
                     created_at datetime DEFAULT CURRENT_TIMESTAMP,
                     updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                     PRIMARY KEY (id),
-                    UNIQUE KEY email_unique (email)
+                    UNIQUE KEY email_unique (email),
+                    KEY created_at_index (created_at),
+                    KEY recommended_category_index (recommended_category)
                 ) $charset_collate;";
 
                 $wpdb->query( $simple_sql );
@@ -152,6 +154,15 @@ class RTBCB_Leads {
             } );
         }
     }
+
+	/**
+	 * Upgrade the leads table schema.
+	 *
+	 * @return void
+	 */
+	public static function upgrade_schema() {
+		self::create_table();
+	}
 
     /**
      * Save a lead to the database.


### PR DESCRIPTION
## Summary
- Remove duplicate leads table creation in DB initializer and delegate to RTBCB_Leads
- Expand leads table schema to include indexes and provide upgrade helper
- Add upgrade routine to migrate existing installs to the indexed schema

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit missing for some suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b385689fe88331afee312df1450206