### PR TITLE
Align leads table schema with indexed upgrade

### DIFF
--- a/inc/class-rtbcb-db.php
+++ b/inc/class-rtbcb-db.php
@@ -14,7 +14,7 @@ class RTBCB_DB {
     /**
      * Current database version.
      */
-    const DB_VERSION = '2.0.1';
+    const DB_VERSION = '2.0.2';
 
     /**
      * Initialize database and handle upgrades.
@@ -22,8 +22,6 @@ class RTBCB_DB {
      * @return void
      */
     public static function init() {
-        self::create_tables();
-
         $current = get_option( 'rtbcb_db_version', '1.0.0' );
 
         if ( version_compare( $current, self::DB_VERSION, '<' ) ) {
@@ -56,39 +54,18 @@ class RTBCB_DB {
 	// Ensure RAG index table is present during upgrades.
 	self::create_rag_table();
 
-	if ( version_compare( $from_version, '2.0.1', '<' ) ) {
-		self::add_embedding_norm_index();
-	}
+        if ( version_compare( $from_version, '2.0.1', '<' ) ) {
+                self::add_embedding_norm_index();
+        }
+
+		if ( version_compare( $from_version, '2.0.2', '<' ) ) {
+			RTBCB_Leads::add_missing_indexes();
+}
 
 	// Future migrations can be handled here.
 
         // Log the upgrade.
         error_log( 'RTBCB: Database upgraded from version ' . $from_version . ' to ' . self::DB_VERSION );
-    }
-
-    /**
-     * Create required database tables.
-     *
-     * @return void
-     */
-    private static function create_tables() {
-        global $wpdb;
-
-        $charset_collate = $wpdb->get_charset_collate();
-
-        // Create leads table.
-        $table_name = $wpdb->prefix . 'rtbcb_leads';
-        $sql        = "CREATE TABLE {$table_name} (
-            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-            email varchar(255) NOT NULL,
-            company_size varchar(50),
-            industry varchar(100),
-            created_at datetime DEFAULT CURRENT_TIMESTAMP,
-            PRIMARY KEY (id)
-        ) {$charset_collate};";
-
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        dbDelta( $sql );
     }
 
     /**

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -152,6 +152,34 @@ class RTBCB_Leads {
             } );
         }
     }
+	/**
+	 * Add missing indexes to the leads table.
+	 *
+	 * Ensures unique and secondary indexes exist for commonly queried fields.
+	 *
+	 * @return void
+	 */
+	public static function add_missing_indexes() {
+		global $wpdb;
+
+		self::$table_name = $wpdb->prefix . 'rtbcb_leads';
+
+		$indexes     = $wpdb->get_results( 'SHOW INDEX FROM ' . self::$table_name, ARRAY_A );
+		$index_names = wp_list_pluck( $indexes, 'Key_name' );
+
+		if ( ! in_array( 'email_unique', $index_names, true ) ) {
+			$wpdb->query( 'ALTER TABLE ' . self::$table_name . ' ADD UNIQUE KEY email_unique (email)' );
+		}
+
+		if ( ! in_array( 'created_at_index', $index_names, true ) ) {
+			$wpdb->query( 'ALTER TABLE ' . self::$table_name . ' ADD KEY created_at_index (created_at)' );
+		}
+
+		if ( ! in_array( 'recommended_category_index', $index_names, true ) ) {
+			$wpdb->query( 'ALTER TABLE ' . self::$table_name . ' ADD KEY recommended_category_index (recommended_category)' );
+		}
+	}
+
 
     /**
      * Save a lead to the database.


### PR DESCRIPTION
## Summary
- Delegate lead table creation to `RTBCB_Leads` and bump DB version
- Add upgrade step ensuring lead indexes exist
- Implement `add_missing_indexes` to enforce unique and secondary indexes

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh >/tmp/unit.log && tail -n 20 /tmp/unit.log` *(phpunit missing; JS tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68b393499104833191c3da448928067d