### PR TITLE
Cache company profile research

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -941,10 +941,10 @@ USER,
 	$industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
 	$company_size = sanitize_text_field( $user_inputs['company_size'] ?? '' );
 
-	$company_profile = rtbcb_get_research_cache( $company_name, $industry, 'company_profile' );
+	$company_profile = rtbcb_get_research_cache( $company_name, $industry, 'company_profile', $company_size );
 	if ( false === $company_profile ) {
 		$company_profile = $this->build_company_profile( $company_name, $industry, $company_size );
-		rtbcb_set_research_cache( $company_name, $industry, 'company_profile', $company_profile );
+		rtbcb_set_research_cache( $company_name, $industry, 'company_profile', $company_profile, 0, $company_size );
 	}
 
 	$research = [

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1622,30 +1622,33 @@ function rtbcb_get_analysis_job_result( $job_id ) {
  * Build a cache key for LLM research results.
  *
  * @param string $company  Company name.
- * @param string $industry Industry name.
- * @param string $type     Cache segment identifier.
+ * @param string $industry     Industry name.
+ * @param string $type         Cache segment identifier.
+ * @param string $company_size Company size.
  *
  * @return string Cache key.
  */
-function rtbcb_get_research_cache_key( $company, $industry, $type ) {
-	$company  = sanitize_title( $company );
-	$industry = sanitize_title( $industry );
-	$type     = sanitize_key( $type );
+function rtbcb_get_research_cache_key( $company, $industry, $type, $company_size = '' ) {
+	$company      = sanitize_title( $company );
+	$industry     = sanitize_title( $industry );
+	$type         = sanitize_key( $type );
+	$company_size = sanitize_title( $company_size );
 
-	return 'rtbcb_' . $type . '_' . md5( $company . '_' . $industry );
+	return 'rtbcb_' . $type . '_' . md5( $company . '_' . $industry . '_' . $company_size );
 }
 
 /**
  * Retrieve cached LLM research data.
  *
  * @param string $company  Company name.
- * @param string $industry Industry name.
- * @param string $type     Cache segment identifier.
+ * @param string $industry     Industry name.
+ * @param string $type         Cache segment identifier.
+ * @param string $company_size Company size.
  *
  * @return mixed Cached data or false when not found.
  */
-function rtbcb_get_research_cache( $company, $industry, $type ) {
-	$key = rtbcb_get_research_cache_key( $company, $industry, $type );
+function rtbcb_get_research_cache( $company, $industry, $type, $company_size = '' ) {
+	$key = rtbcb_get_research_cache_key( $company, $industry, $type, $company_size );
 	return get_transient( $key );
 }
 
@@ -1653,27 +1656,29 @@ function rtbcb_get_research_cache( $company, $industry, $type ) {
  * Store LLM research data in cache.
  *
  * @param string $company  Company name.
- * @param string $industry Industry name.
- * @param string $type     Cache segment identifier.
- * @param mixed  $data     Data to cache.
- * @param int    $ttl      Optional TTL in seconds.
+ * @param string $industry     Industry name.
+ * @param string $type         Cache segment identifier.
+ * @param mixed  $data         Data to cache.
+ * @param int    $ttl          Optional TTL in seconds.
+ * @param string $company_size Company size.
  */
-function rtbcb_set_research_cache( $company, $industry, $type, $data, $ttl = 0 ) {
-	$key = rtbcb_get_research_cache_key( $company, $industry, $type );
+function rtbcb_set_research_cache( $company, $industry, $type, $data, $ttl = 0, $company_size = '' ) {
+	$key = rtbcb_get_research_cache_key( $company, $industry, $type, $company_size );
 	$ttl = (int) $ttl;
 	if ( 0 === $ttl ) {
 		$ttl = DAY_IN_SECONDS;
 	}
-
-	/**
-	 * Filter the research cache TTL.
-	 *
-	 * @param int $ttl Cache duration in seconds.
-	 * @param string $type Cache segment identifier.
-	 * @param string $company Sanitized company name.
-	 * @param string $industry Sanitized industry.
-	 */
-	$ttl = apply_filters( 'rtbcb_research_cache_ttl', $ttl, $type, $company, $industry );
+	
+/**
+ * Filter the research cache TTL.
+ *
+ * @param int    $ttl          Cache duration in seconds.
+ * @param string $type         Cache segment identifier.
+ * @param string $company      Sanitized company name.
+ * @param string $industry     Sanitized industry.
+ * @param string $company_size Sanitized company size.
+ */
+	$ttl = apply_filters( 'rtbcb_research_cache_ttl', $ttl, $type, $company, $industry, $company_size );
 
 	set_transient( $key, $data, $ttl );
 }
@@ -1682,12 +1687,13 @@ function rtbcb_set_research_cache( $company, $industry, $type, $data, $ttl = 0 )
  * Delete cached LLM research data.
  *
  * @param string $company  Company name.
- * @param string $industry Industry name.
- * @param string $type     Cache segment identifier.
+ * @param string $industry     Industry name.
+ * @param string $type         Cache segment identifier.
+ * @param string $company_size Company size.
  */
-function rtbcb_delete_research_cache( $company, $industry, $type ) {
-$key = rtbcb_get_research_cache_key( $company, $industry, $type );
-delete_transient( $key );
+function rtbcb_delete_research_cache( $company, $industry, $type, $company_size = '' ) {
+	$key = rtbcb_get_research_cache_key( $company, $industry, $type, $company_size );
+	delete_transient( $key );
 }
 
 /**

--- a/tests/company-profile-cache.test.php
+++ b/tests/company-profile-cache.test.php
@@ -92,18 +92,36 @@ if ( ! is_array( $result['company_profile'] ) ) {
 	exit( 1 );
 }
 
-$cached = rtbcb_get_research_cache( 'Cache Co', 'finance', 'company_profile' );
+$cached = rtbcb_get_research_cache( 'Cache Co', 'finance', 'company_profile', '$50M-$500M' );
 if ( false === $cached ) {
 	echo "Profile not cached\n";
 	exit( 1 );
 }
 
 $custom = [ 'stage' => 'cached', 'characteristics' => '', 'treasury_focus' => '', 'typical_challenges' => '' ];
-rtbcb_set_research_cache( 'Cache Co', 'finance', 'company_profile', $custom );
+rtbcb_set_research_cache( 'Cache Co', 'finance', 'company_profile', $custom, 0, '$50M-$500M' );
 
 $result2 = $method->invoke( $llm, $inputs );
 if ( 'cached' !== ( $result2['company_profile']['stage'] ?? '' ) ) {
-	echo "Cache not used\n";
+        echo "Cache not used\n";
+        exit( 1 );
+}
+
+$inputs_large = [
+	'company_name' => 'Cache Co',
+	'company_size' => '>$2B',
+	'industry'     => 'finance',
+];
+
+$result3 = $method->invoke( $llm, $inputs_large );
+if ( 'cached' === ( $result3['company_profile']['stage'] ?? '' ) ) {
+        echo "Cache reused for different size\n";
+        exit( 1 );
+}
+
+$cached_large = rtbcb_get_research_cache( 'Cache Co', 'finance', 'company_profile', '>$2B' );
+if ( false === $cached_large ) {
+	echo "Large profile not cached\n";
 	exit( 1 );
 }
 


### PR DESCRIPTION
## Summary
- add company size to research cache key and helper functions
- ensure company-specific research caches by size
- cover varying company sizes with updated cache test

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: RTBCB_EdgeCasesTest::test_handle_form_submission)*

------
https://chatgpt.com/codex/tasks/task_e_68b3958971c08331a4e211fa382efc9a