### PR TITLE
Add heavy feature bypass option and skip AI tasks

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -497,7 +497,8 @@ class RTBCB_Admin {
 		register_setting( 'rtbcb_settings', 'rtbcb_gpt5_timeout', [ 'sanitize_callback' => 'rtbcb_sanitize_api_timeout' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_max_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_max_output_tokens' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_min_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_min_output_tokens' ] );
-		register_setting( 'rtbcb_settings', 'rtbcb_fast_mode', [ 'sanitize_callback' => 'absint' ] );
+               register_setting( 'rtbcb_settings', 'rtbcb_fast_mode', [ 'sanitize_callback' => 'absint' ] );
+               register_setting( 'rtbcb_settings', 'rtbcb_disable_heavy_features', [ 'sanitize_callback' => 'absint' ] );
     }
 
     /**

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -19,6 +19,7 @@ $gpt5_timeout    = rtbcb_get_api_timeout();
 $gpt5_max_output_tokens = get_option( 'rtbcb_gpt5_max_output_tokens', 8000 );
 $gpt5_min_output_tokens = get_option( 'rtbcb_gpt5_min_output_tokens', 256 );
 $fast_mode       = get_option( 'rtbcb_fast_mode', 0 );
+$disable_heavy_features = get_option( 'rtbcb_disable_heavy_features', 0 );
 
 $chat_models = [
     'gpt-5'             => 'gpt-5',
@@ -146,6 +147,15 @@ $embedding_models = [
                 </th>
                 <td>
                     <input type="number" step="0.01" id="rtbcb_bank_fee_baseline" name="rtbcb_bank_fee_baseline" value="<?php echo esc_attr( $bank_fee ); ?>" class="regular-text" />
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="rtbcb_disable_heavy_features"><?php echo esc_html__( 'Disable Heavy Features', 'rtbcb' ); ?></label>
+                </th>
+                <td>
+                    <input type="checkbox" id="rtbcb_disable_heavy_features" name="rtbcb_disable_heavy_features" value="1" <?php checked( 1, $disable_heavy_features ); ?> />
+                    <p class="description"><?php echo esc_html__( 'Temporarily bypass AI enrichment, RAG, and recommendations.', 'rtbcb' ); ?></p>
                 </td>
             </tr>
             <tr>

--- a/docs/TEMPORARY_BYPASS_MODE.md
+++ b/docs/TEMPORARY_BYPASS_MODE.md
@@ -1,0 +1,9 @@
+# Temporary Bypass Mode
+
+The plugin includes a global option to disable heavy AI features when needed.
+
+- Set the **Disable Heavy Features** option in the settings to skip AI enrichment, RAG, and intelligent recommendations.
+- Fast Mode also bypasses these components.
+- A warning appears in the admin area while the bypass is active.
+
+Use this mode to troubleshoot or reduce resource usage, then re‑enable the features for full analysis.

--- a/inc/class-rtbcb-intelligent-recommender.php
+++ b/inc/class-rtbcb-intelligent-recommender.php
@@ -15,6 +15,13 @@ class RTBCB_Intelligent_Recommender extends RTBCB_Category_Recommender {
  * @return array Enhanced recommendation with confidence and alternatives.
  */
 public function recommend_with_ai_insights( $user_inputs, $enriched_profile ) {
+// Return basic recommendation when heavy features are bypassed.
+$fast_mode     = ! empty( $user_inputs['fast_mode'] ) || get_option( 'rtbcb_fast_mode', 0 );
+$disable_heavy = get_option( 'rtbcb_disable_heavy_features', 0 );
+if ( $fast_mode || $disable_heavy ) {
+return RTBCB_Category_Recommender::recommend_category( $user_inputs );
+}
+
 // Get baseline recommendation from parent class.
 $base_recommendation = parent::recommend_category( $user_inputs );
 

--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -77,6 +77,9 @@ class RTBCB_RAG {
      * @return array Matching rows.
      */
     public function search_similar( $query, $top_k = 3 ) {
+        if ( get_option( 'rtbcb_disable_heavy_features', 0 ) || get_option( 'rtbcb_fast_mode', 0 ) ) {
+            return [];
+        }
         $normalized = strtolower( trim( function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $query ) : strip_tags( $query ) ) );
         $version    = function_exists( 'get_option' ) ? (int) get_option( 'rtbcb_rag_cache_version', 1 ) : 1;
         $cache_key  = 'rtbcb_rag_' . md5( $normalized . '|' . $top_k . '|' . $version );

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -40,23 +40,24 @@ require_once __DIR__ . '/config.php';
  * @return string Analysis type.
  */
 function rtbcb_get_analysis_type() {
-	$analysis_type = 'basic';
+$analysis_type = 'basic';
 
-	$enable_ai = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_setting( 'enable_ai_analysis', true ) : true;
+$enable_ai = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_setting( 'enable_ai_analysis', true ) : true;
+$bypass    = get_option( 'rtbcb_disable_heavy_features', 0 ) || get_option( 'rtbcb_fast_mode', 0 );
 
-	if ( $enable_ai ) {
-		$analysis_type = 'enhanced';
-	}
+if ( $enable_ai && ! $bypass ) {
+$analysis_type = 'enhanced';
+}
 
-	if ( function_exists( 'apply_filters' ) ) {
-		$analysis_type = apply_filters( 'rtbcb_analysis_type', $analysis_type );
-	}
+if ( function_exists( 'apply_filters' ) ) {
+$analysis_type = apply_filters( 'rtbcb_analysis_type', $analysis_type );
+}
 
-	if ( ! in_array( $analysis_type, RTBCB_ALLOWED_TIERS, true ) ) {
-		$analysis_type = 'basic';
-	}
+if ( ! in_array( $analysis_type, RTBCB_ALLOWED_TIERS, true ) ) {
+$analysis_type = 'basic';
+}
 
-	return $analysis_type;
+return $analysis_type;
 }
 
 /**
@@ -592,8 +593,8 @@ function rtbcb_sanitize_form_data( $data ) {
 	
 	// Email
 	if ( isset( $data['email'] ) ) {
-		$sanitized['email'] = sanitize_email( $data['email'] );
-	}
+$sanitized['email'] = sanitize_email( $data['email'] );
+}
 	
 	// Text fields
 	$text_fields = [ 'company_size', 'industry' ];
@@ -619,8 +620,8 @@ function rtbcb_sanitize_form_data( $data ) {
 		}
 	}
 	
-	// Pain points array
-	if ( isset( $data['pain_points'] ) && is_array( $data['pain_points'] ) ) {
+// Pain points array
+if ( isset( $data['pain_points'] ) && is_array( $data['pain_points'] ) ) {
 		$valid_pain_points = [
 			'manual_processes',
 			'poor_visibility',
@@ -636,9 +637,13 @@ function rtbcb_sanitize_form_data( $data ) {
 				return in_array( $point, $valid_pain_points, true );
 			}
 		);
-	}
-	
-	return $sanitized;
+}
+
+if ( isset( $data['fast_mode'] ) ) {
+$sanitized['fast_mode'] = absint( $data['fast_mode'] );
+}
+
+return $sanitized;
 }
 
 /**

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2258,18 +2258,34 @@ return $use_comprehensive;
             echo '</div>';
         }
 
-        // Show upgrade notice if applicable
-        if ( get_transient( 'rtbcb_show_upgrade_notice' ) ) {
-            echo '<div class="notice notice-success is-dismissible">';
-            echo '<p>';
-            printf(
-                esc_html__( 'Real Treasury Business Case Builder has been upgraded to version %s with new features including PDF reports, analytics, and enhanced lead tracking!', 'rtbcb' ),
-                RTBCB_VERSION
-            );
-            echo '</p>';
-            echo '</div>';
-            delete_transient( 'rtbcb_show_upgrade_notice' );
-        }
+       // Show bypass notice when heavy features are disabled.
+       if ( current_user_can( 'manage_options' ) && get_option( 'rtbcb_disable_heavy_features', 0 ) ) {
+           $settings_url = admin_url( 'admin.php?page=rtbcb-settings' );
+           echo '<div class="notice notice-warning is-dismissible">';
+           echo '<p>';
+           printf(
+               wp_kses(
+                   __( '<strong>Real Treasury Business Case Builder:</strong> Heavy AI features are temporarily disabled. <a href="%s">Update settings</a> to re-enable.', 'rtbcb' ),
+                   [ 'strong' => [], 'a' => [ 'href' => [] ] ]
+               ),
+               esc_url( $settings_url )
+           );
+           echo '</p>';
+           echo '</div>';
+       }
+
+       // Show upgrade notice if applicable
+       if ( get_transient( 'rtbcb_show_upgrade_notice' ) ) {
+           echo '<div class="notice notice-success is-dismissible">';
+           echo '<p>';
+           printf(
+               esc_html__( 'Real Treasury Business Case Builder has been upgraded to version %s with new features including PDF reports, analytics, and enhanced lead tracking!', 'rtbcb' ),
+               RTBCB_VERSION
+           );
+           echo '</p>';
+           echo '</div>';
+           delete_transient( 'rtbcb_show_upgrade_notice' );
+       }
     }
 
     /**


### PR DESCRIPTION
## Summary
- add global option to disable heavy AI features
- short-circuit AI enrichment, RAG, and smart recommendations when fast mode or bypass is active
- document and warn admins about temporary bypass mode

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*
- `npx markdownlint docs/**/*.md` *(error could not determine executable)*
- `npx --yes markdown-link-check docs/TEMPORARY_BYPASS_MODE.md`

------
https://chatgpt.com/codex/tasks/task_e_68b3b4a55b288331b8ade51e2e050bab