### PR TITLE
Add heavy feature bypass toggle

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -19,6 +19,7 @@ class RTBCB_Admin {
         add_action( 'admin_init', [ $this, 'register_settings' ] );
         add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
         add_action( 'admin_notices', [ $this, 'maybe_show_timeout_notice' ] );
+        add_action( 'admin_notices', [ $this, 'maybe_show_heavy_features_notice' ] );
 
         // AJAX handlers
         add_action( 'wp_ajax_rtbcb_test_connection', [ $this, 'test_api_connection' ] );
@@ -497,7 +498,8 @@ class RTBCB_Admin {
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_timeout', [ 'sanitize_callback' => 'intval' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_max_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_max_output_tokens' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_min_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_min_output_tokens' ] );
-		register_setting( 'rtbcb_settings', 'rtbcb_fast_mode', [ 'sanitize_callback' => 'absint' ] );
+                register_setting( 'rtbcb_settings', 'rtbcb_fast_mode', [ 'sanitize_callback' => 'absint' ] );
+                register_setting( 'rtbcb_settings', 'rtbcb_disable_heavy_features', [ 'sanitize_callback' => 'absint' ] );
     }
 
     /**
@@ -1936,6 +1938,32 @@ class RTBCB_Admin {
                         }
                 }
                 return ( $success / count( $history ) ) * 100;
+        }
+
+        /**
+         * Display notice when heavy AI features are disabled.
+         *
+         * @return void
+         */
+        public function maybe_show_heavy_features_notice() {
+                if ( ! get_option( 'rtbcb_disable_heavy_features', 0 ) ) {
+                        return;
+                }
+                $doc_url = esc_url( RTBCB_URL . 'docs/TEMPORARY_BYPASS_MODE.md' );
+                echo '<div class="notice notice-warning is-dismissible"><p>';
+                printf(
+                        wp_kses(
+                                __( 'Heavy AI features are temporarily disabled. <a href="%s" target="_blank">Learn more</a>.', 'rtbcb' ),
+                                [
+                                        'a' => [
+                                                'href'   => [],
+                                                'target' => [],
+                                        ],
+                                ]
+                        ),
+                        $doc_url
+                );
+                echo '</p></div>';
         }
 
         /**

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -19,6 +19,7 @@ $gpt5_timeout    = rtbcb_get_api_timeout();
 $gpt5_max_output_tokens = get_option( 'rtbcb_gpt5_max_output_tokens', 8000 );
 $gpt5_min_output_tokens = get_option( 'rtbcb_gpt5_min_output_tokens', 256 );
 $fast_mode       = get_option( 'rtbcb_fast_mode', 0 );
+$disable_heavy   = get_option( 'rtbcb_disable_heavy_features', 0 );
 
 $chat_models = [
     'gpt-5'             => 'gpt-5',
@@ -146,6 +147,15 @@ $embedding_models = [
                 </th>
                 <td>
                     <input type="number" step="0.01" id="rtbcb_bank_fee_baseline" name="rtbcb_bank_fee_baseline" value="<?php echo esc_attr( $bank_fee ); ?>" class="regular-text" />
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="rtbcb_disable_heavy_features"><?php echo esc_html__( 'Disable Heavy Features', 'rtbcb' ); ?></label>
+                </th>
+                <td>
+                    <input type="checkbox" id="rtbcb_disable_heavy_features" name="rtbcb_disable_heavy_features" value="1" <?php checked( 1, $disable_heavy ); ?> />
+                    <p class="description"><?php echo esc_html__( 'Temporarily bypass AI enrichment, RAG, and intelligent recommendations.', 'rtbcb' ); ?></p>
                 </td>
             </tr>
             <tr>

--- a/docs/TEMPORARY_BYPASS_MODE.md
+++ b/docs/TEMPORARY_BYPASS_MODE.md
@@ -1,0 +1,12 @@
+# Temporary Bypass Mode
+
+The plugin can temporarily disable heavy AI features when certain services are unavailable or when you
+want faster processing.
+
+- Enable the **Disable Heavy Features** option on the plugin's settings page to bypass AI enrichment,
+    RAG searches, and intelligent recommendations.
+- When enabled, comprehensive reports use fallback logic and a notice is shown in the WordPress admin.
+- Fast Mode also bypasses these features automatically.
+
+To re-enable full functionality, uncheck the setting and save. The notice will disappear after the next
+page load.

--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -39,6 +39,16 @@ class RTBCB_Ajax {
                $workflow_tracker = new RTBCB_Workflow_Tracker();
                $enable_ai        = RTBCB_Settings::get_setting( 'enable_ai_analysis', true );
 
+               $disable_heavy = get_option( 'rtbcb_disable_heavy_features', 0 ) || get_option( 'rtbcb_fast_mode', 0 );
+               if ( ! empty( $user_inputs['fast_mode'] ) ) {
+                       $disable_heavy = true;
+               }
+
+               if ( $disable_heavy ) {
+                       $enable_ai = false;
+                       $workflow_tracker->add_warning( 'heavy_features_disabled', __( 'Heavy features bypassed.', 'rtbcb' ) );
+               }
+
 		add_action(
 			'rtbcb_llm_prompt_sent',
 			function( $prompt ) use ( $workflow_tracker ) {

--- a/inc/class-rtbcb-intelligent-recommender.php
+++ b/inc/class-rtbcb-intelligent-recommender.php
@@ -7,44 +7,49 @@ defined( 'ABSPATH' ) || exit;
  * @package RealTreasuryBusinessCaseBuilder
  */
 class RTBCB_Intelligent_Recommender extends RTBCB_Category_Recommender {
-/**
- * Generate recommendations using AI insights and rule-based scoring.
- *
- * @param array $user_inputs      Original user inputs.
- * @param array $enriched_profile AI-enriched company profile.
- * @return array Enhanced recommendation with confidence and alternatives.
- */
-public function recommend_with_ai_insights( $user_inputs, $enriched_profile ) {
-// Get baseline recommendation from parent class.
-$base_recommendation = parent::recommend_category( $user_inputs );
+       /**
+        * Generate recommendations using AI insights and rule-based scoring.
+        *
+        * @param array $user_inputs      Original user inputs.
+        * @param array $enriched_profile AI-enriched company profile.
+        * @return array Enhanced recommendation with confidence and alternatives.
+        */
+       public function recommend_with_ai_insights( $user_inputs, $enriched_profile ) {
+               // Bypass heavy processing when disabled or in Fast Mode.
+               if ( get_option( 'rtbcb_disable_heavy_features', 0 ) || get_option( 'rtbcb_fast_mode', 0 ) || ! empty( $user_inputs['fast_mode'] ) ) {
+                       return parent::recommend_category( $user_inputs );
+               }
 
-// Apply AI insights to enhance recommendation.
-$ai_factors      = $this->extract_ai_recommendation_factors( $enriched_profile );
-$enhanced_scores = $this->apply_ai_insights_to_scoring(
-$base_recommendation['scores'],
-$ai_factors
-);
+               // Get baseline recommendation from parent class.
+               $base_recommendation = parent::recommend_category( $user_inputs );
 
-// Recalculate recommendation with enhanced scores.
-arsort( $enhanced_scores );
-$recommended = array_key_first( $enhanced_scores );
+               // Apply AI insights to enhance recommendation.
+               $ai_factors      = $this->extract_ai_recommendation_factors( $enriched_profile );
+               $enhanced_scores = $this->apply_ai_insights_to_scoring(
+                       $base_recommendation['scores'],
+                       $ai_factors
+               );
 
-return [
-'recommended'   => $recommended,
-'category_info' => self::get_category_info( $recommended ),
-'scores'        => $enhanced_scores,
-'base_scores'   => $base_recommendation['scores'],
-'confidence'    => $this->calculate_enhanced_confidence( $enhanced_scores, $enriched_profile ),
-'reasoning'     => $this->generate_ai_enhanced_reasoning( $recommended, $enriched_profile, $ai_factors ),
-'alternatives'  => $this->get_intelligent_alternatives( $enhanced_scores, $enriched_profile ),
-'ai_insights'   => [
-'maturity_assessment'    => $ai_factors['maturity_alignment'],
-'implementation_readiness'=> $ai_factors['implementation_readiness'],
-'strategic_fit'          => $ai_factors['strategic_alignment'],
-'risk_assessment'        => $ai_factors['risk_factors'],
-],
-];
-}
+               // Recalculate recommendation with enhanced scores.
+               arsort( $enhanced_scores );
+               $recommended = array_key_first( $enhanced_scores );
+
+               return [
+                       'recommended'   => $recommended,
+                       'category_info' => self::get_category_info( $recommended ),
+                       'scores'        => $enhanced_scores,
+                       'base_scores'   => $base_recommendation['scores'],
+                       'confidence'    => $this->calculate_enhanced_confidence( $enhanced_scores, $enriched_profile ),
+                       'reasoning'     => $this->generate_ai_enhanced_reasoning( $recommended, $enriched_profile, $ai_factors ),
+                       'alternatives'  => $this->get_intelligent_alternatives( $enhanced_scores, $enriched_profile ),
+                       'ai_insights'   => [
+                               'maturity_assessment'     => $ai_factors['maturity_alignment'],
+                               'implementation_readiness'=> $ai_factors['implementation_readiness'],
+                               'strategic_fit'           => $ai_factors['strategic_alignment'],
+                               'risk_assessment'         => $ai_factors['risk_factors'],
+                       ],
+               ];
+       }
 
 /**
  * Extract AI-based recommendation factors.

--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -77,6 +77,9 @@ class RTBCB_RAG {
      * @return array Matching rows.
      */
     public function search_similar( $query, $top_k = 3 ) {
+        if ( get_option( 'rtbcb_disable_heavy_features', 0 ) || get_option( 'rtbcb_fast_mode', 0 ) ) {
+                return [];
+        }
         $normalized = strtolower( trim( function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $query ) : strip_tags( $query ) ) );
         $version    = function_exists( 'get_option' ) ? (int) get_option( 'rtbcb_rag_cache_version', 1 ) : 1;
         $cache_key  = 'rtbcb_rag_' . md5( $normalized . '|' . $top_k . '|' . $version );
@@ -110,6 +113,9 @@ class RTBCB_RAG {
      * @return array List of metadata arrays.
      */
     public function get_context( $query, $top_k = 3 ) {
+        if ( get_option( 'rtbcb_disable_heavy_features', 0 ) || get_option( 'rtbcb_fast_mode', 0 ) ) {
+                return [];
+        }
         $embedding = $this->get_embedding( $query );
         if ( empty( $embedding ) ) {
             return [];

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -50,7 +50,7 @@ class RTBCB_Router {
             // Perform ROI calculations.
             $calculations = RTBCB_Calculator::calculate_roi( $form_data );
 
-            $fast_mode = ! empty( $_POST['fast_mode'] ) || get_option( 'rtbcb_fast_mode', 0 );
+            $fast_mode = ! empty( $_POST['fast_mode'] ) || get_option( 'rtbcb_fast_mode', 0 ) || get_option( 'rtbcb_disable_heavy_features', 0 );
             if ( $fast_mode ) {
                 $report_html = $this->get_fast_report_html( $form_data, $calculations );
 


### PR DESCRIPTION
## Summary
- Add `rtbcb_disable_heavy_features` option with admin UI and notice
- Skip AI enrichment, RAG, and intelligent recommendations when heavy features or Fast Mode are disabled
- Document temporary bypass mode for administrators

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `npx --yes markdownlint-cli docs/**/*.md` *(fails: multiple line length warnings)*
- `npx --yes markdown-link-check docs/TEMPORARY_BYPASS_MODE.md`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4 bash tests/run-tests.sh` *(phpunit: command not found, some tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b39ebc261083319c9b12fb6f8f00e6