### PR TITLE
Fix fast mode setting toggle

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -153,6 +153,7 @@ $embedding_models = [
                     <label for="rtbcb_fast_mode"><?php echo esc_html__( 'Fast Mode', 'rtbcb' ); ?></label>
                 </th>
                 <td>
+                    <input type="hidden" name="rtbcb_fast_mode" value="0" />
                     <input type="checkbox" id="rtbcb_fast_mode" name="rtbcb_fast_mode" value="1" <?php checked( 1, $fast_mode ); ?> />
                     <p class="description"><?php echo esc_html__( 'Generate a basic ROI-only report without AI processing.', 'rtbcb' ); ?></p>
                 </td>


### PR DESCRIPTION
## Summary
- ensure Fast Mode setting posts 0 when unchecked

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b39b70745483319a743bffd1ea0484