### PR TITLE
Add required PHP extension checks

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -239,6 +239,35 @@ class Real_Treasury_BCB {
             return false;
         }
 
+		// Check required PHP extensions.
+		$required_extensions = [ 'curl', 'mbstring' ];
+		$missing_extensions  = [];
+
+		foreach ( $required_extensions as $extension ) {
+			if ( ! extension_loaded( $extension ) ) {
+				$missing_extensions[] = $extension;
+			}
+		}
+
+		if ( ! empty( $missing_extensions ) ) {
+			add_action( 'admin_notices', function() use ( $missing_extensions ) {
+				echo '<div class="notice notice-error"><p>';
+				printf(
+					esc_html(
+						_n(
+							'Real Treasury Business Case Builder requires the following PHP extension: %s.',
+							'Real Treasury Business Case Builder requires the following PHP extensions: %s.',
+							count( $missing_extensions ),
+							'rtbcb'
+						)
+					),
+					esc_html( implode( ', ', $missing_extensions ) )
+				);
+				echo '</p></div>';
+			} );
+			return false;
+		}
+
         return true;
     }
 


### PR DESCRIPTION
## Summary
- verify cURL and mbstring extensions during compatibility checks
- surface missing PHP extensions to administrators and stop initialization

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c7140d988331a1062e500460006e