### PR TITLE
Add option to bypass heavy AI features

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A comprehensive WordPress plugin that helps treasury teams quantify the benefits
 - Reshaped job status data for clearer progress reporting.
 - 📚 Added detailed wizard and API flow documentation in [docs/WIZARD_FORM_API_FLOW.md](docs/WIZARD_FORM_API_FLOW.md).
 - Cached OpenAI model list via WordPress object caching for faster connection tests.
+- Introduced temporary bypass mode via `rtbcb_disable_heavy_features` option to skip heavy AI features.
 
 
 ## 📋 Installation & Setup

--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -18,7 +18,8 @@ class RTBCB_Admin {
         add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
         add_action( 'admin_init', [ $this, 'register_settings' ] );
         add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
-        add_action( 'admin_notices', [ $this, 'maybe_show_timeout_notice' ] );
+add_action( 'admin_notices', [ $this, 'maybe_show_timeout_notice' ] );
+add_action( 'admin_notices', [ $this, 'maybe_show_bypass_notice' ] );
 
         // AJAX handlers
         add_action( 'wp_ajax_rtbcb_test_connection', [ $this, 'test_api_connection' ] );
@@ -504,6 +505,7 @@ class RTBCB_Admin {
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_max_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_max_output_tokens' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_min_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_min_output_tokens' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_fast_mode', [ 'sanitize_callback' => 'absint' ] );
+        register_setting( 'rtbcb_settings', 'rtbcb_disable_heavy_features', [ 'sanitize_callback' => 'absint' ] );
     }
 
     /**
@@ -517,6 +519,20 @@ class RTBCB_Admin {
         $settings['enable_ai_analysis'] = isset( $settings['enable_ai_analysis'] ) ? (bool) $settings['enable_ai_analysis'] : false;
         $settings['enable_charts']      = isset( $settings['enable_charts'] ) ? (bool) $settings['enable_charts'] : false;
         return $settings;
+    }
+
+    /**
+     * Display notice when heavy features are disabled.
+     *
+     * @return void
+     */
+    public function maybe_show_bypass_notice() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        if ( get_option( 'rtbcb_disable_heavy_features', 0 ) ) {
+            echo '<div class="notice notice-warning"><p>' . esc_html__( 'Heavy features are temporarily disabled. AI enrichment, RAG, and intelligent recommendations are bypassed.', 'rtbcb' ) . '</p></div>';
+        }
     }
 
     /**

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -19,6 +19,7 @@ $gpt5_timeout    = rtbcb_get_api_timeout();
 $gpt5_max_output_tokens = get_option( 'rtbcb_gpt5_max_output_tokens', 8000 );
 $gpt5_min_output_tokens = get_option( 'rtbcb_gpt5_min_output_tokens', 256 );
 $fast_mode       = get_option( 'rtbcb_fast_mode', 0 );
+$disable_heavy_features = get_option( 'rtbcb_disable_heavy_features', 0 );
 $feature_settings    = get_option( 'rtbcb_settings', RTBCB_Settings::DEFAULTS );
 $enable_ai_analysis = isset( $feature_settings['enable_ai_analysis'] ) ? (bool) $feature_settings['enable_ai_analysis'] : true;
 $enable_charts      = isset( $feature_settings['enable_charts'] ) ? (bool) $feature_settings['enable_charts'] : true;
@@ -160,6 +161,15 @@ $embedding_models = [
                     <p class="description"><?php echo esc_html__( 'Generate a basic ROI-only report without AI processing.', 'rtbcb' ); ?></p>
                 </td>
             </tr>
+<tr>
+<th scope="row">
+<label for="rtbcb_disable_heavy_features"><?php echo esc_html__( 'Bypass Heavy Features', 'rtbcb' ); ?></label>
+</th>
+<td>
+<input type="checkbox" id="rtbcb_disable_heavy_features" name="rtbcb_disable_heavy_features" value="1" <?php checked( 1, $disable_heavy_features ); ?> />
+<p class="description"><?php echo esc_html__( 'Skip AI enrichment, RAG, and intelligent recommendations temporarily.', 'rtbcb' ); ?></p>
+</td>
+</tr>
             <tr>
                 <th scope="row">
                     <label for="rtbcb_enable_ai_analysis"><?php echo esc_html__( 'Enable AI Analysis', 'rtbcb' ); ?></label>

--- a/docs/TEMPORARY_BYPASS_MODE.md
+++ b/docs/TEMPORARY_BYPASS_MODE.md
@@ -1,0 +1,12 @@
+# Temporary Bypass Mode
+
+The plugin provides a temporary bypass to disable resource-intensive features.
+
+- The `rtbcb_disable_heavy_features` option skips:
+    - AI enrichment
+    - Retrieval augmented generation (RAG)
+    - Intelligent recommendations
+
+This bypass is also activated when **Fast Mode** is enabled.
+
+Use this mode to troubleshoot or reduce API usage. Remember to re-enable full functionality when advanced analysis is needed.

--- a/inc/class-rtbcb-intelligent-recommender.php
+++ b/inc/class-rtbcb-intelligent-recommender.php
@@ -15,14 +15,20 @@ class RTBCB_Intelligent_Recommender extends RTBCB_Category_Recommender {
  * @return array Enhanced recommendation with confidence and alternatives.
  */
 public function recommend_with_ai_insights( $user_inputs, $enriched_profile ) {
+$disable_heavy = get_option( 'rtbcb_disable_heavy_features', 0 ) || get_option( 'rtbcb_fast_mode', 0 ) || ! empty( $user_inputs['fast_mode'] );
 // Get baseline recommendation from parent class.
 $base_recommendation = parent::recommend_category( $user_inputs );
+if ( $disable_heavy ) {
+$base_recommendation['base_scores'] = $base_recommendation['scores'];
+$base_recommendation['ai_insights'] = [];
+return $base_recommendation;
+}
 
 // Apply AI insights to enhance recommendation.
 $ai_factors      = $this->extract_ai_recommendation_factors( $enriched_profile );
 $enhanced_scores = $this->apply_ai_insights_to_scoring(
-$base_recommendation['scores'],
-$ai_factors
+        $base_recommendation['scores'],
+        $ai_factors
 );
 
 // Recalculate recommendation with enhanced scores.
@@ -30,19 +36,19 @@ arsort( $enhanced_scores );
 $recommended = array_key_first( $enhanced_scores );
 
 return [
-'recommended'   => $recommended,
-'category_info' => self::get_category_info( $recommended ),
-'scores'        => $enhanced_scores,
-'base_scores'   => $base_recommendation['scores'],
-'confidence'    => $this->calculate_enhanced_confidence( $enhanced_scores, $enriched_profile ),
-'reasoning'     => $this->generate_ai_enhanced_reasoning( $recommended, $enriched_profile, $ai_factors ),
-'alternatives'  => $this->get_intelligent_alternatives( $enhanced_scores, $enriched_profile ),
-'ai_insights'   => [
-'maturity_assessment'    => $ai_factors['maturity_alignment'],
-'implementation_readiness'=> $ai_factors['implementation_readiness'],
-'strategic_fit'          => $ai_factors['strategic_alignment'],
-'risk_assessment'        => $ai_factors['risk_factors'],
-],
+        'recommended'   => $recommended,
+        'category_info' => self::get_category_info( $recommended ),
+        'scores'        => $enhanced_scores,
+        'base_scores'   => $base_recommendation['scores'],
+        'confidence'    => $this->calculate_enhanced_confidence( $enhanced_scores, $enriched_profile ),
+        'reasoning'     => $this->generate_ai_enhanced_reasoning( $recommended, $enriched_profile, $ai_factors ),
+        'alternatives'  => $this->get_intelligent_alternatives( $enhanced_scores, $enriched_profile ),
+        'ai_insights'   => [
+                'maturity_assessment'    => $ai_factors['maturity_alignment'],
+                'implementation_readiness'=> $ai_factors['implementation_readiness'],
+                'strategic_fit'          => $ai_factors['strategic_alignment'],
+                'risk_assessment'        => $ai_factors['risk_factors'],
+        ],
 ];
 }
 

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -50,7 +50,7 @@ class RTBCB_Router {
             // Perform ROI calculations.
             $calculations = RTBCB_Calculator::calculate_roi( $form_data );
 
-            $fast_mode = 'fast' === $report_type || ! empty( $_POST['fast_mode'] ) || get_option( 'rtbcb_fast_mode', 0 );
+$fast_mode = 'fast' === $report_type || ! empty( $_POST['fast_mode'] ) || get_option( 'rtbcb_fast_mode', 0 ) || get_option( 'rtbcb_disable_heavy_features', 0 );
             if ( $fast_mode ) {
                 $report_html = $this->get_fast_report_html( $form_data, $calculations );
 

--- a/readme.txt
+++ b/readme.txt
@@ -160,6 +160,7 @@ The analytics dashboard uses Chart.js for its visualizations. The library is bun
 * Fixed bulk lead deletion actions within the lead management dashboard.
 * Added test coverage to ensure asynchronous jobs are marked complete correctly.
 * Reshaped job status data for clearer progress reporting.
+* Introduced `rtbcb_disable_heavy_features` option to temporarily bypass AI enrichment, RAG, and intelligent recommendations.
 
 = 2.1.7 =
 * Update documentation to reflect version 2.1.7.


### PR DESCRIPTION
## Summary
- add global `rtbcb_disable_heavy_features` setting and admin notice
- short-circuit AI enrichment, RAG and recommendations when heavy features are bypassed or Fast Mode is used
- document temporary bypass mode and expose option in settings

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `npx markdownlint-cli docs/**/*.md` *(fails: line-length and other issues in existing docs)*
- `npx markdown-link-check docs/TEMPORARY_BYPASS_MODE.md`
- `bash tests/run-tests.sh` *(phpunit: command not found; Jest reported open handles)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ba959f4083318d5e479c131c6eb4