### PR TITLE
Use single-line ABSPATH guard

### DIFF
--- a/admin/analytics-page.php
+++ b/admin/analytics-page.php
@@ -4,9 +4,7 @@
  */
 
 // Exit if accessed directly.
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 $categories = RTBCB_Category_Recommender::get_all_categories();
 $total_leads = $stats['total_leads'] ?? 0;

--- a/admin/calculations-page.php
+++ b/admin/calculations-page.php
@@ -6,9 +6,7 @@
  */
 
 // Exit if accessed directly.
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 $labor_cost = get_option( 'rtbcb_labor_cost_per_hour', 0 );
 $bank_fee   = get_option( 'rtbcb_bank_fee_baseline', 0 );

--- a/admin/dashboard-page.php
+++ b/admin/dashboard-page.php
@@ -4,9 +4,7 @@
  */
 
 // Exit if accessed directly.
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 $total_leads = $stats['total_leads'] ?? 0;
 $recent_leads = $stats['recent_leads'] ?? 0;

--- a/admin/leads-page-enhanced.php
+++ b/admin/leads-page-enhanced.php
@@ -4,9 +4,7 @@
  */
 
 // Exit if accessed directly.
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 $current_page = $leads_data['current_page'] ?? 1;
 $total_pages = $leads_data['total_pages'] ?? 1;

--- a/admin/partials/dashboard-connectivity.php
+++ b/admin/partials/dashboard-connectivity.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 ?>
 <div class="card">
     <h2 class="title"><?php esc_html_e( 'Connectivity Tests & Status', 'rtbcb' ); ?></h2>

--- a/admin/partials/dashboard-test-results.php
+++ b/admin/partials/dashboard-test-results.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 $max_results  = 10;
 $recent_results = [];

--- a/admin/partials/test-company-overview.php
+++ b/admin/partials/test-company-overview.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-company-overview', false ) ) {
     echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-data-enrichment.php
+++ b/admin/partials/test-data-enrichment.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-data-enrichment', false ) ) {
     echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-data-storage.php
+++ b/admin/partials/test-data-storage.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-data-storage', false ) ) {
     echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-estimated-benefits.php
+++ b/admin/partials/test-estimated-benefits.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-estimated-benefits', false ) ) {
     echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-follow-up-email.php
+++ b/admin/partials/test-follow-up-email.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-follow-up-email', false ) ) {
     echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-industry-overview.php
+++ b/admin/partials/test-industry-overview.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 $allowed = rtbcb_require_completed_steps( 'rtbcb-test-industry-overview', false );
 if ( ! $allowed ) {

--- a/admin/partials/test-maturity-model.php
+++ b/admin/partials/test-maturity-model.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-maturity-model', false ) ) {
     echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-rag-market-analysis.php
+++ b/admin/partials/test-rag-market-analysis.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-rag-market-analysis', false ) ) {
     echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-real-treasury-overview.php
+++ b/admin/partials/test-real-treasury-overview.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-real-treasury-overview', false ) ) {
     echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-report-assembly.php
+++ b/admin/partials/test-report-assembly.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 $allowed = rtbcb_require_completed_steps( 'rtbcb-test-report-assembly', false );
 if ( ! $allowed ) {

--- a/admin/partials/test-roadmap-generator.php
+++ b/admin/partials/test-roadmap-generator.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-roadmap-generator', false ) ) {
     echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-roi-calculator.php
+++ b/admin/partials/test-roi-calculator.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-roi-calculator', false ) ) {
     echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-tracking-script.php
+++ b/admin/partials/test-tracking-script.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-tracking-script', false ) ) {
     echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-value-proposition.php
+++ b/admin/partials/test-value-proposition.php
@@ -5,9 +5,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-value-proposition', false ) ) {
     echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -4,9 +4,7 @@
  */
 
 // Exit if accessed directly.
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 $api_key         = get_option( 'rtbcb_openai_api_key', '' );
 $mini_model      = get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) );

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -4,10 +4,7 @@
  *
  * @package RealTreasuryBusinessCaseBuilder
  */
-
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 $company_data   = get_option( 'rtbcb_company_data', [] );
 $company_name   = isset( $company_data['name'] ) ? sanitize_text_field( $company_data['name'] ) : '';
 $test_results  = get_option( 'rtbcb_test_results', [] );

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -11,9 +11,7 @@
  * @package RealTreasuryBusinessCaseBuilder
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 define( 'RTBCB_VERSION', '2.1.8' );
 define( 'RTBCB_FILE', __FILE__ );

--- a/templates/report-template.php
+++ b/templates/report-template.php
@@ -7,9 +7,7 @@
  * @var array $business_case_data Business case data from the LLM.
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 $metadata      = $business_case_data['metadata'] ?? [];
 $analysis_type = $metadata['analysis_type'] ?? 'basic';

--- a/tests/api-tester-gpt5-mini.test.php
+++ b/tests/api-tester-gpt5-mini.test.php
@@ -1,7 +1,9 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', __DIR__ . '/../' );
+	define( 'ABSPATH', __DIR__ . '/../' );
 }
+
+defined( 'ABSPATH' ) || exit;
 
 if ( ! function_exists( 'add_filter' ) ) {
     function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}

--- a/tests/background-job.test.php
+++ b/tests/background-job.test.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+defined( 'ABSPATH' ) || exit;
+
 if ( ! class_exists( 'WP_Error' ) ) {
     class WP_Error {
         private $code;
@@ -115,10 +120,6 @@ if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
 }
 if ( ! defined( 'DAY_IN_SECONDS' ) ) {
     define( 'DAY_IN_SECONDS', 86400 );
-}
-
-if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', __DIR__ . '/' );
 }
 
 if ( ! class_exists( 'RTBCB_Ajax' ) ) {

--- a/tests/company-research-cache.test.php
+++ b/tests/company-research-cache.test.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/../' );
 }
 
+defined( 'ABSPATH' ) || exit;
+
 ini_set( 'error_log', '/dev/null' );
 
 if ( ! function_exists( 'sanitize_text_field' ) ) {

--- a/tests/edge-cases.test.php
+++ b/tests/edge-cases.test.php
@@ -1,7 +1,9 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-define( 'ABSPATH', __DIR__ . '/../' );
+	define( 'ABSPATH', __DIR__ . '/../' );
 }
+
+defined( 'ABSPATH' ) || exit;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/email-and-pdf.test.php
+++ b/tests/email-and-pdf.test.php
@@ -4,6 +4,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+defined( 'ABSPATH' ) || exit;
+
 if ( ! function_exists( 'sanitize_email' ) ) {
 	function sanitize_email( $email ) {
 	    return filter_var( $email, FILTER_SANITIZE_EMAIL );

--- a/tests/helpers/capture-call-openai-body.php
+++ b/tests/helpers/capture-call-openai-body.php
@@ -2,8 +2,10 @@
 // Generate a mock server-side OpenAI request body for temperature tests.
 
 if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', __DIR__ . '/../../' );
+	define( 'ABSPATH', __DIR__ . '/../../' );
 }
+
+defined( 'ABSPATH' ) || exit;
 
 $model = getenv( 'RTBCB_TEST_MODEL' );
 $model = $model ? preg_replace( '/[^A-Za-z0-9\-_.]/', '', $model ) : 'gpt-5-mini';

--- a/tests/job-status.test.php
+++ b/tests/job-status.test.php
@@ -1,7 +1,9 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', __DIR__ . '/../' );
+	define( 'ABSPATH', __DIR__ . '/../' );
 }
+
+defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'WP_Error' ) ) {
     class WP_Error {

--- a/tests/project-growth-path.test.php
+++ b/tests/project-growth-path.test.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/../' );
 }
 
+defined( 'ABSPATH' ) || exit;
+
 if ( ! function_exists( 'add_filter' ) ) {
 	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
 }


### PR DESCRIPTION
## Summary
- replace verbose ABSPATH checks with concise `defined( 'ABSPATH' ) || exit;`
- add consistent guards to admin pages, templates, and test files

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found; JS tests emit submission errors)*
- `phpcs --standard=WordPress` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3cc3a2da0833182a375dc0d7f77a0