### PR TITLE
Optimize lead queries and enable persistent DB connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,19 +70,33 @@ Values outside the `256`–`128000` range are ignored.
 
 Update the list in `inc/helpers.php` if OpenAI changes temperature capabilities.
 
-### Step 3: Enable Persistent Object Cache
+### Step 3: Configure Persistent Database Connections
+
+Reducing connection overhead keeps report generation responsive.
+
+1. Edit `wp-config.php` and prefix the host with `p:`:
+
+    ```php
+    define( 'DB_HOST', 'p:localhost' );
+    ```
+
+2. Or install a pooling plugin such as [HyperDB](https://wordpress.org/plugins/hyperdb/).
+
+See [docs/DATABASE_CONNECTIONS.md](docs/DATABASE_CONNECTIONS.md) for details.
+
+### Step 4: Enable Persistent Object Cache
 
 To persist cached API responses across requests, configure a persistent object cache such as
 [Redis](https://wordpress.org/plugins/redis-cache/) or
 [Memcached](https://wordpress.org/plugins/memcached/). See
 [docs/OBJECT_CACHE.md](docs/OBJECT_CACHE.md) for details.
 
-### Step 4: Configure Database Tables
+### Step 5: Configure Database Tables
 The plugin automatically creates required database tables on activation:
 - `wp_rtbcb_leads` - Lead tracking and analytics
 - `wp_rtbcb_rag_index` - Retrieval-augmented generation index
 
-### Step 5: Display the Form
+### Step 6: Display the Form
 Add the shortcode to any page or post to display a “Generate Business Case” button that launches the form in a modal:
 ```
 [rt_business_case_builder]

--- a/docs/DATABASE_CONNECTIONS.md
+++ b/docs/DATABASE_CONNECTIONS.md
@@ -1,0 +1,14 @@
+# DATABASE_CONNECTIONS
+
+Persistent MySQL connections reduce handshake overhead and keep this plugin responsive during heavy reporting.
+
+- Prefix the database host with `p:` in `wp-config.php` to enable a persistent connection:
+
+    ```php
+    define( 'DB_HOST', 'p:localhost' );
+    ```
+
+- Alternatively, install a pooling plugin such as [HyperDB](https://wordpress.org/plugins/hyperdb/) to manage shared connections.
+
+After configuring persistence, verify the connection by checking that `$wpdb->dbhost` begins with `p:` inside a debugging session.
+

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -408,25 +408,19 @@ class RTBCB_Leads {
             $prepare_values[] = $args['date_to'] . ' 23:59:59';
         }
 
-        $where_clause = implode( ' AND ', $where_conditions );
+		$where_clause = implode( ' AND ', $where_conditions );
 
-        // Get total count
-        $count_sql = "SELECT COUNT(*) FROM " . self::$table_name . " WHERE " . $where_clause;
-        if ( ! empty( $prepare_values ) ) {
-            $total_leads = $wpdb->get_var( $wpdb->prepare( $count_sql, $prepare_values ) );
-        } else {
-            $total_leads = $wpdb->get_var( $count_sql );
-        }
+		// Build pagination.
+		$offset  = ( $args['page'] - 1 ) * $args['per_page'];
+		$orderby = sanitize_sql_orderby( $args['orderby'] . ' ' . $args['order'] );
 
-        // Get leads
-        $offset = ( $args['page'] - 1 ) * $args['per_page'];
-        $orderby = sanitize_sql_orderby( $args['orderby'] . ' ' . $args['order'] );
+		// Fetch leads and total in a single batched query.
+		$sql             = "SELECT SQL_CALC_FOUND_ROWS * FROM " . self::$table_name . " WHERE " . $where_clause . " ORDER BY " . $orderby . " LIMIT %d OFFSET %d";
+		$prepare_values[] = $args['per_page'];
+		$prepare_values[] = $offset;
 
-        $sql = "SELECT * FROM " . self::$table_name . " WHERE " . $where_clause . " ORDER BY " . $orderby . " LIMIT %d OFFSET %d";
-        $prepare_values[] = $args['per_page'];
-        $prepare_values[] = $offset;
-
-        $leads = $wpdb->get_results( $wpdb->prepare( $sql, $prepare_values ), ARRAY_A );
+		$leads       = $wpdb->get_results( $wpdb->prepare( $sql, $prepare_values ), ARRAY_A );
+		$total_leads = (int) $wpdb->get_var( 'SELECT FOUND_ROWS()' );
 
         // Unserialize pain points and decompress report HTML.
         foreach ( $leads as &$lead ) {

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1896,3 +1896,27 @@ function rtbcb_invalidate_rag_cache() {
 	}
 }
 
+
+/**
+ * Enable persistent database connections when supported.
+ *
+ * Reconnects using a host prefixed with `p:` if the current connection is
+ * not already persistent.
+ *
+ * @return void
+ */
+function rtbcb_enable_persistent_connection() {
+	global $wpdb;
+
+	if ( strpos( DB_HOST, 'p:' ) === 0 ) {
+		return;
+	}
+
+	$wpdb->dbhost = 'p:' . DB_HOST;
+	if ( method_exists( $wpdb, 'close' ) ) {
+		$wpdb->close();
+	}
+	$wpdb->db_connect();
+}
+
+add_action( 'plugins_loaded', 'rtbcb_enable_persistent_connection', 1 );


### PR DESCRIPTION
## Summary
- batch lead queries with `SQL_CALC_FOUND_ROWS` to reduce database round-trips
- auto-reconnect with persistent MySQL connections and document setup
- add database connection guide and reference it from project README

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit not found, js runtime errors)*
- `npx markdownlint docs/**/*.md` *(fails: could not determine executable)*
- `npx markdown-link-check docs/DATABASE_CONNECTIONS.md` *(fails: requires install confirmation)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b55088dc83318a9e26a61fe1518f