### PR TITLE
Improve wizard job polling and cancellation

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -602,6 +602,11 @@ class BusinessCaseBuilder {
 
                     const data = await response.json();
 
+                    if (this.pollingCancelled) {
+                        resolve();
+                        return;
+                    }
+
                     if (!data.success) {
                         this.handleError({ message: 'Unable to retrieve job status', type: 'polling_error' });
                         resolve();

--- a/tests/poll-job-show-results.test.js
+++ b/tests/poll-job-show-results.test.js
@@ -5,7 +5,11 @@ describe('pollJob completion', () => {
     test('invokes showResults with report data and clears progress', async () => {
         const nodeGlobal = vm.runInThisContext('this');
 
-        const progressContainer = { style: { display: 'block' }, innerHTML: 'loading' };
+        const progressContainer = {
+            style: { display: 'block' },
+            innerHTML: 'loading',
+            querySelector: () => null
+        };
         const resultsContainer = { innerHTML: '', style: {}, scrollIntoView: () => {} };
 
         nodeGlobal.window = { closeBusinessCaseModal: () => {} };


### PR DESCRIPTION
## Summary
- avoid invoking polling UI updates after cancellation
- stub progress container selector in pollJob completion test

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`
- `npx --yes jest tests/poll-job-show-results.test.js --config '{"testEnvironment":"node"}'`


------
https://chatgpt.com/codex/tasks/task_e_68b3a01df7948331b12e214973e82084