### PR TITLE
Optimize lead queries and enable persistent DB connections

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1901,7 +1901,8 @@ function rtbcb_invalidate_rag_cache() {
  * Enable persistent database connections when supported.
  *
  * Reconnects using a host prefixed with `p:` if the current connection is
- * not already persistent.
+ * not already persistent and persistent connections are allowed. Behavior can
+ * be filtered with `rtbcb_enable_persistent_connection`.
  *
  * @return void
  */
@@ -1909,6 +1910,15 @@ function rtbcb_enable_persistent_connection() {
 	global $wpdb;
 
 	if ( strpos( DB_HOST, 'p:' ) === 0 ) {
+		return;
+	}
+
+	if ( ! ini_get( 'mysqli.allow_persistent' ) ) {
+		return;
+	}
+
+	$enable_persistent = apply_filters( 'rtbcb_enable_persistent_connection', true );
+	if ( ! $enable_persistent ) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- gate persistent MySQL reconnect behind `mysqli.allow_persistent` and filter

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Call to undefined function add_action(), phpunit: command not found)*
- `phpcs --standard=WordPress inc/helpers.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bd11c5bc83319f51cff1ce0a2b04