### PR TITLE
Cache company profile research

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -723,12 +723,13 @@ USER,
 
         $company_name = sanitize_text_field( $user_inputs['company_name'] ?? '' );
         $industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
+        $company_size = sanitize_text_field( $user_inputs['company_size'] ?? '' );
 
-        $company_research = rtbcb_get_research_cache( $company_name, $industry, 'company' );
+        $company_research = rtbcb_get_research_cache( $company_name, $industry, 'company', $company_size );
         if ( false === $company_research ) {
             $company_research = $this->conduct_company_research( $user_inputs );
             if ( ! is_wp_error( $company_research ) ) {
-                rtbcb_set_research_cache( $company_name, $industry, 'company', $company_research );
+                rtbcb_set_research_cache( $company_name, $industry, 'company', $company_research, 0, $company_size );
             }
         }
 

--- a/tests/company-research-cache.test.php
+++ b/tests/company-research-cache.test.php
@@ -1,0 +1,101 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/../' );
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+        function sanitize_text_field( $text ) {
+                $text = is_scalar( $text ) ? (string) $text : '';
+                $text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
+                return trim( $text );
+        }
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+        function sanitize_title( $title ) {
+                $title = strtolower( $title );
+                $title = preg_replace( '/[^a-z0-9]+/', '-', $title );
+                return trim( $title, '-' );
+        }
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+        function sanitize_key( $key ) {
+                $key = strtolower( $key );
+                return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+        }
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+        function set_transient( $name, $value, $expiration ) {
+                global $transients;
+                $transients[ $name ] = $value;
+                return true;
+        }
+}
+
+if ( ! function_exists( 'get_transient' ) ) {
+        function get_transient( $name ) {
+                global $transients;
+                return $transients[ $name ] ?? false;
+        }
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+        function get_option( $name, $default = '' ) {
+                return $default;
+        }
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+        function apply_filters( $tag, $value ) {
+                return $value;
+        }
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+        function add_filter( $tag, $callback, $priority = 10, $accepted_args = 1 ) {}
+}
+
+if ( ! function_exists( '__' ) ) {
+        function __( $text, $domain = null ) {
+                return $text;
+        }
+}
+
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+        define( 'DAY_IN_SECONDS', 86400 );
+}
+
+require_once __DIR__ . '/../inc/helpers.php';
+
+$company = 'Cache Co';
+$industry = 'finance';
+$small = '$50M-$500M';
+$large = '>$2B';
+
+$small_data = [ 'stage' => 'small' ];
+rtbcb_set_research_cache( $company, $industry, 'company', $small_data, 0, $small );
+
+$cached_small = rtbcb_get_research_cache( $company, $industry, 'company', $small );
+if ( 'small' !== ( $cached_small['stage'] ?? '' ) ) {
+        echo "Small size not cached\n";
+        exit( 1 );
+}
+
+$cached_large = rtbcb_get_research_cache( $company, $industry, 'company', $large );
+if ( false !== $cached_large ) {
+        echo "Large size incorrectly reused small cache\n";
+        exit( 1 );
+}
+
+$large_data = [ 'stage' => 'large' ];
+rtbcb_set_research_cache( $company, $industry, 'company', $large_data, 0, $large );
+
+$cached_large = rtbcb_get_research_cache( $company, $industry, 'company', $large );
+if ( 'large' !== ( $cached_large['stage'] ?? '' ) ) {
+        echo "Large size not cached\n";
+        exit( 1 );
+}
+
+echo "company-research-cache.test.php passed\n";

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -116,6 +116,9 @@ php tests/project-growth-path.test.php
 echo "18b. Running company profile cache test..."
 php tests/company-profile-cache.test.php
 
+echo "18c. Running company research cache test..."
+php tests/company-research-cache.test.php
+
 echo "19. Running validator tests..."
 phpunit -c phpunit.xml
 


### PR DESCRIPTION
## Summary
- include company size in top-level company research cache key
- test separate caching per company size and wire into test runner

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found; JS tests show TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68b39a4f63408331bb1a428962be981c