### PR TITLE
Silence API key warning in research cache test

### DIFF
--- a/tests/company-research-cache.test.php
+++ b/tests/company-research-cache.test.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/../' );
 }
 
+ini_set( 'error_log', '/dev/null' );
+
 if ( ! function_exists( 'sanitize_text_field' ) ) {
 	function sanitize_text_field( $text ) {
 		$text = is_scalar( $text ) ? (string) $text : '';


### PR DESCRIPTION
## Summary
- Silence OpenAI API key warning in company research cache test by redirecting error logs to `/dev/null`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=test-model bash tests/run-tests.sh` *(fails: `phpunit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68b3aebf0bc08331992af54e700d2a8a