### PR TITLE
Rename main plugin class to RTBCB_Main

### DIFF
--- a/docs/WIZARD_FORM_API_FLOW.md
+++ b/docs/WIZARD_FORM_API_FLOW.md
@@ -31,7 +31,7 @@ Field definitions come from `templates/business-case-form.php` and the field reg
 
 ## Server-side Processing
 
-`Real_Treasury_BCB::ajax_generate_comprehensive_case()` validates the request and orchestrates report generation:
+`RTBCB_Main::ajax_generate_comprehensive_case()` validates the request and orchestrates report generation:
 
 1. **ROI Calculation** – `RTBCB_Calculator::calculate_roi()` builds conservative, base, and optimistic scenarios.
 2. **Category Recommendation & ROI Refinement** – `RTBCB_Category_Recommender::recommend_category()` scores the selected challenges to suggest a treasury solution type, then `RTBCB_Calculator::calculate_category_refined_roi()` recalculates ROI based on that category.

--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -53,8 +53,8 @@ class RTBCB_Ajax {
                 $scenarios      = RTBCB_Calculator::calculate_roi( $user_inputs );
                 $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
 
-                $plugin = Real_Treasury_BCB::instance();
-                $method = new ReflectionMethod( Real_Treasury_BCB::class, 'generate_business_analysis' );
+                $plugin = RTBCB_Main::instance();
+                $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' );
                 $method->setAccessible( true );
 
                 $chunk_callback = function( $chunk ) {

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -27,11 +27,11 @@ if ( ! defined( 'RTBCB_DEBUG' ) ) {
 /**
  * Enhanced main plugin class.
  */
-class Real_Treasury_BCB {
+class RTBCB_Main {
     /**
      * Singleton instance.
      *
-     * @var Real_Treasury_BCB|null
+     * @var RTBCB_Main|null
      */
     private static $instance = null;
 
@@ -52,7 +52,7 @@ class Real_Treasury_BCB {
     /**
      * Get plugin instance.
      *
-     * @return Real_Treasury_BCB
+     * @return RTBCB_Main
      */
     public static function instance() {
         if ( null === self::$instance ) {
@@ -2540,7 +2540,7 @@ return $use_comprehensive;
 }
 
 // Initialize the plugin
-Real_Treasury_BCB::instance();
+RTBCB_Main::instance();
 
 // Helper functions for use in templates and other plugins
 if ( ! function_exists( 'rtbcb_get_leads_count' ) ) {

--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
@@ -112,8 +112,8 @@ if ( ! function_exists( 'wp_send_json_error' ) ) {
     }
 }
 
-if ( ! class_exists( 'Real_Treasury_BCB' ) ) {
-    class Real_Treasury_BCB {
+if ( ! class_exists( 'RTBCB_Main' ) ) {
+    class RTBCB_Main {
         public function ajax_generate_comprehensive_case() {
             $llm = new RTBCB_LLM();
             $comprehensive_analysis = $llm->generate_comprehensive_business_case( [], [], [], null );
@@ -145,7 +145,7 @@ if ( ! class_exists( 'Real_Treasury_BCB' ) ) {
 final class RTBCB_AjaxGenerateComprehensiveCaseErrorTest extends TestCase {
     public function test_ajax_returns_error_json_when_llm_fails() {
         RTBCB_LLM::$mode = 'generic';
-        $plugin          = new Real_Treasury_BCB();
+        $plugin          = new RTBCB_Main();
         try {
             $plugin->ajax_generate_comprehensive_case();
             $this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
@@ -163,7 +163,7 @@ final class RTBCB_AjaxGenerateComprehensiveCaseErrorTest extends TestCase {
 
     public function test_ajax_returns_api_key_error_when_missing() {
         RTBCB_LLM::$mode = 'no_api_key';
-        $plugin          = new Real_Treasury_BCB();
+        $plugin          = new RTBCB_Main();
         try {
             $plugin->ajax_generate_comprehensive_case();
             $this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
@@ -181,7 +181,7 @@ final class RTBCB_AjaxGenerateComprehensiveCaseErrorTest extends TestCase {
 
     public function test_ajax_returns_http_status_error() {
         RTBCB_LLM::$mode = 'http_status';
-        $plugin          = new Real_Treasury_BCB();
+        $plugin          = new RTBCB_Main();
         try {
             $plugin->ajax_generate_comprehensive_case();
             $this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );

--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
@@ -91,8 +91,8 @@ if ( ! function_exists( 'wp_send_json_error' ) ) {
     }
 }
 
-if ( ! class_exists( 'Real_Treasury_BCB_Fatal' ) ) {
-    class Real_Treasury_BCB_Fatal {
+if ( ! class_exists( 'RTBCB_Main_Fatal' ) ) {
+    class RTBCB_Main_Fatal {
         public function ajax_generate_comprehensive_case() {
             $llm = new RTBCB_LLM();
             try {
@@ -125,7 +125,7 @@ if ( ! class_exists( 'Real_Treasury_BCB_Fatal' ) ) {
 final class RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest extends TestCase {
     public function test_ajax_returns_guidance_when_configuration_error() {
         RTBCB_LLM::$mode = 'fatal_config';
-        $plugin          = new Real_Treasury_BCB_Fatal();
+        $plugin          = new RTBCB_Main_Fatal();
         try {
             $plugin->ajax_generate_comprehensive_case();
             $this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
@@ -141,7 +141,7 @@ final class RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest extends TestCase {
 
     public function test_ajax_returns_generic_message_when_internal_error() {
         RTBCB_LLM::$mode = 'fatal_internal';
-        $plugin          = new Real_Treasury_BCB_Fatal();
+        $plugin          = new RTBCB_Main_Fatal();
         try {
             $plugin->ajax_generate_comprehensive_case();
             $this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );

--- a/tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
+++ b/tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
@@ -66,7 +66,7 @@ return new WP_Error( 'llm_timeout', 'Request timed out' );
 }
 }
 
-class Real_Treasury_BCB {
+class RTBCB_Main {
 private function generate_business_analysis( $user_inputs, $scenarios, $recommendation, $chunk_callback = null ) {
 $start_time      = microtime( true );
 $timeout         = rtbcb_get_api_timeout();
@@ -161,8 +161,8 @@ __( 'Develop implementation roadmap and timeline', 'rtbcb' ),
 
 final class RTBCB_GenerateBusinessAnalysisTimeoutTest extends TestCase {
 public function test_timeout_returns_fallback_analysis() {
-$plugin  = new Real_Treasury_BCB();
-$method  = new ReflectionMethod( Real_Treasury_BCB::class, 'generate_business_analysis' );
+$plugin  = new RTBCB_Main();
+$method  = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' );
 $method->setAccessible( true );
 
 $user_inputs = [ 'company_name' => 'Test Co' ];

--- a/tests/generate-business-analysis.test.php
+++ b/tests/generate-business-analysis.test.php
@@ -70,7 +70,7 @@ return [ 'executive_summary' => 'summary', 'context_used' => $rag_context ];
 }
 }
 
-class Real_Treasury_BCB {
+class RTBCB_Main {
 public $fallback_called = false;
 
 private function generate_business_analysis( $user_inputs, $scenarios, $recommendation, $chunk_callback = null ) {
@@ -152,7 +152,7 @@ final class Generate_Business_Analysis_Test extends TestCase {
     private $plugin;
 
     protected function setUp(): void {
-        $this->plugin = new Real_Treasury_BCB();
+        $this->plugin = new RTBCB_Main();
     }
 
     private function invoke_generate_business_analysis() {

--- a/tests/operational-risks-fallback.test.php
+++ b/tests/operational-risks-fallback.test.php
@@ -83,10 +83,10 @@ return [];
 define( 'ABSPATH', __DIR__ );
 $plugin_code = file_get_contents( __DIR__ . '/../real-treasury-business-case-builder.php' );
 $plugin_code = preg_replace( '/
-?\/\/ Initialize the plugin\s*Real_Treasury_BCB::instance\(\);/', '', $plugin_code );
+?\/\/ Initialize the plugin\s*RTBCB_Main::instance\(\);/', '', $plugin_code );
 eval( '?>' . $plugin_code );
 
-$ref  = new ReflectionClass( 'Real_Treasury_BCB' );
+$ref  = new ReflectionClass( 'RTBCB_Main' );
 $plugin = $ref->newInstanceWithoutConstructor();
 $method = $ref->getMethod( 'transform_data_for_template' );
 $method->setAccessible( true );


### PR DESCRIPTION
## Summary
- rename Real_Treasury_BCB to RTBCB_Main and adjust instantiation
- update AJAX handler, tests, and docs for new class name

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4o-mini bash tests/run-tests.sh` *(fails: Call to undefined function add_action, phpunit not found)*
- `npx --yes markdownlint-cli docs/**/*.md` *(fails: multiple markdown style warnings)*
- `npx --yes markdown-link-check docs/WIZARD_FORM_API_FLOW.md`


------
https://chatgpt.com/codex/tasks/task_e_68b3cc2ee3b48331b497a6de0daadf42