### PR TITLE
Refine ROI calculation with category-specific recalculation

### DIFF
--- a/docs/END_TO_END_WORKFLOW.md
+++ b/docs/END_TO_END_WORKFLOW.md
@@ -21,7 +21,7 @@ This document summarizes the workflow from internal company research to deliveri
 ## 4. Category Recommendation
 
 * The plugin categorizes the user's challenges without an LLM.
-* `RTBCB_Category_Recommender::recommend_category()` scores the input against predefined categories and returns a recommendation with reasoning and confidence.
+* `RTBCB_Category_Recommender::recommend_category()` scores the input against predefined categories and returns a recommendation with reasoning and confidence, then `RTBCB_Calculator::calculate_category_refined_roi()` recalculates ROI using the selected category.
 
 ## 5. Final Report Assembly
 

--- a/docs/WIZARD_FORM_API_FLOW.md
+++ b/docs/WIZARD_FORM_API_FLOW.md
@@ -34,7 +34,7 @@ Field definitions come from `templates/business-case-form.php` and the field reg
 `Real_Treasury_BCB::ajax_generate_comprehensive_case()` validates the request and orchestrates report generation:
 
 1. **ROI Calculation** – `RTBCB_Calculator::calculate_roi()` builds conservative, base, and optimistic scenarios.
-2. **Category Recommendation** – `RTBCB_Category_Recommender::recommend_category()` scores the selected challenges to suggest a treasury solution type.
+2. **Category Recommendation & ROI Refinement** – `RTBCB_Category_Recommender::recommend_category()` scores the selected challenges to suggest a treasury solution type, then `RTBCB_Calculator::calculate_category_refined_roi()` recomputes ROI using the chosen category.
 3. **RAG Search** – `RTBCB_RAG::search_similar()` retrieves supporting context using the company profile and pain points.
 4. **OpenAI Call** – `RTBCB_LLM::generate_comprehensive_business_case()` combines user inputs, ROI data, and RAG context to produce narrative analysis.
 5. **Report Assembly** – `get_comprehensive_report_html()` renders the final HTML which is returned in the AJAX response.
@@ -56,6 +56,7 @@ sequenceDiagram
     JS->>WP: POST rtbcb_generate_case
     WP->>ROI: calculate_roi()
     WP->>Cat: recommend_category()
+    WP->>ROI: calculate_category_refined_roi()
     WP->>RAG: search_similar()
     WP->>LLM: generate_comprehensive_business_case()
     LLM-->>WP: analysis

--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -82,15 +82,17 @@ class RTBCB_Ajax {
                         }
                         $workflow_tracker->complete_step( 'ai_enrichment', $enriched_profile );
 
-			$workflow_tracker->start_step( 'enhanced_roi_calculation' );
-			$enhanced_calculator = new RTBCB_Enhanced_Calculator();
-			$roi_scenarios       = $enhanced_calculator->calculate_enhanced_roi( $user_inputs, $enriched_profile );
-			$workflow_tracker->complete_step( 'enhanced_roi_calculation', $roi_scenarios );
+                        $workflow_tracker->start_step( 'enhanced_roi_calculation' );
+                        $enhanced_calculator   = new RTBCB_Enhanced_Calculator();
+                        $roi_scenarios         = $enhanced_calculator->calculate_enhanced_roi( $user_inputs, $enriched_profile );
+                        $category_recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+                        $roi_scenarios         = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $category_recommendation );
+                        $workflow_tracker->complete_step( 'enhanced_roi_calculation', $roi_scenarios );
 
-			$workflow_tracker->start_step( 'intelligent_recommendations' );
-			$intelligent_recommender = new RTBCB_Intelligent_Recommender();
-			$recommendation          = $intelligent_recommender->recommend_with_ai_insights( $user_inputs, $enriched_profile );
-			$workflow_tracker->complete_step( 'intelligent_recommendations', $recommendation );
+                        $workflow_tracker->start_step( 'intelligent_recommendations' );
+                        $intelligent_recommender = new RTBCB_Intelligent_Recommender();
+                        $recommendation          = $intelligent_recommender->recommend_with_ai_insights( $user_inputs, $enriched_profile );
+                        $workflow_tracker->complete_step( 'intelligent_recommendations', $recommendation );
 
                         $workflow_tracker->start_step( 'hybrid_rag_analysis' );
                         if ( $enable_ai ) {

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -767,18 +767,19 @@ return $use_comprehensive;
 					return;
 				}
 
-				$scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
+                                $scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
 
-				// Get category recommendation.
-				if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
-					wp_send_json_error( [ 'message' => __( 'System error: Recommender not available.', 'rtbcb' ) ], 500 );
-					return;
-				}
+                                // Get category recommendation.
+                                if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
+                                        wp_send_json_error( [ 'message' => __( 'System error: Recommender not available.', 'rtbcb' ) ], 500 );
+                                        return;
+                                }
 
-				$recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+                                $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+                                $scenarios      = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $recommendation );
 
-				// Get RAG context if available.
-				$rag_context = $this->get_rag_context( $user_inputs, $recommendation );
+                                // Get RAG context if available.
+                                $rag_context = $this->get_rag_context( $user_inputs, $recommendation );
 
 				// Generate business case analysis.
 				$comprehensive_analysis = $this->generate_business_analysis( $user_inputs, $scenarios, $rag_context );
@@ -1398,6 +1399,7 @@ return $use_comprehensive;
             $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
             rtbcb_log_api_debug( 'Category recommendation result', $recommendation );
             rtbcb_log_memory_usage( 'after_category_recommendation' );
+            $scenarios = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $recommendation );
 
             // Get RAG context (with memory monitoring)
             $rag_context = [];

--- a/tests/edge-cases.test.php
+++ b/tests/edge-cases.test.php
@@ -95,8 +95,11 @@ return rtrim( $string, '/\\' ) . '/';
 // Stub plugin classes.
 if ( ! class_exists( 'RTBCB_Calculator' ) ) {
 class RTBCB_Calculator {
-public static function calculate_roi( $data ) {
+public static function calculate_roi( $data, $category = null ) {
 return [ 'roi_base' => 1000 ];
+}
+public static function calculate_category_refined_roi( $data, $recommendation ) {
+return self::calculate_roi( $data, $recommendation['category_info'] ?? [] );
 }
 }
 }


### PR DESCRIPTION
## Summary
- allow `RTBCB_Calculator::calculate_roi` to accept an optional category and avoid in-method recommendation
- add `calculate_category_refined_roi` to recompute ROI once a category is known
- invoke category recommendation followed by ROI refinement in workflow step two and update docs

## Testing
- `npx markdownlint docs/**/*.md` *(fails: could not determine executable to run)*
- `npx markdown-link-check docs/WIZARD_FORM_API_FLOW.md` *(fails: package installation prompt)*
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=test RTBCB_TEST_MODEL=dummy bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a3a983d48331b55c4af27b259911