### PR TITLE
Compress report HTML in lead storage

### DIFF
--- a/inc/class-rtbcb-db.php
+++ b/inc/class-rtbcb-db.php
@@ -14,7 +14,7 @@ class RTBCB_DB {
     /**
      * Current database version.
      */
-    const DB_VERSION = '2.0.1';
+    const DB_VERSION = '2.0.2';
 
     /**
      * Initialize database and handle upgrades.
@@ -56,11 +56,15 @@ class RTBCB_DB {
 	// Ensure RAG index table is present during upgrades.
 	self::create_rag_table();
 
-	if ( version_compare( $from_version, '2.0.1', '<' ) ) {
-		self::add_embedding_norm_index();
-	}
+        if ( version_compare( $from_version, '2.0.1', '<' ) ) {
+                self::add_embedding_norm_index();
+        }
 
-	// Future migrations can be handled here.
+        if ( version_compare( $from_version, '2.0.2', '<' ) ) {
+                RTBCB_Leads::convert_report_html_to_compressed();
+        }
+
+        // Future migrations can be handled here.
 
         // Log the upgrade.
         error_log( 'RTBCB: Database upgraded from version ' . $from_version . ' to ' . self::DB_VERSION );

--- a/tests/lead-storage.test.php
+++ b/tests/lead-storage.test.php
@@ -200,6 +200,7 @@ $lead_data = [
 'roi_low'       => 1000,
 'roi_base'      => 2000,
 'roi_high'      => 3000,
+ 'report_html'  => '<div>Report</div>',
 ];
 
 $lead_id = RTBCB_Leads::save_lead( $lead_data );
@@ -219,8 +220,19 @@ echo "Pain points mismatch\n";
 exit( 1 );
 }
 
+if ( '<div>Report</div>' !== ( $retrieved['report_html'] ?? '' ) ) {
+echo "Report HTML mismatch\n";
+exit( 1 );
+}
+
 if ( 1000.0 !== (float) ( $retrieved['roi_low'] ?? 0 ) || 2000.0 !== (float) ( $retrieved['roi_base'] ?? 0 ) || 3000.0 !== (float) ( $retrieved['roi_high'] ?? 0 ) ) {
 echo "ROI mismatch\n";
+exit( 1 );
+}
+
+$raw = $wpdb->get_row( "SELECT report_html FROM rtbcb_leads WHERE id = $lead_id", ARRAY_A );
+if ( '<div>Report</div>' !== gzuncompress( $raw['report_html'] ) ) {
+echo "Compression check failed\n";
 exit( 1 );
 }
 


### PR DESCRIPTION
## Summary
- compress `report_html` before storing leads
- uncompress `report_html` when fetching leads or exporting CSV
- upgrade database and tests to handle compressed `report_html`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=dummy bash tests/run-tests.sh >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b3964b0a408331a883bc9ed2a41986