### PR TITLE
Add caching for RAG search results

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1723,6 +1723,18 @@ function rtbcb_get_report_allowed_html() {
 		$allowed[ $tag ]['data-*'] = true;
 	}
 
-	return $allowed;
+        return $allowed;
+}
+
+/**
+ * Increment the RAG search cache version to invalidate cached results.
+ *
+ * @return void
+ */
+function rtbcb_invalidate_rag_cache() {
+	if ( function_exists( 'get_option' ) && function_exists( 'update_option' ) ) {
+		$version = (int) get_option( 'rtbcb_rag_cache_version', 1 );
+		update_option( 'rtbcb_rag_cache_version', $version + 1 );
+	}
 }
 


### PR DESCRIPTION
## Summary
- cache RAG search results using hashed query keys and object cache
- bump cache version on index rebuild with optional filter

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3857825388331bd84cdc8461ba3b5