### PR TITLE
Compress stored lead reports

### DIFF
--- a/inc/class-rtbcb-db.php
+++ b/inc/class-rtbcb-db.php
@@ -14,7 +14,7 @@ class RTBCB_DB {
     /**
      * Current database version.
      */
-    const DB_VERSION = '2.0.0';
+   const DB_VERSION = '2.1.0';
 
     /**
      * Initialize database and handle upgrades.
@@ -53,14 +53,18 @@ class RTBCB_DB {
             RTBCB_API_Log::init();
         }
 
-        // Ensure RAG index table is present during upgrades.
-        self::create_rag_table();
+       // Ensure RAG index table is present during upgrades.
+       self::create_rag_table();
 
-        // Future migrations can be handled here.
+       if ( version_compare( $from_version, '2.1.0', '<' ) ) {
+           RTBCB_Leads::compress_existing_report_html();
+       }
 
-        // Log the upgrade.
-        error_log( 'RTBCB: Database upgraded from version ' . $from_version . ' to ' . self::DB_VERSION );
-    }
+       // Future migrations can be handled here.
+
+       // Log the upgrade.
+       error_log( 'RTBCB: Database upgraded from version ' . $from_version . ' to ' . self::DB_VERSION );
+   }
 
     /**
      * Create required database tables.

--- a/tests/lead-storage.test.php
+++ b/tests/lead-storage.test.php
@@ -200,6 +200,7 @@ $lead_data = [
 'roi_low'       => 1000,
 'roi_base'      => 2000,
 'roi_high'      => 3000,
+'report_html'  => '<div>Report</div>',
 ];
 
 $lead_id = RTBCB_Leads::save_lead( $lead_data );
@@ -216,6 +217,11 @@ exit( 1 );
 
 if ( [ 'delays', 'errors' ] !== ( $retrieved['pain_points'] ?? [] ) ) {
 echo "Pain points mismatch\n";
+exit( 1 );
+}
+
+if ( '<div>Report</div>' !== ( $retrieved['report_html'] ?? '' ) ) {
+echo "Report HTML mismatch\n";
 exit( 1 );
 }
 


### PR DESCRIPTION
## Summary
- Compress lead `report_html` before database save and decompress on retrieval or CSV export
- Add migration to compress existing lead reports
- Update tests for compressed report storage

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3856f23ec8331baf43acff2f89250