### PR TITLE
Cache company profile research

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -723,12 +723,13 @@ USER,
 
         $company_name = sanitize_text_field( $user_inputs['company_name'] ?? '' );
         $industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
+        $company_size = sanitize_text_field( $user_inputs['company_size'] ?? '' );
 
-        $company_research = rtbcb_get_research_cache( $company_name, $industry, 'company' );
+        $company_research = rtbcb_get_research_cache( $company_name, $industry, 'company', $company_size );
         if ( false === $company_research ) {
             $company_research = $this->conduct_company_research( $user_inputs );
             if ( ! is_wp_error( $company_research ) ) {
-                rtbcb_set_research_cache( $company_name, $industry, 'company', $company_research );
+                rtbcb_set_research_cache( $company_name, $industry, 'company', $company_research, 0, $company_size );
             }
         }
 

--- a/tests/company-research-cache.test.php
+++ b/tests/company-research-cache.test.php
@@ -1,0 +1,184 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $text ) {
+		$text = is_scalar( $text ) ? (string) $text : '';
+		$text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
+		return trim( $text );
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ) {
+		$title = strtolower( $title );
+		$title = preg_replace( '/[^a-z0-9]+/', '-', $title );
+		return trim( $title, '-' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		$key = strtolower( $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( $name, $value, $expiration ) {
+		global $transients;
+		$transients[ $name ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_transient' ) ) {
+	function get_transient( $name ) {
+		global $transients;
+		return $transients[ $name ] ?? false;
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $name, $default = '' ) {
+		return $default;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $tag, $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $tag, $callback, $priority = 10, $accepted_args = 1 ) {}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data ) {
+		return json_encode( $data );
+	}
+}
+
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 86400 );
+}
+
+require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
+
+$llm = new class extends RTBCB_LLM {
+        public $calls = 0;
+
+        public function __construct() {
+                $this->api_key     = 'test-key';
+                $this->gpt5_config = [];
+        }
+
+        protected function conduct_company_research( $user_inputs ) {
+                $this->calls++;
+                return [ 'company_profile' => [ 'size' => $user_inputs['company_size'] ] ];
+        }
+
+        protected function analyze_industry_context( $user_inputs ) {
+                return [];
+        }
+
+        protected function research_treasury_solutions( $user_inputs, $context_chunks ) {
+                return [];
+        }
+
+        protected function select_optimal_model( $user_inputs, $context_chunks ) {
+                return '';
+        }
+
+        protected function build_comprehensive_prompt( $user_inputs, $roi_data, $company_research, $industry_analysis, $tech_landscape ) {
+                return '';
+        }
+
+        protected function build_context_for_responses( $history ) {
+                return [];
+        }
+
+        protected function tokens_for_report( $report ) {
+                return 0;
+        }
+
+        protected function call_openai_with_retry( $model, $context, $tokens ) {
+                return [];
+        }
+
+        protected function parse_comprehensive_response( $response ) {
+                return [
+                        'executive_summary'         => [],
+                        'operational_analysis'      => [],
+                        'industry_insights'         => [],
+                        'technology_recommendations'=> [],
+                        'financial_analysis'        => [],
+                        'risk_mitigation'           => [],
+                        'next_steps'               => [],
+                ];
+        }
+
+        protected function enhance_with_research( $parsed, $company_research, $industry_analysis, $tech_landscape ) {
+                return [
+                        'executive_summary' => [],
+                        'research'          => [ 'company' => $company_research, 'technology' => $tech_landscape ],
+                        'industry_insights' => [],
+                        'technology_recommendations' => [],
+                        'financial_analysis' => [],
+                        'risk_mitigation' => [],
+                        'next_steps' => [],
+                ];
+        }
+};
+
+$inputs_small = [
+        'company_name' => 'Cache Co',
+        'industry'     => 'finance',
+        'company_size' => '$50M-$500M',
+];
+$result_small = $llm->generate_comprehensive_business_case( $inputs_small, [], [] );
+if ( '$50M-$500M' !== ( $result_small['company_profile']['size'] ?? '' ) ) {
+        echo "Small research not generated\n";
+        exit( 1 );
+}
+if ( 1 !== $llm->calls ) {
+        echo "Research method not called for small size\n";
+        exit( 1 );
+}
+$cached_small = rtbcb_get_research_cache( 'Cache Co', 'finance', 'company', '$50M-$500M' );
+if ( false === $cached_small ) {
+        echo "Small company research not cached\n";
+        exit( 1 );
+}
+
+$inputs_large = [
+        'company_name' => 'Cache Co',
+        'industry'     => 'finance',
+        'company_size' => '>$2B',
+];
+$result_large = $llm->generate_comprehensive_business_case( $inputs_large, [], [] );
+if ( '>$2B' !== ( $result_large['company_profile']['size'] ?? '' ) ) {
+        echo "Cache reused for different size\n";
+        exit( 1 );
+}
+if ( 2 !== $llm->calls ) {
+        echo "Research method not called for large size\n";
+        exit( 1 );
+}
+$cached_large = rtbcb_get_research_cache( 'Cache Co', 'finance', 'company', '>$2B' );
+if ( false === $cached_large ) {
+        echo "Large company research not cached\n";
+        exit( 1 );
+}
+
+echo "company-research-cache.test.php passed\n";

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -116,6 +116,9 @@ php tests/project-growth-path.test.php
 echo "18b. Running company profile cache test..."
 php tests/company-profile-cache.test.php
 
+echo "18c. Running company research cache test..."
+php tests/company-research-cache.test.php
+
 echo "19. Running validator tests..."
 phpunit -c phpunit.xml
 


### PR DESCRIPTION
## Summary
- pass company size into top-level company research cache
- test company research caching for different company sizes
- run company research cache test in the test suite

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found; TypeError during JS tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b398ccef60833196e2bc161428431e