### PR TITLE
feat: add bypass mode for heavy AI features

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -19,6 +19,7 @@ class RTBCB_Admin {
         add_action( 'admin_init', [ $this, 'register_settings' ] );
         add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
         add_action( 'admin_notices', [ $this, 'maybe_show_timeout_notice' ] );
+        add_action( 'admin_notices', [ $this, 'maybe_show_bypass_notice' ] );
 
         // AJAX handlers
         add_action( 'wp_ajax_rtbcb_test_connection', [ $this, 'test_api_connection' ] );
@@ -504,6 +505,7 @@ class RTBCB_Admin {
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_max_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_max_output_tokens' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_gpt5_min_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_min_output_tokens' ] );
         register_setting( 'rtbcb_settings', 'rtbcb_fast_mode', [ 'sanitize_callback' => 'absint' ] );
+        register_setting( 'rtbcb_settings', 'rtbcb_disable_heavy_features', [ 'sanitize_callback' => 'absint' ] );
     }
 
     /**
@@ -1990,4 +1992,17 @@ class RTBCB_Admin {
                         echo '</p></div>';
                 }
         }
+
+
+    /**
+     * Display notice when heavy features are disabled.
+     *
+     * @return void
+     */
+    public function maybe_show_bypass_notice() {
+        if ( get_option( 'rtbcb_disable_heavy_features', 0 ) ) {
+            echo '<div class="notice notice-warning"><p>' . esc_html__( 'Heavy AI features are temporarily disabled. Remove the rtbcb_disable_heavy_features option to restore full functionality.', 'rtbcb' ) . '</p></div>';
+        }
+    }
+
 }

--- a/docs/BYPASS_MODE.md
+++ b/docs/BYPASS_MODE.md
@@ -1,0 +1,9 @@
+# Bypass Mode
+
+When heavy features are unavailable or need to be skipped, the plugin can fall back to a lighter workflow.
+
+- Set the `rtbcb_disable_heavy_features` option to `1` to bypass AI enrichment, RAG, and intelligent recommendations.
+- Enabling Fast Mode also triggers the bypass.
+- Administrators see a warning notice while the bypass is active.
+
+Remove the option or disable Fast Mode to restore full functionality.

--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -98,7 +98,8 @@ class RTBCB_Ajax {
         public static function process_comprehensive_case( $user_inputs, $job_id = '' ) {
                $request_start    = microtime( true );
                $workflow_tracker = new RTBCB_Workflow_Tracker();
-               $enable_ai        = RTBCB_Settings::get_setting( 'enable_ai_analysis', true );
+               $bypass_heavy    = rtbcb_heavy_features_disabled();
+               $enable_ai        = ! $bypass_heavy && RTBCB_Settings::get_setting( 'enable_ai_analysis', true );
 
 		add_action(
 			'rtbcb_llm_prompt_sent',
@@ -108,6 +109,62 @@ class RTBCB_Ajax {
 		);
 
 		try {
+                        if ( $bypass_heavy ) {
+                                $workflow_tracker->add_warning( 'heavy_features_bypassed', __( 'AI features temporarily disabled.', 'rtbcb' ) );
+                                $workflow_tracker->start_step( 'ai_enrichment' );
+                                $enriched_profile = self::create_fallback_profile( $user_inputs );
+                                $workflow_tracker->complete_step( 'ai_enrichment', $enriched_profile );
+                                if ( $job_id ) {
+                                        RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enriched_profile' => $enriched_profile ] );
+                                }
+
+                                $workflow_tracker->start_step( 'enhanced_roi_calculation' );
+                                $roi_scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
+                                $workflow_tracker->complete_step( 'enhanced_roi_calculation', $roi_scenarios );
+                                if ( $job_id ) {
+                                        RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enhanced_roi' => $roi_scenarios ] );
+                                }
+
+                                $workflow_tracker->start_step( 'intelligent_recommendations' );
+                                $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+                                $workflow_tracker->complete_step( 'intelligent_recommendations', $recommendation );
+                                if ( $job_id ) {
+                                        RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'category' => $recommendation['recommended'] ] );
+                                }
+
+                                $workflow_tracker->start_step( 'hybrid_rag_analysis' );
+                                $final_analysis = self::create_fallback_analysis( $enriched_profile, $roi_scenarios );
+                                $workflow_tracker->complete_step( 'hybrid_rag_analysis', $final_analysis );
+                                if ( $job_id ) {
+                                        RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'analysis' => $final_analysis ] );
+                                }
+
+                                $chart_data = self::prepare_chart_data( $roi_scenarios );
+
+                                $workflow_tracker->start_step( 'data_structuring' );
+                                $structured_report_data = self::structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $chart_data, $request_start );
+                                $workflow_tracker->complete_step( 'data_structuring', $structured_report_data );
+                                if ( $job_id ) {
+                                        RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'report_data' => $structured_report_data ] );
+                                }
+
+                                $lead_id    = self::save_lead_data_async( $user_inputs, $structured_report_data );
+                                $lead_email = ! empty( $user_inputs['email'] ) ? sanitize_email( $user_inputs['email'] ) : '';
+
+                                $debug_info           = $workflow_tracker->get_debug_info();
+                                $debug_info['lead_id'] = $lead_id;
+                                if ( $lead_email ) {
+                                        $debug_info['lead_email'] = $lead_email;
+                                }
+                                self::store_workflow_history( $debug_info, $lead_id, $lead_email );
+
+                                return [
+                                        'report_data'   => $structured_report_data,
+                                        'workflow_info' => $debug_info,
+                                        'lead_id'       => $lead_id,
+                                        'analysis_type' => rtbcb_get_analysis_type(),
+                                ];
+                        }
                         $workflow_tracker->start_step( 'ai_enrichment' );
                         if ( $enable_ai ) {
                                 $enriched_profile = new WP_Error( 'llm_missing', 'LLM service unavailable.' );
@@ -138,9 +195,14 @@ class RTBCB_Ajax {
                                 RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enhanced_roi' => $roi_scenarios ] );
                         }
 
-			$workflow_tracker->start_step( 'intelligent_recommendations' );
-			$intelligent_recommender = new RTBCB_Intelligent_Recommender();
-			$recommendation          = $intelligent_recommender->recommend_with_ai_insights( $user_inputs, $enriched_profile );
+                        $workflow_tracker->start_step( 'intelligent_recommendations' );
+                        if ( $enable_ai ) {
+                                $intelligent_recommender = new RTBCB_Intelligent_Recommender();
+                                $recommendation          = $intelligent_recommender->recommend_with_ai_insights( $user_inputs, $enriched_profile );
+                        } else {
+                                $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+                                $workflow_tracker->add_warning( 'intelligent_recommendations_disabled', __( 'AI analysis disabled.', 'rtbcb' ) );
+                        }
                         $workflow_tracker->complete_step( 'intelligent_recommendations', $recommendation );
                         if ( $job_id ) {
                                 RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'category' => $recommendation['recommended'] ] );

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -716,6 +716,10 @@ USER,
      * @return array|WP_Error Comprehensive analysis array or error object.
      */
     public function generate_comprehensive_business_case( $user_inputs, $roi_data, $context_chunks = [], $chunk_callback = null ) {
+
+        if ( rtbcb_heavy_features_disabled() ) {
+            return new WP_Error( 'heavy_features_disabled', __( 'AI features are disabled.', 'rtbcb' ) );
+        }
         $this->current_inputs = $user_inputs;
 
         if ( empty( $this->api_key ) ) {
@@ -1882,6 +1886,10 @@ return $analysis;
 	 * @return array|WP_Error Enriched company profile or error.
 	 */
 	public function enrich_company_profile( $user_inputs ) {
+
+        if ( rtbcb_heavy_features_disabled() ) {
+            return new WP_Error( 'heavy_features_disabled', __( 'AI features are disabled.', 'rtbcb' ) );
+        }
 	if ( empty( $this->api_key ) ) {
 	return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
 	}
@@ -2060,6 +2068,10 @@ return $analysis;
 	 * @return array|WP_Error Strategic analysis or error.
 	 */
 	public function generate_strategic_analysis( $enriched_profile, $roi_scenarios, $recommendation, $rag_baseline ) {
+
+        if ( rtbcb_heavy_features_disabled() ) {
+            return new WP_Error( 'heavy_features_disabled', __( 'AI features are disabled.', 'rtbcb' ) );
+        }
 	if ( empty( $this->api_key ) ) {
 	return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
 	}

--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -77,6 +77,10 @@ class RTBCB_RAG {
      * @return array Matching rows.
      */
     public function search_similar( $query, $top_k = 3 ) {
+
+        if ( rtbcb_heavy_features_disabled() ) {
+            return [];
+        }
         $normalized = strtolower( trim( function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $query ) : strip_tags( $query ) ) );
         $version    = function_exists( 'get_option' ) ? (int) get_option( 'rtbcb_rag_cache_version', 1 ) : 1;
         $cache_key  = 'rtbcb_rag_' . md5( $normalized . '|' . $top_k . '|' . $version );
@@ -110,6 +114,10 @@ class RTBCB_RAG {
      * @return array List of metadata arrays.
      */
     public function get_context( $query, $top_k = 3 ) {
+
+        if ( rtbcb_heavy_features_disabled() ) {
+            return [];
+        }
         $embedding = $this->get_embedding( $query );
         if ( empty( $embedding ) ) {
             return [];

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -55,7 +55,7 @@ class RTBCB_Router {
                             $recommendation['category_info']
                         );
 
-            $fast_mode = 'fast' === $report_type || ! empty( $_POST['fast_mode'] ) || get_option( 'rtbcb_fast_mode', 0 );
+            $fast_mode = 'fast' === $report_type || ! empty( $_POST['fast_mode'] ) || rtbcb_heavy_features_disabled();
             if ( $fast_mode ) {
                 $report_html = $this->get_fast_report_html( $form_data, $calculations );
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -82,6 +82,15 @@ function rtbcb_has_openai_api_key() {
 }
 
 /**
+ * Check if heavy AI features are disabled.
+ *
+ * @return bool True if heavy features should be bypassed.
+ */
+function rtbcb_heavy_features_disabled() {
+	return (bool) ( get_option( 'rtbcb_disable_heavy_features', 0 ) || get_option( 'rtbcb_fast_mode', 0 ) );
+}
+
+/**
  * Perform a remote POST request with retry logic.
  *
  * Uses exponential backoff with jitter between attempts. Retries are


### PR DESCRIPTION
## Summary
- add global `rtbcb_disable_heavy_features` option and helper
- skip AI enrichment, RAG, and intelligent recommendations when bypass or Fast Mode is active
- show admin notice and document temporary bypass mode

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Call to undefined function add_action(); phpunit: command not found)*
- `npx markdownlint docs/**/*.md`
- `npx markdown-link-check docs/BYPASS_MODE.md`


------
https://chatgpt.com/codex/tasks/task_e_68b3c390529c8331ab8f31776149949a