### PR TITLE
Fix ROI clamping for asynchronous workflows

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -106,15 +106,12 @@ class RTBCB_Ajax {
 			}
 		
 		$workflow_tracker->start_step( 'category_refined_roi' );
-		$refined_roi = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $recommendation['category_info'] );
-		$refined_roi['sensitivity_analysis'] = $roi_scenarios['sensitivity_analysis'] ?? [];
-		$refined_roi['confidence_metrics']   = $roi_scenarios['confidence_metrics'] ?? [];
-		$roi_scenarios                       = $refined_roi;
+		$roi_scenarios = self::clamp_roi_scenarios_to_category( $roi_scenarios, $recommendation['category_info'] );
 		$workflow_tracker->complete_step( 'category_refined_roi', $roi_scenarios );
-			if ( $job_id ) {
+		if ( $job_id ) {
 			RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'refined_roi' => $roi_scenarios ] );
 		}
-		
+
 		$workflow_tracker->start_step( 'hybrid_rag_analysis' );
                         if ( $enable_ai ) {
                                 $rag_baseline = [];
@@ -374,6 +371,39 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 			return RTBCB_Leads::save_lead( $lead_data );
 		}
 		return null;
+	}
+
+	/**
+	 * Clamp ROI scenarios to the recommended category's ROI range.
+	 *
+	 * @param array $roi_scenarios ROI scenarios to clamp.
+	 * @param array $category      Recommended category info.
+	 * @return array Clamped ROI scenarios.
+	 */
+	private static function clamp_roi_scenarios_to_category( $roi_scenarios, $category ) {
+		$min_roi = $category['roi_range'][0] ?? 0;
+		$max_roi = $category['roi_range'][1] ?? $min_roi;
+
+		foreach ( [ 'conservative', 'base', 'optimistic' ] as $key ) {
+			if ( isset( $roi_scenarios[ $key ]['total_annual_benefit'] ) ) {
+				$benefit = $roi_scenarios[ $key ]['total_annual_benefit'];
+				$clamped = max( $min_roi, min( $benefit, $max_roi ) );
+				$roi_scenarios[ $key ]['total_annual_benefit'] = $clamped;
+				$avg_cost = ( $min_roi + $max_roi ) / 2;
+				$roi_scenarios[ $key ]['roi_percentage'] = $avg_cost > 0 ? ( $clamped / $avg_cost ) * 100 : 0;
+			}
+		}
+
+		if ( isset( $roi_scenarios['sensitivity_analysis'] ) && is_array( $roi_scenarios['sensitivity_analysis'] ) ) {
+			foreach ( $roi_scenarios['sensitivity_analysis'] as &$analysis ) {
+				if ( isset( $analysis['adjusted_benefit'] ) ) {
+					$analysis['adjusted_benefit'] = max( $min_roi, min( $analysis['adjusted_benefit'], $max_roi ) );
+				}
+			}
+			unset( $analysis );
+		}
+
+		return $roi_scenarios;
 	}
 
 	private static function calculate_business_case_strength( $roi_scenarios, $recommendation ) {


### PR DESCRIPTION
## Summary
- preserve enhanced ROI by clamping scenarios to the recommended category range instead of recomputing
- add helper to apply category bounds without discarding AI-driven metrics

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found; Jest did not exit one second after the test run has completed)*
- `phpcs --standard=WordPress inc/class-rtbcb-ajax.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c03e5d9c8331a6b7cc9099b63192