### PR TITLE
Add retryable HTTP helper and apply across external requests

### DIFF
--- a/inc/class-rtbcb-api-tester.php
+++ b/inc/class-rtbcb-api-tester.php
@@ -70,7 +70,7 @@ class RTBCB_API_Tester {
             'timeout' => $timeout,
         ];
 
-        $response = wp_remote_post( 'https://api.openai.com/v1/responses', $args );
+$response = rtbcb_wp_remote_post_with_retry( 'https://api.openai.com/v1/responses', $args );
 
         if ( is_wp_error( $response ) ) {
             return [

--- a/inc/class-rtbcb-logger.php
+++ b/inc/class-rtbcb-logger.php
@@ -8,16 +8,16 @@ defined( 'ABSPATH' ) || exit;
  */
 
 /**
- * Structured logging for API interactions.
- */
-class RTBCB_Logger {
-    /**
-     * Send a structured log record.
-     *
-     * @param string $event   Event name.
-     * @param array  $context Context data.
-     * @return void
-     */
+         * Structured logging for API interactions.
+         */
+        class RTBCB_Logger {
+            /**
+             * Send a structured log record.
+             *
+             * @param string $event   Event name.
+             * @param array  $context Context data.
+             * @return void
+             */
     public static function log( $event, $context = [] ) {
         $record = [
             'timestamp' => gmdate( 'c' ),
@@ -28,15 +28,15 @@ class RTBCB_Logger {
         error_log( 'RTBCB_LOG: ' . wp_json_encode( $record ) );
 
         $endpoint = sanitize_text_field( get_option( 'rtbcb_log_endpoint', '' ) );
-        if ( $endpoint ) {
-            wp_remote_post(
-                $endpoint,
-                [
-                    'headers' => [ 'Content-Type' => 'application/json' ],
-                    'body'    => wp_json_encode( $record ),
-                    'timeout' => 2,
-                ]
-            );
+                if ( $endpoint ) {
+                        rtbcb_wp_remote_post_with_retry(
+                        $endpoint,
+                        [
+                        'headers' => [ 'Content-Type' => 'application/json' ],
+                        'body'    => wp_json_encode( $record ),
+                        'timeout' => 2,
+                        ]
+                        );
         }
     }
 

--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -189,7 +189,7 @@ class RTBCB_RAG {
             'timeout' => rtbcb_get_api_timeout(),
         ];
 
-        $response = wp_remote_post( $endpoint, $args );
+$response = rtbcb_wp_remote_post_with_retry( $endpoint, $args );
         if ( is_wp_error( $response ) ) {
             return [];
         }

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -53,6 +53,68 @@ function rtbcb_has_openai_api_key() {
 }
 
 /**
+ * Perform a remote POST request with retry logic.
+ *
+ * Uses exponential backoff with jitter between attempts. Retries are
+ * triggered for transport errors, HTTP 429 responses and server errors.
+ * Client errors (4xx) other than 429 will return immediately.
+ *
+ * @param string $url         Endpoint URL.
+ * @param array  $args        Arguments for {@see wp_remote_post()}.
+ * @param int    $max_retries Optional. Number of attempts. Default 3.
+ * @return array|WP_Error HTTP response array or WP_Error on failure.
+ */
+function rtbcb_wp_remote_post_with_retry( $url, $args = [], $max_retries = 3 ) {
+$url         = function_exists( 'esc_url_raw' ) ? esc_url_raw( $url ) : $url;
+	$max_retries = max( 1, (int) $max_retries );
+
+	$base_timeout    = isset( $args['timeout'] ) ? (int) $args['timeout'] : rtbcb_get_api_timeout();
+	$max_retry_time  = isset( $args['max_retry_time'] ) ? (int) $args['max_retry_time'] : $base_timeout * $max_retries;
+	unset( $args['max_retry_time'] );
+	$current_timeout = $base_timeout;
+	$start_time      = microtime( true );
+
+	for ( $attempt = 1; $attempt <= $max_retries; $attempt++ ) {
+		$elapsed = microtime( true ) - $start_time;
+		if ( $elapsed >= $max_retry_time ) {
+			break;
+		}
+
+		$remaining       = $max_retry_time - $elapsed;
+		$args['timeout'] = min( $current_timeout, $remaining );
+
+		$response = wp_remote_post( $url, $args );
+		if ( ! is_wp_error( $response ) ) {
+			$status = (int) wp_remote_retrieve_response_code( $response );
+			if ( $status >= 200 && $status < 300 ) {
+				return $response;
+			}
+
+			if ( $status >= 400 && $status < 500 && 429 !== $status ) {
+				return new WP_Error(
+					'http_error',
+					sprintf( __( 'HTTP error %d', 'rtbcb' ), $status ),
+					[ 'status' => $status ]
+				);
+			}
+		}
+
+		if ( $attempt < $max_retries ) {
+			$current_timeout = min( $current_timeout + 5, $max_retry_time );
+
+			$elapsed = microtime( true ) - $start_time;
+			$delay   = min( pow( 2, $attempt - 1 ), $max_retry_time - $elapsed );
+			if ( $delay > 0 ) {
+				$jitter = wp_rand( 0, 1000 ) / 1000;
+				usleep( (int) ( ( $delay + $jitter ) * 1000000 ) );
+			}
+		}
+	}
+
+	return $response;
+}
+
+/**
  * Determine if an error indicates an OpenAI configuration issue.
  *
  * Checks for common phrases like a missing API key or invalid model.
@@ -848,23 +910,23 @@ function rtbcb_test_generate_category_recommendation( $analysis ) {
 			$input .= "\nExtra Requirements: {$payload['extra_requirements']}";
 		}
 
-		$response = wp_remote_post(
-			'https://api.openai.com/v1/responses',
-			[
-				'headers' => [
-					'Content-Type'  => 'application/json',
-					'Authorization' => 'Bearer ' . $api_key,
-				],
-				'body'    => wp_json_encode(
-					[
-						'model'        => $model,
-						'instructions' => $system_prompt,
-						'input'        => $input,
-					]
-				),
-			                   'timeout' => rtbcb_get_api_timeout(),
-			            ]
-			    );
+                $response = rtbcb_wp_remote_post_with_retry(
+                        'https://api.openai.com/v1/responses',
+                        [
+                                'headers' => [
+                                        'Content-Type'  => 'application/json',
+                                        'Authorization' => 'Bearer ' . $api_key,
+                                ],
+                                'body'    => wp_json_encode(
+                                        [
+                                                'model'        => $model,
+                                                'instructions' => $system_prompt,
+                                                'input'        => $input,
+                                        ]
+                                ),
+                                'timeout' => rtbcb_get_api_timeout(),
+                        ]
+                );
 
 		if ( is_wp_error( $response ) ) {
 			return new WP_Error( 'llm_failure', __( 'Unable to generate recommendation at this time.', 'rtbcb' ) );
@@ -1378,21 +1440,21 @@ function rtbcb_handle_openai_responses_job( $job_id, $user_id ) {
 		$timeout = 120;
 	}
 
-	$response = wp_remote_post(
-		'https://api.openai.com/v1/responses',
-		[
-			'headers' => [
-				'Content-Type'  => 'application/json',
-				'Authorization' => 'Bearer ' . $api_key,
-			],
-			'body'    => $body,
-			'timeout' => $timeout,
-		]
-	);
+        $response = rtbcb_wp_remote_post_with_retry(
+                'https://api.openai.com/v1/responses',
+                [
+                        'headers' => [
+                                'Content-Type'  => 'application/json',
+                                'Authorization' => 'Bearer ' . $api_key,
+                        ],
+                        'body'    => $body,
+                        'timeout' => $timeout,
+                ]
+        );
 
 	if ( is_wp_error( $response ) ) {
 			    if ( class_exists( 'RTBCB_API_Log' ) ) {
-			            RTBCB_API_Log::save_log( $body_array, [ 'error' => $response->get_error_message() ], $user_id, $user_email, $company_name );
+				    RTBCB_API_Log::save_log( $body_array, [ 'error' => $response->get_error_message() ], $user_id, $user_email, $company_name );
 			    }
 		set_transient(
 			'rtbcb_openai_job_' . $job_id,


### PR DESCRIPTION
## Summary
- add `rtbcb_wp_remote_post_with_retry` with exponential backoff
- replace direct `wp_remote_post` usage in logging, RAG embeddings, API tester and OpenAI helpers

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-5-mini bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b385bd31c48331a041a72cc0d1f347