### PR TITLE
Compress stored lead reports

### DIFF
--- a/inc/class-rtbcb-db.php
+++ b/inc/class-rtbcb-db.php
@@ -14,7 +14,7 @@ class RTBCB_DB {
     /**
      * Current database version.
      */
-    const DB_VERSION = '2.0.2';
+    const DB_VERSION = '2.0.3';
 
     /**
      * Initialize database and handle upgrades.
@@ -58,9 +58,13 @@ class RTBCB_DB {
                 self::add_embedding_norm_index();
         }
 
-		if ( version_compare( $from_version, '2.0.2', '<' ) ) {
-			RTBCB_Leads::add_missing_indexes();
-}
+                if ( version_compare( $from_version, '2.0.2', '<' ) ) {
+                        RTBCB_Leads::add_missing_indexes();
+                }
+
+                if ( version_compare( $from_version, '2.0.3', '<' ) ) {
+                        RTBCB_Leads::compress_existing_report_html();
+                }
 
 	// Future migrations can be handled here.
 

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -159,8 +159,8 @@ class RTBCB_Leads {
 	 *
 	 * @return void
 	 */
-	public static function add_missing_indexes() {
-		global $wpdb;
+        public static function add_missing_indexes() {
+                global $wpdb;
 
 		self::$table_name = $wpdb->prefix . 'rtbcb_leads';
 
@@ -175,10 +175,41 @@ class RTBCB_Leads {
 			$wpdb->query( 'ALTER TABLE ' . self::$table_name . ' ADD KEY created_at_index (created_at)' );
 		}
 
-		if ( ! in_array( 'recommended_category_index', $index_names, true ) ) {
-			$wpdb->query( 'ALTER TABLE ' . self::$table_name . ' ADD KEY recommended_category_index (recommended_category)' );
-		}
-	}
+                if ( ! in_array( 'recommended_category_index', $index_names, true ) ) {
+                        $wpdb->query( 'ALTER TABLE ' . self::$table_name . ' ADD KEY recommended_category_index (recommended_category)' );
+                }
+        }
+
+    /**
+     * Compress existing report_html entries.
+     *
+     * @return void
+     */
+    public static function compress_existing_report_html() {
+        global $wpdb;
+
+        self::$table_name = $wpdb->prefix . 'rtbcb_leads';
+
+        $leads = $wpdb->get_results(
+            "SELECT id, report_html FROM " . self::$table_name . " WHERE report_html != ''",
+            ARRAY_A
+        );
+
+        foreach ( $leads as $lead ) {
+            if ( false !== @gzuncompress( $lead['report_html'] ) ) {
+                continue;
+            }
+
+            $compressed = gzcompress( $lead['report_html'] );
+            $wpdb->update(
+                self::$table_name,
+                [ 'report_html' => $compressed ],
+                [ 'id' => $lead['id'] ],
+                [ '%s' ],
+                [ '%d' ]
+            );
+        }
+    }
 
 
     /**
@@ -218,6 +249,10 @@ class RTBCB_Leads {
             'utm_medium'              => sanitize_text_field( $_GET['utm_medium'] ?? '' ),
             'utm_campaign'            => sanitize_text_field( $_GET['utm_campaign'] ?? '' ),
         ];
+
+        if ( ! empty( $sanitized_data['report_html'] ) ) {
+            $sanitized_data['report_html'] = gzcompress( $sanitized_data['report_html'] );
+        }
 
         // Prepare format array to match the sanitized data
         $formats = [
@@ -305,6 +340,13 @@ class RTBCB_Leads {
 
         if ( $result ) {
             $result['pain_points'] = maybe_unserialize( $result['pain_points'] );
+
+            if ( ! empty( $result['report_html'] ) ) {
+                $uncompressed = @gzuncompress( $result['report_html'] );
+                if ( false !== $uncompressed ) {
+                    $result['report_html'] = $uncompressed;
+                }
+            }
         }
 
         return $result;
@@ -376,9 +418,16 @@ class RTBCB_Leads {
 
         $leads = $wpdb->get_results( $wpdb->prepare( $sql, $prepare_values ), ARRAY_A );
 
-        // Unserialize pain points
+        // Unserialize pain points and decompress report HTML.
         foreach ( $leads as &$lead ) {
             $lead['pain_points'] = maybe_unserialize( $lead['pain_points'] );
+
+            if ( ! empty( $lead['report_html'] ) ) {
+                $uncompressed = @gzuncompress( $lead['report_html'] );
+                if ( false !== $uncompressed ) {
+                    $lead['report_html'] = $uncompressed;
+                }
+            }
         }
 
         return [

--- a/tests/lead-storage.test.php
+++ b/tests/lead-storage.test.php
@@ -200,6 +200,7 @@ $lead_data = [
 'roi_low'       => 1000,
 'roi_base'      => 2000,
 'roi_high'      => 3000,
+'report_html'   => '<p>Report</p>',
 ];
 
 $lead_id = RTBCB_Leads::save_lead( $lead_data );
@@ -221,6 +222,17 @@ exit( 1 );
 
 if ( 1000.0 !== (float) ( $retrieved['roi_low'] ?? 0 ) || 2000.0 !== (float) ( $retrieved['roi_base'] ?? 0 ) || 3000.0 !== (float) ( $retrieved['roi_high'] ?? 0 ) ) {
 echo "ROI mismatch\n";
+exit( 1 );
+}
+
+if ( '<p>Report</p>' !== ( $retrieved['report_html'] ?? '' ) ) {
+echo "Report HTML mismatch\n";
+exit( 1 );
+}
+
+$all = RTBCB_Leads::get_all_leads( [ 'per_page' => 1 ] );
+if ( '<p>Report</p>' !== ( $all['leads'][0]['report_html'] ?? '' ) ) {
+echo "All leads report HTML mismatch\n";
 exit( 1 );
 }
 


### PR DESCRIPTION
## Summary
- compress `report_html` before saving leads and decompress on retrieval
- upgrade existing lead records to the new compressed format
- add coverage for compressed report handling

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=sk-123 RTBCB_TEST_MODEL=gpt-4o-mini bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a69b6d908331b4a6014e22970a61