### PR TITLE
Increase API timeout default and configuration range

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ If you encounter `Unchecked runtime.lastError` messages, they typically originat
 
 ### Server Timeouts
 
-Large reports can take several minutes to generate. Increase server and PHP timeout limits to avoid gateway errors. In nginx, raise `proxy_read_timeout` and `fastcgi_read_timeout`:
+The plugin's API request timeout defaults to 300 seconds and can be increased up to 600 seconds in the settings page. Large reports can take several minutes to generate. Increase server and PHP timeout limits to avoid gateway errors. In nginx, raise `proxy_read_timeout` and `fastcgi_read_timeout`:
 
 ```nginx
 location ~ \.php$ {

--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -493,7 +493,7 @@ class RTBCB_Admin {
         register_setting( 'rtbcb_settings', 'rtbcb_embedding_model', [ 'sanitize_callback' => 'sanitize_text_field' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_labor_cost_per_hour', [ 'sanitize_callback' => 'floatval' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_bank_fee_baseline', [ 'sanitize_callback' => 'floatval' ] );
-        register_setting( 'rtbcb_settings', 'rtbcb_gpt5_timeout', [ 'sanitize_callback' => 'intval' ] );
+        register_setting( 'rtbcb_settings', 'rtbcb_gpt5_timeout', [ 'sanitize_callback' => 'rtbcb_sanitize_timeout' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_max_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_max_output_tokens' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_min_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_min_output_tokens' ] );
     }

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -97,8 +97,8 @@ $embedding_models = [
                     <label for="rtbcb_gpt5_timeout"><?php echo esc_html__( 'API Request Timeout (seconds)', 'rtbcb' ); ?></label>
                 </th>
                 <td>
-                    <input type="number" id="rtbcb_gpt5_timeout" name="rtbcb_gpt5_timeout" value="<?php echo esc_attr( $gpt5_timeout ); ?>" class="small-text" />
-                    <p class="description"><?php echo esc_html__( 'Maximum time to wait for OpenAI responses.', 'rtbcb' ); ?></p>
+                    <input type="number" id="rtbcb_gpt5_timeout" name="rtbcb_gpt5_timeout" value="<?php echo esc_attr( $gpt5_timeout ); ?>" class="small-text" min="1" max="600" />
+                    <p class="description"><?php echo esc_html__( 'Maximum time to wait for OpenAI responses (default 300, max 600).', 'rtbcb' ); ?></p>
                 </td>
             </tr>
             <tr>

--- a/docs/timeout-config.md
+++ b/docs/timeout-config.md
@@ -1,5 +1,7 @@
 # Timeout Configuration
 
+The plugin's API request timeout defaults to 300 seconds and can be adjusted up to 600 seconds from the settings page.
+
 To prevent gateway timeout errors when generating large reports, adjust server and PHP timeouts:
 
 ## nginx

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2308,7 +2308,7 @@ return $analysis;
 	 */
 	private function call_openai_with_retry( $model, $prompt, $max_output_tokens = null, $max_retries = null, $chunk_handler = null ) {
 	        $max_retries     = $max_retries ?? intval( $this->gpt5_config['max_retries'] );
-	        $base_timeout    = intval( $this->gpt5_config['timeout'] ?? 180 );
+	        $base_timeout    = intval( $this->gpt5_config['timeout'] ?? 300 );
 	        $current_timeout = $base_timeout;
 	        $current_tokens  = $max_output_tokens;
 	        $max_retry_time  = max( $base_timeout, intval( $this->gpt5_config['max_retry_time'] ?? $base_timeout ) );
@@ -2469,7 +2469,7 @@ return $analysis;
 
         do_action( 'rtbcb_llm_prompt_sent', $body );
 
-        $timeout   = intval( $this->gpt5_config['timeout'] ?? 180 );
+        $timeout   = intval( $this->gpt5_config['timeout'] ?? 300 );
         $payload   = wp_json_encode( $body );
         $streamed  = '';
         $ch        = curl_init( $endpoint );

--- a/inc/config.php
+++ b/inc/config.php
@@ -42,9 +42,9 @@ function rtbcb_get_gpt5_config( $overrides = [] ) {
         'min_output_tokens' => 256,
         'temperature'       => 0.7,
         'store'             => true,
-        'timeout'           => function_exists( 'rtbcb_get_api_timeout' ) ? rtbcb_get_api_timeout() : (int) get_option( 'rtbcb_gpt5_timeout', 180 ),
+        'timeout'           => function_exists( 'rtbcb_get_api_timeout' ) ? rtbcb_get_api_timeout() : (int) get_option( 'rtbcb_gpt5_timeout', 300 ),
         'max_retries'       => 2,
-        'max_retry_time'    => function_exists( 'rtbcb_get_api_timeout' ) ? rtbcb_get_api_timeout() : (int) get_option( 'rtbcb_gpt5_timeout', 180 ),
+        'max_retry_time'    => function_exists( 'rtbcb_get_api_timeout' ) ? rtbcb_get_api_timeout() : (int) get_option( 'rtbcb_gpt5_timeout', 300 ),
         'reasoning_effort'  => 'medium',
         'text_verbosity'    => 'medium',
     ];

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -11,10 +11,10 @@ defined( 'ABSPATH' ) || exit;
  * Allows filtering via `rtbcb_api_timeout` to adjust how long remote
  * requests may take before failing.
  *
- * @return int Timeout in seconds.
- */
+ * @return int Timeout in seconds. Defaults to 300.
+*/
 function rtbcb_get_api_timeout() {
-		$timeout = (int) get_option( 'rtbcb_gpt5_timeout', 180 );
+        $timeout = (int) get_option( 'rtbcb_gpt5_timeout', 300 );
 
 	/**
 	 * Filter the API request timeout.
@@ -25,7 +25,21 @@ function rtbcb_get_api_timeout() {
 		return (int) apply_filters( 'rtbcb_api_timeout', $timeout );
 	}
 
-		return $timeout;
+        return $timeout;
+}
+
+/**
+ * Sanitize the API timeout option.
+ *
+ * Ensures the timeout stays within the 1-600 second range.
+ *
+ * @param mixed $value Raw option value.
+ * @return int Sanitized timeout.
+ */
+function rtbcb_sanitize_timeout( $value ) {
+	$value = intval( $value );
+
+	return min( 600, max( 1, $value ) );
 }
 
 require_once __DIR__ . '/config.php';

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,8 @@ environment variable, or by creating a `rtbcb-config.json` file in the plugin di
 
 Values outside the 256–128,000 range are ignored.
 
+By default, API requests time out after 300 seconds. You can adjust this limit up to 600 seconds in the plugin settings.
+
 == Testing Dashboard ==
 From the WordPress admin, go to **Real Treasury → Test Dashboard** and click
 **Run All Tests** to execute the full suite. A progress bar indicates overall

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1131,8 +1131,9 @@ return $use_comprehensive;
 
         rtbcb_setup_ajax_logging();
         rtbcb_increase_memory_limit();
-        if ( ! ini_get( 'safe_mode' ) ) {
-            set_time_limit( 300 );
+        $timeout = absint( rtbcb_get_api_timeout() );
+        if ( ! ini_get( 'safe_mode' ) && $timeout > 0 ) {
+            set_time_limit( $timeout );
         }
 
         try {


### PR DESCRIPTION
## Summary
- raise API timeout default to 300s and allow configuration up to 600s
- add sanitization for timeout setting and apply across helpers, config, and LLM
- update settings UI, documentation, and set_time_limit usage

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b385abd6e48331a3fa03f20a906036