### PR TITLE
Implement analysis tiers and version-aware templates

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -117,7 +117,7 @@ class RTBCB_Ajax {
 				'report_data'   => $structured_report_data,
 				'workflow_info' => $debug_info,
 				'lead_id'       => $lead_id,
-				'analysis_type' => 'enhanced_comprehensive',
+                               'analysis_type' => rtbcb_get_analysis_type(),
 			];
 		} catch ( Exception $e ) {
 			$workflow_tracker->add_error( 'exception', $e->getMessage() );
@@ -241,7 +241,7 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 			'metadata' => [
 				'company_name'   => $user_inputs['company_name'],
 				'analysis_date'  => current_time( 'Y-m-d' ),
-				'analysis_type'  => 'comprehensive_enhanced',
+                               'analysis_type'  => rtbcb_get_analysis_type(),
 				'confidence_level' => $final_analysis['confidence_level'] ?? 0.85,
 				'processing_time' => microtime( true ) - $request_start,
 			],

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -427,7 +427,7 @@ USER,
             'references'     => array_map( 'esc_url_raw', array_filter( (array) $json['references'] ) ),
             'metrics'        => $metrics,
             'generated_at'   => current_time( 'Y-m-d H:i:s' ),
-            'analysis_type'  => 'comprehensive_company_overview',
+            'analysis_type'  => rtbcb_get_analysis_type() . '_company_overview',
         ];
     }
 

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -332,6 +332,7 @@ class RTBCB_Router {
            'metadata'           => [
                'company_name'     => $company_name,
                'analysis_date'    => current_time( 'Y-m-d' ),
+               'analysis_type'    => rtbcb_get_analysis_type(),
                'confidence_level' => floatval( $business_case_data['confidence'] ),
                'processing_time'  => intval( $business_case_data['processing_time'] ),
            ],

--- a/inc/config.php
+++ b/inc/config.php
@@ -1,6 +1,10 @@
 <?php
 defined( 'ABSPATH' ) || exit;
 
+if ( ! defined( 'RTBCB_ALLOWED_TIERS' ) ) {
+	define( 'RTBCB_ALLOWED_TIERS', [ 'basic', 'enhanced', 'premium' ] );
+}
+
 /**
  * Configuration defaults for Real Treasury Business Case Builder.
  *

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -31,6 +31,34 @@ function rtbcb_get_api_timeout() {
 require_once __DIR__ . '/config.php';
 
 /**
+ * Determine the current analysis tier.
+ *
+ * Uses plugin settings to detect enabled features and maps them to one of
+ * the allowed tiers. The value can be filtered via `rtbcb_analysis_type`.
+ *
+ * @return string Analysis type.
+ */
+function rtbcb_get_analysis_type() {
+	$analysis_type = 'basic';
+
+	$enable_ai = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_setting( 'enable_ai_analysis', true ) : true;
+
+	if ( $enable_ai ) {
+		$analysis_type = 'enhanced';
+	}
+
+	if ( function_exists( 'apply_filters' ) ) {
+		$analysis_type = apply_filters( 'rtbcb_analysis_type', $analysis_type );
+	}
+
+	if ( ! in_array( $analysis_type, RTBCB_ALLOWED_TIERS, true ) ) {
+		$analysis_type = 'basic';
+	}
+
+	return $analysis_type;
+}
+
+/**
  * Retrieve the OpenAI API key from plugin settings.
  *
  * Reads the value stored in the WordPress options table.

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -826,7 +826,7 @@ return $use_comprehensive;
 					'report_html'            => $report_html,
 					'lead_id'                => $lead_id,
 					'company_name'           => $user_inputs['company_name'],
-					'analysis_type'          => 'comprehensive_enhanced',
+                                        'analysis_type'          => rtbcb_get_analysis_type(),
 					'memory_info'            => rtbcb_get_memory_status(),
 				];
 
@@ -1705,7 +1705,7 @@ return $use_comprehensive;
                 'report_html'            => $report_html,
                 'lead_id'                => $lead_id,
                 'company_name'           => $user_inputs['company_name'],
-                'analysis_type'          => 'comprehensive',
+                'analysis_type'          => rtbcb_get_analysis_type(),
                 'api_used'               => ! empty( get_option( 'rtbcb_openai_api_key' ) ),
                 'fallback_used'          => isset( $comprehensive_analysis['enhanced_fallback'] ),
                 'memory_info'            => rtbcb_get_memory_status(),
@@ -1928,6 +1928,7 @@ return $use_comprehensive;
            'metadata'           => [
                'company_name'     => $company_name,
                'analysis_date'    => current_time( 'Y-m-d' ),
+               'analysis_type'    => rtbcb_get_analysis_type(),
                'confidence_level' => floatval( $business_case_data['confidence'] ),
                'processing_time'  => intval( $business_case_data['processing_time'] ),
            ],
@@ -1991,6 +1992,7 @@ return $use_comprehensive;
            'metadata'           => [
                'company_name'     => '',
                'analysis_date'    => '',
+               'analysis_type'    => '',
                'confidence_level' => 0,
                'processing_time'  => 0,
            ],

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -28,6 +28,7 @@ $rag_context          = $report_data['rag_context'] ?? [];
 
 $company_name    = $metadata['company_name'] ?? __( 'Your Company', 'rtbcb' );
 $analysis_date   = $metadata['analysis_date'] ?? current_time( 'Y-m-d' );
+$analysis_type   = $metadata['analysis_type'] ?? 'basic';
 $confidence_level = round( ( $metadata['confidence_level'] ?? 0.85 ) * 100 );
 $processing_time = $metadata['processing_time'] ?? 0;
 ?>
@@ -63,12 +64,17 @@ $processing_time = $metadata['processing_time'] ?? 0;
 						<span class="rtbcb-meta-label"><?php echo esc_html__( 'Processing Time', 'rtbcb' ); ?></span>
 						<span class="rtbcb-meta-value"><?php echo esc_html( round( $processing_time, 1 ) ); ?>s</span>
 					</div>
-					<div class="rtbcb-meta-item">
-						<span class="rtbcb-meta-icon">📊</span>
-						<span class="rtbcb-meta-label"><?php echo esc_html__( 'Analysis Type', 'rtbcb' ); ?></span>
-						<span class="rtbcb-meta-value"><?php echo esc_html__( 'Comprehensive Enhanced', 'rtbcb' ); ?></span>
-					</div>
-				</div>
+	                                    <div class="rtbcb-meta-item">
+	                                            <span class="rtbcb-meta-icon">📊</span>
+	                                            <span class="rtbcb-meta-label"><?php echo esc_html__( 'Analysis Type', 'rtbcb' ); ?></span>
+	                                            <span class="rtbcb-meta-value"><?php echo esc_html( ucfirst( $analysis_type ) ); ?></span>
+	                                    </div>
+	                                    <div class="rtbcb-meta-item">
+	                                            <span class="rtbcb-meta-icon">🏷️</span>
+	                                            <span class="rtbcb-meta-label"><?php echo esc_html__( 'Version', 'rtbcb' ); ?></span>
+                                                <span class="rtbcb-meta-value"><?php echo esc_html( defined( 'RTBCB_VERSION' ) ? RTBCB_VERSION : 'dev' ); ?></span>
+                                        </div>
+                                </div>
 			</div>
 
 			<!-- Key Metrics Dashboard -->
@@ -400,8 +406,8 @@ $processing_time = $metadata['processing_time'] ?? 0;
 <?php endif; ?>
 
 	<!-- Supporting Context Section -->
-	<?php if ( ! empty( $rag_context ) ) : ?>
-	<div class="rtbcb-section-enhanced rtbcb-supporting-context">
+	    <?php if ( 'basic' !== $analysis_type && ! empty( $rag_context ) ) : ?>
+	    <div class="rtbcb-section-enhanced rtbcb-supporting-context">
 		<div class="rtbcb-section-header-enhanced">
 			<h2 class="rtbcb-section-title">
 				<span class="rtbcb-section-icon">📚</span>

--- a/templates/report-template.php
+++ b/templates/report-template.php
@@ -8,79 +8,84 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
-$rag_context = $business_case_data['rag_context'] ?? [];
+$metadata      = $business_case_data['metadata'] ?? [];
+$analysis_type = $metadata['analysis_type'] ?? 'basic';
+$rag_context   = $business_case_data['rag_context'] ?? [];
 ?>
 <div class="rtbcb-report">
-    <h2><?php echo esc_html__( 'Business Case Report', 'rtbcb' ); ?></h2>
-    <?php if ( ! empty( $business_case_data['narrative'] ) ) : ?>
-        <p><?php echo esc_html( $business_case_data['narrative'] ); ?></p>
-    <?php endif; ?>
+	<h2><?php echo esc_html__( 'Business Case Report', 'rtbcb' ); ?></h2>
+	<p class="rtbcb-version-tag"><?php printf( esc_html__( 'Version %s', 'rtbcb' ), esc_html( defined( 'RTBCB_VERSION' ) ? RTBCB_VERSION : 'dev' ) ); ?></p>
+	<?php if ( ! empty( $business_case_data['narrative'] ) ) : ?>
+	    <p><?php echo esc_html( $business_case_data['narrative'] ); ?></p>
+	<?php endif; ?>
 
-    <?php if ( ! empty( $business_case_data['risks'] ) ) : ?>
-        <h3><?php echo esc_html__( 'Risks', 'rtbcb' ); ?></h3>
-        <ul>
-            <?php foreach ( (array) $business_case_data['risks'] as $risk ) : ?>
-                <li><?php echo esc_html( $risk ); ?></li>
-            <?php endforeach; ?>
-        </ul>
-    <?php endif; ?>
+	<?php if ( ! empty( $business_case_data['risks'] ) ) : ?>
+	    <h3><?php echo esc_html__( 'Risks', 'rtbcb' ); ?></h3>
+	    <ul>
+	        <?php foreach ( (array) $business_case_data['risks'] as $risk ) : ?>
+	            <li><?php echo esc_html( $risk ); ?></li>
+	        <?php endforeach; ?>
+	    </ul>
+	<?php endif; ?>
 
-    <?php if ( ! empty( $business_case_data['assumptions_explained'] ) ) : ?>
-        <h3><?php echo esc_html__( 'Assumptions', 'rtbcb' ); ?></h3>
-        <ul>
-            <?php foreach ( (array) $business_case_data['assumptions_explained'] as $assumption ) : ?>
-                <li><?php echo esc_html( $assumption ); ?></li>
-            <?php endforeach; ?>
-        </ul>
-    <?php endif; ?>
+	<?php if ( ! empty( $business_case_data['assumptions_explained'] ) ) : ?>
+	    <h3><?php echo esc_html__( 'Assumptions', 'rtbcb' ); ?></h3>
+	    <ul>
+	        <?php foreach ( (array) $business_case_data['assumptions_explained'] as $assumption ) : ?>
+	            <li><?php echo esc_html( $assumption ); ?></li>
+	        <?php endforeach; ?>
+	    </ul>
+	<?php endif; ?>
 
-    <?php if ( ! empty( $business_case_data['citations'] ) ) : ?>
-        <h3><?php echo esc_html__( 'Citations', 'rtbcb' ); ?></h3>
-        <ol>
-            <?php foreach ( (array) $business_case_data['citations'] as $citation ) : ?>
-                <li>
-                    <?php
-                    if ( is_array( $citation ) && ! empty( $citation['url'] ) ) {
-                        $url  = esc_url( $citation['url'] );
-                        $text = ! empty( $citation['text'] ) ? esc_html( $citation['text'] ) : $url;
-                        echo '<a href="' . $url . '">' . $text . '</a>';
-                    } else {
-                        echo esc_html( is_array( $citation ) ? wp_json_encode( $citation ) : $citation );
-                    }
-                    ?>
-                </li>
-            <?php endforeach; ?>
-        </ol>
-    <?php endif; ?>
+	<?php if ( ! empty( $business_case_data['citations'] ) ) : ?>
+	    <h3><?php echo esc_html__( 'Citations', 'rtbcb' ); ?></h3>
+	    <ol>
+	        <?php foreach ( (array) $business_case_data['citations'] as $citation ) : ?>
+	            <li>
+	                <?php
+	                if ( is_array( $citation ) && ! empty( $citation['url'] ) ) {
+	                    $url  = esc_url( $citation['url'] );
+	                    $text = ! empty( $citation['text'] ) ? esc_html( $citation['text'] ) : $url;
+	                    echo '<a href="' . $url . '">' . $text . '</a>';
+	                } else {
+	                    echo esc_html( is_array( $citation ) ? wp_json_encode( $citation ) : $citation );
+	                }
+	                ?>
+	            </li>
+	        <?php endforeach; ?>
+	    </ol>
+	<?php endif; ?>
 
-    <?php if ( ! empty( $business_case_data['next_actions'] ) ) : ?>
-        <h3><?php echo esc_html__( 'Next Actions', 'rtbcb' ); ?></h3>
-        <ul>
-            <?php foreach ( (array) $business_case_data['next_actions'] as $action ) : ?>
-                <li><?php echo esc_html( $action ); ?></li>
-            <?php endforeach; ?>
-        </ul>
-    <?php endif; ?>
+	<?php if ( ! empty( $business_case_data['next_actions'] ) ) : ?>
+	    <h3><?php echo esc_html__( 'Next Actions', 'rtbcb' ); ?></h3>
+	    <ul>
+	        <?php foreach ( (array) $business_case_data['next_actions'] as $action ) : ?>
+	            <li><?php echo esc_html( $action ); ?></li>
+	        <?php endforeach; ?>
+	    </ul>
+	<?php endif; ?>
 
-    <?php if ( isset( $business_case_data['confidence'] ) ) : ?>
-        <p><?php printf( esc_html__( 'Confidence: %s%%', 'rtbcb' ), esc_html( round( (float) $business_case_data['confidence'] * 100 ) ) ); ?></p>
-    <?php endif; ?>
+	<?php if ( isset( $business_case_data['confidence'] ) ) : ?>
+	    <p><?php printf( esc_html__( 'Confidence: %s%%', 'rtbcb' ), esc_html( round( (float) $business_case_data['confidence'] * 100 ) ) ); ?></p>
+	<?php endif; ?>
 
-    <?php if ( ! empty( $business_case_data['recommended_category'] ) ) : ?>
-        <p><?php echo esc_html__( 'Recommended Category:', 'rtbcb' ) . ' ' . esc_html( $business_case_data['recommended_category'] ); ?></p>
-    <?php endif; ?>
+	<?php if ( ! empty( $business_case_data['recommended_category'] ) ) : ?>
+	    <p><?php echo esc_html__( 'Recommended Category:', 'rtbcb' ) . ' ' . esc_html( $business_case_data['recommended_category'] ); ?></p>
+	<?php endif; ?>
 
-	<h3><?php echo esc_html__( 'Context', 'rtbcb' ); ?></h3>
-	<?php if ( ! empty( $rag_context ) ) : ?>
-		<ul>
-			<?php foreach ( (array) $rag_context as $context_item ) : ?>
-				<li><?php echo esc_html( $context_item ); ?></li>
-			<?php endforeach; ?>
-		</ul>
-	<?php else : ?>
-		<p><?php echo esc_html__( 'No additional context available.', 'rtbcb' ); ?></p>
+	<?php if ( 'basic' !== $analysis_type ) : ?>
+	    <h3><?php echo esc_html__( 'Context', 'rtbcb' ); ?></h3>
+	    <?php if ( ! empty( $rag_context ) ) : ?>
+	            <ul>
+	                    <?php foreach ( (array) $rag_context as $context_item ) : ?>
+	                            <li><?php echo esc_html( $context_item ); ?></li>
+	                    <?php endforeach; ?>
+	            </ul>
+	    <?php else : ?>
+	            <p><?php echo esc_html__( 'No additional context available.', 'rtbcb' ); ?></p>
+	    <?php endif; ?>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
## Summary
- define allowed analysis tiers and helper to determine active tier
- include analysis type in report metadata
- display plugin version and conditionally render context sections in report templates

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3919c50d08331aa244bbb61875b52