### PR TITLE
Validate report data structure before rendering

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1805,10 +1805,12 @@ return $use_comprehensive;
             $report_data = $this->transform_data_for_template( $business_case_data );
 
             if ( is_wp_error( $report_data ) ) {
+                $error_data = $report_data->get_error_data();
                 rtbcb_log_error(
                     'Report data transformation failed',
                     [
-                        'error' => $report_data->get_error_message(),
+                        'error'        => $report_data->get_error_message(),
+                        'missing_keys' => $error_data['status']['missing_keys'] ?? [],
                     ]
                 );
 
@@ -2035,6 +2037,14 @@ return $use_comprehensive;
            'valid'        => empty( $missing_sections ),
            'missing_keys' => $missing_sections,
        ];
+
+       if ( ! empty( $missing_sections ) ) {
+           return new WP_Error(
+               'rtbcb_missing_report_sections',
+               __( 'Missing required report sections.', 'rtbcb' ),
+               $report_data
+           );
+       }
 
        return $report_data;
    }


### PR DESCRIPTION
## Summary
- Validate comprehensive report data against required sections and return `WP_Error` when any are missing
- Log validation failures in `get_comprehensive_report_html()` before rendering
- Update operational risks fallback test to expect validation errors

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4o-mini bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b39885ee0c83319ca71b25c01c9eec