### PR TITLE
Generate and email report upon job completion

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -144,25 +144,29 @@ class RTBCB_Ajax {
 			return;
 		}
 
-		if (
-			'completed' === ( $status['status'] ?? '' ) &&
-			! empty( $status['result']['report_data'] )
-		) {
-			$result                = $status['result'];
-			$status['report_data'] = $result['report_data'];
-			if ( is_array( $result ) ) {
-				foreach ( $result as $key => $value ) {
-					if ( 'report_data' === $key ) {
-						continue;
-					}
-					$status[ $key ] = $value;
-				}
-			}
-			unset( $status['result'] );
-		}
+               if (
+                       'completed' === ( $status['status'] ?? '' ) &&
+                       ! empty( $status['result']['report_data'] )
+               ) {
+                       $result                = $status['result'];
+                       $status['report_data'] = $result['report_data'];
+                       if ( is_array( $result ) ) {
+                               foreach ( $result as $key => $value ) {
+                                       if ( 'report_data' === $key ) {
+                                               continue;
+                                       }
+                                       $status[ $key ] = $value;
+                               }
+                       }
+                       unset( $status['result'] );
+               }
 
-		wp_send_json_success( $status );
-	}
+               if ( ! empty( $status['download_url'] ) ) {
+                       $status['download_url'] = esc_url_raw( $status['download_url'] );
+               }
+
+               wp_send_json_success( $status );
+       }
 
        private static function collect_and_validate_user_inputs() {
                $validator = new RTBCB_Validator();


### PR DESCRIPTION
## Summary
- Generate report HTML and PDF when background jobs complete, email the PDF to the user, and store a download link in the job transient
- Expose the report download URL via the job status endpoint
- Add helper functions for rendering report HTML and saving report files, with updated tests validating download link and email

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit missing, WordPress coding standards skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b385b6a8008331bdb7776b99478753