### PR TITLE
Expose AI and chart settings

### DIFF
--- a/admin/analytics-page.php
+++ b/admin/analytics-page.php
@@ -14,6 +14,7 @@ $recent_leads = $stats['recent_leads'] ?? 0;
 $category_stats = $stats['by_category'] ?? [];
 $size_stats = $stats['by_company_size'] ?? [];
 $roi_stats = $stats['average_roi'] ?? [];
+$enable_charts = RTBCB_Settings::get_setting( 'enable_charts', true );
 ?>
 
 <div class="wrap rtbcb-admin-page">
@@ -76,6 +77,7 @@ $roi_stats = $stats['average_roi'] ?? [];
         </div>
     </div>
 
+    <?php if ( $enable_charts ) : ?>
     <!-- Charts Section -->
     <div class="rtbcb-charts-grid">
         <!-- Category Distribution Chart -->
@@ -475,7 +477,8 @@ function initializeAnalyticsCharts() {
         showFallback('rtbcb-trends-chart');
     }
 }
-</script>
+    </script>
+    <?php endif; ?>
 
 <style>
 /* Analytics page specific styles */

--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -74,13 +74,18 @@ class RTBCB_Admin {
             return;
 	}
 
-        wp_enqueue_script( 'chart-js', RTBCB_URL . 'public/js/chart.min.js', [], '3.9.1', true );
-        wp_enqueue_script( 
-            'rtbcb-admin', 
-            RTBCB_URL . 'admin/js/rtbcb-admin.js', 
-            [ 'jquery', 'chart-js' ], 
-            RTBCB_VERSION, 
-            true 
+        $deps          = [ 'jquery' ];
+        $enable_charts = RTBCB_Settings::get_setting( 'enable_charts', true );
+        if ( $enable_charts ) {
+            wp_enqueue_script( 'chart-js', RTBCB_URL . 'public/js/chart.min.js', [], '3.9.1', true );
+            $deps[] = 'chart-js';
+        }
+        wp_enqueue_script(
+            'rtbcb-admin',
+            RTBCB_URL . 'admin/js/rtbcb-admin.js',
+            $deps,
+            RTBCB_VERSION,
+            true
         );
         wp_enqueue_style(
             'rtbcb-admin',
@@ -487,6 +492,7 @@ class RTBCB_Admin {
      * @return void
      */
     public function register_settings() {
+        register_setting( 'rtbcb_settings', 'rtbcb_settings', [ 'sanitize_callback' => [ $this, 'sanitize_settings' ] ] );
         register_setting( 'rtbcb_settings', 'rtbcb_openai_api_key', [ 'sanitize_callback' => 'sanitize_text_field' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_mini_model', [ 'sanitize_callback' => 'sanitize_text_field' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_premium_model', [ 'sanitize_callback' => 'sanitize_text_field' ] );
@@ -497,7 +503,20 @@ class RTBCB_Admin {
 		register_setting( 'rtbcb_settings', 'rtbcb_gpt5_timeout', [ 'sanitize_callback' => 'rtbcb_sanitize_api_timeout' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_max_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_max_output_tokens' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_min_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_min_output_tokens' ] );
-		register_setting( 'rtbcb_settings', 'rtbcb_fast_mode', [ 'sanitize_callback' => 'absint' ] );
+        register_setting( 'rtbcb_settings', 'rtbcb_fast_mode', [ 'sanitize_callback' => 'absint' ] );
+    }
+
+    /**
+     * Sanitize rtbcb_settings option.
+     *
+     * @param array $settings Settings array.
+     * @return array
+     */
+    public function sanitize_settings( $settings ) {
+        $settings = is_array( $settings ) ? $settings : [];
+        $settings['enable_ai_analysis'] = isset( $settings['enable_ai_analysis'] ) ? (bool) $settings['enable_ai_analysis'] : false;
+        $settings['enable_charts']      = isset( $settings['enable_charts'] ) ? (bool) $settings['enable_charts'] : false;
+        return $settings;
     }
 
     /**

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -19,6 +19,9 @@ $gpt5_timeout    = rtbcb_get_api_timeout();
 $gpt5_max_output_tokens = get_option( 'rtbcb_gpt5_max_output_tokens', 8000 );
 $gpt5_min_output_tokens = get_option( 'rtbcb_gpt5_min_output_tokens', 256 );
 $fast_mode       = get_option( 'rtbcb_fast_mode', 0 );
+$feature_settings    = get_option( 'rtbcb_settings', RTBCB_Settings::DEFAULTS );
+$enable_ai_analysis = isset( $feature_settings['enable_ai_analysis'] ) ? (bool) $feature_settings['enable_ai_analysis'] : true;
+$enable_charts      = isset( $feature_settings['enable_charts'] ) ? (bool) $feature_settings['enable_charts'] : true;
 
 $chat_models = [
     'gpt-5'             => 'gpt-5',
@@ -155,6 +158,24 @@ $embedding_models = [
                 <td>
                     <input type="checkbox" id="rtbcb_fast_mode" name="rtbcb_fast_mode" value="1" <?php checked( 1, $fast_mode ); ?> />
                     <p class="description"><?php echo esc_html__( 'Generate a basic ROI-only report without AI processing.', 'rtbcb' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="rtbcb_enable_ai_analysis"><?php echo esc_html__( 'Enable AI Analysis', 'rtbcb' ); ?></label>
+                </th>
+                <td>
+                    <input type="checkbox" id="rtbcb_enable_ai_analysis" name="rtbcb_settings[enable_ai_analysis]" value="1" <?php checked( $enable_ai_analysis ); ?> />
+                    <p class="description"><?php echo esc_html__( 'Use AI services for enhanced insights and recommendations.', 'rtbcb' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="rtbcb_enable_charts"><?php echo esc_html__( 'Enable Charts', 'rtbcb' ); ?></label>
+                </th>
+                <td>
+                    <input type="checkbox" id="rtbcb_enable_charts" name="rtbcb_settings[enable_charts]" value="1" <?php checked( $enable_charts ); ?> />
+                    <p class="description"><?php echo esc_html__( 'Display visual charts in reports and analytics.', 'rtbcb' ); ?></p>
                 </td>
             </tr>
         </table>

--- a/inc/class-rtbcb-settings.php
+++ b/inc/class-rtbcb-settings.php
@@ -27,6 +27,7 @@ class RTBCB_Settings {
         'bank_fee_reduction'        => [ 'min' => 5, 'max' => 10 ],
         'baseline_bank_fee_multiplier' => 15000,
         'enable_ai_analysis'        => true,
+        'enable_charts'            => true,
     ];
 
     /**

--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -548,12 +548,15 @@ class BusinessCaseBuilder {
         const progressContainer = document.getElementById('rtbcb-progress-container');
         if (progressContainer) {
             const companyName = this.form.querySelector('[name="company_name"]')?.value || 'your company';
+            const initialText = window.rtbcbAjax?.settings?.enable_ai_analysis
+                ? `Analyzing ${this.escapeHTML(companyName)}'s treasury operations...`
+                : 'Calculating ROI...';
             progressContainer.innerHTML = `
                 <div class="rtbcb-progress-content">
                     <div class="rtbcb-progress-spinner"></div>
                     <div class="rtbcb-progress-text">Generating Your Business Case</div>
                     <div class="rtbcb-progress-step">
-                        <span class="rtbcb-progress-step-text" id="rtbcb-progress-status">Analyzing ${this.escapeHTML(companyName)}'s treasury operations...</span>
+                        <span class="rtbcb-progress-step-text" id="rtbcb-progress-status">${initialText}</span>
                     </div>
                 </div>
             `;
@@ -731,6 +734,10 @@ class BusinessCaseBuilder {
     }
 
     initializeReportCharts(container) {
+        if ( window.rtbcbAjax?.settings && window.rtbcbAjax.settings.enable_charts === false ) {
+            console.log('RTBCB: Charts disabled in settings');
+            return;
+        }
         const chartCanvas = container.querySelector('#rtbcb-roi-chart');
         if (!chartCanvas) return;
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -423,14 +423,19 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 			);
 		}
 
-	    // Chart.js for report visualizations
-	    wp_enqueue_script(
-	        'chartjs',
-	        RTBCB_URL . 'public/js/chart.min.js',
-	        [],
-	        '3.9.1',
-	        true
-	    );
+            $enable_charts = RTBCB_Settings::get_setting( 'enable_charts', true );
+            $report_deps   = [];
+            if ( $enable_charts ) {
+                // Chart.js for report visualizations
+                wp_enqueue_script(
+                    'chartjs',
+                    RTBCB_URL . 'public/js/chart.min.js',
+                    [],
+                    '3.9.1',
+                    true
+                );
+                $report_deps[] = 'chartjs';
+            }
 
 	    // DOMPurify for sanitization with CDN fallback
 	    $dompurify_cdn   = 'https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.2/purify.min.js';
@@ -463,12 +468,12 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 		// Main report functionality
 		$report_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb-report.js' : 'rtbcb-report.min.js';
 		wp_enqueue_script(
-			'rtbcb-report',
-			RTBCB_URL . 'public/js/' . $report_file,
-			[ 'chartjs', 'dompurify' ],
-			RTBCB_VERSION,
-			true
-		);
+                'rtbcb-report',
+                RTBCB_URL . 'public/js/' . $report_file,
+                array_merge( $report_deps, [ 'dompurify' ] ),
+                RTBCB_VERSION,
+                true
+            );
 
 		// Main plugin script
 		$main_script = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb.js' : 'rtbcb.min.js';
@@ -509,13 +514,15 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 	                'select_pain_points'      => __( 'Please select at least one pain point.', 'rtbcb' ),
 	                'email_confirmation'      => __( 'Your report will arrive by email shortly.', 'rtbcb' ),
 	            ],
-	            'settings'    => [
-	                'pdf_enabled'            => get_option( 'rtbcb_pdf_enabled', true ),
-	                'comprehensive_analysis' => get_option( 'rtbcb_comprehensive_analysis', true ),
-	                'professional_reports'   => get_option( 'rtbcb_professional_reports', true ),
-	            ],
-	        ]
-	    );
+                    'settings'    => [
+                        'pdf_enabled'            => get_option( 'rtbcb_pdf_enabled', true ),
+                        'comprehensive_analysis' => get_option( 'rtbcb_comprehensive_analysis', true ),
+                        'professional_reports'   => get_option( 'rtbcb_professional_reports', true ),
+                        'enable_ai_analysis'     => RTBCB_Settings::get_setting( 'enable_ai_analysis', true ),
+                        'enable_charts'          => RTBCB_Settings::get_setting( 'enable_charts', true ),
+                    ],
+                ]
+            );
 
 	    // Report configuration
 	    $config             = rtbcb_get_gpt5_config();

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -25,6 +25,7 @@ $operational_insights = $report_data['operational_insights'] ?? [];
 $risk_analysis        = $report_data['risk_analysis'] ?? [];
 $action_plan          = $report_data['action_plan'] ?? [];
 $rag_context          = $report_data['rag_context'] ?? [];
+$enable_charts        = RTBCB_Settings::get_setting( 'enable_charts', true );
 
 $company_name    = $metadata['company_name'] ?? __( 'Your Company', 'rtbcb' );
 $analysis_date   = $metadata['analysis_date'] ?? current_time( 'Y-m-d' );
@@ -204,25 +205,27 @@ $processing_time = $metadata['processing_time'] ?? 0;
 		</div>
 		
 		<div id="financial-content" class="rtbcb-section-content">
-			<!-- ROI Scenarios Chart -->
-			<div class="rtbcb-roi-chart-container">
-				<h3><?php echo esc_html__( 'ROI Scenario Analysis', 'rtbcb' ); ?></h3>
-				<canvas id="rtbcb-roi-chart" width="800" height="400"></canvas>
-				<div class="rtbcb-chart-legend">
-					<div class="rtbcb-legend-item">
-						<span class="rtbcb-legend-color conservative"></span>
-						<span><?php echo esc_html__( 'Conservative Scenario', 'rtbcb' ); ?></span>
-					</div>
-					<div class="rtbcb-legend-item">
-						<span class="rtbcb-legend-color base"></span>
-						<span><?php echo esc_html__( 'Base Case', 'rtbcb' ); ?></span>
-					</div>
-					<div class="rtbcb-legend-item">
-						<span class="rtbcb-legend-color optimistic"></span>
-						<span><?php echo esc_html__( 'Optimistic Scenario', 'rtbcb' ); ?></span>
-					</div>
-				</div>
-			</div>
+                <!-- ROI Scenarios Chart -->
+                <?php if ( $enable_charts ) : ?>
+                <div class="rtbcb-roi-chart-container">
+                        <h3><?php echo esc_html__( 'ROI Scenario Analysis', 'rtbcb' ); ?></h3>
+                        <canvas id="rtbcb-roi-chart" width="800" height="400"></canvas>
+                        <div class="rtbcb-chart-legend">
+                                <div class="rtbcb-legend-item">
+                                        <span class="rtbcb-legend-color conservative"></span>
+                                        <span><?php echo esc_html__( 'Conservative Scenario', 'rtbcb' ); ?></span>
+                                </div>
+                                <div class="rtbcb-legend-item">
+                                        <span class="rtbcb-legend-color base"></span>
+                                        <span><?php echo esc_html__( 'Base Case', 'rtbcb' ); ?></span>
+                                </div>
+                                <div class="rtbcb-legend-item">
+                                        <span class="rtbcb-legend-color optimistic"></span>
+                                        <span><?php echo esc_html__( 'Optimistic Scenario', 'rtbcb' ); ?></span>
+                                </div>
+                        </div>
+                </div>
+                <?php endif; ?>
 
 			<!-- ROI Breakdown -->
 			<div class="rtbcb-roi-breakdown-enhanced">
@@ -479,8 +482,10 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function initializeROIChart() {
-	const ctx = document.getElementById('rtbcb-roi-chart');
-	if (!ctx) return;
+        const ctx = document.getElementById('rtbcb-roi-chart');
+        if ( ! ctx || typeof Chart === 'undefined' ) {
+                return;
+        }
 	
 	const roiData = <?php echo wp_json_encode( $financial_analysis['roi_scenarios'] ?? [] ); ?>;
 	


### PR DESCRIPTION
## Summary
- add `enable_ai_analysis` and `enable_charts` defaults and sanitize support
- allow toggling AI analysis and charts from plugin settings
- conditionally enqueue Chart.js and skip chart rendering when disabled

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found; TypeError in JS test)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ae2b905483319db0fb697cf9f8d5