### PR TITLE
Cache company profile research

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -941,10 +941,12 @@ USER,
 	$industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
 	$company_size = sanitize_text_field( $user_inputs['company_size'] ?? '' );
 
-	$company_profile = rtbcb_get_research_cache( $company_name, $industry, 'company_profile' );
+	$size_key        = sanitize_title( $company_size );
+	$cache_segment   = 'company_profile_' . $size_key;
+	$company_profile = rtbcb_get_research_cache( $company_name, $industry, $cache_segment );
 	if ( false === $company_profile ) {
 		$company_profile = $this->build_company_profile( $company_name, $industry, $company_size );
-		rtbcb_set_research_cache( $company_name, $industry, 'company_profile', $company_profile );
+		rtbcb_set_research_cache( $company_name, $industry, $cache_segment, $company_profile );
 	}
 
 	$research = [

--- a/tests/company-profile-cache.test.php
+++ b/tests/company-profile-cache.test.php
@@ -92,18 +92,27 @@ if ( ! is_array( $result['company_profile'] ) ) {
 	exit( 1 );
 }
 
-$cached = rtbcb_get_research_cache( 'Cache Co', 'finance', 'company_profile' );
+$size_key = sanitize_title( $inputs['company_size'] );
+$cached = rtbcb_get_research_cache( 'Cache Co', 'finance', 'company_profile_' . $size_key );
 if ( false === $cached ) {
 	echo "Profile not cached\n";
 	exit( 1 );
 }
 
 $custom = [ 'stage' => 'cached', 'characteristics' => '', 'treasury_focus' => '', 'typical_challenges' => '' ];
-rtbcb_set_research_cache( 'Cache Co', 'finance', 'company_profile', $custom );
+rtbcb_set_research_cache( 'Cache Co', 'finance', 'company_profile_' . $size_key, $custom );
 
 $result2 = $method->invoke( $llm, $inputs );
 if ( 'cached' !== ( $result2['company_profile']['stage'] ?? '' ) ) {
 	echo "Cache not used\n";
+	exit( 1 );
+}
+
+$inputs2 = $inputs;
+$inputs2['company_size'] = '$500M-$1B';
+$result3 = $method->invoke( $llm, $inputs2 );
+if ( 'cached' === ( $result3['company_profile']['stage'] ?? '' ) ) {
+	echo "Cache used across sizes\n";
 	exit( 1 );
 }
 


### PR DESCRIPTION
## Summary
- include company size in company profile cache key to avoid cross-size reuse
- extend tests to cover company size specific caching

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b394f596748331ab4737ab3342be45