### PR TITLE
Render provisional job data during polling

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -677,8 +677,21 @@ class BusinessCaseBuilder {
         if (basic_roi) {
             const roiEl = document.getElementById('rtbcb-progress-basic-roi');
             if (roiEl && !roiEl.textContent) {
-                roiEl.textContent = `ROI: ${basic_roi}`;
-                roiEl.style.display = 'block';
+                let percentage = '';
+
+                if (typeof basic_roi === 'object') {
+                    const baseROI = basic_roi?.financial_analysis?.roi_scenarios?.base?.roi_percentage;
+                    if (typeof baseROI === 'number') {
+                        percentage = `${Math.round(baseROI)}%`;
+                    }
+                } else {
+                    percentage = `${basic_roi}`;
+                }
+
+                if (percentage) {
+                    roiEl.textContent = `ROI: ${percentage}`;
+                    roiEl.style.display = 'block';
+                }
             }
         }
     }

--- a/tests/poll-job-partial-fields.test.js
+++ b/tests/poll-job-partial-fields.test.js
@@ -35,7 +35,13 @@ describe('pollJob provisional data', () => {
                     success: true,
                     data: {
                         status: 'processing',
-                        basic_roi: '50%',
+                        basic_roi: {
+                            financial_analysis: {
+                                roi_scenarios: {
+                                    base: { roi_percentage: 50 }
+                                }
+                            }
+                        },
                         category: 'Treasury Tech'
                     }
                 })


### PR DESCRIPTION
## Summary
- format provisional ROI data by extracting base scenario ROI percentage
- update unit test to mock ROI object structure

## Testing
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4o-mini-tests bash tests/run-tests.sh` *(phpunit: command not found)*
- `npx --yes jest tests/poll-job-partial-fields.test.js --config '{"testEnvironment":"node"}' --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b3b99a03f083318ea8b3e146c3fbd1