### PR TITLE
feat: add streaming support for business analysis

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -861,9 +861,9 @@ $batch_prompts['tech'] = [
                 'content' => $prompt,
             ],
         ];
-        $context = $this->build_context_for_responses( $history );
-        $tokens  = $this->tokens_for_report( 'comprehensive_business_case' );
-        $response = $this->call_openai_with_retry( $model, $context, $tokens );
+		$context = $this->build_context_for_responses( $history );
+		$tokens  = $this->tokens_for_report( 'comprehensive_business_case' );
+		$response = $this->call_openai_with_retry( $model, $context, $tokens, null, $chunk_callback );
 
         if ( is_wp_error( $response ) ) {
             return $response;


### PR DESCRIPTION
## Summary
- forward chunk callbacks when generating comprehensive analysis so OpenAI streaming reaches the AJAX endpoint

## Testing
- `php -l inc/class-rtbcb-llm.php`
- `bash tests/run-tests.sh` *(phpunit: command not found; some JS tests passed but Jest did not exit cleanly)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bcfabcc08331b1c5be4563fb8bd8