### PR TITLE
Defer chart data assembly until analysis completion

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -122,13 +122,15 @@ class RTBCB_Ajax {
                                 $final_analysis = self::create_fallback_analysis( $enriched_profile, $roi_scenarios );
                                 $workflow_tracker->add_warning( 'hybrid_rag_disabled', __( 'AI analysis disabled.', 'rtbcb' ) );
                         }
-                        $workflow_tracker->complete_step( 'hybrid_rag_analysis', $final_analysis );
-                        if ( $job_id ) {
-                                RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'analysis' => $final_analysis ] );
-                        }
+                       $workflow_tracker->complete_step( 'hybrid_rag_analysis', $final_analysis );
+                       if ( $job_id ) {
+                               RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'analysis' => $final_analysis ] );
+                       }
 
-			$workflow_tracker->start_step( 'data_structuring' );
-			$structured_report_data = self::structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $request_start );
+                       $chart_data = self::prepare_chart_data( $roi_scenarios );
+
+                       $workflow_tracker->start_step( 'data_structuring' );
+                       $structured_report_data = self::structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $chart_data, $request_start );
                         $workflow_tracker->complete_step( 'data_structuring', $structured_report_data );
                         if ( $job_id ) {
                                 RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'report_data' => $structured_report_data ] );
@@ -260,7 +262,7 @@ class RTBCB_Ajax {
 		];
 	}
 
-private static function structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $request_start ) {
+private static function structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $chart_data, $request_start ) {
 	$operational_analysis = (array) ( $final_analysis['operational_analysis'] ?? [] );
 	$current_state_assessment = (array) ( $operational_analysis['current_state_assessment'] ?? [] );
 	if ( empty( $current_state_assessment ) ) {
@@ -300,12 +302,13 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 				'maturity_assessment' => $enriched_profile['maturity_assessment'] ?? [],
 				'competitive_position'=> $enriched_profile['competitive_position'] ?? [],
 			],
-			'financial_analysis' => [
-				'roi_scenarios'        => self::format_roi_scenarios( $roi_scenarios ),
-				'investment_breakdown' => $final_analysis['financial_analysis']['investment_breakdown'] ?? [],
-				'payback_analysis'     => $final_analysis['financial_analysis']['payback_analysis'] ?? [],
-				'sensitivity_analysis' => $roi_scenarios['sensitivity_analysis'] ?? [],
-			],
+                       'financial_analysis' => [
+                               'roi_scenarios'        => self::format_roi_scenarios( $roi_scenarios ),
+                               'investment_breakdown' => $final_analysis['financial_analysis']['investment_breakdown'] ?? [],
+                               'payback_analysis'     => $final_analysis['financial_analysis']['payback_analysis'] ?? [],
+                               'sensitivity_analysis' => $roi_scenarios['sensitivity_analysis'] ?? [],
+                               'chart_data'           => $chart_data,
+                       ],
 			'technology_strategy' => [
 				'recommended_category' => $recommendation['recommended'],
 				'category_details'     => $recommendation['category_info'],
@@ -354,18 +357,73 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 		];
 	}
 
-	private static function save_lead_data_async( $user_inputs, $structured_report_data ) {
-		if ( class_exists( 'RTBCB_Leads' ) ) {
-			$lead_data = array_merge( $user_inputs, [ 'report_data' => $structured_report_data ] );
-			return RTBCB_Leads::save_lead( $lead_data );
-		}
-		return null;
-	}
+        private static function save_lead_data_async( $user_inputs, $structured_report_data ) {
+                if ( class_exists( 'RTBCB_Leads' ) ) {
+                        $lead_data = array_merge( $user_inputs, [ 'report_data' => $structured_report_data ] );
+                        return RTBCB_Leads::save_lead( $lead_data );
+                }
+                return null;
+        }
 
-	private static function calculate_business_case_strength( $roi_scenarios, $recommendation ) {
-		$base = $roi_scenarios['base']['total_annual_benefit'] ?? 0;
-		return $base > 0 ? 'strong' : 'weak';
-	}
+       /**
+        * Prepare chart data for ROI visualization.
+        *
+        * @param array $roi_scenarios ROI scenarios.
+        * @return array Chart.js compatible data structure.
+        */
+       private static function prepare_chart_data( $roi_scenarios ) {
+               return [
+                       'labels'   => [
+                               __( 'Labor Savings', 'rtbcb' ),
+                               __( 'Fee Savings', 'rtbcb' ),
+                               __( 'Error Reduction', 'rtbcb' ),
+                               __( 'Total Benefit', 'rtbcb' ),
+                       ],
+                       'datasets' => [
+                               [
+                                       'label'           => __( 'Conservative', 'rtbcb' ),
+                                       'data'            => [
+                                               $roi_scenarios['conservative']['labor_savings'] ?? 0,
+                                               $roi_scenarios['conservative']['fee_savings'] ?? 0,
+                                               $roi_scenarios['conservative']['error_reduction'] ?? 0,
+                                               $roi_scenarios['conservative']['total_annual_benefit'] ?? 0,
+                                       ],
+                                       'backgroundColor' => 'rgba(239, 68, 68, 0.8)',
+                                       'borderColor'     => 'rgba(239, 68, 68, 1)',
+                                       'borderWidth'     => 1,
+                               ],
+                               [
+                                       'label'           => __( 'Base Case', 'rtbcb' ),
+                                       'data'            => [
+                                               $roi_scenarios['base']['labor_savings'] ?? 0,
+                                               $roi_scenarios['base']['fee_savings'] ?? 0,
+                                               $roi_scenarios['base']['error_reduction'] ?? 0,
+                                               $roi_scenarios['base']['total_annual_benefit'] ?? 0,
+                                       ],
+                                       'backgroundColor' => 'rgba(59, 130, 246, 0.8)',
+                                       'borderColor'     => 'rgba(59, 130, 246, 1)',
+                                       'borderWidth'     => 1,
+                               ],
+                               [
+                                       'label'           => __( 'Optimistic', 'rtbcb' ),
+                                       'data'            => [
+                                               $roi_scenarios['optimistic']['labor_savings'] ?? 0,
+                                               $roi_scenarios['optimistic']['fee_savings'] ?? 0,
+                                               $roi_scenarios['optimistic']['error_reduction'] ?? 0,
+                                               $roi_scenarios['optimistic']['total_annual_benefit'] ?? 0,
+                                       ],
+                                       'backgroundColor' => 'rgba(16, 185, 129, 0.8)',
+                                       'borderColor'     => 'rgba(16, 185, 129, 1)',
+                                       'borderWidth'     => 1,
+                               ],
+                       ],
+               ];
+       }
+
+       private static function calculate_business_case_strength( $roi_scenarios, $recommendation ) {
+               $base = $roi_scenarios['base']['total_annual_benefit'] ?? 0;
+               return $base > 0 ? 'strong' : 'weak';
+       }
 
 	private static function format_roi_scenarios( $roi_scenarios ) {
 		return $roi_scenarios;

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -482,64 +482,27 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function initializeROIChart() {
-        const ctx = document.getElementById('rtbcb-roi-chart');
-        if ( ! ctx || typeof Chart === 'undefined' ) {
-                return;
-        }
-	
-	const roiData = <?php echo wp_json_encode( $financial_analysis['roi_scenarios'] ?? [] ); ?>;
-	
-	new Chart(ctx, {
+	const ctx = document.getElementById('rtbcb-roi-chart');
+	if ( ! ctx || typeof Chart === 'undefined' ) {
+		return;
+	}
+
+	const chartData = <?php echo wp_json_encode( $financial_analysis['chart_data'] ?? [] ); ?>;
+	if ( ! chartData.labels ) {
+		return;
+	}
+
+	new Chart( ctx, {
 		type: 'bar',
-		data: {
-			labels: ['<?php echo esc_js( __( 'Labor Savings', 'rtbcb' ) ); ?>', '<?php echo esc_js( __( 'Fee Savings', 'rtbcb' ) ); ?>', '<?php echo esc_js( __( 'Error Reduction', 'rtbcb' ) ); ?>', '<?php echo esc_js( __( 'Total Benefit', 'rtbcb' ) ); ?>'],
-			datasets: [
-				{
-					label: '<?php echo esc_js( __( 'Conservative', 'rtbcb' ) ); ?>',
-					data: [
-						roiData.conservative?.labor_savings || 0,
-						roiData.conservative?.fee_savings || 0, 
-						roiData.conservative?.error_reduction || 0,
-						roiData.conservative?.total_annual_benefit || 0
-					],
-					backgroundColor: 'rgba(239, 68, 68, 0.8)',
-					borderColor: 'rgba(239, 68, 68, 1)',
-					borderWidth: 1
-				},
-				{
-					label: '<?php echo esc_js( __( 'Base Case', 'rtbcb' ) ); ?>',
-					data: [
-						roiData.base?.labor_savings || 0,
-						roiData.base?.fee_savings || 0,
-						roiData.base?.error_reduction || 0,
-						roiData.base?.total_annual_benefit || 0
-					],
-					backgroundColor: 'rgba(59, 130, 246, 0.8)',
-					borderColor: 'rgba(59, 130, 246, 1)',
-					borderWidth: 1
-				},
-				{
-					label: '<?php echo esc_js( __( 'Optimistic', 'rtbcb' ) ); ?>',
-					data: [
-						roiData.optimistic?.labor_savings || 0,
-						roiData.optimistic?.fee_savings || 0,
-						roiData.optimistic?.error_reduction || 0,
-						roiData.optimistic?.total_annual_benefit || 0
-					],
-					backgroundColor: 'rgba(16, 185, 129, 0.8)',
-					borderColor: 'rgba(16, 185, 129, 1)',
-					borderWidth: 1
-				}
-			]
-		},
+		data: chartData,
 		options: {
 			responsive: true,
 			scales: {
 				y: {
 					beginAtZero: true,
 					ticks: {
-						callback: function(value) {
-							return '$' + new Intl.NumberFormat().format(value);
+						callback: function( value ) {
+							return '$' + new Intl.NumberFormat().format( value );
 						}
 					}
 				}
@@ -547,15 +510,16 @@ function initializeROIChart() {
 			plugins: {
 				tooltip: {
 					callbacks: {
-						label: function(context) {
-							return context.dataset.label + ': $' + new Intl.NumberFormat().format(context.raw);
+						label: function( context ) {
+							return context.dataset.label + ': $' + new Intl.NumberFormat().format( context.raw );
 						}
 					}
 				}
 			}
 		}
-	});
+	} );
 }
+
 
 function initializeSectionToggles() {
 	document.querySelectorAll('.rtbcb-section-toggle').forEach(toggle => {


### PR DESCRIPTION
## Summary
- Add `prepare_chart_data` to build Chart.js datasets from ROI scenarios
- Invoke chart preparation after AI analysis and include results in structured report data
- Render charts using prepared data in `comprehensive-report-template.php`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b937832c83319f383a1ebe1ca013