### PR TITLE
Track intermediate background job results

### DIFF
--- a/tests/job-status.test.php
+++ b/tests/job-status.test.php
@@ -97,8 +97,9 @@ assert_same( 50.0, $data['data']['percent'], 'Percent mismatch' );
 
 $_GET['job_id'] = 'job2';
 RTBCB_Background_Job::$data['job2'] = [
-    'status' => 'completed',
-    'result' => [ 'report_data' => [ 'foo' => 'bar' ], 'lead_id' => 5 ],
+    'status'      => 'completed',
+    'report_data' => [ 'foo' => 'bar' ],
+    'lead_id'     => 5,
 ];
 try {
     RTBCB_Ajax::get_job_status();


### PR DESCRIPTION
## Summary
- Accumulate partial pipeline outputs in background job transient via new `update_status` helper
- Report step-specific data like ROI and category from `process_comprehensive_case`
- Flatten stored results in `get_status` and `get_job_status` responses

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4 bash tests/run-tests.sh` *(phpunit missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b390e2ed5c8331a57547dcd900f0df