### PR TITLE
Cache and schedule lead metrics refresh

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -304,7 +304,7 @@ class RTBCB_Admin {
      * @return void
     */
     public function render_dashboard() {
-        $stats = RTBCB_Leads::get_statistics();
+        $stats = RTBCB_Leads::get_cached_statistics();
         $recent_leads_data = RTBCB_Leads::get_all_leads( [ 'per_page' => 5, 'orderby' => 'created_at', 'order' => 'DESC' ] );
 
         include RTBCB_DIR . 'admin/dashboard-page.php';
@@ -368,7 +368,7 @@ class RTBCB_Admin {
      * @return void
      */
     public function render_analytics() {
-        $stats = RTBCB_Leads::get_statistics();
+        $stats = RTBCB_Leads::get_cached_statistics();
         $monthly_trends = $this->get_monthly_trends();
         
         include RTBCB_DIR . 'admin/analytics-page.php';

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -19,6 +19,13 @@ class RTBCB_Leads {
     private static $table_name;
 
     /**
+     * Option name for cached statistics.
+     *
+     * @var string
+     */
+    private static $cache_option = 'rtbcb_lead_stats';
+
+    /**
      * Create the leads table with improved error handling.
      *
      * @return bool True on success, false on failure.
@@ -233,6 +240,7 @@ class RTBCB_Leads {
                     return false;
                 }
 
+                self::update_cached_statistics();
                 return intval( $existing_lead['id'] );
             } else {
                 // Insert new lead
@@ -247,7 +255,9 @@ class RTBCB_Leads {
                     return false;
                 }
 
-                return $wpdb->insert_id;
+                $lead_id = $wpdb->insert_id;
+                self::update_cached_statistics();
+                return $lead_id;
             }
         } catch ( Exception $e ) {
             error_log( 'RTBCB: Exception in save_lead: ' . $e->getMessage() );
@@ -404,10 +414,34 @@ class RTBCB_Leads {
 
         // Recent activity (last 30 days)
         $stats['recent_leads'] = $wpdb->get_var(
-            "SELECT COUNT(*) FROM " . self::$table_name . " 
+            "SELECT COUNT(*) FROM " . self::$table_name . "
              WHERE created_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)"
         );
 
+        return $stats;
+    }
+
+    /**
+     * Update cached statistics option.
+     *
+     * @return array Cached statistics.
+     */
+    public static function update_cached_statistics() {
+        $stats = self::get_statistics();
+        update_option( self::$cache_option, $stats );
+        return $stats;
+    }
+
+    /**
+     * Retrieve cached statistics.
+     *
+     * @return array Cached statistics.
+     */
+    public static function get_cached_statistics() {
+        $stats = get_option( self::$cache_option, [] );
+        if ( empty( $stats ) ) {
+            $stats = self::update_cached_statistics();
+        }
         return $stats;
     }
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -293,6 +293,13 @@ wp_schedule_event( time(), 'hourly', 'rtbcb_cleanup_jobs' );
 }
 
 add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
+
+        // Schedule lead metrics refresh
+        if ( ! wp_next_scheduled( 'rtbcb_refresh_lead_metrics' ) ) {
+            wp_schedule_event( time(), 'hourly', 'rtbcb_refresh_lead_metrics' );
+        }
+
+        add_action( 'rtbcb_refresh_lead_metrics', [ 'RTBCB_Leads', 'update_cached_statistics' ] );
 }
 
     /**
@@ -2275,6 +2282,7 @@ return $use_comprehensive;
         // Clear scheduled events
         wp_clear_scheduled_hook( 'rtbcb_rebuild_rag_index' );
         wp_clear_scheduled_hook( 'rtbcb_cleanup_data' );
+        wp_clear_scheduled_hook( 'rtbcb_refresh_lead_metrics' );
 
         // Flush rewrite rules
         flush_rewrite_rules();
@@ -2476,7 +2484,7 @@ if ( ! function_exists( 'rtbcb_get_leads_count' ) ) {
      * @return int
      */
     function rtbcb_get_leads_count() {
-        $stats = RTBCB_Leads::get_statistics();
+        $stats = RTBCB_Leads::get_cached_statistics();
         return intval( $stats['total_leads'] ?? 0 );
     }
 }
@@ -2488,7 +2496,7 @@ if ( ! function_exists( 'rtbcb_get_average_roi' ) ) {
      * @return float
      */
     function rtbcb_get_average_roi() {
-        $stats = RTBCB_Leads::get_statistics();
+        $stats = RTBCB_Leads::get_cached_statistics();
         return floatval( $stats['average_roi']['avg_base'] ?? 0 );
     }
 }

--- a/tests/lead-storage.test.php
+++ b/tests/lead-storage.test.php
@@ -65,6 +65,16 @@ return $text;
 }
 }
 
+if ( ! function_exists( 'update_option' ) ) {
+function update_option( $option, $value ) {}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+function get_option( $option, $default = false ) {
+return $default;
+}
+}
+
 class WPDB_Memory {
     public $prefix = '';
     public $insert_id = 0;


### PR DESCRIPTION
## Summary
- cache aggregated lead metrics in a dedicated option
- refresh lead metrics on cron and after lead updates
- read cached metrics on dashboard and analytics pages

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3978b3ec48331afb65f44b4fd6848