### PR TITLE
fix: preserve legacy zero API timeout values

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -129,7 +129,8 @@ function rtbcb_model_supports_temperature( $model ) {
 /**
  * Sanitize the API timeout option.
  *
- * Ensures the value stays within the allowed 1-600 second range.
+ * Ensures the value stays within the allowed 1-600 second range while
+ * preserving legacy zero values by falling back to the default 300 seconds.
  *
  * @param mixed $value Raw option value.
  * @return int Sanitized timeout in seconds.
@@ -137,7 +138,11 @@ function rtbcb_model_supports_temperature( $model ) {
 function rtbcb_sanitize_api_timeout( $value ) {
 	$value = intval( $value );
 
-	return min( 600, max( 1, $value ) );
+	if ( $value <= 0 ) {
+		return 300;
+	}
+
+	return min( 600, $value );
 }
 
 /**


### PR DESCRIPTION
## Summary
- treat empty or zero API timeout values as 300s to preserve legacy behavior

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*
- `markdownlint docs/**/*.md` *(fails: MD013 line length, MD040, MD012, MD022)*
- `markdown-link-check docs/timeout-config.md`


------
https://chatgpt.com/codex/tasks/task_e_68b3a970ccbc8331882c65af12048dd4