### PR TITLE
Add fast bypass for heavy AI features

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -19,6 +19,7 @@ class RTBCB_Admin {
         add_action( 'admin_init', [ $this, 'register_settings' ] );
         add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
         add_action( 'admin_notices', [ $this, 'maybe_show_timeout_notice' ] );
+        add_action( 'admin_notices', [ $this, 'maybe_show_heavy_features_notice' ] );
 
         // AJAX handlers
         add_action( 'wp_ajax_rtbcb_test_connection', [ $this, 'test_api_connection' ] );
@@ -496,6 +497,7 @@ class RTBCB_Admin {
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_timeout', [ 'sanitize_callback' => 'intval' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_max_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_max_output_tokens' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_min_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_min_output_tokens' ] );
+        register_setting( 'rtbcb_settings', 'rtbcb_disable_heavy_features', [ 'sanitize_callback' => 'rest_sanitize_boolean' ] );
     }
 
     /**
@@ -1912,6 +1914,33 @@ class RTBCB_Admin {
                         }
                 }
                 return ( $success / count( $history ) ) * 100;
+        }
+
+        /**
+         * Display notice when heavy features are disabled.
+         *
+         * @return void
+         */
+        public function maybe_show_heavy_features_notice() {
+                if ( ! current_user_can( 'manage_options' ) || ! rtbcb_heavy_features_disabled() ) {
+                        return;
+                }
+
+                $doc_url = esc_url( RTBCB_URL . 'docs/TEMPORARY_BYPASS_MODE.md' );
+                echo '<div class="notice notice-warning"><p>';
+                printf(
+                        wp_kses(
+                                __( 'Heavy AI features are temporarily disabled. <a href="%s" target="_blank">Learn more</a>.', 'rtbcb' ),
+                                [
+                                        'a' => [
+                                                'href'   => [],
+                                                'target' => [],
+                                        ],
+                                ]
+                        ),
+                        $doc_url
+                );
+                echo '</p></div>';
         }
 
         /**

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -18,6 +18,7 @@ $bank_fee        = get_option( 'rtbcb_bank_fee_baseline', '' );
 $gpt5_timeout    = rtbcb_get_api_timeout();
 $gpt5_max_output_tokens = get_option( 'rtbcb_gpt5_max_output_tokens', 8000 );
 $gpt5_min_output_tokens = get_option( 'rtbcb_gpt5_min_output_tokens', 256 );
+$disable_heavy_features = (bool) get_option( 'rtbcb_disable_heavy_features', false );
 
 $chat_models = [
     'gpt-5'             => 'gpt-5',
@@ -145,6 +146,15 @@ $embedding_models = [
                 </th>
                 <td>
                     <input type="number" step="0.01" id="rtbcb_bank_fee_baseline" name="rtbcb_bank_fee_baseline" value="<?php echo esc_attr( $bank_fee ); ?>" class="regular-text" />
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="rtbcb_disable_heavy_features"><?php echo esc_html__( 'Disable Heavy Features', 'rtbcb' ); ?></label>
+                </th>
+                <td>
+                    <input type="checkbox" id="rtbcb_disable_heavy_features" name="rtbcb_disable_heavy_features" value="1" <?php checked( $disable_heavy_features ); ?> />
+                    <p class="description"><?php echo esc_html__( 'Temporarily bypass AI enrichment, RAG, and intelligent recommendations.', 'rtbcb' ); ?></p>
                 </td>
             </tr>
         </table>

--- a/docs/TEMPORARY_BYPASS_MODE.md
+++ b/docs/TEMPORARY_BYPASS_MODE.md
@@ -1,0 +1,22 @@
+# Temporary Bypass Mode
+
+The plugin can temporarily bypass AI enrichment, RAG searches and intelligent recommendations.
+
+## Enabling
+
+- Check the **Disable Heavy Features** option in the plugin settings.
+- Or define the `RTBCB_FAST_MODE` constant in `wp-config.php`:
+
+```php
+define( 'RTBCB_FAST_MODE', true );
+```
+
+## Effects
+
+- Skips calls to OpenAI and the RAG index.
+- Uses basic category recommendations and fallback analysis.
+- Displays an admin notice while active.
+
+## Disabling
+
+- Uncheck the option or remove the constant.

--- a/inc/class-rtbcb-intelligent-recommender.php
+++ b/inc/class-rtbcb-intelligent-recommender.php
@@ -15,6 +15,10 @@ class RTBCB_Intelligent_Recommender extends RTBCB_Category_Recommender {
  * @return array Enhanced recommendation with confidence and alternatives.
  */
 public function recommend_with_ai_insights( $user_inputs, $enriched_profile ) {
+if ( rtbcb_heavy_features_disabled() ) {
+return parent::recommend_category( $user_inputs );
+}
+
 // Get baseline recommendation from parent class.
 $base_recommendation = parent::recommend_category( $user_inputs );
 

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -1687,10 +1687,13 @@ return $analysis;
 	 * @param array $user_inputs Validated user inputs.
 	 * @return array|WP_Error Enriched company profile or error.
 	 */
-	public function enrich_company_profile( $user_inputs ) {
-	if ( empty( $this->api_key ) ) {
-	return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-	}
+       public function enrich_company_profile( $user_inputs ) {
+       if ( rtbcb_heavy_features_disabled() ) {
+       return new WP_Error( 'heavy_features_disabled', __( 'Heavy features disabled.', 'rtbcb' ) );
+       }
+       if ( empty( $this->api_key ) ) {
+       return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+       }
 	
 	$system_prompt = $this->build_enrichment_system_prompt();
 	$user_prompt   = $this->build_enrichment_user_prompt( $user_inputs );
@@ -1865,10 +1868,13 @@ return $analysis;
 	 * @param array $rag_baseline     RAG search results.
 	 * @return array|WP_Error Strategic analysis or error.
 	 */
-	public function generate_strategic_analysis( $enriched_profile, $roi_scenarios, $recommendation, $rag_baseline ) {
-	if ( empty( $this->api_key ) ) {
-	return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-	}
+       public function generate_strategic_analysis( $enriched_profile, $roi_scenarios, $recommendation, $rag_baseline ) {
+       if ( rtbcb_heavy_features_disabled() ) {
+       return new WP_Error( 'heavy_features_disabled', __( 'Heavy features disabled.', 'rtbcb' ) );
+       }
+       if ( empty( $this->api_key ) ) {
+       return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+       }
 	
 	$system_prompt = $this->build_strategic_analysis_system_prompt();
 	$user_prompt   = $this->build_strategic_analysis_user_prompt(

--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -61,6 +61,9 @@ class RTBCB_RAG {
      * @return array Matching rows.
      */
     public function search_similar( $query, $top_k = 3 ) {
+        if ( rtbcb_heavy_features_disabled() ) {
+            return [];
+        }
         $query_embedding = $this->get_embedding( $query );
         return $this->cosine_similarity_search( $query_embedding, $top_k );
     }

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -61,9 +61,32 @@ function rtbcb_has_openai_api_key() {
  * @return bool True if the error appears configuration related.
  */
 function rtbcb_is_openai_configuration_error( $e ) {
-	$message = strtolower( $e->getMessage() );
+        $message = strtolower( $e->getMessage() );
 
-	return false !== strpos( $message, 'api key' ) || false !== strpos( $message, 'model' );
+        return false !== strpos( $message, 'api key' ) || false !== strpos( $message, 'model' );
+}
+
+/**
+ * Determine if heavy features are disabled.
+ *
+ * Checks the global option or Fast Mode constant to see if AI enrichment,
+ * RAG, and intelligent recommendations should be bypassed.
+ *
+ * @return bool Whether heavy features are disabled.
+ */
+function rtbcb_heavy_features_disabled() {
+        $disabled = (bool) get_option( 'rtbcb_disable_heavy_features', false );
+
+        if ( defined( 'RTBCB_FAST_MODE' ) && RTBCB_FAST_MODE ) {
+                $disabled = true;
+        }
+
+        /**
+         * Filter whether heavy features are disabled.
+         *
+         * @param bool $disabled Current disabled state.
+         */
+        return (bool) apply_filters( 'rtbcb_heavy_features_disabled', $disabled );
 }
 
 /**

--- a/tests/heavy-features-bypass.test.php
+++ b/tests/heavy-features-bypass.test.php
@@ -1,0 +1,43 @@
+<?php
+define( 'ABSPATH', __DIR__ . '/' );
+if ( ! function_exists( '__' ) ) {
+    function __( $text, $domain = null ) {
+        return $text;
+    }
+}
+if ( ! function_exists( 'add_filter' ) ) {
+    function add_filter( $tag, $func, $priority = 10, $args = 1 ) {}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+    function apply_filters( $tag, $value ) {
+        return $value;
+    }
+}
+if ( ! function_exists( 'get_option' ) ) {
+    $GLOBALS['rtbcb_options'] = [];
+    function get_option( $name, $default = false ) {
+        return $GLOBALS['rtbcb_options'][ $name ] ?? $default;
+    }
+    function update_option( $name, $value ) {
+        $GLOBALS['rtbcb_options'][ $name ] = $value;
+    }
+}
+require_once __DIR__ . '/../inc/helpers.php';
+require_once __DIR__ . '/../inc/class-rtbcb-category-recommender.php';
+require_once __DIR__ . '/../inc/class-rtbcb-intelligent-recommender.php';
+
+update_option( 'rtbcb_disable_heavy_features', true );
+
+if ( ! rtbcb_heavy_features_disabled() ) {
+    echo "heavy-features-bypass.test.php failed (flag)\n";
+    exit( 1 );
+}
+
+$recommender = new RTBCB_Intelligent_Recommender();
+$result = $recommender->recommend_with_ai_insights( [ 'company_size' => 'small' ], [] );
+if ( isset( $result['ai_insights'] ) ) {
+    echo "heavy-features-bypass.test.php failed (ai_insights)\n";
+    exit( 1 );
+}
+
+echo "heavy-features-bypass.test.php passed\n";

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -113,7 +113,10 @@ fi
 echo "18. Running project growth path test..."
 php tests/project-growth-path.test.php
 
-echo "19. Running validator tests..."
+echo "19. Running heavy features bypass test..."
+php tests/heavy-features-bypass.test.php
+
+echo "20. Running validator tests..."
 phpunit -c phpunit.xml
 
 echo "================================================"


### PR DESCRIPTION
## Summary
- add `rtbcb_disable_heavy_features` option and helper
- skip AI enrichment, RAG and recommendations when bypass or `RTBCB_FAST_MODE` is active
- surface admin notice and document temporary bypass mode

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `npx --yes markdown-link-check docs/TEMPORARY_BYPASS_MODE.md`
- `bash tests/run-tests.sh` *(phpunit missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b385c0a554833190f82aa0c1cbc8d3