### PR TITLE
Send report email after job completion

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -197,13 +197,15 @@ class RTBCB_Ajax {
                         if ( in_array( $field, [ 'state', 'created', 'updated', 'result' ], true ) ) {
                                 continue;
                         }
-                        if ( 'percent' === $field ) {
-                                $response[ $field ] = floatval( $value );
-                        } elseif ( in_array( $field, [ 'step', 'message' ], true ) && is_string( $value ) ) {
-                                $response[ $field ] = sanitize_text_field( $value );
-                        } else {
-                                $response[ $field ] = $value;
-                        }
+			if ( 'percent' === $field ) {
+				$response[ $field ] = floatval( $value );
+			} elseif ( 'download_url' === $field && is_string( $value ) ) {
+				$response[ $field ] = function_exists( 'esc_url_raw' ) ? esc_url_raw( $value ) : $value;
+			} elseif ( in_array( $field, [ 'step', 'message' ], true ) && is_string( $value ) ) {
+				$response[ $field ] = sanitize_text_field( $value );
+			} else {
+				$response[ $field ] = $value;
+			}
                 }
 
                 if ( isset( $status['result'] ) ) {

--- a/tests/background-job.test.php
+++ b/tests/background-job.test.php
@@ -50,6 +50,18 @@ if ( ! function_exists( 'delete_transient' ) ) {
     }
 }
 
+global $sent_report_email;
+$sent_report_email = [];
+if ( ! function_exists( 'rtbcb_send_report_email' ) ) {
+    function rtbcb_send_report_email( $form_data, $path ) {
+        global $sent_report_email;
+        $sent_report_email = [
+            'form_data' => $form_data,
+            'path'      => $path,
+        ];
+    }
+}
+
 if ( ! function_exists( 'wp_schedule_single_event' ) ) {
     function wp_schedule_single_event( $timestamp, $hook, $args ) {
         global $scheduled_events;
@@ -158,6 +170,9 @@ $final = RTBCB_Background_Job::get_status( $job_id );
 assert_true( isset( $final['basic_roi'] ), 'basic_roi missing' );
 assert_true( isset( $final['category'] ), 'category missing' );
 assert_true( 'completed' === get_transient( $job_id )['state'], 'Job not completed' );
+global $sent_report_email;
+assert_true( isset( $final['download_url'] ), 'download_url missing' );
+assert_true( ! empty( $sent_report_email['path'] ), 'Report email not sent' );
 
 // Error job flow.
 RTBCB_Ajax::$mode = 'error';

--- a/tests/job-status.test.php
+++ b/tests/job-status.test.php
@@ -109,6 +109,18 @@ assert_same( 'completed', $data['data']['status'], 'Completed status mismatch' )
 assert_same( [ 'foo' => 'bar' ], $data['data']['report_data'], 'Report data missing' );
 assert_same( 5, $data['data']['lead_id'], 'Lead ID mismatch' );
 
+$_GET['job_id'] = 'job3';
+RTBCB_Background_Job::$data['job3'] = [
+    'state'        => 'completed',
+    'download_url' => 'http://example.com/report.pdf',
+];
+try {
+    RTBCB_Ajax::get_job_status();
+} catch ( RTBCB_JSON_Response $e ) {
+    $data = $e->data;
+}
+assert_same( 'http://example.com/report.pdf', $data['data']['download_url'], 'Download URL mismatch' );
+
 $_GET['job_id'] = 'missing';
 try {
     RTBCB_Ajax::get_job_status();


### PR DESCRIPTION
## Summary
- Generate report HTML/PDF when background job completes and email to the user
- Record a download URL in job status and expose it via AJAX
- Update background job and status tests for new download link behavior

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b4297698833190043bbb65c2e275