### PR TITLE
Defer RAG context retrieval until needed

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -1349,8 +1349,8 @@ $batch_prompts['tech'] = [
     /**
      * Execute company, industry, and technology research in a single LLM call.
      *
-     * @param array $user_inputs    Sanitized user inputs.
-     * @param array $context_chunks Optional context strings.
+     * @param array                     $user_inputs    Sanitized user inputs.
+     * @param callable|array|Traversable $context_chunks Optional context strings.
      * @return array|WP_Error {
      *     @type array  $company_research  Company research data.
      *     @type array  $industry_analysis Industry analysis data.
@@ -1672,14 +1672,21 @@ SYSTEM;
     /**
      * Select the optimal model for comprehensive analysis.
      *
-     * @param array $user_inputs    Sanitized user inputs.
-     * @param array $context_chunks Optional context strings.
+      * @param array                     $user_inputs    Sanitized user inputs.
+      * @param callable|array|Traversable $context_chunks Optional context strings.
      * @return string Model identifier.
      */
     private function select_optimal_model( $user_inputs, $context_chunks ) {
-        $model = $this->get_model( 'advanced' );
+        $model         = $this->get_model( 'advanced' );
+        $context_count = 0;
 
-        if ( count( $context_chunks ) < 3 ) {
+        if ( is_callable( $context_chunks ) || $context_chunks instanceof Traversable ) {
+            // Lazily provided context; treat as empty without invoking.
+        } elseif ( is_array( $context_chunks ) || $context_chunks instanceof Countable ) {
+            $context_count = count( $context_chunks );
+        }
+
+        if ( $context_count < 3 ) {
             $model = $this->get_model( 'premium' );
         }
 


### PR DESCRIPTION
## Summary
- Guard `select_optimal_model()` against callable or Traversable context

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=dummy bash tests/run-tests.sh` *(fails: phpunit not found; aborted as Node tests hung)*

------
https://chatgpt.com/codex/tasks/task_e_68b3aca042f88331a33285b63a3734a6