### PR TITLE
Generate and email reports after background job completion

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -175,14 +175,18 @@ class RTBCB_Ajax {
 			$result                  = $status['result'];
 			$response['report_data'] = $result['report_data'];
 			if ( is_array( $result ) ) {
-			       foreach ( $result as $key => $value ) {
-			               if ( 'report_data' === $key ) {
-			                       continue;
-			               }
-			               $response[ $key ] = $value;
-			       }
-			}
-		}
+                               foreach ( $result as $key => $value ) {
+                                       if ( 'report_data' === $key ) {
+                                               continue;
+                                       }
+                                       if ( 'download_url' === $key ) {
+                                               $response[ $key ] = esc_url_raw( $value );
+                                       } else {
+                                               $response[ $key ] = $value;
+                                       }
+                               }
+                       }
+               }
 
 		wp_send_json_success( $response );
        }

--- a/tests/background-job.test.php
+++ b/tests/background-job.test.php
@@ -106,6 +106,28 @@ if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', __DIR__ . '/' );
 }
 
+if ( ! class_exists( 'RTBCB_Router' ) ) {
+    class RTBCB_Router {
+        public function get_comprehensive_report_html( $result ) {
+            return '<html></html>';
+        }
+    }
+}
+
+if ( ! function_exists( 'rtbcb_generate_report_files' ) ) {
+    function rtbcb_generate_report_files( $html, $lead_id ) {
+        return [
+            'html_path' => '/tmp/report.html',
+            'pdf_path'  => '/tmp/report.pdf',
+            'pdf_url'   => 'http://example.com/report.pdf',
+        ];
+    }
+}
+
+if ( ! function_exists( 'rtbcb_send_report_email' ) ) {
+    function rtbcb_send_report_email( $form_data, $report_path ) {}
+}
+
 if ( ! class_exists( 'RTBCB_Ajax' ) ) {
     class RTBCB_Ajax {
         public static $mode = 'success';
@@ -144,6 +166,7 @@ $statuses = array_column( $transient_log[ $job_id ], 'status' );
 assert_true( $statuses === [ 'queued', 'processing', 'processing', 'processing', 'processing', 'processing', 'processing', 'completed' ], 'Status flow incorrect: ' . json_encode( $statuses ) );
 assert_true( $transient_log[ $job_id ][2]['step'] === 'ai_enrichment', 'First step missing' );
 assert_true( 'completed' === get_transient( $job_id )['status'], 'Job not completed' );
+assert_true( 'http://example.com/report.pdf' === get_transient( $job_id )['result']['download_url'], 'Download URL missing' );
 
 // Error job flow.
 RTBCB_Ajax::$mode = 'error';

--- a/tests/job-status.test.php
+++ b/tests/job-status.test.php
@@ -98,7 +98,7 @@ assert_same( 50.0, $data['data']['percent'], 'Percent mismatch' );
 $_GET['job_id'] = 'job2';
 RTBCB_Background_Job::$data['job2'] = [
     'status' => 'completed',
-    'result' => [ 'report_data' => [ 'foo' => 'bar' ], 'lead_id' => 5 ],
+    'result' => [ 'report_data' => [ 'foo' => 'bar' ], 'lead_id' => 5, 'download_url' => 'http://example.com/report.pdf' ],
 ];
 try {
     RTBCB_Ajax::get_job_status();
@@ -108,6 +108,7 @@ try {
 assert_same( 'completed', $data['data']['status'], 'Completed status mismatch' );
 assert_same( [ 'foo' => 'bar' ], $data['data']['report_data'], 'Report data missing' );
 assert_same( 5, $data['data']['lead_id'], 'Lead ID mismatch' );
+assert_same( 'http://example.com/report.pdf', $data['data']['download_url'], 'Download URL mismatch' );
 
 $_GET['job_id'] = 'missing';
 try {


### PR DESCRIPTION
## Summary
- create helper to generate report HTML and PDF files
- email report PDF and store download link when background job completes
- expose download link via job status API and add test coverage

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4 bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b39d0bd8908331be6494453deecab1