### PR TITLE
fix: guard polling against stale job IDs

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -586,7 +586,7 @@ class BusinessCaseBuilder {
         const MAX_DURATION = 20 * 60 * 1000; // 20 minutes
         const MAX_ATTEMPTS = 600; // 600 attempts * 2s = 20 minutes max
 
-        if (this.pollingCancelled) {
+        if (this.pollingCancelled || jobId !== this.activeJobId) {
             return;
         }
 
@@ -606,6 +606,10 @@ class BusinessCaseBuilder {
             });
 
             const data = await response.json();
+
+            if (jobId !== this.activeJobId) {
+                return;
+            }
 
             if (!data.success) {
                 this.handleError({ message: 'Unable to retrieve job status', type: 'polling_error' });


### PR DESCRIPTION
## Summary
- ignore stale job responses by checking active job ID before updating state

## Testing
- `bash tests/run-tests.sh` *(phpunit: command not found; pollJob tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ac6dc6e883318dc82e486d97f83f