### PR TITLE
Cache report templates and purge on lead updates

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -312,13 +312,13 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 		];
 	}
 
-	private static function save_lead_data_async( $user_inputs, $structured_report_data ) {
-		if ( class_exists( 'RTBCB_Leads' ) ) {
-			$lead_data = array_merge( $user_inputs, [ 'report_data' => $structured_report_data ] );
-			return RTBCB_Leads::save_lead( $lead_data );
-		}
-		return null;
-	}
+       private static function save_lead_data_async( $user_inputs, $structured_report_data ) {
+               if ( class_exists( 'RTBCB_Leads' ) ) {
+                       $lead_data = array_merge( $user_inputs, [ 'report_data' => $structured_report_data ] );
+                       return RTBCB_Leads::save_lead( $lead_data, $structured_report_data );
+               }
+               return null;
+       }
 
 	private static function calculate_business_case_strength( $roi_scenarios, $recommendation ) {
 		$base = $roi_scenarios['base']['total_annual_benefit'] ?? 0;

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -10,6 +10,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class RTBCB_Leads - Enhanced version with full tracking capabilities.
  */
+require_once __DIR__ . '/helpers.php';
 class RTBCB_Leads {
     /**
      * Database table name.
@@ -159,7 +160,7 @@ class RTBCB_Leads {
      * @param array $lead_data Lead information.
      * @return int|false Lead ID or false on failure.
      */
-    public static function save_lead( $lead_data ) {
+    public static function save_lead( $lead_data, $report_data = [] ) {
         global $wpdb;
 
         // Validate required fields
@@ -233,6 +234,10 @@ class RTBCB_Leads {
                     return false;
                 }
 
+                if ( ! empty( $report_data ) ) {
+                    rtbcb_purge_report_cache( $report_data );
+                }
+
                 return intval( $existing_lead['id'] );
             } else {
                 // Insert new lead
@@ -245,6 +250,10 @@ class RTBCB_Leads {
                 if ( false === $result ) {
                     error_log( 'RTBCB: Database insert failed: ' . $wpdb->last_error );
                     return false;
+                }
+
+                if ( ! empty( $report_data ) ) {
+                    rtbcb_purge_report_cache( $report_data );
                 }
 
                 return $wpdb->insert_id;

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1753,6 +1753,32 @@ function rtbcb_get_report_allowed_html() {
 }
 
 /**
+ * Purge cached report HTML for given data.
+ *
+ * @param array $data Report source data.
+ *
+ * @return void
+ */
+function rtbcb_purge_report_cache( $data ) {
+       if ( ! function_exists( 'wp_cache_delete' ) ) {
+               return;
+       }
+
+       $data      = is_array( $data ) ? $data : [];
+       $data_hash = md5( wp_json_encode( $data ) );
+
+       $templates = [
+               RTBCB_DIR . 'templates/report-template.php',
+               RTBCB_DIR . 'templates/comprehensive-report-template.php',
+       ];
+
+       foreach ( $templates as $template_path ) {
+               $cache_key = md5( $template_path . ':' . $data_hash );
+               wp_cache_delete( $cache_key, 'rtbcb_reports' );
+       }
+}
+
+/**
  * Increment the RAG search cache version to invalidate cached results.
  *
  * @return void

--- a/tests/edge-cases.test.php
+++ b/tests/edge-cases.test.php
@@ -123,7 +123,7 @@ return [];
 
 if ( ! class_exists( 'RTBCB_Leads' ) ) {
 class RTBCB_Leads {
-public function save_lead( $form_data, $business_case_data ) {
+public static function save_lead( $form_data, $business_case_data = [] ) {
 return 1;
 }
 }

--- a/tests/lead-storage.test.php
+++ b/tests/lead-storage.test.php
@@ -8,6 +8,8 @@ define( 'ABSPATH', $temp_root . '/' );
 
 defined( 'ABSPATH' ) || exit;
 
+require_once __DIR__ . '/../inc/helpers.php';
+
 if ( ! defined( 'DB_NAME' ) ) {
 define( 'DB_NAME', 'testdb' );
 }


### PR DESCRIPTION
## Summary
- Cache basic and comprehensive report HTML keyed by hashed input to skip redundant template rendering
- Add helper to purge cached report templates and invoke during lead saves

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit not found, JS submission errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b39b37f84c833185ae187bd3b35fa8