### PR TITLE
Add category-aware ROI refinement

### DIFF
--- a/docs/END_TO_END_WORKFLOW.md
+++ b/docs/END_TO_END_WORKFLOW.md
@@ -10,20 +10,17 @@ This document summarizes the workflow from internal company research to deliveri
 
 ## 2. User Form Submission (Public)
 
-* A public user completes the multi-step form rendered by `templates/business-case-form.php`.
-* Input data is sanitized and stored for downstream processing.
+- A public user completes the multi-step form rendered by `templates/business-case-form.php`.
+- Input data is sanitized and stored for downstream processing.
+- `RTBCB_Category_Recommender::recommend_category()` scores the input against predefined categories.
+- `RTBCB_Calculator::calculate_category_refined_roi()` recomputes ROI using the category output.
 
 ## 3. Business Case Generation
 
-* `RTBCB_LLM::generate_business_case()` combines sanitized user inputs with ROI data and optional RAG context.
-* The LLM returns JSON containing executive summaries, operational analysis, industry insights, and financial analysis blocks.
+- `RTBCB_LLM::generate_business_case()` combines sanitized user inputs with ROI data and optional RAG context.
+- The LLM returns JSON containing executive summaries, operational analysis, industry insights, and financial analysis blocks.
 
-## 4. Category Recommendation
+## 4. Final Report Assembly
 
-* The plugin categorizes the user's challenges without an LLM.
-* `RTBCB_Category_Recommender::recommend_category()` scores the input against predefined categories and returns a recommendation with reasoning and confidence.
-
-## 5. Final Report Assembly
-
-* Outputs from the LLM and category recommender are merged with ROI calculations.
-* The result is rendered via `templates/comprehensive-report-template.php` and enhanced in `public/js/rtbcb-report.js` before being shown to the user.
+- Outputs from the LLM and category recommender are merged with ROI calculations.
+- The result is rendered via `templates/comprehensive-report-template.php` and enhanced in `public/js/rtbcb-report.js` before being shown to the user.

--- a/docs/WIZARD_FORM_API_FLOW.md
+++ b/docs/WIZARD_FORM_API_FLOW.md
@@ -35,9 +35,10 @@ Field definitions come from `templates/business-case-form.php` and the field reg
 
 1. **ROI Calculation** – `RTBCB_Calculator::calculate_roi()` builds conservative, base, and optimistic scenarios.
 2. **Category Recommendation** – `RTBCB_Category_Recommender::recommend_category()` scores the selected challenges to suggest a treasury solution type.
-3. **RAG Search** – `RTBCB_RAG::search_similar()` retrieves supporting context using the company profile and pain points.
-4. **OpenAI Call** – `RTBCB_LLM::generate_comprehensive_business_case()` combines user inputs, ROI data, and RAG context to produce narrative analysis.
-5. **Report Assembly** – `get_comprehensive_report_html()` renders the final HTML which is returned in the AJAX response.
+3. **ROI Refinement** – `RTBCB_Calculator::calculate_category_refined_roi()` recomputes ROI using the recommended category.
+4. **RAG Search** – `RTBCB_RAG::search_similar()` retrieves supporting context using the company profile and pain points.
+5. **OpenAI Call** – `RTBCB_LLM::generate_comprehensive_business_case()` combines user inputs, ROI data, and RAG context to produce narrative analysis.
+6. **Report Assembly** – `get_comprehensive_report_html()` renders the final HTML which is returned in the AJAX response.
 
 ## End-to-End Flow
 
@@ -56,6 +57,7 @@ sequenceDiagram
     JS->>WP: POST rtbcb_generate_case
     WP->>ROI: calculate_roi()
     WP->>Cat: recommend_category()
+    WP->>ROI: calculate_category_refined_roi()
     WP->>RAG: search_similar()
     WP->>LLM: generate_comprehensive_business_case()
     LLM-->>WP: analysis

--- a/inc/class-rtbcb-calculator.php
+++ b/inc/class-rtbcb-calculator.php
@@ -17,13 +17,12 @@ class RTBCB_Calculator {
      * Calculate ROI scenarios for given inputs.
      *
      * @param array $user_inputs User provided inputs.
+     * @param array $category    Optional category info.
      * @return array
      */
-    public static function calculate_roi( $user_inputs ) {
-        $settings       = RTBCB_Settings::get_all();
-        $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
-        $category       = $recommendation['category_info'];
-        $industry_mult  = self::get_industry_benchmark( $user_inputs['industry'] ?? '' );
+    public static function calculate_roi( $user_inputs, $category = [] ) {
+        $settings      = RTBCB_Settings::get_all();
+        $industry_mult = self::get_industry_benchmark( $user_inputs['industry'] ?? '' );
 
         $scenarios = [];
         foreach ( [ 'conservative', 'base', 'optimistic' ] as $scenario ) {
@@ -31,6 +30,18 @@ class RTBCB_Calculator {
         }
 
         return $scenarios;
+    }
+
+    /**
+     * Recalculate ROI using category recommendation.
+     *
+     * @param array $user_inputs    User provided inputs.
+     * @param array $recommendation Category recommendation output.
+     * @return array
+     */
+    public static function calculate_category_refined_roi( $user_inputs, $recommendation ) {
+        $category = $recommendation['category_info'] ?? [];
+        return self::calculate_roi( $user_inputs, $category );
     }
 
     /**

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -48,7 +48,8 @@ class RTBCB_Router {
             }
 
             // Perform ROI calculations.
-            $calculations = RTBCB_Calculator::calculate_roi( $form_data );
+            $category_output = RTBCB_Category_Recommender::recommend_category( $form_data );
+            $calculations    = RTBCB_Calculator::calculate_category_refined_roi( $form_data, $category_output );
 
             $fast_mode = 'fast' === $report_type || ! empty( $_POST['fast_mode'] ) || get_option( 'rtbcb_fast_mode', 0 );
             if ( $fast_mode ) {

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -767,25 +767,25 @@ return $use_comprehensive;
 				return;
 			}
 
-			try {
-				// Calculate ROI scenarios.
-				if ( ! class_exists( 'RTBCB_Calculator' ) ) {
-					wp_send_json_error( [ 'message' => __( 'System error: Calculator not available.', 'rtbcb' ) ], 500 );
-					return;
-				}
+                        try {
+                                // Get category recommendation.
+                                if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
+                                        wp_send_json_error( [ 'message' => __( 'System error: Recommender not available.', 'rtbcb' ) ], 500 );
+                                        return;
+                                }
 
-				$scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
+                                $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
 
-				// Get category recommendation.
-				if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
-					wp_send_json_error( [ 'message' => __( 'System error: Recommender not available.', 'rtbcb' ) ], 500 );
-					return;
-				}
+                                // Calculate ROI scenarios.
+                                if ( ! class_exists( 'RTBCB_Calculator' ) ) {
+                                        wp_send_json_error( [ 'message' => __( 'System error: Calculator not available.', 'rtbcb' ) ], 500 );
+                                        return;
+                                }
 
-				$recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+                                $scenarios = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $recommendation );
 
-				// Get RAG context if available.
-				$rag_context = $this->get_rag_context( $user_inputs, $recommendation );
+                                // Get RAG context if available.
+                                $rag_context = $this->get_rag_context( $user_inputs, $recommendation );
 
 				// Generate business case analysis.
 				$comprehensive_analysis = $this->generate_business_analysis( $user_inputs, $scenarios, $rag_context );
@@ -1390,11 +1390,6 @@ return $use_comprehensive;
                 return;
             }
 
-            rtbcb_log_api_debug( 'Starting ROI calculation' );
-            $scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
-            rtbcb_log_api_debug( 'ROI scenarios calculated', $scenarios );
-            rtbcb_log_memory_usage( 'after_roi_calculation' );
-
             // Get category recommendation
             if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
                 rtbcb_log_error( 'Category Recommender class not found' );
@@ -1406,6 +1401,11 @@ return $use_comprehensive;
             $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
             rtbcb_log_api_debug( 'Category recommendation result', $recommendation );
             rtbcb_log_memory_usage( 'after_category_recommendation' );
+
+            rtbcb_log_api_debug( 'Starting ROI calculation' );
+            $scenarios = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $recommendation );
+            rtbcb_log_api_debug( 'ROI scenarios calculated', $scenarios );
+            rtbcb_log_memory_usage( 'after_roi_calculation' );
 
             // Get RAG context (with memory monitoring)
             $rag_context = [];

--- a/tests/edge-cases.test.php
+++ b/tests/edge-cases.test.php
@@ -95,8 +95,19 @@ return rtrim( $string, '/\\' ) . '/';
 // Stub plugin classes.
 if ( ! class_exists( 'RTBCB_Calculator' ) ) {
 class RTBCB_Calculator {
-public static function calculate_roi( $data ) {
+public static function calculate_roi( $data, $category = [] ) {
 return [ 'roi_base' => 1000 ];
+}
+public static function calculate_category_refined_roi( $data, $recommendation ) {
+return self::calculate_roi( $data, $recommendation['category_info'] ?? [] );
+}
+}
+}
+
+if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
+class RTBCB_Category_Recommender {
+public static function recommend_category( $inputs ) {
+return [ 'recommended' => 'cash_tools', 'category_info' => [] ];
 }
 }
 }


### PR DESCRIPTION
## Summary
- Accept optional category input in `RTBCB_Calculator::calculate_roi` and expose new `calculate_category_refined_roi`
- Rework workflow to recommend category first and then recompute ROI
- Document updated flow and provide test stubs

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `npx markdownlint-cli docs/END_TO_END_WORKFLOW.md docs/WIZARD_FORM_API_FLOW.md` *(fails: line length, list style)*
- `npx markdown-link-check docs/END_TO_END_WORKFLOW.md`
- `npx markdown-link-check docs/WIZARD_FORM_API_FLOW.md`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4.1 bash tests/run-tests.sh` *(fails: phpunit not found)*
- `phpcs --standard=WordPress inc/class-rtbcb-calculator.php inc/class-rtbcb-router.php real-treasury-business-case-builder.php tests/edge-cases.test.php` *(fails: phpcs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3afb7ff408331aa4350239b3bba4c