### PR TITLE
Cache company profile research

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -936,21 +936,26 @@ USER,
      * @param array $user_inputs User-provided company details.
      * @return array Structured research data.
      */
-    private function conduct_company_research( $user_inputs ) {
-        $company_name = sanitize_text_field( $user_inputs['company_name'] ?? '' );
-        $industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
-        $company_size = sanitize_text_field( $user_inputs['company_size'] ?? '' );
+	private function conduct_company_research( $user_inputs ) {
+	$company_name = sanitize_text_field( $user_inputs['company_name'] ?? '' );
+	$industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
+	$company_size = sanitize_text_field( $user_inputs['company_size'] ?? '' );
 
-        // Simulate company research (in real implementation, this could query APIs, databases, etc.)
-        $research = [
-            'company_profile'       => $this->build_company_profile( $company_name, $industry, $company_size ),
-            'industry_positioning'  => $this->analyze_market_position( $industry, $company_size ),
-            'treasury_maturity'     => $this->assess_treasury_maturity( $user_inputs ),
-            'competitive_landscape' => $this->analyze_competitive_context( $industry ),
-            'growth_trajectory'     => $this->project_growth_path( $company_size, $industry ),
-        ];
+	$company_profile = rtbcb_get_research_cache( $company_name, $industry, 'company_profile' );
+	if ( false === $company_profile ) {
+		$company_profile = $this->build_company_profile( $company_name, $industry, $company_size );
+		rtbcb_set_research_cache( $company_name, $industry, 'company_profile', $company_profile );
+	}
 
-        $this->last_company_research = wp_json_encode( $research );
+	$research = [
+		'company_profile'       => $company_profile,
+		'industry_positioning'  => $this->analyze_market_position( $industry, $company_size ),
+		'treasury_maturity'     => $this->assess_treasury_maturity( $user_inputs ),
+		'competitive_landscape' => $this->analyze_competitive_context( $industry ),
+		'growth_trajectory'     => $this->project_growth_path( $company_size, $industry ),
+	];
+
+	$this->last_company_research = wp_json_encode( $research );
 
         return $research;
     }

--- a/tests/company-profile-cache.test.php
+++ b/tests/company-profile-cache.test.php
@@ -1,0 +1,110 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $text ) {
+		$text = is_scalar( $text ) ? (string) $text : '';
+		$text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
+		return trim( $text );
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ) {
+		$title = strtolower( $title );
+		$title = preg_replace( '/[^a-z0-9]+/', '-', $title );
+		return trim( $title, '-' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		$key = strtolower( $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( $name, $value, $expiration ) {
+		global $transients;
+		$transients[ $name ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_transient' ) ) {
+	function get_transient( $name ) {
+		global $transients;
+		return $transients[ $name ] ?? false;
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $name, $default = '' ) {
+		return $default;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $tag, $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $tag, $callback, $priority = 10, $accepted_args = 1 ) {}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data ) {
+		return json_encode( $data );
+	}
+}
+
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 86400 );
+}
+
+require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
+
+$llm = new RTBCB_LLM();
+$method = new ReflectionMethod( RTBCB_LLM::class, 'conduct_company_research' );
+$method->setAccessible( true );
+
+$inputs = [
+	'company_name' => 'Cache Co',
+	'company_size' => '$50M-$500M',
+	'industry'     => 'finance',
+];
+
+$result = $method->invoke( $llm, $inputs );
+
+if ( ! is_array( $result['company_profile'] ) ) {
+	echo "Profile not returned\n";
+	exit( 1 );
+}
+
+$cached = rtbcb_get_research_cache( 'Cache Co', 'finance', 'company_profile' );
+if ( false === $cached ) {
+	echo "Profile not cached\n";
+	exit( 1 );
+}
+
+$custom = [ 'stage' => 'cached', 'characteristics' => '', 'treasury_focus' => '', 'typical_challenges' => '' ];
+rtbcb_set_research_cache( 'Cache Co', 'finance', 'company_profile', $custom );
+
+$result2 = $method->invoke( $llm, $inputs );
+if ( 'cached' !== ( $result2['company_profile']['stage'] ?? '' ) ) {
+	echo "Cache not used\n";
+	exit( 1 );
+}
+
+echo "company-profile-cache.test.php passed\n";

--- a/tests/project-growth-path.test.php
+++ b/tests/project-growth-path.test.php
@@ -1,51 +1,79 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', __DIR__ . '/../' );
+	define( 'ABSPATH', __DIR__ . '/../' );
 }
 
 if ( ! function_exists( 'add_filter' ) ) {
-    function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
+	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
 }
 
 if ( ! function_exists( 'get_option' ) ) {
-    function get_option( $name, $default = '' ) {
-        return $default;
-    }
+	function get_option( $name, $default = '' ) {
+		return $default;
+	}
 }
 
 require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
 
 if ( ! class_exists( 'WP_Error' ) ) {
-    class WP_Error {
-        public function __construct( $code = '', $message = '' ) {}
-    }
+	class WP_Error {
+		public function __construct( $code = '', $message = '' ) {}
+	}
 }
 
 if ( ! function_exists( '__' ) ) {
-    function __( $text, $domain = null ) {
-        return $text;
-    }
+	function __( $text, $domain = null ) {
+		return $text;
+	}
 }
 
 if ( ! function_exists( 'sanitize_text_field' ) ) {
-    function sanitize_text_field( $text ) {
-        $text = is_scalar( $text ) ? (string) $text : '';
-        $text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
-        return trim( $text );
-    }
+	function sanitize_text_field( $text ) {
+		$text = is_scalar( $text ) ? (string) $text : '';
+		$text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
+		return trim( $text );
+	}
 }
 
 if ( ! function_exists( 'sanitize_key' ) ) {
-    function sanitize_key( $key ) {
-        $key = strtolower( $key );
-        return preg_replace( '/[^a-z0-9_\-]/', '', $key );
-    }
+	function sanitize_key( $key ) {
+		$key = strtolower( $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ) {
+		$title = strtolower( $title );
+		$title = preg_replace( '/[^a-z0-9]+/', '-', $title );
+		return trim( $title, '-' );
+	}
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( $name, $value, $expiration ) {}
+}
+
+if ( ! function_exists( 'get_transient' ) ) {
+	function get_transient( $name ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $tag, $value ) {
+		return $value;
+	}
+}
+
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 86400 );
 }
 
 if ( ! function_exists( 'wp_json_encode' ) ) {
-    function wp_json_encode( $data ) {
-        return json_encode( $data );
-    }
+	function wp_json_encode( $data ) {
+		return json_encode( $data );
+	}
 }
 
 $llm = new RTBCB_LLM();
@@ -55,31 +83,31 @@ $method->setAccessible( true );
 $result = $method->invoke( $llm, '$50M-$500M', 'technology' );
 
 if ( 'scaling trajectory' !== $result['size_outlook'] ) {
-    echo "Unexpected size outlook\n";
-    exit( 1 );
+	echo "Unexpected size outlook\n";
+	exit( 1 );
 }
 
 if ( 'rapid expansion' !== $result['industry_outlook'] ) {
-    echo "Unexpected industry outlook\n";
-    exit( 1 );
+	echo "Unexpected industry outlook\n";
+	exit( 1 );
 }
 
 $research_method = new ReflectionMethod( RTBCB_LLM::class, 'conduct_company_research' );
 $research_method->setAccessible( true );
 $research = $research_method->invoke( $llm, [
-    'company_name' => 'Test Co',
-    'company_size' => '$50M-$500M',
-    'industry'     => 'technology',
+	'company_name' => 'Test Co',
+	'company_size' => '$50M-$500M',
+	'industry'     => 'technology',
 ] );
 
 if ( ! is_array( $research ) ) {
-    echo "Research did not return array\n";
-    exit( 1 );
+	echo "Research did not return array\n";
+	exit( 1 );
 }
 
 if ( 'scaling trajectory' !== $research['growth_trajectory']['size_outlook'] ) {
-    echo "Growth trajectory mismatch\n";
-    exit( 1 );
+	echo "Growth trajectory mismatch\n";
+	exit( 1 );
 }
 
 $prop = new ReflectionProperty( RTBCB_LLM::class, 'last_company_research' );
@@ -87,15 +115,15 @@ $prop->setAccessible( true );
 $serialized = $prop->getValue( $llm );
 
 if ( ! is_string( $serialized ) ) {
-    echo "Serialized research missing\n";
-    exit( 1 );
+	echo "Serialized research missing\n";
+	exit( 1 );
 }
 
 $decoded = json_decode( $serialized, true );
 
 if ( 'rapid expansion' !== $decoded['growth_trajectory']['industry_outlook'] ) {
-    echo "Serialized research mismatch\n";
-    exit( 1 );
+	echo "Serialized research mismatch\n";
+	exit( 1 );
 }
 
 echo "project-growth-path.test.php passed\n";

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -113,6 +113,9 @@ fi
 echo "18. Running project growth path test..."
 php tests/project-growth-path.test.php
 
+echo "18b. Running company profile cache test..."
+php tests/company-profile-cache.test.php
+
 echo "19. Running validator tests..."
 phpunit -c phpunit.xml
 


### PR DESCRIPTION
## Summary
- cache company profile generation and reuse cached data when available
- allow tuning cache lifetime through `rtbcb_research_cache_ttl`
- add regression tests for company profile caching and update existing tests

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: `phpunit: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_68b3856c655883319c7082c02edd1492