### PR TITLE
Cache report templates and purge cache on lead updates

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -268,12 +268,13 @@ class RTBCB_Router {
         }
 
         $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
-        $report_data        = $business_case_data['report_data'] ?? null;
-        $hash_source        = $report_data ?: $business_case_data;
-        $data_hash          = md5( wp_json_encode( $hash_source ) );
-        $cache_key          = md5( $template_path . ':' . $data_hash );
+	$report_data        = $business_case_data['report_data'] ?? null;
+	$hash_source        = $report_data ?: $business_case_data;
+	$data_hash          = md5( wp_json_encode( $hash_source ) );
+	$version            = rtbcb_get_report_cache_version();
+	$cache_key          = md5( $template_path . ':' . $data_hash . ':' . $version );
 
-        $cached_html = wp_cache_get( $cache_key, 'rtbcb_reports' );
+	$cached_html = wp_cache_get( $cache_key, 'rtbcb_reports' );
         if ( false !== $cached_html ) {
             return $cached_html;
         }
@@ -332,12 +333,13 @@ class RTBCB_Router {
 
        $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
 
-       $report_data = $business_case_data['report_data'] ?? null;
-       $hash_source = $report_data ?: $business_case_data;
-       $data_hash  = md5( wp_json_encode( $hash_source ) );
-       $cache_key  = md5( $template_path . ':' . $data_hash );
+	$report_data = $business_case_data['report_data'] ?? null;
+	$hash_source = $report_data ?: $business_case_data;
+	$data_hash  = md5( wp_json_encode( $hash_source ) );
+	$version    = rtbcb_get_report_cache_version();
+	$cache_key  = md5( $template_path . ':' . $data_hash . ':' . $version );
 
-       $cached_html = wp_cache_get( $cache_key, 'rtbcb_reports' );
+	$cached_html = wp_cache_get( $cache_key, 'rtbcb_reports' );
        if ( false !== $cached_html ) {
            return $cached_html;
        }

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -816,11 +816,11 @@ function rtbcb_log_memory_usage( $stage ) {
 }
 
 function rtbcb_get_memory_status() {
-        return [
-                'current' => memory_get_usage( true ),
-                'peak'    => memory_get_peak_usage( true ),
-                'limit'   => wp_convert_hr_to_bytes( ini_get( 'memory_limit' ) ),
-        ];
+		return [
+		        'current' => memory_get_usage( true ),
+		        'peak'    => memory_get_peak_usage( true ),
+		        'limit'   => wp_convert_hr_to_bytes( ini_get( 'memory_limit' ) ),
+		];
 }
 
 /**
@@ -841,26 +841,26 @@ function rtbcb_get_memory_status() {
  * @return bool True when synchronous execution is allowed.
  */
 function rtbcb_is_simple_case( $user_inputs ) {
-        $user_inputs = is_array( $user_inputs ) ? $user_inputs : [];
+		$user_inputs = is_array( $user_inputs ) ? $user_inputs : [];
 
-        // Thresholds for determining a simple case.
-        $max_banks = 2;  // No more than two banking relationships.
-        $max_ftes  = 2;  // Teams of two FTEs or fewer.
-        $max_hours = 20; // Twenty or fewer total manual hours per week.
+		// Thresholds for determining a simple case.
+		$max_banks = 2;  // No more than two banking relationships.
+		$max_ftes  = 2;  // Teams of two FTEs or fewer.
+		$max_hours = 20; // Twenty or fewer total manual hours per week.
 
-        $num_banks = absint( $user_inputs['num_banks'] ?? 0 );
-        $ftes      = absint( $user_inputs['ftes'] ?? 0 );
-        $hours     = absint( $user_inputs['hours_reconciliation'] ?? 0 ) + absint( $user_inputs['hours_cash_positioning'] ?? 0 );
+		$num_banks = absint( $user_inputs['num_banks'] ?? 0 );
+		$ftes      = absint( $user_inputs['ftes'] ?? 0 );
+		$hours     = absint( $user_inputs['hours_reconciliation'] ?? 0 ) + absint( $user_inputs['hours_cash_positioning'] ?? 0 );
 
-        $is_simple = ( $num_banks <= $max_banks && $ftes <= $max_ftes && $hours <= $max_hours );
+		$is_simple = ( $num_banks <= $max_banks && $ftes <= $max_ftes && $hours <= $max_hours );
 
-        /**
-         * Filter whether a case is simple enough for synchronous execution.
-         *
-         * @param bool  $is_simple   Whether case is considered simple.
-         * @param array $user_inputs User input data.
-         */
-        return (bool) apply_filters( 'rtbcb_is_simple_case', $is_simple, $user_inputs );
+		/**
+		 * Filter whether a case is simple enough for synchronous execution.
+		 *
+		 * @param bool  $is_simple   Whether case is considered simple.
+		 * @param array $user_inputs User input data.
+		 */
+		return (bool) apply_filters( 'rtbcb_is_simple_case', $is_simple, $user_inputs );
 }
 
 /**
@@ -986,23 +986,23 @@ function rtbcb_test_generate_category_recommendation( $analysis ) {
 			$input .= "\nExtra Requirements: {$payload['extra_requirements']}";
 		}
 
-                $response = rtbcb_wp_remote_post_with_retry(
-                        'https://api.openai.com/v1/responses',
-                        [
-                                'headers' => [
-                                        'Content-Type'  => 'application/json',
-                                        'Authorization' => 'Bearer ' . $api_key,
-                                ],
-                                'body'    => wp_json_encode(
-                                        [
-                                                'model'        => $model,
-                                                'instructions' => $system_prompt,
-                                                'input'        => $input,
-                                        ]
-                                ),
-                                'timeout' => rtbcb_get_api_timeout(),
-                        ]
-                );
+		        $response = rtbcb_wp_remote_post_with_retry(
+		                'https://api.openai.com/v1/responses',
+		                [
+		                        'headers' => [
+		                                'Content-Type'  => 'application/json',
+		                                'Authorization' => 'Bearer ' . $api_key,
+		                        ],
+		                        'body'    => wp_json_encode(
+		                                [
+		                                        'model'        => $model,
+		                                        'instructions' => $system_prompt,
+		                                        'input'        => $input,
+		                                ]
+		                        ),
+		                        'timeout' => rtbcb_get_api_timeout(),
+		                ]
+		        );
 
 		if ( is_wp_error( $response ) ) {
 			return new WP_Error( 'llm_failure', __( 'Unable to generate recommendation at this time.', 'rtbcb' ) );
@@ -1516,17 +1516,17 @@ function rtbcb_handle_openai_responses_job( $job_id, $user_id ) {
 		$timeout = 120;
 	}
 
-        $response = rtbcb_wp_remote_post_with_retry(
-                'https://api.openai.com/v1/responses',
-                [
-                        'headers' => [
-                                'Content-Type'  => 'application/json',
-                                'Authorization' => 'Bearer ' . $api_key,
-                        ],
-                        'body'    => $body,
-                        'timeout' => $timeout,
-                ]
-        );
+		$response = rtbcb_wp_remote_post_with_retry(
+		        'https://api.openai.com/v1/responses',
+		        [
+		                'headers' => [
+		                        'Content-Type'  => 'application/json',
+		                        'Authorization' => 'Bearer ' . $api_key,
+		                ],
+		                'body'    => $body,
+		                'timeout' => $timeout,
+		        ]
+		);
 
 	if ( is_wp_error( $response ) ) {
 			    if ( class_exists( 'RTBCB_API_Log' ) ) {
@@ -1861,7 +1861,7 @@ function rtbcb_get_report_allowed_html() {
 		$allowed[ $tag ]['data-*'] = true;
 	}
 
-        return $allowed;
+		return $allowed;
 }
 
 /**
@@ -1870,30 +1870,39 @@ function rtbcb_get_report_allowed_html() {
  * @return void
  */
 function rtbcb_invalidate_rag_cache() {
-        if ( function_exists( 'get_option' ) && function_exists( 'update_option' ) ) {
-                $version = (int) get_option( 'rtbcb_rag_cache_version', 1 );
-                update_option( 'rtbcb_rag_cache_version', $version + 1 );
-        }
+		if ( function_exists( 'get_option' ) && function_exists( 'update_option' ) ) {
+		        $version = (int) get_option( 'rtbcb_rag_cache_version', 1 );
+		        update_option( 'rtbcb_rag_cache_version', $version + 1 );
+		}
 }
 
 /**
  * Clear cached report HTML entries.
  *
- * Removes all cached report templates to ensure fresh rendering when lead data changes.
+ * Retrieves the current report cache version for versioned cache keys.
+ *
+ * @return int
+ */
+function rtbcb_get_report_cache_version() {
+	$version = wp_cache_get( 'report_cache_version', 'rtbcb_reports' );
+
+	if ( false === $version ) {
+		$version = 1;
+		wp_cache_set( 'report_cache_version', $version, 'rtbcb_reports' );
+	}
+
+	return (int) $version;
+}
+
+/**
+ * Clear cached report HTML entries.
+ *
+ * Bumps the report cache version so previously cached templates are ignored.
  *
  * @return void
  */
 function rtbcb_clear_report_cache() {
-        global $wp_object_cache;
-
-        if ( ! isset( $wp_object_cache->cache ) || ! is_array( $wp_object_cache->cache ) ) {
-                return;
-        }
-
-        if ( isset( $wp_object_cache->cache['rtbcb_reports'] ) && is_array( $wp_object_cache->cache['rtbcb_reports'] ) ) {
-                foreach ( array_keys( $wp_object_cache->cache['rtbcb_reports'] ) as $key ) {
-                        wp_cache_delete( $key, 'rtbcb_reports' );
-                }
-        }
+	$version = rtbcb_get_report_cache_version();
+	wp_cache_set( 'report_cache_version', $version + 1, 'rtbcb_reports' );
 }
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1797,12 +1797,13 @@ return $use_comprehensive;
 
         $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
 
-        $report_data = $business_case_data['report_data'] ?? null;
-        $hash_source = $report_data ?: $business_case_data;
-        $data_hash  = md5( wp_json_encode( $hash_source ) );
-        $cache_key  = md5( $template_path . ':' . $data_hash );
+	$report_data = $business_case_data['report_data'] ?? null;
+	$hash_source = $report_data ?: $business_case_data;
+	$data_hash  = md5( wp_json_encode( $hash_source ) );
+	$version    = rtbcb_get_report_cache_version();
+	$cache_key  = md5( $template_path . ':' . $data_hash . ':' . $version );
 
-        $cached_html = wp_cache_get( $cache_key, 'rtbcb_reports' );
+	$cached_html = wp_cache_get( $cache_key, 'rtbcb_reports' );
         if ( false !== $cached_html ) {
             return $cached_html;
         }


### PR DESCRIPTION
## Summary
- version report cache keys and increment version to invalidate stale entries
- use version-aware keys when caching report HTML

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b57fa66883319ca7d01036867e16