### PR TITLE
Add fast mode report template and routing

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -16,7 +16,7 @@ class RTBCB_Router {
     /**
      * Handle form submission and generate the business case.
      *
-     * @param string $report_type Optional report type (basic or comprehensive).
+     * @param string $report_type Optional report type (fast, basic or comprehensive).
      *
      * @return void
      */
@@ -50,7 +50,7 @@ class RTBCB_Router {
             // Perform ROI calculations.
             $calculations = RTBCB_Calculator::calculate_roi( $form_data );
 
-            $fast_mode = ! empty( $_POST['fast_mode'] ) || get_option( 'rtbcb_fast_mode', 0 );
+            $fast_mode = 'fast' === $report_type || ! empty( $_POST['fast_mode'] ) || get_option( 'rtbcb_fast_mode', 0 );
             if ( $fast_mode ) {
                 $report_html = $this->get_fast_report_html( $form_data, $calculations );
 

--- a/templates/fast-report-template.php
+++ b/templates/fast-report-template.php
@@ -12,13 +12,22 @@ $roi_low  = isset( $calculations['conservative']['roi_percentage'] ) ? floatval(
 $roi_base = isset( $calculations['base']['roi_percentage'] ) ? floatval( $calculations['base']['roi_percentage'] ) : 0;
 $roi_high = isset( $calculations['optimistic']['roi_percentage'] ) ? floatval( $calculations['optimistic']['roi_percentage'] ) : 0;
 ?>
-	<div class="rtbcb-fast-report">
-		<h2><?php echo esc_html( $company_name ); ?></h2>
-		<h3><?php esc_html_e( 'ROI Summary', 'rtbcb' ); ?></h3>
-		<ul>
-			<li><?php printf( esc_html__( 'Conservative ROI: %s%%', 'rtbcb' ), esc_html( number_format_i18n( $roi_low, 2 ) ) ); ?></li>
-			<li><?php printf( esc_html__( 'Base ROI: %s%%', 'rtbcb' ), esc_html( number_format_i18n( $roi_base, 2 ) ) ); ?></li>
-			<li><?php printf( esc_html__( 'Optimistic ROI: %s%%', 'rtbcb' ), esc_html( number_format_i18n( $roi_high, 2 ) ) ); ?></li>
-		</ul>
-	</div>
-
+<div class="rtbcb-fast-report">
+	<h2><?php echo esc_html( $company_name ); ?></h2>
+	<p>
+		<?php
+		printf(
+			esc_html__( 'Based on your inputs, the projected ROI for %1$s ranges from %2$s%% to %3$s%%.', 'rtbcb' ),
+			esc_html( $company_name ),
+			esc_html( number_format_i18n( $roi_low, 2 ) ),
+			esc_html( number_format_i18n( $roi_high, 2 ) )
+		);
+		?>
+	</p>
+	<h3><?php esc_html_e( 'ROI Summary', 'rtbcb' ); ?></h3>
+	<ul>
+		<li><?php printf( esc_html__( 'Conservative ROI: %s%%', 'rtbcb' ), esc_html( number_format_i18n( $roi_low, 2 ) ) ); ?></li>
+		<li><?php printf( esc_html__( 'Base ROI: %s%%', 'rtbcb' ), esc_html( number_format_i18n( $roi_base, 2 ) ) ); ?></li>
+		<li><?php printf( esc_html__( 'Optimistic ROI: %s%%', 'rtbcb' ), esc_html( number_format_i18n( $roi_high, 2 ) ) ); ?></li>
+	</ul>
+</div>


### PR DESCRIPTION
## Summary
- add fast-mode report template with brief narrative and ROI summary
- route Fast Mode requests to the new template when report_type is "fast"

## Testing
- `php -l templates/fast-report-template.php`
- `php -l inc/class-rtbcb-router.php`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*
- `phpcs --standard=WordPress inc/class-rtbcb-router.php templates/fast-report-template.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b39d5fe0f08331a12cc7cc3f3f4c00