### PR TITLE
Cache report templates and purge cache on lead updates

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -548,6 +548,7 @@ class RTBCB_Admin {
         $result = $wpdb->delete( $table_name, [ 'id' => $lead_id ], [ '%d' ] );
 
         if ( $result ) {
+            rtbcb_clear_report_cache();
             wp_send_json_success( [ 'message' => __( 'Lead deleted successfully.', 'rtbcb' ) ] );
         } else {
             wp_send_json_error( [ 'message' => __( 'Failed to delete lead.', 'rtbcb' ) ] );
@@ -593,8 +594,9 @@ class RTBCB_Admin {
                 );
                 
                 if ( $result ) {
-                    wp_send_json_success( [ 
-                        'message' => sprintf( __( '%d leads deleted successfully.', 'rtbcb' ), $result ) 
+                    rtbcb_clear_report_cache();
+                    wp_send_json_success( [
+                        'message' => sprintf( __( '%d leads deleted successfully.', 'rtbcb' ), $result )
                     ] );
                 } else {
                     wp_send_json_error( [ 'message' => __( 'Failed to delete leads.', 'rtbcb' ) ] );

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -269,6 +269,7 @@ class RTBCB_Leads {
                 }
 
                 self::update_cached_statistics();
+                rtbcb_clear_report_cache();
                 return intval( $existing_lead['id'] );
             } else {
                 // Insert new lead
@@ -285,6 +286,7 @@ class RTBCB_Leads {
 
                 $lead_id = $wpdb->insert_id;
                 self::update_cached_statistics();
+                rtbcb_clear_report_cache();
                 return $lead_id;
             }
         } catch ( Exception $e ) {

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1870,9 +1870,30 @@ function rtbcb_get_report_allowed_html() {
  * @return void
  */
 function rtbcb_invalidate_rag_cache() {
-	if ( function_exists( 'get_option' ) && function_exists( 'update_option' ) ) {
-		$version = (int) get_option( 'rtbcb_rag_cache_version', 1 );
-		update_option( 'rtbcb_rag_cache_version', $version + 1 );
-	}
+        if ( function_exists( 'get_option' ) && function_exists( 'update_option' ) ) {
+                $version = (int) get_option( 'rtbcb_rag_cache_version', 1 );
+                update_option( 'rtbcb_rag_cache_version', $version + 1 );
+        }
+}
+
+/**
+ * Clear cached report HTML entries.
+ *
+ * Removes all cached report templates to ensure fresh rendering when lead data changes.
+ *
+ * @return void
+ */
+function rtbcb_clear_report_cache() {
+        global $wp_object_cache;
+
+        if ( ! isset( $wp_object_cache->cache ) || ! is_array( $wp_object_cache->cache ) ) {
+                return;
+        }
+
+        if ( isset( $wp_object_cache->cache['rtbcb_reports'] ) && is_array( $wp_object_cache->cache['rtbcb_reports'] ) ) {
+                foreach ( array_keys( $wp_object_cache->cache['rtbcb_reports'] ) as $key ) {
+                        wp_cache_delete( $key, 'rtbcb_reports' );
+                }
+        }
 }
 


### PR DESCRIPTION
## Summary
- cache report and comprehensive template HTML using a hash-based key in the router
- add helper to clear cached report templates and invoke it when leads are saved or deleted
- purge report cache when bulk deleting leads in the admin

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a7dedf4c8331abf2dbbd72e8f389