### PR TITLE
Lazy-load RAG context in business analysis

### DIFF
--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
@@ -76,7 +76,7 @@ if ( ! function_exists( 'rtbcb_log_memory_usage' ) ) {
 if ( ! class_exists( 'RTBCB_LLM' ) ) {
     class RTBCB_LLM {
         public static $mode = 'generic';
-        public function generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context ) {
+        public function generate_comprehensive_business_case( $user_inputs, $scenarios, $context_fetcher ) {
             if ( 'no_api_key' === self::$mode ) {
                 return new WP_Error( 'no_api_key', 'OpenAI API key not configured.' );
             }
@@ -116,7 +116,7 @@ if ( ! class_exists( 'Real_Treasury_BCB' ) ) {
     class Real_Treasury_BCB {
         public function ajax_generate_comprehensive_case() {
             $llm = new RTBCB_LLM();
-            $comprehensive_analysis = $llm->generate_comprehensive_business_case( [], [], [] );
+            $comprehensive_analysis = $llm->generate_comprehensive_business_case( [], [], null );
             if ( is_wp_error( $comprehensive_analysis ) ) {
                 $error_message  = $comprehensive_analysis->get_error_message();
                 $error_code     = $comprehensive_analysis->get_error_code();

--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
@@ -55,7 +55,7 @@ if ( ! function_exists( 'rtbcb_is_openai_configuration_error' ) ) {
 if ( ! class_exists( 'RTBCB_LLM' ) ) {
     class RTBCB_LLM {
         public static $mode = 'ok';
-        public function generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context ) {
+        public function generate_comprehensive_business_case( $user_inputs, $scenarios, $context_fetcher ) {
             if ( 'fatal_config' === self::$mode ) {
                 throw new Error( 'Missing API key' );
             }
@@ -96,7 +96,7 @@ if ( ! class_exists( 'Real_Treasury_BCB_Fatal' ) ) {
         public function ajax_generate_comprehensive_case() {
             $llm = new RTBCB_LLM();
             try {
-                $llm->generate_comprehensive_business_case( [], [], [] );
+                $llm->generate_comprehensive_business_case( [], [], null );
             } catch ( Error $e ) {
                 $error_code    = 'E_LLM_FATAL';
                 $error_message = $e->getMessage();

--- a/tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
+++ b/tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
@@ -51,7 +51,7 @@ function rtbcb_log_error( $message, $details = '' ) {
 }
 
 class RTBCB_LLM {
-public function generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context ) {
+public function generate_comprehensive_business_case( $user_inputs, $scenarios, $context_fetcher ) {
 return $this->call_openai_with_retry( '', '', 0 );
 }
 
@@ -61,7 +61,7 @@ return new WP_Error( 'llm_timeout', 'Request timed out' );
 }
 
 class Real_Treasury_BCB {
-private function generate_business_analysis( $user_inputs, $scenarios, $rag_context ) {
+private function generate_business_analysis( $user_inputs, $scenarios, $recommendation ) {
 if ( ! class_exists( 'RTBCB_LLM' ) ) {
 return new WP_Error( 'llm_unavailable', __( 'AI analysis service unavailable.', 'rtbcb' ) );
 }
@@ -72,16 +72,16 @@ return $this->generate_fallback_analysis( $user_inputs, $scenarios );
 
 try {
 $llm    = new RTBCB_LLM();
-$result = $llm->generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context );
+$result = $llm->generate_comprehensive_business_case( $user_inputs, $scenarios, null );
 
 if ( is_wp_error( $result ) ) {
-return $this->generate_fallback_analysis( $user_inputs, $scenarios );
+return [ $this->generate_fallback_analysis( $user_inputs, $scenarios ), [] ];
 }
 
-return $result;
+return [ $result, [] ];
 } catch ( Exception $e ) {
 rtbcb_log_error( 'LLM analysis failed', $e->getMessage() );
-return $this->generate_fallback_analysis( $user_inputs, $scenarios );
+return [ $this->generate_fallback_analysis( $user_inputs, $scenarios ), [] ];
 }
 }
 

--- a/tests/edge-cases.test.php
+++ b/tests/edge-cases.test.php
@@ -103,11 +103,11 @@ return [ 'roi_base' => 1000 ];
 
 if ( ! class_exists( 'RTBCB_LLM' ) ) {
 class RTBCB_LLM {
-public function generate_business_case( $form_data, $calculations, $rag_context, $model ) {
+public function generate_business_case( $form_data, $calculations, $context_fetcher, $model ) {
 return [ 'roi_base' => 1000 ];
 }
 
-public function generate_comprehensive_business_case( $form_data, $calculations, $rag_context ) {
+public function generate_comprehensive_business_case( $form_data, $calculations, $context_fetcher ) {
 return [ 'roi_base' => 1000 ];
 }
 }

--- a/tests/generate-business-analysis.test.php
+++ b/tests/generate-business-analysis.test.php
@@ -49,7 +49,7 @@ if ( ! function_exists( 'rtbcb_has_openai_api_key' ) ) {
 if ( ! class_exists( 'RTBCB_LLM' ) ) {
     class RTBCB_LLM {
         public static $called = false;
-        public function generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context ) {
+        public function generate_comprehensive_business_case( $user_inputs, $scenarios, $context_fetcher ) {
             self::$called = true;
             return [ 'result' => 'llm' ];
         }
@@ -59,7 +59,7 @@ if ( ! class_exists( 'RTBCB_LLM' ) ) {
 class Real_Treasury_BCB {
     public $fallback_called = false;
 
-    private function generate_business_analysis( $user_inputs, $scenarios, $rag_context ) {
+    private function generate_business_analysis( $user_inputs, $scenarios, $recommendation ) {
         if ( ! class_exists( 'RTBCB_LLM' ) ) {
             return new WP_Error( 'llm_unavailable', __( 'AI analysis service unavailable.', 'rtbcb' ) );
         }
@@ -70,16 +70,16 @@ class Real_Treasury_BCB {
 
         try {
             $llm    = new RTBCB_LLM();
-            $result = $llm->generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context );
+            $result = $llm->generate_comprehensive_business_case( $user_inputs, $scenarios, null );
 
             if ( is_wp_error( $result ) ) {
-                return $this->generate_fallback_analysis( $user_inputs, $scenarios );
+                return [ $this->generate_fallback_analysis( $user_inputs, $scenarios ), [] ];
             }
 
-            return $result;
+            return [ $result, [] ];
         } catch ( Exception $e ) {
             rtbcb_log_error( 'LLM analysis failed', $e->getMessage() );
-            return $this->generate_fallback_analysis( $user_inputs, $scenarios );
+            return [ $this->generate_fallback_analysis( $user_inputs, $scenarios ), [] ];
         }
     }
 


### PR DESCRIPTION
## Summary
- Defer RAG context retrieval until business analysis requires it, returning both the analysis and any fetched context.
- Allow RTBCB_LLM to accept a context-fetching callback and only invoke it when the tech landscape needs extra data.
- Adjust tests to use the new lazy RAG mechanism.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38e4dd52c83318eed1bbcec082018