### PR TITLE
Track partial job progress in background case generation

### DIFF
--- a/tests/job-status.test.php
+++ b/tests/job-status.test.php
@@ -79,7 +79,7 @@ function assert_same( $expected, $actual, $message ) {
 $_GET['rtbcb_nonce'] = 'nonce';
 $_GET['job_id']      = 'job1';
 RTBCB_Background_Job::$data['job1'] = [
-    'status'  => 'processing',
+    'state'   => 'processing',
     'step'    => 'enrich',
     'message' => 'Working',
     'percent' => 50,
@@ -97,7 +97,7 @@ assert_same( 50.0, $data['data']['percent'], 'Percent mismatch' );
 
 $_GET['job_id'] = 'job2';
 RTBCB_Background_Job::$data['job2'] = [
-    'status' => 'completed',
+    'state'  => 'completed',
     'result' => [ 'report_data' => [ 'foo' => 'bar' ], 'lead_id' => 5 ],
 ];
 try {


### PR DESCRIPTION
## Summary
- add `update_status` helper that stores job state and cumulative payload
- report step outputs via `update_status` during `process_comprehensive_case`
- expose merged state and partial data through `get_status` and AJAX API

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a429b0388331b8204dc4e0d58486