### PR TITLE
Add category-aware ROI refinement

### DIFF
--- a/docs/END_TO_END_WORKFLOW.md
+++ b/docs/END_TO_END_WORKFLOW.md
@@ -18,10 +18,11 @@ This document summarizes the workflow from internal company research to deliveri
 * `RTBCB_LLM::generate_business_case()` combines sanitized user inputs with ROI data and optional RAG context.
 * The LLM returns JSON containing executive summaries, operational analysis, industry insights, and financial analysis blocks.
 
-## 4. Category Recommendation
+## 4. Category Recommendation & ROI Refinement
 
 * The plugin categorizes the user's challenges without an LLM.
 * `RTBCB_Category_Recommender::recommend_category()` scores the input against predefined categories and returns a recommendation with reasoning and confidence.
+* `RTBCB_Calculator::calculate_category_refined_roi()` recomputes ROI using the recommended category.
 
 ## 5. Final Report Assembly
 

--- a/docs/WIZARD_FORM_API_FLOW.md
+++ b/docs/WIZARD_FORM_API_FLOW.md
@@ -34,7 +34,7 @@ Field definitions come from `templates/business-case-form.php` and the field reg
 `Real_Treasury_BCB::ajax_generate_comprehensive_case()` validates the request and orchestrates report generation:
 
 1. **ROI Calculation** – `RTBCB_Calculator::calculate_roi()` builds conservative, base, and optimistic scenarios.
-2. **Category Recommendation** – `RTBCB_Category_Recommender::recommend_category()` scores the selected challenges to suggest a treasury solution type.
+2. **Category Recommendation & ROI Refinement** – `RTBCB_Category_Recommender::recommend_category()` scores the selected challenges and `RTBCB_Calculator::calculate_category_refined_roi()` recomputes ROI.
 3. **RAG Search** – `RTBCB_RAG::search_similar()` retrieves supporting context using the company profile and pain points.
 4. **OpenAI Call** – `RTBCB_LLM::generate_comprehensive_business_case()` combines user inputs, ROI data, and RAG context to produce narrative analysis.
 5. **Report Assembly** – `get_comprehensive_report_html()` renders the final HTML which is returned in the AJAX response.

--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -60,10 +60,12 @@ class RTBCB_Ajax {
 			}
 			$workflow_tracker->complete_step( 'ai_enrichment', $enriched_profile );
 
-			$workflow_tracker->start_step( 'enhanced_roi_calculation' );
-			$enhanced_calculator = new RTBCB_Enhanced_Calculator();
-			$roi_scenarios       = $enhanced_calculator->calculate_enhanced_roi( $user_inputs, $enriched_profile );
-			$workflow_tracker->complete_step( 'enhanced_roi_calculation', $roi_scenarios );
+						$workflow_tracker->start_step( 'enhanced_roi_calculation' );
+						$enhanced_calculator = new RTBCB_Enhanced_Calculator();
+						$roi_scenarios       = $enhanced_calculator->calculate_enhanced_roi( $user_inputs, $enriched_profile );
+						$category_output     = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+						$roi_scenarios       = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $category_output );
+						$workflow_tracker->complete_step( 'enhanced_roi_calculation', $roi_scenarios );
 
 			$workflow_tracker->start_step( 'intelligent_recommendations' );
 			$intelligent_recommender = new RTBCB_Intelligent_Recommender();
@@ -141,8 +143,8 @@ class RTBCB_Ajax {
 		$status = RTBCB_Background_Job::get_status( $job_id );
 		if ( is_wp_error( $status ) ) {
 			$status = [
-			       'status'  => 'error',
-			       'message' => sanitize_text_field( $status->get_error_message() ),
+				   'status'  => 'error',
+				   'message' => sanitize_text_field( $status->get_error_message() ),
 			];
 		}
 
@@ -152,7 +154,7 @@ class RTBCB_Ajax {
 
 		foreach ( [ 'step', 'message', 'percent' ] as $field ) {
 			if ( isset( $status[ $field ] ) ) {
-			       $response[ $field ] = 'percent' === $field ? floatval( $status[ $field ] ) : sanitize_text_field( $status[ $field ] );
+				   $response[ $field ] = 'percent' === $field ? floatval( $status[ $field ] ) : sanitize_text_field( $status[ $field ] );
 			}
 		}
 
@@ -163,19 +165,19 @@ class RTBCB_Ajax {
 			$result                  = $status['result'];
 			$response['report_data'] = $result['report_data'];
 			if ( is_array( $result ) ) {
-			       foreach ( $result as $key => $value ) {
-			               if ( 'report_data' === $key ) {
-			                       continue;
-			               }
-			               $response[ $key ] = $value;
-			       }
+				   foreach ( $result as $key => $value ) {
+						   if ( 'report_data' === $key ) {
+								   continue;
+						   }
+						   $response[ $key ] = $value;
+				   }
 			}
 		}
 
 		wp_send_json_success( $response );
-       }
+	   }
 
-       private static function collect_and_validate_user_inputs() {
+	   private static function collect_and_validate_user_inputs() {
 		$validator = new RTBCB_Validator();
 		$validated = $validator->validate( $_POST );
 
@@ -184,7 +186,7 @@ class RTBCB_Ajax {
 		}
 
 		return $validated;
-       }
+	   }
 
 	private static function create_fallback_profile( $user_inputs ) {
 		return [

--- a/inc/class-rtbcb-calculator.php
+++ b/inc/class-rtbcb-calculator.php
@@ -13,193 +13,204 @@ defined( 'ABSPATH' ) || exit;
  * Provides static ROI calculation helpers.
  */
 class RTBCB_Calculator {
-    /**
-     * Calculate ROI scenarios for given inputs.
-     *
-     * @param array $user_inputs User provided inputs.
-     * @return array
-     */
-    public static function calculate_roi( $user_inputs ) {
-        $settings       = RTBCB_Settings::get_all();
-        $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
-        $category       = $recommendation['category_info'];
-        $industry_mult  = self::get_industry_benchmark( $user_inputs['industry'] ?? '' );
+	/**
+	 * Calculate ROI scenarios for given inputs.
+	 *
+	 * @param array $user_inputs User provided inputs.
+	 * @return array
+	 */
+	public static function calculate_roi( $user_inputs, $category = [] ) {
+		$settings       = RTBCB_Settings::get_all();
+		$industry_mult  = self::get_industry_benchmark( $user_inputs['industry'] ?? '' );
 
-        $scenarios = [];
-        foreach ( [ 'conservative', 'base', 'optimistic' ] as $scenario ) {
-            $scenarios[ $scenario ] = self::calculate_scenario( $user_inputs, $settings, $category, $scenario, $industry_mult );
-        }
+		$scenarios = [];
+		foreach ( [ 'conservative', 'base', 'optimistic' ] as $scenario ) {
+			$scenarios[ $scenario ] = self::calculate_scenario( $user_inputs, $settings, $category, $scenario, $industry_mult );
+		}
 
-        return $scenarios;
-    }
+		return $scenarios;
+	}
+	/**
+	 * Recalculate ROI using category recommendation output.
+	 *
+	 * @param array $user_inputs     User provided inputs.
+	 * @param array $category_output Category recommendation output.
+	 * @return array
+	 */
+	public static function calculate_category_refined_roi( $user_inputs, $category_output ) {
+		$category = $category_output["category_info"] ?? [];
 
-    /**
-     * Calculate ROI for a scenario.
-     *
-     * @param array  $inputs        User inputs.
-     * @param array  $settings      Plugin settings.
-     * @param array  $category      Recommended category info.
-     * @param string $scenario_type Scenario type.
-     * @param float  $industry_mult Industry benchmark multiplier.
-     * @return array
-     */
-    private static function calculate_scenario( $inputs, $settings, $category, $scenario_type, $industry_mult ) {
-        /**
-         * Filters the scenario multipliers used to adjust ROI calculations.
-         *
-         * @param array  $multipliers   Associative array of scenario multipliers.
-         * @param array  $inputs        User provided inputs.
-         * @param array  $settings      Plugin settings.
-         * @param array  $category      Recommended category info.
-         * @param string $scenario_type Scenario type.
-         * @param float  $industry_mult Industry benchmark multiplier.
-         */
-        $multipliers = apply_filters(
-            'rtbcb_roi_multipliers',
-            [
-                'conservative' => 0.8,
-                'base'         => 1.0,
-                'optimistic'   => 1.2,
-            ],
-            $inputs,
-            $settings,
-            $category,
-            $scenario_type,
-            $industry_mult
-        );
-        $multiplier  = $multipliers[ $scenario_type ];
+		return self::calculate_roi( $user_inputs, $category );
+	}
 
-        $labor_savings   = self::calculate_labor_savings( $inputs, $settings, $multiplier );
-        $fee_savings     = self::calculate_fee_savings( $inputs, $settings, $multiplier );
-        $error_reduction = self::calculate_error_reduction( $inputs, $settings, $multiplier );
 
-        $total_annual_benefit = ( $labor_savings + $fee_savings + $error_reduction ) * $industry_mult;
+	/**
+	 * Calculate ROI for a scenario.
+	 *
+	 * @param array  $inputs        User inputs.
+	 * @param array  $settings      Plugin settings.
+	 * @param array  $category      Recommended category info.
+	 * @param string $scenario_type Scenario type.
+	 * @param float  $industry_mult Industry benchmark multiplier.
+	 * @return array
+	 */
+	private static function calculate_scenario( $inputs, $settings, $category, $scenario_type, $industry_mult ) {
+		/**
+		 * Filters the scenario multipliers used to adjust ROI calculations.
+		 *
+		 * @param array  $multipliers   Associative array of scenario multipliers.
+		 * @param array  $inputs        User provided inputs.
+		 * @param array  $settings      Plugin settings.
+		 * @param array  $category      Recommended category info.
+		 * @param string $scenario_type Scenario type.
+		 * @param float  $industry_mult Industry benchmark multiplier.
+		 */
+		$multipliers = apply_filters(
+			'rtbcb_roi_multipliers',
+			[
+				'conservative' => 0.8,
+				'base'         => 1.0,
+				'optimistic'   => 1.2,
+			],
+			$inputs,
+			$settings,
+			$category,
+			$scenario_type,
+			$industry_mult
+		);
+		$multiplier  = $multipliers[ $scenario_type ];
 
-        $min_roi = $category['roi_range'][0] ?? 0;
-        $max_roi = $category['roi_range'][1] ?? $total_annual_benefit;
-        $total_annual_benefit = max( $min_roi, min( $total_annual_benefit, $max_roi ) );
+		$labor_savings   = self::calculate_labor_savings( $inputs, $settings, $multiplier );
+		$fee_savings     = self::calculate_fee_savings( $inputs, $settings, $multiplier );
+		$error_reduction = self::calculate_error_reduction( $inputs, $settings, $multiplier );
 
-        $avg_cost      = ( $min_roi + $max_roi ) / 2;
-        $roi_percentage = $avg_cost > 0 ? ( $total_annual_benefit / $avg_cost ) * 100 : 0;
+		$total_annual_benefit = ( $labor_savings + $fee_savings + $error_reduction ) * $industry_mult;
 
-        return [
-            'labor_savings'        => $labor_savings,
-            'fee_savings'          => $fee_savings,
-            'error_reduction'      => $error_reduction,
-            'total_annual_benefit' => $total_annual_benefit,
-            'roi_percentage'       => $roi_percentage,
-            'assumptions'          => self::get_scenario_assumptions( $scenario_type, $multiplier, $industry_mult ),
-        ];
-    }
+		$min_roi = $category['roi_range'][0] ?? 0;
+		$max_roi = $category['roi_range'][1] ?? $total_annual_benefit;
+		$total_annual_benefit = max( $min_roi, min( $total_annual_benefit, $max_roi ) );
 
-    /**
-     * Calculate labor cost savings.
-     *
-     * @param array $inputs     User inputs.
-     * @param array $settings   Plugin settings.
-     * @param float $multiplier Scenario multiplier.
-     *
-     * @return float Annual labor savings.
-     */
-    private static function calculate_labor_savings( $inputs, $settings, $multiplier ) {
-        $hourly_cost = isset( $settings['labor_cost_per_hour'] ) ? floatval( $settings['labor_cost_per_hour'] ) : 100;
-        $weekly_hours = ( isset( $inputs['hours_reconciliation'] ) ? floatval( $inputs['hours_reconciliation'] ) : 0 )
-            + ( isset( $inputs['hours_cash_positioning'] ) ? floatval( $inputs['hours_cash_positioning'] ) : 0 );
-        $efficiency   = 0.30 * $multiplier;
-        $hours_saved  = $weekly_hours * $efficiency;
+		$avg_cost      = ( $min_roi + $max_roi ) / 2;
+		$roi_percentage = $avg_cost > 0 ? ( $total_annual_benefit / $avg_cost ) * 100 : 0;
 
-        return $hours_saved * 52 * $hourly_cost;
-    }
+		return [
+			'labor_savings'        => $labor_savings,
+			'fee_savings'          => $fee_savings,
+			'error_reduction'      => $error_reduction,
+			'total_annual_benefit' => $total_annual_benefit,
+			'roi_percentage'       => $roi_percentage,
+			'assumptions'          => self::get_scenario_assumptions( $scenario_type, $multiplier, $industry_mult ),
+		];
+	}
 
-    /**
-     * Calculate bank fee savings.
-     *
-     * @param array $inputs     User inputs.
-     * @param array $settings   Plugin settings.
-     * @param float $multiplier Scenario multiplier.
-     *
-     * @return float Annual fee savings.
-     */
-    private static function calculate_fee_savings( $inputs, $settings, $multiplier ) {
-        $num_banks = isset( $inputs['num_banks'] ) ? intval( $inputs['num_banks'] ) : 0;
-        $baseline  = isset( $settings['bank_fee_baseline'] ) ? floatval( $settings['bank_fee_baseline'] ) : 15000;
-        $rate      = 0.08 * $multiplier;
+	/**
+	 * Calculate labor cost savings.
+	 *
+	 * @param array $inputs     User inputs.
+	 * @param array $settings   Plugin settings.
+	 * @param float $multiplier Scenario multiplier.
+	 *
+	 * @return float Annual labor savings.
+	 */
+	private static function calculate_labor_savings( $inputs, $settings, $multiplier ) {
+		$hourly_cost = isset( $settings['labor_cost_per_hour'] ) ? floatval( $settings['labor_cost_per_hour'] ) : 100;
+		$weekly_hours = ( isset( $inputs['hours_reconciliation'] ) ? floatval( $inputs['hours_reconciliation'] ) : 0 )
+			+ ( isset( $inputs['hours_cash_positioning'] ) ? floatval( $inputs['hours_cash_positioning'] ) : 0 );
+		$efficiency   = 0.30 * $multiplier;
+		$hours_saved  = $weekly_hours * $efficiency;
 
-        return $num_banks * $baseline * $rate;
-    }
+		return $hours_saved * 52 * $hourly_cost;
+	}
 
-    /**
-     * Calculate savings from error reduction.
-     *
-     * @param array $inputs     User inputs.
-     * @param array $settings   Plugin settings.
-     * @param float $multiplier Scenario multiplier.
-     *
-     * @return float Annual error reduction benefit.
-     */
-    private static function calculate_error_reduction( $inputs, $settings, $multiplier ) {
-        /**
-         * Filters the base error cost map used for calculating error reduction savings.
-         *
-         * @param array $cost_map   Map of company sizes to base error costs.
-         * @param array $inputs     User provided inputs.
-         * @param array $settings   Plugin settings.
-         * @param float $multiplier Scenario multiplier.
-         */
-        $cost_map = apply_filters(
-            'rtbcb_error_cost_map',
-            [
-                '<$50M'       => 25000,
-                '$50M-$500M'  => 75000,
-                '$500M-$2B'   => 200000,
-                '>$2B'        => 500000,
-            ],
-            $inputs,
-            $settings,
-            $multiplier
-        );
-        $company_size = isset( $inputs['company_size'] ) ? $inputs['company_size'] : '';
-        $base_cost    = isset( $cost_map[ $company_size ] ) ? $cost_map[ $company_size ] : 50000;
-        $reduction    = 0.25 * $multiplier;
+	/**
+	 * Calculate bank fee savings.
+	 *
+	 * @param array $inputs     User inputs.
+	 * @param array $settings   Plugin settings.
+	 * @param float $multiplier Scenario multiplier.
+	 *
+	 * @return float Annual fee savings.
+	 */
+	private static function calculate_fee_savings( $inputs, $settings, $multiplier ) {
+		$num_banks = isset( $inputs['num_banks'] ) ? intval( $inputs['num_banks'] ) : 0;
+		$baseline  = isset( $settings['bank_fee_baseline'] ) ? floatval( $settings['bank_fee_baseline'] ) : 15000;
+		$rate      = 0.08 * $multiplier;
 
-        return $base_cost * $reduction;
-    }
+		return $num_banks * $baseline * $rate;
+	}
 
-    /**
-     * Get scenario assumptions.
-     *
-     * @param string $scenario_type Scenario key.
-     * @param float  $multiplier    Scenario multiplier.
-     * @param float  $industry_mult Industry multiplier.
-     *
-     * @return array Assumptions for the scenario.
-     */
-    private static function get_scenario_assumptions( $scenario_type, $multiplier, $industry_mult ) {
-        return [
-            'name'                  => ucfirst( $scenario_type ),
-            'efficiency_improvement'=> 0.30 * $multiplier,
-            'error_reduction'       => 0.25 * $multiplier,
-            'fee_reduction'         => 0.08 * $multiplier,
-            'industry_benchmark'    => $industry_mult,
-        ];
-    }
+	/**
+	 * Calculate savings from error reduction.
+	 *
+	 * @param array $inputs     User inputs.
+	 * @param array $settings   Plugin settings.
+	 * @param float $multiplier Scenario multiplier.
+	 *
+	 * @return float Annual error reduction benefit.
+	 */
+	private static function calculate_error_reduction( $inputs, $settings, $multiplier ) {
+		/**
+		 * Filters the base error cost map used for calculating error reduction savings.
+		 *
+		 * @param array $cost_map   Map of company sizes to base error costs.
+		 * @param array $inputs     User provided inputs.
+		 * @param array $settings   Plugin settings.
+		 * @param float $multiplier Scenario multiplier.
+		 */
+		$cost_map = apply_filters(
+			'rtbcb_error_cost_map',
+			[
+				'<$50M'       => 25000,
+				'$50M-$500M'  => 75000,
+				'$500M-$2B'   => 200000,
+				'>$2B'        => 500000,
+			],
+			$inputs,
+			$settings,
+			$multiplier
+		);
+		$company_size = isset( $inputs['company_size'] ) ? $inputs['company_size'] : '';
+		$base_cost    = isset( $cost_map[ $company_size ] ) ? $cost_map[ $company_size ] : 50000;
+		$reduction    = 0.25 * $multiplier;
 
-    /**
-     * Retrieve industry benchmark multiplier.
-     *
-     * @param string $industry Industry identifier.
-     * @return float Multiplier.
-     */
-    private static function get_industry_benchmark( $industry ) {
-        $benchmarks = [
-            'manufacturing' => 0.9,
-            'technology'    => 1.1,
-            'finance'       => 1.05,
-            'retail'        => 0.95,
-        ];
+		return $base_cost * $reduction;
+	}
 
-        $industry = strtolower( $industry );
+	/**
+	 * Get scenario assumptions.
+	 *
+	 * @param string $scenario_type Scenario key.
+	 * @param float  $multiplier    Scenario multiplier.
+	 * @param float  $industry_mult Industry multiplier.
+	 *
+	 * @return array Assumptions for the scenario.
+	 */
+	private static function get_scenario_assumptions( $scenario_type, $multiplier, $industry_mult ) {
+		return [
+			'name'                  => ucfirst( $scenario_type ),
+			'efficiency_improvement'=> 0.30 * $multiplier,
+			'error_reduction'       => 0.25 * $multiplier,
+			'fee_reduction'         => 0.08 * $multiplier,
+			'industry_benchmark'    => $industry_mult,
+		];
+	}
 
-        return $benchmarks[ $industry ] ?? 1.0;
-    }
+	/**
+	 * Retrieve industry benchmark multiplier.
+	 *
+	 * @param string $industry Industry identifier.
+	 * @return float Multiplier.
+	 */
+	private static function get_industry_benchmark( $industry ) {
+		$benchmarks = [
+			'manufacturing' => 0.9,
+			'technology'    => 1.1,
+			'finance'       => 1.05,
+			'retail'        => 0.95,
+		];
+
+		$industry = strtolower( $industry );
+
+		return $benchmarks[ $industry ] ?? 1.0;
+	}
 }

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -13,520 +13,525 @@ require_once __DIR__ . '/helpers.php';
  * Class RTBCB_Router.
  */
 class RTBCB_Router {
-    /**
-     * Handle form submission and generate the business case.
-     *
-     * @param string $report_type Optional report type (basic or comprehensive).
-     *
-     * @return void
-     */
-    public function handle_form_submission( $report_type = 'basic' ) {
-        // Nonce verification.
-        if (
-            ! isset( $_POST['rtbcb_nonce'] )
-            || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ), 'rtbcb_generate' )
-        ) {
-            wp_send_json_error( [ 'message' => __( 'Nonce verification failed.', 'rtbcb' ) ], 403 );
-            return;
-        }
+	/**
+	 * Handle form submission and generate the business case.
+	 *
+	 * @param string $report_type Optional report type (basic or comprehensive).
+	 *
+	 * @return void
+	 */
+	public function handle_form_submission( $report_type = 'basic' ) {
+		// Nonce verification.
+		if (
+			! isset( $_POST['rtbcb_nonce'] )
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ), 'rtbcb_generate' )
+		) {
+			wp_send_json_error( [ 'message' => __( 'Nonce verification failed.', 'rtbcb' ) ], 403 );
+			return;
+		}
 
-        try {
-            // Sanitize and validate input.
-            $validator      = new RTBCB_Validator();
-            $validated_data = $validator->validate( $_POST );
+		try {
+			// Sanitize and validate input.
+			$validator      = new RTBCB_Validator();
+			$validated_data = $validator->validate( $_POST );
 
-            if ( isset( $validated_data['error'] ) ) {
-                wp_send_json_error( [ 'message' => $validated_data['error'] ], 400 );
-                return;
-            }
+			if ( isset( $validated_data['error'] ) ) {
+				wp_send_json_error( [ 'message' => $validated_data['error'] ], 400 );
+				return;
+			}
 
-            $form_data = $validated_data;
+			$form_data = $validated_data;
 
-            // Determine report type from request if provided.
-            if ( isset( $_POST['report_type'] ) ) {
-                $report_type = sanitize_text_field( wp_unslash( $_POST['report_type'] ) );
-            }
+			// Determine report type from request if provided.
+			if ( isset( $_POST['report_type'] ) ) {
+				$report_type = sanitize_text_field( wp_unslash( $_POST['report_type'] ) );
+			}
 
-            // Instantiate necessary classes.
-            $llm = new RTBCB_LLM();
-            $rag = new RTBCB_RAG();
+			// Instantiate necessary classes.
+			$llm = new RTBCB_LLM();
+			$rag = new RTBCB_RAG();
 
-            // Perform calculations.
-            $calculations = RTBCB_Calculator::calculate_roi( $form_data );
+			// Perform baseline calculations and category refinement.
+			$calculations      = RTBCB_Calculator::calculate_roi( $form_data );
+			$category_output   = RTBCB_Category_Recommender::recommend_category( $form_data );
+			$calculations      = RTBCB_Calculator::calculate_category_refined_roi( $form_data, $category_output );
 
-            // Generate context from RAG.
-            $rag_context = $rag->get_context( $form_data['company_description'] );
+			// Generate context from RAG.
+			$rag_context = $rag->get_context( $form_data['company_description'] );
 
-            if ( 'comprehensive' === $report_type ) {
-                // Generate comprehensive business case with LLM.
-                $business_case_data = $llm->generate_comprehensive_business_case( $form_data, $calculations, $rag_context );
-            } else {
-                // Route to the appropriate model.
-                $model = $this->route_model( $form_data, $rag_context );
-                if ( is_wp_error( $model ) ) {
-                    throw new Exception( $model->get_error_message() );
-                }
+			if ( 'comprehensive' === $report_type ) {
+				// Generate comprehensive business case with LLM.
+				$business_case_data = $llm->generate_comprehensive_business_case( $form_data, $calculations, $rag_context );
+			} else {
+				// Route to the appropriate model.
+				$model = $this->route_model( $form_data, $rag_context );
+				if ( is_wp_error( $model ) ) {
+					throw new Exception( $model->get_error_message() );
+				}
 
-                // Generate basic business case with LLM.
-                $business_case_data = $llm->generate_business_case( $form_data, $calculations, $rag_context, $model );
-            }
+				// Generate basic business case with LLM.
+				$business_case_data = $llm->generate_business_case( $form_data, $calculations, $rag_context, $model );
+			}
 
-            // Check for LLM generation errors before proceeding.
-            if ( is_wp_error( $business_case_data ) ) {
-                $error_message = $business_case_data->get_error_message();
-                $error_data    = $business_case_data->get_error_data();
-                $status        = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
+			// Attach category recommendation to business case data.
+			$business_case_data['recommendation'] = $category_output;
 
-                wp_send_json_error(
-                    [
-                        'message'    => $error_message,
-                        'error_code' => $business_case_data->get_error_code(),
-                    ],
-                    $status
-                );
-                return;
-            }
+			// Check for LLM generation errors before proceeding.
+			if ( is_wp_error( $business_case_data ) ) {
+				$error_message = $business_case_data->get_error_message();
+				$error_data    = $business_case_data->get_error_data();
+				$status        = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
 
-            // Generate report HTML based on type.
-            $report_html = 'comprehensive' === $report_type ?
-                $this->get_comprehensive_report_html( $business_case_data ) :
-                $this->get_report_html( $business_case_data );
+				wp_send_json_error(
+					[
+						'message'    => $error_message,
+						'error_code' => $business_case_data->get_error_code(),
+					],
+					$status
+				);
+				return;
+			}
 
-            // Save the lead.
-            $leads   = new RTBCB_Leads();
-            $lead_id = $leads->save_lead( $form_data, $business_case_data );
+			// Generate report HTML based on type.
+			$report_html = 'comprehensive' === $report_type ?
+				$this->get_comprehensive_report_html( $business_case_data ) :
+				$this->get_report_html( $business_case_data );
 
-            // Write report HTML to temporary file in uploads directory.
-            $upload_dir  = wp_upload_dir();
-            $reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
-            if ( ! file_exists( $reports_dir ) ) {
-                wp_mkdir_p( $reports_dir );
-            }
+			// Save the lead.
+			$leads   = new RTBCB_Leads();
+			$lead_id = $leads->save_lead( $form_data, $business_case_data );
 
-            $filepath = trailingslashit( $reports_dir ) . 'report-' . $lead_id . '.html';
-            file_put_contents( $filepath, $report_html );
+			// Write report HTML to temporary file in uploads directory.
+			$upload_dir  = wp_upload_dir();
+			$reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
+			if ( ! file_exists( $reports_dir ) ) {
+				wp_mkdir_p( $reports_dir );
+			}
 
-            // Prepare and send the report email.
-            $to      = sanitize_email( $form_data['email'] );
-            $subject = sprintf(
-                __( 'Your Business Case from %s', 'rtbcb' ),
-                get_bloginfo( 'name' )
-            );
-            $message = __( 'Thank you for using the Business Case Builder. Your report is attached.', 'rtbcb' );
-            wp_mail( $to, $subject, $message, [], [ $filepath ] );
+			$filepath = trailingslashit( $reports_dir ) . 'report-' . $lead_id . '.html';
+			file_put_contents( $filepath, $report_html );
 
-            // Clean up temporary file.
-            if ( file_exists( $filepath ) ) {
-                unlink( $filepath );
-            }
+			// Prepare and send the report email.
+			$to      = sanitize_email( $form_data['email'] );
+			$subject = sprintf(
+				__( 'Your Business Case from %s', 'rtbcb' ),
+				get_bloginfo( 'name' )
+			);
+			$message = __( 'Thank you for using the Business Case Builder. Your report is attached.', 'rtbcb' );
+			wp_mail( $to, $subject, $message, [], [ $filepath ] );
 
-            // Send success response.
-            wp_send_json_success(
-                [
-                    'message'     => __( 'Business case generated successfully.', 'rtbcb' ),
-                    'report_id'   => $lead_id,
-                    'report_html' => $report_html,
-                ]
-            );
-        } catch ( Exception $e ) {
-            // Log the detailed error to debug.log.
-            error_log( 'RTBCB Form Submission Error: ' . $e->getMessage() );
+			// Clean up temporary file.
+			if ( file_exists( $filepath ) ) {
+				unlink( $filepath );
+			}
 
-            // Send a generic error response to the client.
-            wp_send_json_error(
-                [
-                    'message' => sprintf(
-                        __( 'An unexpected error occurred while generating your report. Please check the server logs for more details. Error: %s', 'rtbcb' ),
-                        $e->getMessage()
-                    ),
-                ],
-                500
-            );
-        }
-    }
-    /**
-     * Route to the appropriate LLM model.
-     *
-     * @param array $inputs User inputs.
-     * @param array $chunks Context chunks.
-     *
-     * @return string|WP_Error Model name or error if no model configured.
-     */
-    public function route_model( $inputs, $chunks ) {
-        $complexity = $this->calculate_complexity( $inputs, $chunks );
-        $category   = RTBCB_Category_Recommender::recommend_category( $inputs )['recommended'];
+			// Send success response.
+			wp_send_json_success(
+				[
+					'message'     => __( 'Business case generated successfully.', 'rtbcb' ),
+					'report_id'   => $lead_id,
+					'report_html' => $report_html,
+				]
+			);
+		} catch ( Exception $e ) {
+			// Log the detailed error to debug.log.
+			error_log( 'RTBCB Form Submission Error: ' . $e->getMessage() );
 
-        // Get available models
-        $mini_model    = get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) );
-        $premium_model = get_option( 'rtbcb_premium_model', rtbcb_get_default_model( 'premium' ) );
+			// Send a generic error response to the client.
+			wp_send_json_error(
+				[
+					'message' => sprintf(
+						__( 'An unexpected error occurred while generating your report. Please check the server logs for more details. Error: %s', 'rtbcb' ),
+						$e->getMessage()
+					),
+				],
+				500
+			);
+		}
+	}
+	/**
+	 * Route to the appropriate LLM model.
+	 *
+	 * @param array $inputs User inputs.
+	 * @param array $chunks Context chunks.
+	 *
+	 * @return string|WP_Error Model name or error if no model configured.
+	 */
+	public function route_model( $inputs, $chunks ) {
+		$complexity = $this->calculate_complexity( $inputs, $chunks );
+		$category   = RTBCB_Category_Recommender::recommend_category( $inputs )['recommended'];
 
-        // Start with mini model as default
-        $model     = $mini_model;
-        $reasoning = 'Default mini model for basic requests';
+		// Get available models
+		$mini_model    = get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) );
+		$premium_model = get_option( 'rtbcb_premium_model', rtbcb_get_default_model( 'premium' ) );
 
-        if ( $complexity > 0.6 || 'trms' === $category ) {
-            $model     = $premium_model;
-            $reasoning = 'Premium model for high complexity or TRMS category';
-        } elseif ( 'tms_lite' === $category && $complexity > 0.4 ) {
-            $model     = $premium_model;
-            $reasoning = 'Premium model for TMS-Lite with moderate complexity';
-        }
+		// Start with mini model as default
+		$model     = $mini_model;
+		$reasoning = 'Default mini model for basic requests';
 
-        // Validate selected model
-        if ( empty( $model ) ) {
-            $error = new WP_Error(
-                'rtbcb_missing_model',
-                __( 'No language model configured. Please review the plugin settings.', 'rtbcb' )
-            );
-            error_log( 'RTBCB: ' . $error->get_error_message() );
-            return $error;
-        }
+		if ( $complexity > 0.6 || 'trms' === $category ) {
+			$model     = $premium_model;
+			$reasoning = 'Premium model for high complexity or TRMS category';
+		} elseif ( 'tms_lite' === $category && $complexity > 0.4 ) {
+			$model     = $premium_model;
+			$reasoning = 'Premium model for TMS-Lite with moderate complexity';
+		}
 
-        error_log( "RTBCB: Model selected: {$model} (Complexity: {$complexity}, Category: {$category}, Reason: {$reasoning})" );
+		// Validate selected model
+		if ( empty( $model ) ) {
+			$error = new WP_Error(
+				'rtbcb_missing_model',
+				__( 'No language model configured. Please review the plugin settings.', 'rtbcb' )
+			);
+			error_log( 'RTBCB: ' . $error->get_error_message() );
+			return $error;
+		}
 
-        return $model;
-    }
+		error_log( "RTBCB: Model selected: {$model} (Complexity: {$complexity}, Category: {$category}, Reason: {$reasoning})" );
 
-    /**
-     * Calculate complexity score for model routing.
-     *
-     * @param array $inputs User inputs.
-     * @param array $chunks Context chunks.
-     *
-     * @return float Complexity score between 0 and 1.
-     */
-    private function calculate_complexity( $inputs, $chunks ) {
-        $score = 0;
+		return $model;
+	}
 
-        $pain_points = isset( $inputs['pain_points'] ) ? (array) $inputs['pain_points'] : [];
-        $score      += count( $pain_points ) * 0.1;
-        $score      += count( $chunks ) * 0.2;
+	/**
+	 * Calculate complexity score for model routing.
+	 *
+	 * @param array $inputs User inputs.
+	 * @param array $chunks Context chunks.
+	 *
+	 * @return float Complexity score between 0 and 1.
+	 */
+	private function calculate_complexity( $inputs, $chunks ) {
+		$score = 0;
 
-        if ( isset( $inputs['company_size'] ) && '>$2B' === $inputs['company_size'] ) {
-            $score += 0.3;
-        }
+		$pain_points = isset( $inputs['pain_points'] ) ? (array) $inputs['pain_points'] : [];
+		$score      += count( $pain_points ) * 0.1;
+		$score      += count( $chunks ) * 0.2;
 
-        return min( 1.0, $score );
-    }
+		if ( isset( $inputs['company_size'] ) && '>$2B' === $inputs['company_size'] ) {
+			$score += 0.3;
+		}
 
-    /**
-     * Generate report HTML.
-     *
-     * @param array $business_case_data Business case data.
-     *
-     * @return string Report HTML.
-     */
-    public function get_report_html( $business_case_data ) {
-        $template_path = RTBCB_DIR . 'templates/report-template.php';
+		return min( 1.0, $score );
+	}
 
-        if ( ! file_exists( $template_path ) ) {
-            return '';
-        }
+	/**
+	 * Generate report HTML.
+	 *
+	 * @param array $business_case_data Business case data.
+	 *
+	 * @return string Report HTML.
+	 */
+	public function get_report_html( $business_case_data ) {
+		$template_path = RTBCB_DIR . 'templates/report-template.php';
 
-        $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
+		if ( ! file_exists( $template_path ) ) {
+			return '';
+		}
 
-        ob_start();
-        include $template_path;
-        $html = ob_get_clean();
+		$business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
 
-        return wp_kses( $html, rtbcb_get_report_allowed_html() );
-    }
+		ob_start();
+		include $template_path;
+		$html = ob_get_clean();
+
+		return wp_kses( $html, rtbcb_get_report_allowed_html() );
+	}
 
    /**
-    * Generate comprehensive report HTML from template with proper data transformation.
-    *
-    * @param array $business_case_data Business case data.
-    *
-    * @return string
-    */
-    private function get_comprehensive_report_html( $business_case_data ) {
-        $template_path = RTBCB_DIR . 'templates/comprehensive-report-template.php';
+	* Generate comprehensive report HTML from template with proper data transformation.
+	*
+	* @param array $business_case_data Business case data.
+	*
+	* @return string
+	*/
+	private function get_comprehensive_report_html( $business_case_data ) {
+		$template_path = RTBCB_DIR . 'templates/comprehensive-report-template.php';
 
-        if ( file_exists( $template_path ) ) {
-            rtbcb_log_api_debug( 'Router: using comprehensive template', [ 'template_path' => $template_path ] );
-        } else {
-            rtbcb_log_api_debug( 'Router: comprehensive template missing, using basic template', [ 'template_path' => $template_path ] );
-            return $this->get_report_html( $business_case_data );
-        }
+		if ( file_exists( $template_path ) ) {
+			rtbcb_log_api_debug( 'Router: using comprehensive template', [ 'template_path' => $template_path ] );
+		} else {
+			rtbcb_log_api_debug( 'Router: comprehensive template missing, using basic template', [ 'template_path' => $template_path ] );
+			return $this->get_report_html( $business_case_data );
+		}
 
-       $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
+	   $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
 
-       $report_data = $business_case_data['report_data'] ?? null;
-       $hash_source = $report_data ?: $business_case_data;
-       $data_hash  = md5( wp_json_encode( $hash_source ) );
-       $cache_key  = md5( $template_path . ':' . $data_hash );
+	   $report_data = $business_case_data['report_data'] ?? null;
+	   $hash_source = $report_data ?: $business_case_data;
+	   $data_hash  = md5( wp_json_encode( $hash_source ) );
+	   $cache_key  = md5( $template_path . ':' . $data_hash );
 
-       $cached_html = wp_cache_get( $cache_key, 'rtbcb_reports' );
-       if ( false !== $cached_html ) {
-           return $cached_html;
-       }
+	   $cached_html = wp_cache_get( $cache_key, 'rtbcb_reports' );
+	   if ( false !== $cached_html ) {
+		   return $cached_html;
+	   }
 
-       if ( null === $report_data ) {
-           // Transform data structure for comprehensive template.
-           $report_data = $this->transform_data_for_template( $business_case_data );
-       }
+	   if ( null === $report_data ) {
+		   // Transform data structure for comprehensive template.
+		   $report_data = $this->transform_data_for_template( $business_case_data );
+	   }
 
-       ob_start();
-       include $template_path;
-       $html = ob_get_clean();
-       $html = wp_kses( $html, rtbcb_get_report_allowed_html() );
+	   ob_start();
+	   include $template_path;
+	   $html = ob_get_clean();
+	   $html = wp_kses( $html, rtbcb_get_report_allowed_html() );
 
-       wp_cache_set( $cache_key, $html, 'rtbcb_reports', HOUR_IN_SECONDS );
+	   wp_cache_set( $cache_key, $html, 'rtbcb_reports', HOUR_IN_SECONDS );
 
-       return $html;
+	   return $html;
    }
 
    /**
-    * Transform LLM response data into the structure expected by comprehensive template.
-    *
-    * @param array $business_case_data Business case data.
-    *
-    * @return array
-    */
+	* Transform LLM response data into the structure expected by comprehensive template.
+	*
+	* @param array $business_case_data Business case data.
+	*
+	* @return array
+	*/
    private function transform_data_for_template( $business_case_data ) {
-       $defaults = [
-           'company_name'           => '',
-           'base_roi'               => 0,
-           'roi_base'               => 0,
-           'recommended_category'   => '',
-           'category_info'          => [],
-           'executive_summary'      => '',
-           'narrative'              => '',
-           'executive_recommendation' => '',
-           'recommendation'         => '',
-           'payback_months'         => 'N/A',
-           'sensitivity_analysis'   => [],
-           'company_analysis'       => '',
-           'maturity_level'         => 'intermediate',
-           'current_state_analysis' => '',
-           'market_analysis'        => '',
-           'tech_adoption_level'    => 'medium',
-           'operational_analysis'   => [],
-           'risks'                  => [],
-           'confidence'             => 0.85,
-           'processing_time'        => 0,
-       ];
-       $business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
+	   $defaults = [
+		   'company_name'           => '',
+		   'base_roi'               => 0,
+		   'roi_base'               => 0,
+		   'recommended_category'   => '',
+		   'category_info'          => [],
+		   'executive_summary'      => '',
+		   'narrative'              => '',
+		   'executive_recommendation' => '',
+		   'recommendation'         => '',
+		   'payback_months'         => 'N/A',
+		   'sensitivity_analysis'   => [],
+		   'company_analysis'       => '',
+		   'maturity_level'         => 'intermediate',
+		   'current_state_analysis' => '',
+		   'market_analysis'        => '',
+		   'tech_adoption_level'    => 'medium',
+		   'operational_analysis'   => [],
+		   'risks'                  => [],
+		   'confidence'             => 0.85,
+		   'processing_time'        => 0,
+	   ];
+	   $business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
 
-       // Get current company data.
-       $company      = rtbcb_get_current_company();
-       $company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
+	   // Get current company data.
+	   $company      = rtbcb_get_current_company();
+	   $company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
 
-       // Derive recommended category and details from recommendation if not provided.
-       $recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
-       $category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
+	   // Derive recommended category and details from recommendation if not provided.
+	   $recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
+	   $category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
 
-       // Prepare operational and risk data with fallbacks.
-       $operational_analysis = array_map( 'sanitize_text_field', (array) $business_case_data['operational_analysis'] );
-       if ( empty( $operational_analysis ) ) {
-           $operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
-       }
+	   // Prepare operational and risk data with fallbacks.
+	   $operational_analysis = array_map( 'sanitize_text_field', (array) $business_case_data['operational_analysis'] );
+	   if ( empty( $operational_analysis ) ) {
+		   $operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
+	   }
 
-       $implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
-       if ( empty( $implementation_risks ) ) {
-           $implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
-       }
+	   $implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
+	   if ( empty( $implementation_risks ) ) {
+		   $implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
+	   }
 
-       // Create structured data format expected by template.
-       $report_data = [
-           'metadata'           => [
-               'company_name'     => $company_name,
-               'analysis_date'    => current_time( 'Y-m-d' ),
-               'confidence_level' => floatval( $business_case_data['confidence'] ),
-               'processing_time'  => intval( $business_case_data['processing_time'] ),
-           ],
-           'executive_summary'  => [
-               'strategic_positioning'    => wp_kses_post( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
-               'key_value_drivers'       => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation' => wp_kses_post( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
-               'business_case_strength'  => $this->determine_business_case_strength( $business_case_data ),
-           ],
-           'financial_analysis' => [
-               'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
-               'payback_analysis'   => [
-                   'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
-               ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
-           ],
-           'company_intelligence' => [
-               'enriched_profile' => [
-                   'enhanced_description' => wp_kses_post( $business_case_data['company_analysis'] ),
-                   'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
-                   'treasury_maturity'    => [
-                       'current_state' => wp_kses_post( $business_case_data['current_state_analysis'] ),
-                   ],
-               ],
-               'industry_context' => [
-                   'sector_analysis' => [
-                       'market_dynamics' => wp_kses_post( $business_case_data['market_analysis'] ),
-                   ],
-                   'benchmarking'   => [
-                       'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
-                   ],
-               ],
-           ],
-           'technology_strategy' => [
-               'recommended_category' => $recommended_category,
-               'category_details'     => $category_details,
-           ],
-           'operational_insights' => $operational_analysis,
-           'risk_analysis'        => [
-               'implementation_risks' => $implementation_risks,
-           ],
-           'action_plan'          => [
-               'immediate_steps'      => $this->extract_immediate_steps( $business_case_data ),
-               'short_term_milestones'=> $this->extract_short_term_steps( $business_case_data ),
-               'long_term_objectives' => $this->extract_long_term_steps( $business_case_data ),
-           ],
-       ];
+	   // Create structured data format expected by template.
+	   $report_data = [
+		   'metadata'           => [
+			   'company_name'     => $company_name,
+			   'analysis_date'    => current_time( 'Y-m-d' ),
+			   'confidence_level' => floatval( $business_case_data['confidence'] ),
+			   'processing_time'  => intval( $business_case_data['processing_time'] ),
+		   ],
+		   'executive_summary'  => [
+			   'strategic_positioning'    => wp_kses_post( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
+			   'key_value_drivers'       => $this->extract_value_drivers( $business_case_data ),
+			   'executive_recommendation' => wp_kses_post( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
+			   'business_case_strength'  => $this->determine_business_case_strength( $business_case_data ),
+		   ],
+		   'financial_analysis' => [
+			   'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
+			   'payback_analysis'   => [
+				   'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
+			   ],
+			   'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
+		   ],
+		   'company_intelligence' => [
+			   'enriched_profile' => [
+				   'enhanced_description' => wp_kses_post( $business_case_data['company_analysis'] ),
+				   'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
+				   'treasury_maturity'    => [
+					   'current_state' => wp_kses_post( $business_case_data['current_state_analysis'] ),
+				   ],
+			   ],
+			   'industry_context' => [
+				   'sector_analysis' => [
+					   'market_dynamics' => wp_kses_post( $business_case_data['market_analysis'] ),
+				   ],
+				   'benchmarking'   => [
+					   'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
+				   ],
+			   ],
+		   ],
+		   'technology_strategy' => [
+			   'recommended_category' => $recommended_category,
+			   'category_details'     => $category_details,
+		   ],
+		   'operational_insights' => $operational_analysis,
+		   'risk_analysis'        => [
+			   'implementation_risks' => $implementation_risks,
+		   ],
+		   'action_plan'          => [
+			   'immediate_steps'      => $this->extract_immediate_steps( $business_case_data ),
+			   'short_term_milestones'=> $this->extract_short_term_steps( $business_case_data ),
+			   'long_term_objectives' => $this->extract_long_term_steps( $business_case_data ),
+		   ],
+	   ];
 
-       return $report_data;
+	   return $report_data;
    }
 
    /**
-    * Extract value drivers from business case data.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
+	* Extract value drivers from business case data.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
    private function extract_value_drivers( $data ) {
-       $drivers = [];
+	   $drivers = [];
 
-       // Extract from various possible sources.
-       if ( ! empty( $data['value_drivers'] ) ) {
-           $drivers = (array) $data['value_drivers'];
-       } elseif ( ! empty( $data['key_benefits'] ) ) {
-           $drivers = (array) $data['key_benefits'];
-       } else {
-           // Default value drivers.
-           $drivers = [
-               __( 'Automated cash management processes', 'rtbcb' ),
-               __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
-               __( 'Reduced operational risk and errors', 'rtbcb' ),
-               __( 'Improved regulatory compliance', 'rtbcb' ),
-           ];
-       }
+	   // Extract from various possible sources.
+	   if ( ! empty( $data['value_drivers'] ) ) {
+		   $drivers = (array) $data['value_drivers'];
+	   } elseif ( ! empty( $data['key_benefits'] ) ) {
+		   $drivers = (array) $data['key_benefits'];
+	   } else {
+		   // Default value drivers.
+		   $drivers = [
+			   __( 'Automated cash management processes', 'rtbcb' ),
+			   __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
+			   __( 'Reduced operational risk and errors', 'rtbcb' ),
+			   __( 'Improved regulatory compliance', 'rtbcb' ),
+		   ];
+	   }
 
-       return array_slice( $drivers, 0, 4 );
+	   return array_slice( $drivers, 0, 4 );
    }
 
    /**
-    * Format ROI scenarios for template.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
+	* Format ROI scenarios for template.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
    private function format_roi_scenarios( $data ) {
-       // Try to get ROI data from various possible locations.
-       if ( ! empty( $data['scenarios'] ) ) {
-           return $data['scenarios'];
-       }
+	   // Try to get ROI data from various possible locations.
+	   if ( ! empty( $data['scenarios'] ) ) {
+		   return $data['scenarios'];
+	   }
 
-       if ( ! empty( $data['roi_scenarios'] ) ) {
-           return $data['roi_scenarios'];
-       }
+	   if ( ! empty( $data['roi_scenarios'] ) ) {
+		   return $data['roi_scenarios'];
+	   }
 
-       // Fallback to default structure.
-       return [
-           'conservative' => [
-               'total_annual_benefit' => $data['roi_low'] ?? 0,
-               'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
-           ],
-           'base' => [
-               'total_annual_benefit' => $data['roi_base'] ?? 0,
-               'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
-           ],
-           'optimistic' => [
-               'total_annual_benefit' => $data['roi_high'] ?? 0,
-               'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
-           ],
-       ];
+	   // Fallback to default structure.
+	   return [
+		   'conservative' => [
+			   'total_annual_benefit' => $data['roi_low'] ?? 0,
+			   'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
+			   'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
+			   'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
+		   ],
+		   'base' => [
+			   'total_annual_benefit' => $data['roi_base'] ?? 0,
+			   'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
+			   'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
+			   'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
+		   ],
+		   'optimistic' => [
+			   'total_annual_benefit' => $data['roi_high'] ?? 0,
+			   'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
+			   'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
+			   'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
+		   ],
+	   ];
    }
 
    /**
-    * Determine business case strength based on ROI.
-    *
-    * @param array $data Business case data.
-    *
-    * @return string
-    */
+	* Determine business case strength based on ROI.
+	*
+	* @param array $data Business case data.
+	*
+	* @return string
+	*/
    private function determine_business_case_strength( $data ) {
-       $base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
+	   $base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
 
-       if ( $base_roi > 500000 ) {
-           return 'Compelling';
-       } elseif ( $base_roi > 200000 ) {
-           return 'Strong';
-       } elseif ( $base_roi > 50000 ) {
-           return 'Moderate';
-       } else {
-           return 'Developing';
-       }
+	   if ( $base_roi > 500000 ) {
+		   return 'Compelling';
+	   } elseif ( $base_roi > 200000 ) {
+		   return 'Strong';
+	   } elseif ( $base_roi > 50000 ) {
+		   return 'Moderate';
+	   } else {
+		   return 'Developing';
+	   }
    }
 
    /**
-    * Extract action steps from business case data.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
+	* Extract action steps from business case data.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
    private function extract_immediate_steps( $data ) {
-       if ( ! empty( $data['next_actions'] ) ) {
-           $all_actions = (array) $data['next_actions'];
-           return array_slice( $all_actions, 0, 3 );
-       }
+	   if ( ! empty( $data['next_actions'] ) ) {
+		   $all_actions = (array) $data['next_actions'];
+		   return array_slice( $all_actions, 0, 3 );
+	   }
 
-       return [
-           __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
-           __( 'Form project steering committee', 'rtbcb' ),
-           __( 'Conduct detailed requirements gathering', 'rtbcb' ),
-       ];
+	   return [
+		   __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
+		   __( 'Form project steering committee', 'rtbcb' ),
+		   __( 'Conduct detailed requirements gathering', 'rtbcb' ),
+	   ];
    }
 
    /**
-    * Extract short term action steps.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
+	* Extract short term action steps.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
    private function extract_short_term_steps( $data ) {
-       if ( ! empty( $data['implementation_steps'] ) ) {
-           $steps = (array) $data['implementation_steps'];
-           return array_slice( $steps, 0, 4 );
-       }
+	   if ( ! empty( $data['implementation_steps'] ) ) {
+		   $steps = (array) $data['implementation_steps'];
+		   return array_slice( $steps, 0, 4 );
+	   }
 
-       return [
-           __( 'Issue RFP to qualified vendors', 'rtbcb' ),
-           __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
-           __( 'Negotiate contracts and terms', 'rtbcb' ),
-           __( 'Begin system implementation planning', 'rtbcb' ),
-       ];
+	   return [
+		   __( 'Issue RFP to qualified vendors', 'rtbcb' ),
+		   __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
+		   __( 'Negotiate contracts and terms', 'rtbcb' ),
+		   __( 'Begin system implementation planning', 'rtbcb' ),
+	   ];
    }
 
    /**
-    * Extract long term action steps.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
+	* Extract long term action steps.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
    private function extract_long_term_steps( $data ) {
-       return [
-           __( 'Complete system implementation and testing', 'rtbcb' ),
-           __( 'Conduct user training and change management', 'rtbcb' ),
-           __( 'Measure and optimize system performance', 'rtbcb' ),
-           __( 'Expand functionality and integration capabilities', 'rtbcb' ),
-       ];
+	   return [
+		   __( 'Complete system implementation and testing', 'rtbcb' ),
+		   __( 'Conduct user training and change management', 'rtbcb' ),
+		   __( 'Measure and optimize system performance', 'rtbcb' ),
+		   __( 'Expand functionality and integration capabilities', 'rtbcb' ),
+	   ];
    }
 }
 

--- a/tests/edge-cases.test.php
+++ b/tests/edge-cases.test.php
@@ -95,8 +95,19 @@ return rtrim( $string, '/\\' ) . '/';
 // Stub plugin classes.
 if ( ! class_exists( 'RTBCB_Calculator' ) ) {
 class RTBCB_Calculator {
-public static function calculate_roi( $data ) {
+public static function calculate_roi( $data, $category = [] ) {
 return [ 'roi_base' => 1000 ];
+}
+public static function calculate_category_refined_roi( $inputs, $category_output ) {
+return self::calculate_roi( $inputs, $category_output['category_info'] ?? [] );
+}
+}
+}
+
+if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
+class RTBCB_Category_Recommender {
+public static function recommend_category( $inputs ) {
+return [ 'recommended' => 'cash_tools', 'category_info' => [] ];
 }
 }
 }


### PR DESCRIPTION
## Summary
- allow optional category data in `calculate_roi` and add `calculate_category_refined_roi`
- run category recommendation and ROI refinement in workflow step two
- document updated category refinement step in workflow docs

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3904d4d90833181b42e99b7606543