### PR TITLE
Add heavy feature bypass option

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -19,6 +19,7 @@ class RTBCB_Admin {
         add_action( 'admin_init', [ $this, 'register_settings' ] );
         add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
         add_action( 'admin_notices', [ $this, 'maybe_show_timeout_notice' ] );
+        add_action( 'admin_notices', [ $this, 'maybe_show_bypass_notice' ] );
 
         // AJAX handlers
         add_action( 'wp_ajax_rtbcb_test_connection', [ $this, 'test_api_connection' ] );
@@ -497,7 +498,8 @@ class RTBCB_Admin {
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_timeout', [ 'sanitize_callback' => 'intval' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_max_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_max_output_tokens' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_min_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_min_output_tokens' ] );
-		register_setting( 'rtbcb_settings', 'rtbcb_fast_mode', [ 'sanitize_callback' => 'absint' ] );
+        register_setting( 'rtbcb_settings', 'rtbcb_fast_mode', [ 'sanitize_callback' => 'absint' ] );
+        register_setting( 'rtbcb_settings', 'rtbcb_disable_heavy_features', [ 'sanitize_callback' => 'absint' ] );
     }
 
     /**
@@ -1967,4 +1969,33 @@ class RTBCB_Admin {
                         echo '</p></div>';
                 }
         }
+
+       /**
+        * Display warning when heavy features are disabled.
+        *
+        * @return void
+        */
+       public function maybe_show_bypass_notice() {
+               if ( ! current_user_can( 'manage_options' ) ) {
+                       return;
+               }
+
+               if ( get_option( 'rtbcb_disable_heavy_features', 0 ) ) {
+                       $doc_url = esc_url( RTBCB_URL . 'docs/TEMPORARY_BYPASS_MODE.md' );
+                       echo '<div class="notice notice-warning is-dismissible"><p>';
+                       printf(
+                               wp_kses(
+                                       __( 'Heavy features are temporarily disabled. <a href="%s" target="_blank">Learn more</a>.', 'rtbcb' ),
+                                       [
+                                               'a' => [
+                                                       'href'   => [],
+                                                       'target' => [],
+                                               ],
+                                       ]
+                               ),
+                               $doc_url
+                       );
+                       echo '</p></div>';
+               }
+       }
 }

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -19,6 +19,7 @@ $gpt5_timeout    = rtbcb_get_api_timeout();
 $gpt5_max_output_tokens = get_option( 'rtbcb_gpt5_max_output_tokens', 8000 );
 $gpt5_min_output_tokens = get_option( 'rtbcb_gpt5_min_output_tokens', 256 );
 $fast_mode       = get_option( 'rtbcb_fast_mode', 0 );
+$disable_heavy   = get_option( 'rtbcb_disable_heavy_features', 0 );
 
 $chat_models = [
     'gpt-5'             => 'gpt-5',
@@ -155,6 +156,15 @@ $embedding_models = [
                 <td>
                     <input type="checkbox" id="rtbcb_fast_mode" name="rtbcb_fast_mode" value="1" <?php checked( 1, $fast_mode ); ?> />
                     <p class="description"><?php echo esc_html__( 'Generate a basic ROI-only report without AI processing.', 'rtbcb' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="rtbcb_disable_heavy_features"><?php echo esc_html__( 'Disable Heavy Features', 'rtbcb' ); ?></label>
+                </th>
+                <td>
+                    <input type="checkbox" id="rtbcb_disable_heavy_features" name="rtbcb_disable_heavy_features" value="1" <?php checked( 1, $disable_heavy ); ?> />
+                    <p class="description"><?php echo esc_html__( 'Temporarily bypass AI enrichment, RAG, and intelligent recommendations.', 'rtbcb' ); ?></p>
                 </td>
             </tr>
         </table>

--- a/docs/TEMPORARY_BYPASS_MODE.md
+++ b/docs/TEMPORARY_BYPASS_MODE.md
@@ -1,0 +1,12 @@
+# Temporary Bypass Mode
+
+The plugin can temporarily skip heavy features like AI enrichment, RAG searches, and
+intelligent recommendations. This is useful during service interruptions or when
+fast ROI-only results are sufficient.
+
+- Enable **Disable Heavy Features** from the plugin settings to bypass these steps.
+- The existing **Fast Mode** option also bypasses heavy features.
+- An admin notice appears while the bypass is active.
+- Disable the option to restore full functionality.
+
+For more details see the settings page in your WordPress dashboard.

--- a/inc/class-rtbcb-intelligent-recommender.php
+++ b/inc/class-rtbcb-intelligent-recommender.php
@@ -15,14 +15,18 @@ class RTBCB_Intelligent_Recommender extends RTBCB_Category_Recommender {
  * @return array Enhanced recommendation with confidence and alternatives.
  */
 public function recommend_with_ai_insights( $user_inputs, $enriched_profile ) {
-// Get baseline recommendation from parent class.
-$base_recommendation = parent::recommend_category( $user_inputs );
+	// Get baseline recommendation from parent class.
+	$base_recommendation = parent::recommend_category( $user_inputs );
+
+	if ( rtbcb_heavy_features_disabled() ) {
+		return $base_recommendation;
+	}
 
 // Apply AI insights to enhance recommendation.
 $ai_factors      = $this->extract_ai_recommendation_factors( $enriched_profile );
 $enhanced_scores = $this->apply_ai_insights_to_scoring(
-$base_recommendation['scores'],
-$ai_factors
+        $base_recommendation['scores'],
+        $ai_factors
 );
 
 // Recalculate recommendation with enhanced scores.
@@ -30,19 +34,19 @@ arsort( $enhanced_scores );
 $recommended = array_key_first( $enhanced_scores );
 
 return [
-'recommended'   => $recommended,
-'category_info' => self::get_category_info( $recommended ),
-'scores'        => $enhanced_scores,
-'base_scores'   => $base_recommendation['scores'],
-'confidence'    => $this->calculate_enhanced_confidence( $enhanced_scores, $enriched_profile ),
-'reasoning'     => $this->generate_ai_enhanced_reasoning( $recommended, $enriched_profile, $ai_factors ),
-'alternatives'  => $this->get_intelligent_alternatives( $enhanced_scores, $enriched_profile ),
-'ai_insights'   => [
-'maturity_assessment'    => $ai_factors['maturity_alignment'],
-'implementation_readiness'=> $ai_factors['implementation_readiness'],
-'strategic_fit'          => $ai_factors['strategic_alignment'],
-'risk_assessment'        => $ai_factors['risk_factors'],
-],
+        'recommended'   => $recommended,
+        'category_info' => self::get_category_info( $recommended ),
+        'scores'        => $enhanced_scores,
+        'base_scores'   => $base_recommendation['scores'],
+        'confidence'    => $this->calculate_enhanced_confidence( $enhanced_scores, $enriched_profile ),
+        'reasoning'     => $this->generate_ai_enhanced_reasoning( $recommended, $enriched_profile, $ai_factors ),
+        'alternatives'  => $this->get_intelligent_alternatives( $enhanced_scores, $enriched_profile ),
+        'ai_insights'   => [
+                'maturity_assessment'     => $ai_factors['maturity_alignment'],
+                'implementation_readiness'=> $ai_factors['implementation_readiness'],
+                'strategic_fit'           => $ai_factors['strategic_alignment'],
+                'risk_assessment'         => $ai_factors['risk_factors'],
+        ],
 ];
 }
 

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -50,7 +50,7 @@ class RTBCB_Router {
             // Perform ROI calculations.
             $calculations = RTBCB_Calculator::calculate_roi( $form_data );
 
-            $fast_mode = 'fast' === $report_type || ! empty( $_POST['fast_mode'] ) || get_option( 'rtbcb_fast_mode', 0 );
+            $fast_mode = 'fast' === $report_type || ! empty( $_POST['fast_mode'] ) || rtbcb_heavy_features_disabled();
             if ( $fast_mode ) {
                 $report_html = $this->get_fast_report_html( $form_data, $calculations );
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -31,6 +31,23 @@ function rtbcb_get_api_timeout() {
 require_once __DIR__ . '/config.php';
 
 /**
+ * Check if heavy features are disabled globally.
+ *
+ * Combines the temporary bypass option and Fast Mode toggle to determine
+ * whether AI enrichment, RAG, and intelligent recommendations should run.
+ *
+ * @return bool True when heavy features should be skipped.
+ */
+function rtbcb_heavy_features_disabled() {
+        if ( function_exists( 'get_option' ) ) {
+                return (bool) get_option( 'rtbcb_disable_heavy_features', 0 )
+                        || (bool) get_option( 'rtbcb_fast_mode', 0 );
+        }
+
+        return false;
+}
+
+/**
  * Determine the current analysis tier.
  *
  * Uses plugin settings to detect enabled features and maps them to one of
@@ -39,13 +56,13 @@ require_once __DIR__ . '/config.php';
  * @return string Analysis type.
  */
 function rtbcb_get_analysis_type() {
-	$analysis_type = 'basic';
+       $analysis_type = 'basic';
 
-	$enable_ai = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_setting( 'enable_ai_analysis', true ) : true;
+       $enable_ai = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_setting( 'enable_ai_analysis', true ) : true;
 
-	if ( $enable_ai ) {
-		$analysis_type = 'enhanced';
-	}
+       if ( $enable_ai && ! rtbcb_heavy_features_disabled() ) {
+               $analysis_type = 'enhanced';
+       }
 
 	if ( function_exists( 'apply_filters' ) ) {
 		$analysis_type = apply_filters( 'rtbcb_analysis_type', $analysis_type );

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,10 @@ environment variable, or by creating a `rtbcb-config.json` file in the plugin di
 
 Values outside the 256–128,000 range are ignored.
 
+Administrators can temporarily bypass AI enrichment and related heavy features by enabling
+the **Disable Heavy Features** option on the settings page. This mode produces basic
+ROI-only reports and displays an admin notice until the option is turned off.
+
 == Testing Dashboard ==
 From the WordPress admin, go to **Real Treasury → Test Dashboard** and click
 **Run All Tests** to execute the full suite. A progress bar indicates overall


### PR DESCRIPTION
## Summary
- add global option to disable heavy AI features and fall back to basic analysis
- short-circuit enrichment, RAG search, and intelligent recommendations when bypass or Fast Mode is active
- document temporary bypass mode and alert admins when it is enabled

## Testing
- `markdownlint docs/**/*.md` *(fails: MD013/line-length, MD022/blanks-around-headings, MD040/fenced-code-language, MD012/no-multiple-blanks)*
- `markdown-link-check docs/TEMPORARY_BYPASS_MODE.md`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(partial: PHP syntax checks only)*

------
https://chatgpt.com/codex/tasks/task_e_68b3aa414d008331a57b6aca8b1a17a5