### PR TITLE
Use tabs for indentation across PHP files

### DIFF
--- a/admin/analytics-page.php
+++ b/admin/analytics-page.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Analytics admin page for Real Treasury Business Case Builder plugin.
- */
+	* Analytics admin page for Real Treasury Business Case Builder plugin.
+	*/
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
@@ -16,615 +16,615 @@ $enable_charts = RTBCB_Settings::get_setting( 'enable_charts', true );
 ?>
 
 <div class="wrap rtbcb-admin-page">
-    <div class="rtbcb-admin-header">
-        <h1><?php echo esc_html__( 'Analytics & Insights', 'rtbcb' ); ?></h1>
-        <div class="rtbcb-date-range">
-            <select id="rtbcb-analytics-period">
-                <option value="30"><?php esc_html_e( 'Last 30 days', 'rtbcb' ); ?></option>
-                <option value="90"><?php esc_html_e( 'Last 90 days', 'rtbcb' ); ?></option>
-                <option value="365"><?php esc_html_e( 'Last year', 'rtbcb' ); ?></option>
-                <option value="all"><?php esc_html_e( 'All time', 'rtbcb' ); ?></option>
-            </select>
-        </div>
-    </div>
+	<div class="rtbcb-admin-header">
+		<h1><?php echo esc_html__( 'Analytics & Insights', 'rtbcb' ); ?></h1>
+		<div class="rtbcb-date-range">
+			<select id="rtbcb-analytics-period">
+				<option value="30"><?php esc_html_e( 'Last 30 days', 'rtbcb' ); ?></option>
+				<option value="90"><?php esc_html_e( 'Last 90 days', 'rtbcb' ); ?></option>
+				<option value="365"><?php esc_html_e( 'Last year', 'rtbcb' ); ?></option>
+				<option value="all"><?php esc_html_e( 'All time', 'rtbcb' ); ?></option>
+			</select>
+		</div>
+	</div>
 
-    <!-- Key Metrics -->
-    <div class="rtbcb-metrics-grid">
-        <div class="rtbcb-metric-card">
-            <div class="rtbcb-metric-icon">
-                <span class="dashicons dashicons-groups"></span>
-            </div>
-            <div class="rtbcb-metric-content">
-                <div class="rtbcb-metric-value"><?php echo esc_html( number_format( $total_leads ) ); ?></div>
-                <div class="rtbcb-metric-label"><?php esc_html_e( 'Total Leads', 'rtbcb' ); ?></div>
-            </div>
-        </div>
+	<!-- Key Metrics -->
+	<div class="rtbcb-metrics-grid">
+		<div class="rtbcb-metric-card">
+			<div class="rtbcb-metric-icon">
+				<span class="dashicons dashicons-groups"></span>
+			</div>
+			<div class="rtbcb-metric-content">
+				<div class="rtbcb-metric-value"><?php echo esc_html( number_format( $total_leads ) ); ?></div>
+				<div class="rtbcb-metric-label"><?php esc_html_e( 'Total Leads', 'rtbcb' ); ?></div>
+			</div>
+		</div>
 
-        <div class="rtbcb-metric-card">
-            <div class="rtbcb-metric-icon rtbcb-metric-trend-up">
-                <span class="dashicons dashicons-arrow-up-alt2"></span>
-            </div>
-            <div class="rtbcb-metric-content">
-                <div class="rtbcb-metric-value"><?php echo esc_html( number_format( $recent_leads ) ); ?></div>
-                <div class="rtbcb-metric-label"><?php esc_html_e( 'This Month', 'rtbcb' ); ?></div>
-            </div>
-        </div>
+		<div class="rtbcb-metric-card">
+			<div class="rtbcb-metric-icon rtbcb-metric-trend-up">
+				<span class="dashicons dashicons-arrow-up-alt2"></span>
+			</div>
+			<div class="rtbcb-metric-content">
+				<div class="rtbcb-metric-value"><?php echo esc_html( number_format( $recent_leads ) ); ?></div>
+				<div class="rtbcb-metric-label"><?php esc_html_e( 'This Month', 'rtbcb' ); ?></div>
+			</div>
+		</div>
 
-        <div class="rtbcb-metric-card">
-            <div class="rtbcb-metric-icon rtbcb-metric-roi">
-                <span class="dashicons dashicons-chart-line"></span>
-            </div>
-            <div class="rtbcb-metric-content">
-                <div class="rtbcb-metric-value">
-                    $<?php echo esc_html( number_format( intval( $roi_stats['avg_base'] ?? 0 ) ) ); ?>
-                </div>
-                <div class="rtbcb-metric-label"><?php esc_html_e( 'Avg. ROI', 'rtbcb' ); ?></div>
-            </div>
-        </div>
+		<div class="rtbcb-metric-card">
+			<div class="rtbcb-metric-icon rtbcb-metric-roi">
+				<span class="dashicons dashicons-chart-line"></span>
+			</div>
+			<div class="rtbcb-metric-content">
+				<div class="rtbcb-metric-value">
+					$<?php echo esc_html( number_format( intval( $roi_stats['avg_base'] ?? 0 ) ) ); ?>
+				</div>
+				<div class="rtbcb-metric-label"><?php esc_html_e( 'Avg. ROI', 'rtbcb' ); ?></div>
+			</div>
+		</div>
 
-        <div class="rtbcb-metric-card">
-            <div class="rtbcb-metric-icon rtbcb-metric-conversion">
-                <span class="dashicons dashicons-yes-alt"></span>
-            </div>
-            <div class="rtbcb-metric-content">
-                <div class="rtbcb-metric-value">
-                    <?php echo $total_leads > 0 ? esc_html( number_format( ( $recent_leads / max( 1, $total_leads ) ) * 100, 1 ) ) : '0'; ?>%
-                </div>
-                <div class="rtbcb-metric-label"><?php esc_html_e( 'Growth Rate', 'rtbcb' ); ?></div>
-            </div>
-        </div>
-    </div>
+		<div class="rtbcb-metric-card">
+			<div class="rtbcb-metric-icon rtbcb-metric-conversion">
+				<span class="dashicons dashicons-yes-alt"></span>
+			</div>
+			<div class="rtbcb-metric-content">
+				<div class="rtbcb-metric-value">
+					<?php echo $total_leads > 0 ? esc_html( number_format( ( $recent_leads / max( 1, $total_leads ) ) * 100, 1 ) ) : '0'; ?>%
+				</div>
+				<div class="rtbcb-metric-label"><?php esc_html_e( 'Growth Rate', 'rtbcb' ); ?></div>
+			</div>
+		</div>
+	</div>
 
-    <?php if ( $enable_charts ) : ?>
-    <!-- Charts Section -->
-    <div class="rtbcb-charts-grid">
-        <!-- Category Distribution Chart -->
-        <div class="rtbcb-chart-card">
-            <div class="rtbcb-chart-header">
-                <h3><?php esc_html_e( 'Recommended Categories', 'rtbcb' ); ?></h3>
-                <p class="rtbcb-chart-description">
-                    <?php esc_html_e( 'Distribution of solution categories recommended to leads', 'rtbcb' ); ?>
-                </p>
-            </div>
-            <div class="rtbcb-chart-container">
-                <canvas id="rtbcb-category-chart" width="400" height="200"></canvas>
-            </div>
-            <div class="rtbcb-chart-legend">
-                <?php foreach ( $category_stats as $stat ) : ?>
-                    <?php 
-                    $category_info = $categories[ $stat['recommended_category'] ] ?? [];
-                    $category_name = $category_info['name'] ?? ucfirst( str_replace( '_', ' ', $stat['recommended_category'] ) );
-                    ?>
-                    <div class="rtbcb-legend-item">
-                        <span class="rtbcb-legend-color rtbcb-cat-<?php echo esc_attr( $stat['recommended_category'] ); ?>"></span>
-                        <span class="rtbcb-legend-label"><?php echo esc_html( $category_name ); ?></span>
-                        <span class="rtbcb-legend-value"><?php echo esc_html( $stat['count'] ); ?></span>
-                    </div>
-                <?php endforeach; ?>
-            </div>
-        </div>
+	<?php if ( $enable_charts ) : ?>
+	<!-- Charts Section -->
+	<div class="rtbcb-charts-grid">
+		<!-- Category Distribution Chart -->
+		<div class="rtbcb-chart-card">
+			<div class="rtbcb-chart-header">
+				<h3><?php esc_html_e( 'Recommended Categories', 'rtbcb' ); ?></h3>
+				<p class="rtbcb-chart-description">
+					<?php esc_html_e( 'Distribution of solution categories recommended to leads', 'rtbcb' ); ?>
+				</p>
+			</div>
+			<div class="rtbcb-chart-container">
+				<canvas id="rtbcb-category-chart" width="400" height="200"></canvas>
+			</div>
+			<div class="rtbcb-chart-legend">
+				<?php foreach ( $category_stats as $stat ) : ?>
+					<?php 
+					$category_info = $categories[ $stat['recommended_category'] ] ?? [];
+					$category_name = $category_info['name'] ?? ucfirst( str_replace( '_', ' ', $stat['recommended_category'] ) );
+					?>
+					<div class="rtbcb-legend-item">
+						<span class="rtbcb-legend-color rtbcb-cat-<?php echo esc_attr( $stat['recommended_category'] ); ?>"></span>
+						<span class="rtbcb-legend-label"><?php echo esc_html( $category_name ); ?></span>
+						<span class="rtbcb-legend-value"><?php echo esc_html( $stat['count'] ); ?></span>
+					</div>
+				<?php endforeach; ?>
+			</div>
+		</div>
 
-        <!-- Company Size Distribution -->
-        <div class="rtbcb-chart-card">
-            <div class="rtbcb-chart-header">
-                <h3><?php esc_html_e( 'Company Size Distribution', 'rtbcb' ); ?></h3>
-                <p class="rtbcb-chart-description">
-                    <?php esc_html_e( 'Breakdown of leads by company revenue size', 'rtbcb' ); ?>
-                </p>
-            </div>
-            <div class="rtbcb-chart-container">
-                <canvas id="rtbcb-size-chart" width="400" height="200"></canvas>
-            </div>
-            <div class="rtbcb-chart-stats">
-                <?php foreach ( $size_stats as $stat ) : ?>
-                    <div class="rtbcb-stat-item">
-                        <div class="rtbcb-stat-label"><?php echo esc_html( $stat['company_size'] ); ?></div>
-                        <div class="rtbcb-stat-value"><?php echo esc_html( $stat['count'] ); ?> leads</div>
-                        <div class="rtbcb-stat-percentage">
-                            <?php echo $total_leads > 0 ? esc_html( number_format( ( $stat['count'] / $total_leads ) * 100, 1 ) ) : '0'; ?>%
-                        </div>
-                    </div>
-                <?php endforeach; ?>
-            </div>
-        </div>
+		<!-- Company Size Distribution -->
+		<div class="rtbcb-chart-card">
+			<div class="rtbcb-chart-header">
+				<h3><?php esc_html_e( 'Company Size Distribution', 'rtbcb' ); ?></h3>
+				<p class="rtbcb-chart-description">
+					<?php esc_html_e( 'Breakdown of leads by company revenue size', 'rtbcb' ); ?>
+				</p>
+			</div>
+			<div class="rtbcb-chart-container">
+				<canvas id="rtbcb-size-chart" width="400" height="200"></canvas>
+			</div>
+			<div class="rtbcb-chart-stats">
+				<?php foreach ( $size_stats as $stat ) : ?>
+					<div class="rtbcb-stat-item">
+						<div class="rtbcb-stat-label"><?php echo esc_html( $stat['company_size'] ); ?></div>
+						<div class="rtbcb-stat-value"><?php echo esc_html( $stat['count'] ); ?> leads</div>
+						<div class="rtbcb-stat-percentage">
+							<?php echo $total_leads > 0 ? esc_html( number_format( ( $stat['count'] / $total_leads ) * 100, 1 ) ) : '0'; ?>%
+						</div>
+					</div>
+				<?php endforeach; ?>
+			</div>
+		</div>
 
-        <!-- ROI Analysis -->
-        <div class="rtbcb-chart-card rtbcb-chart-wide">
-            <div class="rtbcb-chart-header">
-                <h3><?php esc_html_e( 'ROI Analysis', 'rtbcb' ); ?></h3>
-                <p class="rtbcb-chart-description">
-                    <?php esc_html_e( 'Average ROI projections across all scenarios', 'rtbcb' ); ?>
-                </p>
-            </div>
-            <div class="rtbcb-roi-overview">
-                <div class="rtbcb-roi-stat">
-                    <div class="rtbcb-roi-label"><?php esc_html_e( 'Conservative', 'rtbcb' ); ?></div>
-                    <div class="rtbcb-roi-value">$<?php echo esc_html( number_format( intval( $roi_stats['avg_low'] ?? 0 ) ) ); ?></div>
-                </div>
-                <div class="rtbcb-roi-stat rtbcb-roi-primary">
-                    <div class="rtbcb-roi-label"><?php esc_html_e( 'Base Case', 'rtbcb' ); ?></div>
-                    <div class="rtbcb-roi-value">$<?php echo esc_html( number_format( intval( $roi_stats['avg_base'] ?? 0 ) ) ); ?></div>
-                </div>
-                <div class="rtbcb-roi-stat">
-                    <div class="rtbcb-roi-label"><?php esc_html_e( 'Optimistic', 'rtbcb' ); ?></div>
-                    <div class="rtbcb-roi-value">$<?php echo esc_html( number_format( intval( $roi_stats['avg_high'] ?? 0 ) ) ); ?></div>
-                </div>
-            </div>
-        </div>
+		<!-- ROI Analysis -->
+		<div class="rtbcb-chart-card rtbcb-chart-wide">
+			<div class="rtbcb-chart-header">
+				<h3><?php esc_html_e( 'ROI Analysis', 'rtbcb' ); ?></h3>
+				<p class="rtbcb-chart-description">
+					<?php esc_html_e( 'Average ROI projections across all scenarios', 'rtbcb' ); ?>
+				</p>
+			</div>
+			<div class="rtbcb-roi-overview">
+				<div class="rtbcb-roi-stat">
+					<div class="rtbcb-roi-label"><?php esc_html_e( 'Conservative', 'rtbcb' ); ?></div>
+					<div class="rtbcb-roi-value">$<?php echo esc_html( number_format( intval( $roi_stats['avg_low'] ?? 0 ) ) ); ?></div>
+				</div>
+				<div class="rtbcb-roi-stat rtbcb-roi-primary">
+					<div class="rtbcb-roi-label"><?php esc_html_e( 'Base Case', 'rtbcb' ); ?></div>
+					<div class="rtbcb-roi-value">$<?php echo esc_html( number_format( intval( $roi_stats['avg_base'] ?? 0 ) ) ); ?></div>
+				</div>
+				<div class="rtbcb-roi-stat">
+					<div class="rtbcb-roi-label"><?php esc_html_e( 'Optimistic', 'rtbcb' ); ?></div>
+					<div class="rtbcb-roi-value">$<?php echo esc_html( number_format( intval( $roi_stats['avg_high'] ?? 0 ) ) ); ?></div>
+				</div>
+			</div>
+		</div>
 
-        <!-- Monthly Trends -->
-        <div class="rtbcb-chart-card rtbcb-chart-wide">
-            <div class="rtbcb-chart-header">
-                <h3><?php esc_html_e( 'Lead Generation Trends', 'rtbcb' ); ?></h3>
-                <p class="rtbcb-chart-description">
-                    <?php esc_html_e( 'Monthly lead volume and average ROI over time', 'rtbcb' ); ?>
-                </p>
-            </div>
-            <div class="rtbcb-chart-container">
-                <canvas id="rtbcb-trends-chart" width="800" height="300"></canvas>
-            </div>
-        </div>
-    </div>
+		<!-- Monthly Trends -->
+		<div class="rtbcb-chart-card rtbcb-chart-wide">
+			<div class="rtbcb-chart-header">
+				<h3><?php esc_html_e( 'Lead Generation Trends', 'rtbcb' ); ?></h3>
+				<p class="rtbcb-chart-description">
+					<?php esc_html_e( 'Monthly lead volume and average ROI over time', 'rtbcb' ); ?>
+				</p>
+			</div>
+			<div class="rtbcb-chart-container">
+				<canvas id="rtbcb-trends-chart" width="800" height="300"></canvas>
+			</div>
+		</div>
+	</div>
 
-    <!-- Insights Section -->
-    <div class="rtbcb-insights-section">
-        <h2><?php esc_html_e( 'Key Insights', 'rtbcb' ); ?></h2>
-        <div class="rtbcb-insights-grid">
-            <?php if ( ! empty( $category_stats ) ) : ?>
-                <?php 
-                $top_category = array_reduce( $category_stats, function( $carry, $item ) {
-                    return ( ! $carry || $item['count'] > $carry['count'] ) ? $item : $carry;
-                } );
-                
-                if ( $top_category ) {
-                    $top_cat_info = $categories[ $top_category['recommended_category'] ] ?? [];
-                    $top_cat_name = $top_cat_info['name'] ?? '';
-                    $top_percentage = $total_leads > 0 ? ( $top_category['count'] / $total_leads ) * 100 : 0;
-                }
-                ?>
-                <div class="rtbcb-insight-card">
-                    <div class="rtbcb-insight-icon">
-                        <span class="dashicons dashicons-star-filled"></span>
-                    </div>
-                    <div class="rtbcb-insight-content">
-                        <h4><?php esc_html_e( 'Most Popular Category', 'rtbcb' ); ?></h4>
-                        <p>
-                            <?php 
-                            printf( 
-                                esc_html__( '%1$s is recommended for %2$d%% of leads (%3$d out of %4$d).', 'rtbcb' ),
-                                esc_html( $top_cat_name ?? 'Unknown' ),
-                                esc_html( number_format( $top_percentage ?? 0, 1 ) ),
-                                esc_html( $top_category['count'] ?? 0 ),
-                                esc_html( $total_leads )
-                            );
-                            ?>
-                        </p>
-                    </div>
-                </div>
-            <?php endif; ?>
+	<!-- Insights Section -->
+	<div class="rtbcb-insights-section">
+		<h2><?php esc_html_e( 'Key Insights', 'rtbcb' ); ?></h2>
+		<div class="rtbcb-insights-grid">
+			<?php if ( ! empty( $category_stats ) ) : ?>
+				<?php 
+				$top_category = array_reduce( $category_stats, function( $carry, $item ) {
+					return ( ! $carry || $item['count'] > $carry['count'] ) ? $item : $carry;
+				} );
+				
+				if ( $top_category ) {
+					$top_cat_info = $categories[ $top_category['recommended_category'] ] ?? [];
+					$top_cat_name = $top_cat_info['name'] ?? '';
+					$top_percentage = $total_leads > 0 ? ( $top_category['count'] / $total_leads ) * 100 : 0;
+				}
+				?>
+				<div class="rtbcb-insight-card">
+					<div class="rtbcb-insight-icon">
+						<span class="dashicons dashicons-star-filled"></span>
+					</div>
+					<div class="rtbcb-insight-content">
+						<h4><?php esc_html_e( 'Most Popular Category', 'rtbcb' ); ?></h4>
+						<p>
+							<?php 
+							printf( 
+								esc_html__( '%1$s is recommended for %2$d%% of leads (%3$d out of %4$d).', 'rtbcb' ),
+								esc_html( $top_cat_name ?? 'Unknown' ),
+								esc_html( number_format( $top_percentage ?? 0, 1 ) ),
+								esc_html( $top_category['count'] ?? 0 ),
+								esc_html( $total_leads )
+							);
+							?>
+						</p>
+					</div>
+				</div>
+			<?php endif; ?>
 
-            <?php if ( ! empty( $size_stats ) ) : ?>
-                <?php 
-                $enterprise_count = 0;
-                $smb_count = 0;
-                
-                foreach ( $size_stats as $stat ) {
-                    if ( in_array( $stat['company_size'], [ '>$2B', '$500M-$2B' ], true ) ) {
-                        $enterprise_count += $stat['count'];
-                    } else {
-                        $smb_count += $stat['count'];
-                    }
-                }
-                
-                $enterprise_percentage = $total_leads > 0 ? ( $enterprise_count / $total_leads ) * 100 : 0;
-                ?>
-                <div class="rtbcb-insight-card">
-                    <div class="rtbcb-insight-icon">
-                        <span class="dashicons dashicons-building"></span>
-                    </div>
-                    <div class="rtbcb-insight-content">
-                        <h4><?php esc_html_e( 'Market Segment', 'rtbcb' ); ?></h4>
-                        <p>
-                            <?php 
-                            printf( 
-                                esc_html__( '%1$d%% of leads are enterprise-level companies ($500M+ revenue), indicating strong interest from larger organizations.', 'rtbcb' ),
-                                esc_html( number_format( $enterprise_percentage, 1 ) )
-                            );
-                            ?>
-                        </p>
-                    </div>
-                </div>
-            <?php endif; ?>
+			<?php if ( ! empty( $size_stats ) ) : ?>
+				<?php 
+				$enterprise_count = 0;
+				$smb_count = 0;
+				
+				foreach ( $size_stats as $stat ) {
+					if ( in_array( $stat['company_size'], [ '>$2B', '$500M-$2B' ], true ) ) {
+						$enterprise_count += $stat['count'];
+					} else {
+						$smb_count += $stat['count'];
+					}
+				}
+				
+				$enterprise_percentage = $total_leads > 0 ? ( $enterprise_count / $total_leads ) * 100 : 0;
+				?>
+				<div class="rtbcb-insight-card">
+					<div class="rtbcb-insight-icon">
+						<span class="dashicons dashicons-building"></span>
+					</div>
+					<div class="rtbcb-insight-content">
+						<h4><?php esc_html_e( 'Market Segment', 'rtbcb' ); ?></h4>
+						<p>
+							<?php 
+							printf( 
+								esc_html__( '%1$d%% of leads are enterprise-level companies ($500M+ revenue), indicating strong interest from larger organizations.', 'rtbcb' ),
+								esc_html( number_format( $enterprise_percentage, 1 ) )
+							);
+							?>
+						</p>
+					</div>
+				</div>
+			<?php endif; ?>
 
-            <div class="rtbcb-insight-card">
-                <div class="rtbcb-insight-icon">
-                    <span class="dashicons dashicons-money-alt"></span>
-                </div>
-                <div class="rtbcb-insight-content">
-                    <h4><?php esc_html_e( 'ROI Potential', 'rtbcb' ); ?></h4>
-                    <p>
-                        <?php 
-                        $avg_roi = intval( $roi_stats['avg_base'] ?? 0 );
-                        if ( $avg_roi > 100000 ) {
-                            printf( 
-                                esc_html__( 'Average projected ROI of $%s demonstrates strong value proposition for treasury technology investments.', 'rtbcb' ),
-                                esc_html( number_format( $avg_roi ) )
-                            );
-                        } else {
-                            esc_html_e( 'ROI calculations show significant potential for operational efficiency improvements.', 'rtbcb' );
-                        }
-                        ?>
-                    </p>
-                </div>
-            </div>
+			<div class="rtbcb-insight-card">
+				<div class="rtbcb-insight-icon">
+					<span class="dashicons dashicons-money-alt"></span>
+				</div>
+				<div class="rtbcb-insight-content">
+					<h4><?php esc_html_e( 'ROI Potential', 'rtbcb' ); ?></h4>
+					<p>
+						<?php 
+						$avg_roi = intval( $roi_stats['avg_base'] ?? 0 );
+						if ( $avg_roi > 100000 ) {
+							printf( 
+								esc_html__( 'Average projected ROI of $%s demonstrates strong value proposition for treasury technology investments.', 'rtbcb' ),
+								esc_html( number_format( $avg_roi ) )
+							);
+						} else {
+							esc_html_e( 'ROI calculations show significant potential for operational efficiency improvements.', 'rtbcb' );
+						}
+						?>
+					</p>
+				</div>
+			</div>
 
-            <div class="rtbcb-insight-card">
-                <div class="rtbcb-insight-icon">
-                    <span class="dashicons dashicons-calendar-alt"></span>
-                </div>
-                <div class="rtbcb-insight-content">
-                    <h4><?php esc_html_e( 'Recent Activity', 'rtbcb' ); ?></h4>
-                    <p>
-                        <?php 
-                        if ( $recent_leads > 0 ) {
-                            printf( 
-                                esc_html__( '%1$d new leads in the last 30 days shows growing interest in treasury technology solutions.', 'rtbcb' ),
-                                esc_html( $recent_leads )
-                            );
-                        } else {
-                            esc_html_e( 'Consider marketing efforts to drive more lead generation activity.', 'rtbcb' );
-                        }
-                        ?>
-                    </p>
-                </div>
-            </div>
-        </div>
-    </div>
+			<div class="rtbcb-insight-card">
+				<div class="rtbcb-insight-icon">
+					<span class="dashicons dashicons-calendar-alt"></span>
+				</div>
+				<div class="rtbcb-insight-content">
+					<h4><?php esc_html_e( 'Recent Activity', 'rtbcb' ); ?></h4>
+					<p>
+						<?php 
+						if ( $recent_leads > 0 ) {
+							printf( 
+								esc_html__( '%1$d new leads in the last 30 days shows growing interest in treasury technology solutions.', 'rtbcb' ),
+								esc_html( $recent_leads )
+							);
+						} else {
+							esc_html_e( 'Consider marketing efforts to drive more lead generation activity.', 'rtbcb' );
+						}
+						?>
+					</p>
+				</div>
+			</div>
+		</div>
+	</div>
 </div>
 
 <script type="text/javascript">
 document.addEventListener('DOMContentLoaded', function() {
-    initializeAnalyticsCharts();
+	initializeAnalyticsCharts();
 });
 
 function initializeAnalyticsCharts() {
-    const fallbackMessage = '<?php echo esc_js( __( 'Chart unavailable', 'rtbcb' ) ); ?>';
-    const showFallback = (id) => {
-        const canvas = document.getElementById(id);
-        if (canvas) {
-            const div = document.createElement('div');
-            div.textContent = fallbackMessage;
-            canvas.replaceWith(div);
-        }
-    };
+	const fallbackMessage = '<?php echo esc_js( __( 'Chart unavailable', 'rtbcb' ) ); ?>';
+	const showFallback = (id) => {
+		const canvas = document.getElementById(id);
+		if (canvas) {
+			const div = document.createElement('div');
+			div.textContent = fallbackMessage;
+			canvas.replaceWith(div);
+		}
+	};
 
-    if (typeof Chart === 'undefined') {
-        showFallback('rtbcb-category-chart');
-        showFallback('rtbcb-size-chart');
-        showFallback('rtbcb-trends-chart');
-        return;
-    }
+	if (typeof Chart === 'undefined') {
+		showFallback('rtbcb-category-chart');
+		showFallback('rtbcb-size-chart');
+		showFallback('rtbcb-trends-chart');
+		return;
+	}
 
-    // Category Distribution Chart
-    const categoryData = <?php echo wp_json_encode( $category_stats ); ?>;
-    const categoryLabels = categoryData.map(item => {
-        const categories = <?php echo wp_json_encode( $categories ); ?>;
-        return categories[item.recommended_category]?.name || item.recommended_category;
-    });
-    const categoryValues = categoryData.map(item => item.count);
-    const categoryColors = ['#7216f4', '#8f47f6', '#c77dff', '#e0aaff', '#f3c4fb'];
+	// Category Distribution Chart
+	const categoryData = <?php echo wp_json_encode( $category_stats ); ?>;
+	const categoryLabels = categoryData.map(item => {
+		const categories = <?php echo wp_json_encode( $categories ); ?>;
+		return categories[item.recommended_category]?.name || item.recommended_category;
+	});
+	const categoryValues = categoryData.map(item => item.count);
+	const categoryColors = ['#7216f4', '#8f47f6', '#c77dff', '#e0aaff', '#f3c4fb'];
 
-    if (categoryData.length > 0) {
-        try {
-            new Chart(document.getElementById('rtbcb-category-chart'), {
-                type: 'doughnut',
-                data: {
-                    labels: categoryLabels,
-                    datasets: [{
-                        data: categoryValues,
-                        backgroundColor: categoryColors.slice(0, categoryData.length),
-                        borderWidth: 0
-                    }]
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: {
-                        legend: {
-                            display: false
-                        },
-                        tooltip: {
-                            callbacks: {
-                                label: function(context) {
-                                    const value = context.parsed;
-                                    const total = context.dataset.data.reduce((a, b) => a + b, 0);
-                                    const percentage = ((value / total) * 100).toFixed(1);
-                                    return `${context.label}: ${value} (${percentage}%)`;
-                                }
-                            }
-                        }
-                    }
-                }
-            });
-        } catch (error) {
-            showFallback('rtbcb-category-chart');
-        }
-    } else {
-        showFallback('rtbcb-category-chart');
-    }
+	if (categoryData.length > 0) {
+		try {
+			new Chart(document.getElementById('rtbcb-category-chart'), {
+				type: 'doughnut',
+				data: {
+					labels: categoryLabels,
+					datasets: [{
+						data: categoryValues,
+						backgroundColor: categoryColors.slice(0, categoryData.length),
+						borderWidth: 0
+					}]
+				},
+				options: {
+					responsive: true,
+					maintainAspectRatio: false,
+					plugins: {
+						legend: {
+							display: false
+						},
+						tooltip: {
+							callbacks: {
+								label: function(context) {
+									const value = context.parsed;
+									const total = context.dataset.data.reduce((a, b) => a + b, 0);
+									const percentage = ((value / total) * 100).toFixed(1);
+									return `${context.label}: ${value} (${percentage}%)`;
+								}
+							}
+						}
+					}
+				}
+			});
+		} catch (error) {
+			showFallback('rtbcb-category-chart');
+		}
+	} else {
+		showFallback('rtbcb-category-chart');
+	}
 
-    // Company Size Chart
-    const sizeData = <?php echo wp_json_encode( $size_stats ); ?>;
-    const sizeLabels = sizeData.map(item => item.company_size);
-    const sizeValues = sizeData.map(item => item.count);
-    const sizeColors = ['#dbeafe', '#dcfce7', '#fef3c7', '#fde2e8'];
+	// Company Size Chart
+	const sizeData = <?php echo wp_json_encode( $size_stats ); ?>;
+	const sizeLabels = sizeData.map(item => item.company_size);
+	const sizeValues = sizeData.map(item => item.count);
+	const sizeColors = ['#dbeafe', '#dcfce7', '#fef3c7', '#fde2e8'];
 
-    if (sizeData.length > 0) {
-        try {
-            new Chart(document.getElementById('rtbcb-size-chart'), {
-                type: 'bar',
-                data: {
-                    labels: sizeLabels,
-                    datasets: [{
-                        data: sizeValues,
-                        backgroundColor: sizeColors.slice(0, sizeData.length),
-                        borderColor: ['#1e40af', '#166534', '#92400e', '#be185d'],
-                        borderWidth: 1
-                    }]
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: {
-                        legend: {
-                            display: false
-                        }
-                    },
-                    scales: {
-                        y: {
-                            beginAtZero: true,
-                            ticks: {
-                                stepSize: 1
-                            }
-                        }
-                    }
-                }
-            });
-        } catch (error) {
-            showFallback('rtbcb-size-chart');
-        }
-    } else {
-        showFallback('rtbcb-size-chart');
-    }
+	if (sizeData.length > 0) {
+		try {
+			new Chart(document.getElementById('rtbcb-size-chart'), {
+				type: 'bar',
+				data: {
+					labels: sizeLabels,
+					datasets: [{
+						data: sizeValues,
+						backgroundColor: sizeColors.slice(0, sizeData.length),
+						borderColor: ['#1e40af', '#166534', '#92400e', '#be185d'],
+						borderWidth: 1
+					}]
+				},
+				options: {
+					responsive: true,
+					maintainAspectRatio: false,
+					plugins: {
+						legend: {
+							display: false
+						}
+					},
+					scales: {
+						y: {
+							beginAtZero: true,
+							ticks: {
+								stepSize: 1
+							}
+						}
+					}
+				}
+			});
+		} catch (error) {
+			showFallback('rtbcb-size-chart');
+		}
+	} else {
+		showFallback('rtbcb-size-chart');
+	}
 
-    // Trends Chart
-    const trendsData = <?php echo wp_json_encode( $monthly_trends ); ?>;
-    const trendLabels = trendsData.map(item => {
-        const date = new Date(item.month + '-01');
-        return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
-    });
-    const leadCounts = trendsData.map(item => parseInt(item.leads));
-    const avgROIs = trendsData.map(item => Math.round(parseFloat(item.avg_roi || 0) / 1000)); // Convert to thousands
+	// Trends Chart
+	const trendsData = <?php echo wp_json_encode( $monthly_trends ); ?>;
+	const trendLabels = trendsData.map(item => {
+		const date = new Date(item.month + '-01');
+		return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+	});
+	const leadCounts = trendsData.map(item => parseInt(item.leads));
+	const avgROIs = trendsData.map(item => Math.round(parseFloat(item.avg_roi || 0) / 1000)); // Convert to thousands
 
-    if (trendsData.length > 0) {
-    try {
-        new Chart(document.getElementById('rtbcb-trends-chart'), {
-                type: 'line',
-                data: {
-                    labels: trendLabels,
-                    datasets: [
-                        {
-                            label: 'Leads',
-                            data: leadCounts,
-                            backgroundColor: 'rgba(114, 22, 244, 0.1)',
-                            borderColor: '#7216f4',
-                            borderWidth: 2,
-                            fill: true,
-                            yAxisID: 'y'
-                        },
-                        {
-                            label: 'Avg ROI (K)',
-                            data: avgROIs,
-                            backgroundColor: 'rgba(16, 185, 129, 0.1)',
-                            borderColor: '#10b981',
-                            borderWidth: 2,
-                            fill: true,
-                            yAxisID: 'y1'
-                        }
-                    ]
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: {
-                        legend: {
-                            position: 'top'
-                        }
-                    },
-                    scales: {
-                        y: {
-                            type: 'linear',
-                            display: true,
-                            position: 'left',
-                            beginAtZero: true,
-                            title: {
-                                display: true,
-                                text: 'Number of Leads'
-                            }
-                        },
-                        y1: {
-                            type: 'linear',
-                            display: true,
-                            position: 'right',
-                            beginAtZero: true,
-                            title: {
-                                display: true,
-                                text: 'Average ROI (Thousands)'
-                            },
-                            grid: {
-                                drawOnChartArea: false
-                            }
-                        }
-                    }
-                }
-            });
-    } catch (error) {
-        showFallback('rtbcb-trends-chart');
-    }
-    } else {
-        showFallback('rtbcb-trends-chart');
-    }
+	if (trendsData.length > 0) {
+	try {
+		new Chart(document.getElementById('rtbcb-trends-chart'), {
+				type: 'line',
+				data: {
+					labels: trendLabels,
+					datasets: [
+						{
+							label: 'Leads',
+							data: leadCounts,
+							backgroundColor: 'rgba(114, 22, 244, 0.1)',
+							borderColor: '#7216f4',
+							borderWidth: 2,
+							fill: true,
+							yAxisID: 'y'
+						},
+						{
+							label: 'Avg ROI (K)',
+							data: avgROIs,
+							backgroundColor: 'rgba(16, 185, 129, 0.1)',
+							borderColor: '#10b981',
+							borderWidth: 2,
+							fill: true,
+							yAxisID: 'y1'
+						}
+					]
+				},
+				options: {
+					responsive: true,
+					maintainAspectRatio: false,
+					plugins: {
+						legend: {
+							position: 'top'
+						}
+					},
+					scales: {
+						y: {
+							type: 'linear',
+							display: true,
+							position: 'left',
+							beginAtZero: true,
+							title: {
+								display: true,
+								text: 'Number of Leads'
+							}
+						},
+						y1: {
+							type: 'linear',
+							display: true,
+							position: 'right',
+							beginAtZero: true,
+							title: {
+								display: true,
+								text: 'Average ROI (Thousands)'
+							},
+							grid: {
+								drawOnChartArea: false
+							}
+						}
+					}
+				}
+			});
+	} catch (error) {
+		showFallback('rtbcb-trends-chart');
+	}
+	} else {
+		showFallback('rtbcb-trends-chart');
+	}
 }
-    </script>
-    <?php endif; ?>
+	</script>
+	<?php endif; ?>
 
 <style>
 /* Analytics page specific styles */
 .rtbcb-admin-page {
-    background: #f1f1f1;
-    margin: 0 -20px -20px -2px;
-    padding: 20px;
+	background: #f1f1f1;
+	margin: 0 -20px -20px -2px;
+	padding: 20px;
 }
 
 .rtbcb-admin-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 30px;
-    background: white;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 30px;
+	background: white;
+	padding: 20px;
+	border-radius: 8px;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .rtbcb-admin-header h1 {
-    margin: 0;
-    color: #1f2937;
+	margin: 0;
+	color: #1f2937;
 }
 
 .rtbcb-date-range select {
-    padding: 8px 12px;
-    border: 1px solid #d1d5db;
-    border-radius: 6px;
-    font-size: 14px;
+	padding: 8px 12px;
+	border: 1px solid #d1d5db;
+	border-radius: 6px;
+	font-size: 14px;
 }
 
 /* Metrics Grid */
 .rtbcb-metrics-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 20px;
-    margin-bottom: 30px;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+	gap: 20px;
+	margin-bottom: 30px;
 }
 
 .rtbcb-metric-card {
-    background: white;
-    padding: 24px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    display: flex;
-    align-items: center;
-    gap: 16px;
+	background: white;
+	padding: 24px;
+	border-radius: 8px;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+	display: flex;
+	align-items: center;
+	gap: 16px;
 }
 
 .rtbcb-metric-icon {
-    width: 48px;
-    height: 48px;
-    border-radius: 50%;
-    background: #f3f4f6;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #6b7280;
-    font-size: 24px;
+	width: 48px;
+	height: 48px;
+	border-radius: 50%;
+	background: #f3f4f6;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: #6b7280;
+	font-size: 24px;
 }
 
 .rtbcb-metric-trend-up {
-    background: #dcfce7;
-    color: #166534;
+	background: #dcfce7;
+	color: #166534;
 }
 
 .rtbcb-metric-roi {
-    background: #e0e7ff;
-    color: #3730a3;
+	background: #e0e7ff;
+	color: #3730a3;
 }
 
 .rtbcb-metric-conversion {
-    background: #fef3c7;
-    color: #92400e;
+	background: #fef3c7;
+	color: #92400e;
 }
 
 .rtbcb-metric-value {
-    font-size: 28px;
-    font-weight: 700;
-    color: #111827;
-    margin-bottom: 4px;
+	font-size: 28px;
+	font-weight: 700;
+	color: #111827;
+	margin-bottom: 4px;
 }
 
 .rtbcb-metric-label {
-    font-size: 14px;
-    color: #6b7280;
-    font-weight: 500;
+	font-size: 14px;
+	color: #6b7280;
+	font-weight: 500;
 }
 
 /* Charts Grid */
 .rtbcb-charts-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-    gap: 20px;
-    margin-bottom: 30px;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+	gap: 20px;
+	margin-bottom: 30px;
 }
 
 .rtbcb-chart-wide {
-    grid-column: 1 / -1;
+	grid-column: 1 / -1;
 }
 
 .rtbcb-chart-card {
-    background: white;
-    padding: 24px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+	background: white;
+	padding: 24px;
+	border-radius: 8px;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .rtbcb-chart-header {
-    margin-bottom: 20px;
+	margin-bottom: 20px;
 }
 
 .rtbcb-chart-header h3 {
-    margin: 0 0 8px 0;
-    color: #111827;
-    font-size: 18px;
+	margin: 0 0 8px 0;
+	color: #111827;
+	font-size: 18px;
 }
 
 .rtbcb-chart-description {
-    margin: 0;
-    color: #6b7280;
-    font-size: 14px;
+	margin: 0;
+	color: #6b7280;
+	font-size: 14px;
 }
 
 .rtbcb-chart-container {
-    height: 250px;
-    position: relative;
+	height: 250px;
+	position: relative;
 }
 
 .rtbcb-chart-legend {
-    margin-top: 20px;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
+	margin-top: 20px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
 }
 
 .rtbcb-legend-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 14px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-size: 14px;
 }
 
 .rtbcb-legend-color {
-    width: 12px;
-    height: 12px;
-    border-radius: 2px;
+	width: 12px;
+	height: 12px;
+	border-radius: 2px;
 }
 
 .rtbcb-legend-color.rtbcb-cat-cash_tools { background: #7216f4; }
@@ -632,156 +632,156 @@ function initializeAnalyticsCharts() {
 .rtbcb-legend-color.rtbcb-cat-trms { background: #c77dff; }
 
 .rtbcb-legend-label {
-    flex: 1;
-    color: #374151;
+	flex: 1;
+	color: #374151;
 }
 
 .rtbcb-legend-value {
-    font-weight: 600;
-    color: #111827;
+	font-weight: 600;
+	color: #111827;
 }
 
 .rtbcb-chart-stats {
-    margin-top: 20px;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 16px;
+	margin-top: 20px;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+	gap: 16px;
 }
 
 .rtbcb-stat-item {
-    text-align: center;
-    padding: 12px;
-    background: #f9fafb;
-    border-radius: 6px;
+	text-align: center;
+	padding: 12px;
+	background: #f9fafb;
+	border-radius: 6px;
 }
 
 .rtbcb-stat-label {
-    font-size: 12px;
-    color: #6b7280;
-    margin-bottom: 4px;
+	font-size: 12px;
+	color: #6b7280;
+	margin-bottom: 4px;
 }
 
 .rtbcb-stat-value {
-    font-size: 16px;
-    font-weight: 600;
-    color: #111827;
-    margin-bottom: 2px;
+	font-size: 16px;
+	font-weight: 600;
+	color: #111827;
+	margin-bottom: 2px;
 }
 
 .rtbcb-stat-percentage {
-    font-size: 11px;
-    color: #059669;
-    font-weight: 500;
+	font-size: 11px;
+	color: #059669;
+	font-weight: 500;
 }
 
 /* ROI Overview */
 .rtbcb-roi-overview {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 20px;
-    margin-top: 20px;
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 20px;
+	margin-top: 20px;
 }
 
 .rtbcb-roi-stat {
-    text-align: center;
-    padding: 20px;
-    background: #f9fafb;
-    border-radius: 8px;
-    border: 2px solid transparent;
+	text-align: center;
+	padding: 20px;
+	background: #f9fafb;
+	border-radius: 8px;
+	border: 2px solid transparent;
 }
 
 .rtbcb-roi-primary {
-    background: #f0f9ff;
-    border-color: #0ea5e9;
+	background: #f0f9ff;
+	border-color: #0ea5e9;
 }
 
 .rtbcb-roi-label {
-    font-size: 14px;
-    color: #6b7280;
-    margin-bottom: 8px;
-    font-weight: 500;
+	font-size: 14px;
+	color: #6b7280;
+	margin-bottom: 8px;
+	font-weight: 500;
 }
 
 .rtbcb-roi-value {
-    font-size: 24px;
-    font-weight: 700;
-    color: #059669;
+	font-size: 24px;
+	font-weight: 700;
+	color: #059669;
 }
 
 /* Insights Section */
 .rtbcb-insights-section {
-    background: white;
-    padding: 24px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+	background: white;
+	padding: 24px;
+	border-radius: 8px;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .rtbcb-insights-section h2 {
-    margin: 0 0 20px 0;
-    color: #111827;
+	margin: 0 0 20px 0;
+	color: #111827;
 }
 
 .rtbcb-insights-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 20px;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+	gap: 20px;
 }
 
 .rtbcb-insight-card {
-    display: flex;
-    gap: 16px;
-    padding: 20px;
-    background: #f9fafb;
-    border-radius: 8px;
-    border-left: 4px solid #7216f4;
+	display: flex;
+	gap: 16px;
+	padding: 20px;
+	background: #f9fafb;
+	border-radius: 8px;
+	border-left: 4px solid #7216f4;
 }
 
 .rtbcb-insight-icon {
-    width: 40px;
-    height: 40px;
-    background: #7216f4;
-    color: white;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
+	width: 40px;
+	height: 40px;
+	background: #7216f4;
+	color: white;
+	border-radius: 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
 }
 
 .rtbcb-insight-content h4 {
-    margin: 0 0 8px 0;
-    color: #111827;
-    font-size: 16px;
+	margin: 0 0 8px 0;
+	color: #111827;
+	font-size: 16px;
 }
 
 .rtbcb-insight-content p {
-    margin: 0;
-    color: #4b5563;
-    font-size: 14px;
-    line-height: 1.5;
+	margin: 0;
+	color: #4b5563;
+	font-size: 14px;
+	line-height: 1.5;
 }
 
 @media (max-width: 768px) {
-    .rtbcb-admin-header {
-        flex-direction: column;
-        gap: 16px;
-        align-items: stretch;
-    }
-    
-    .rtbcb-metrics-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    .rtbcb-charts-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    .rtbcb-roi-overview {
-        grid-template-columns: 1fr;
-    }
-    
-    .rtbcb-insights-grid {
-        grid-template-columns: 1fr;
-    }
+	.rtbcb-admin-header {
+		flex-direction: column;
+		gap: 16px;
+		align-items: stretch;
+	}
+	
+	.rtbcb-metrics-grid {
+		grid-template-columns: 1fr;
+	}
+	
+	.rtbcb-charts-grid {
+		grid-template-columns: 1fr;
+	}
+	
+	.rtbcb-roi-overview {
+		grid-template-columns: 1fr;
+	}
+	
+	.rtbcb-insights-grid {
+		grid-template-columns: 1fr;
+	}
 }
 </style>

--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -1,153 +1,153 @@
 <?php
 /**
- * API logs admin page.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* API logs admin page.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 ?>
 <div class="wrap">
-    <h1><?php echo esc_html__( 'API Logs', 'rtbcb' ); ?></h1>
-    <p>
-        <button id="rtbcb-clear-logs" class="button" data-nonce="<?php echo esc_attr( $nonce ); ?>">
-            <?php esc_html_e( 'Clear All Logs', 'rtbcb' ); ?>
-        </button>
-    </p>
-    <div class="rtbcb-log-table-wrapper">
-        <table class="widefat fixed striped">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e( 'ID', 'rtbcb' ); ?></th>
-                    <th><?php esc_html_e( 'Email', 'rtbcb' ); ?></th>
-                    <th><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></th>
-                    <th><?php esc_html_e( 'Request', 'rtbcb' ); ?></th>
-                    <th><?php esc_html_e( 'Tokens', 'rtbcb' ); ?></th>
-                    <th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
-                    <th><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
-                    <th><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php if ( ! empty( $logs_data['logs'] ) ) : ?>
-                    <?php foreach ( $logs_data['logs'] as $log ) :
-                        $request  = json_decode( $log['request_json'], true );
-                        $response = json_decode( $log['response_json'], true );
-                        $summary  = '';
-                        if ( isset( $request['messages'][0]['content'] ) ) {
-                            $summary = wp_trim_words( $request['messages'][0]['content'], 10, '...' );
-                        } else {
-                            $summary = wp_trim_words( $log['request_json'], 10, '...' );
-                        }
-                        $status = isset( $response['error'] ) ? __( 'Error', 'rtbcb' ) : __( 'OK', 'rtbcb' );
-                    ?>
-                    <tr data-id="<?php echo esc_attr( $log['id'] ); ?>" data-request="<?php echo esc_attr( $log['request_json'] ); ?>" data-response="<?php echo esc_attr( $log['response_json'] ); ?>">
-                        <td><?php echo esc_html( $log['id'] ); ?></td>
-                        <td><?php echo esc_html( $log['user_email'] ); ?></td>
-                        <td><?php echo esc_html( $log['company_name'] ); ?></td>
-                        <td><?php echo esc_html( $summary ); ?></td>
-                        <td><?php echo esc_html( $log['total_tokens'] ); ?></td>
-                        <td><?php echo esc_html( $status ); ?></td>
-                        <td><?php echo esc_html( $log['created_at'] ); ?></td>
-                        <td>
-                            <button class="button rtbcb-view-log">
-                                <?php esc_html_e( 'View', 'rtbcb' ); ?>
-                            </button>
-                            <button class="button rtbcb-delete-log" data-id="<?php echo esc_attr( $log['id'] ); ?>" data-nonce="<?php echo esc_attr( $nonce ); ?>">
-                                <?php esc_html_e( 'Delete', 'rtbcb' ); ?>
-                            </button>
-                        </td>
-                    </tr>
-                    <?php endforeach; ?>
-                <?php else : ?>
-                    <tr>
-                        <td colspan="8"><?php esc_html_e( 'No logs found.', 'rtbcb' ); ?></td>
-                    </tr>
-                <?php endif; ?>
-            </tbody>
-        </table>
-    </div>
-    <?php
-    $total_pages = ceil( $logs_data['total'] / $per_page );
-    if ( $total_pages > 1 ) :
-        ?>
-        <div class="tablenav">
-            <div class="tablenav-pages">
-                <?php
-                echo wp_kses_post(
-                    paginate_links(
-                        [
-                            'base'      => add_query_arg( 'paged', '%#%' ),
-                            'format'    => '',
-                            'prev_text' => __( '&laquo;', 'rtbcb' ),
-                            'next_text' => __( '&raquo;', 'rtbcb' ),
-                            'total'     => $total_pages,
-                            'current'   => $paged,
-                        ]
-                    )
-                );
-                ?>
-            </div>
-        </div>
-    <?php endif; ?>
+	<h1><?php echo esc_html__( 'API Logs', 'rtbcb' ); ?></h1>
+	<p>
+		<button id="rtbcb-clear-logs" class="button" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+			<?php esc_html_e( 'Clear All Logs', 'rtbcb' ); ?>
+		</button>
+	</p>
+	<div class="rtbcb-log-table-wrapper">
+		<table class="widefat fixed striped">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'ID', 'rtbcb' ); ?></th>
+					<th><?php esc_html_e( 'Email', 'rtbcb' ); ?></th>
+					<th><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></th>
+					<th><?php esc_html_e( 'Request', 'rtbcb' ); ?></th>
+					<th><?php esc_html_e( 'Tokens', 'rtbcb' ); ?></th>
+					<th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
+					<th><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
+					<th><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php if ( ! empty( $logs_data['logs'] ) ) : ?>
+					<?php foreach ( $logs_data['logs'] as $log ) :
+						$request  = json_decode( $log['request_json'], true );
+						$response = json_decode( $log['response_json'], true );
+						$summary  = '';
+						if ( isset( $request['messages'][0]['content'] ) ) {
+							$summary = wp_trim_words( $request['messages'][0]['content'], 10, '...' );
+						} else {
+							$summary = wp_trim_words( $log['request_json'], 10, '...' );
+						}
+						$status = isset( $response['error'] ) ? __( 'Error', 'rtbcb' ) : __( 'OK', 'rtbcb' );
+					?>
+					<tr data-id="<?php echo esc_attr( $log['id'] ); ?>" data-request="<?php echo esc_attr( $log['request_json'] ); ?>" data-response="<?php echo esc_attr( $log['response_json'] ); ?>">
+						<td><?php echo esc_html( $log['id'] ); ?></td>
+						<td><?php echo esc_html( $log['user_email'] ); ?></td>
+						<td><?php echo esc_html( $log['company_name'] ); ?></td>
+						<td><?php echo esc_html( $summary ); ?></td>
+						<td><?php echo esc_html( $log['total_tokens'] ); ?></td>
+						<td><?php echo esc_html( $status ); ?></td>
+						<td><?php echo esc_html( $log['created_at'] ); ?></td>
+						<td>
+							<button class="button rtbcb-view-log">
+								<?php esc_html_e( 'View', 'rtbcb' ); ?>
+							</button>
+							<button class="button rtbcb-delete-log" data-id="<?php echo esc_attr( $log['id'] ); ?>" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+								<?php esc_html_e( 'Delete', 'rtbcb' ); ?>
+							</button>
+						</td>
+					</tr>
+					<?php endforeach; ?>
+				<?php else : ?>
+					<tr>
+						<td colspan="8"><?php esc_html_e( 'No logs found.', 'rtbcb' ); ?></td>
+					</tr>
+				<?php endif; ?>
+			</tbody>
+		</table>
+	</div>
+	<?php
+	$total_pages = ceil( $logs_data['total'] / $per_page );
+	if ( $total_pages > 1 ) :
+		?>
+		<div class="tablenav">
+			<div class="tablenav-pages">
+				<?php
+				echo wp_kses_post(
+					paginate_links(
+						[
+							'base'      => add_query_arg( 'paged', '%#%' ),
+							'format'    => '',
+							'prev_text' => __( '&laquo;', 'rtbcb' ),
+							'next_text' => __( '&raquo;', 'rtbcb' ),
+							'total'     => $total_pages,
+							'current'   => $paged,
+						]
+					)
+				);
+				?>
+			</div>
+		</div>
+	<?php endif; ?>
 </div>
 <div id="rtbcb-log-modal" style="display:none;">
-    <div class="rtbcb-modal-content">
-        <pre id="rtbcb-log-detail"></pre>
-        <button class="button" id="rtbcb-close-log"><?php esc_html_e( 'Close', 'rtbcb' ); ?></button>
-    </div>
+	<div class="rtbcb-modal-content">
+		<pre id="rtbcb-log-detail"></pre>
+		<button class="button" id="rtbcb-close-log"><?php esc_html_e( 'Close', 'rtbcb' ); ?></button>
+	</div>
 </div>
 <script type="text/javascript">
 jQuery(function($){
-    $('#rtbcb-clear-logs').on('click', function(e){
-        e.preventDefault();
-        if (!confirm('<?php echo esc_js( __( 'Are you sure you want to clear all logs?', 'rtbcb' ) ); ?>')) {
-            return;
-        }
-        $.post(window.rtbcbAdmin.ajax_url, {
-            action: 'rtbcb_clear_logs',
-            nonce: $(this).data('nonce')
-        }, function(resp){
-            if (resp.success) {
-                location.reload();
-            } else {
-                alert(resp.data && resp.data.message ? resp.data.message : 'Error');
-            }
-        });
-    });
-    $('.rtbcb-delete-log').on('click', function(e){
-        e.preventDefault();
-        if (!confirm('<?php echo esc_js( __( 'Delete this log?', 'rtbcb' ) ); ?>')) {
-            return;
-        }
-        var id = $(this).data('id');
-        var nonce = $(this).data('nonce');
-        $.post(window.rtbcbAdmin.ajax_url, {
-            action: 'rtbcb_delete_log',
-            nonce: nonce,
-            id: id
-        }, function(resp){
-            if (resp.success) {
-                $('tr[data-id="' + id + '"]').remove();
-            } else {
-                alert(resp.data && resp.data.message ? resp.data.message : 'Error');
-            }
-        });
-    });
-    $('.rtbcb-view-log').on('click', function(e){
-        e.preventDefault();
-        var $row = $(this).closest('tr');
-        var req = $row.attr('data-request');
-        var res = $row.attr('data-response');
-        try { req = JSON.stringify(JSON.parse(req), null, 2); } catch (err) {}
-        try { res = JSON.stringify(JSON.parse(res), null, 2); } catch (err) {}
-        var content = 'Request:\n' + req + '\n\nResponse:\n' + res;
-        $('#rtbcb-log-detail').text(content);
-        $('#rtbcb-log-modal').show();
-    });
-    $('#rtbcb-close-log').on('click', function(){
-        $('#rtbcb-log-modal').hide();
-    });
+	$('#rtbcb-clear-logs').on('click', function(e){
+		e.preventDefault();
+		if (!confirm('<?php echo esc_js( __( 'Are you sure you want to clear all logs?', 'rtbcb' ) ); ?>')) {
+			return;
+		}
+		$.post(window.rtbcbAdmin.ajax_url, {
+			action: 'rtbcb_clear_logs',
+			nonce: $(this).data('nonce')
+		}, function(resp){
+			if (resp.success) {
+				location.reload();
+			} else {
+				alert(resp.data && resp.data.message ? resp.data.message : 'Error');
+			}
+		});
+	});
+	$('.rtbcb-delete-log').on('click', function(e){
+		e.preventDefault();
+		if (!confirm('<?php echo esc_js( __( 'Delete this log?', 'rtbcb' ) ); ?>')) {
+			return;
+		}
+		var id = $(this).data('id');
+		var nonce = $(this).data('nonce');
+		$.post(window.rtbcbAdmin.ajax_url, {
+			action: 'rtbcb_delete_log',
+			nonce: nonce,
+			id: id
+		}, function(resp){
+			if (resp.success) {
+				$('tr[data-id="' + id + '"]').remove();
+			} else {
+				alert(resp.data && resp.data.message ? resp.data.message : 'Error');
+			}
+		});
+	});
+	$('.rtbcb-view-log').on('click', function(e){
+		e.preventDefault();
+		var $row = $(this).closest('tr');
+		var req = $row.attr('data-request');
+		var res = $row.attr('data-response');
+		try { req = JSON.stringify(JSON.parse(req), null, 2); } catch (err) {}
+		try { res = JSON.stringify(JSON.parse(res), null, 2); } catch (err) {}
+		var content = 'Request:\n' + req + '\n\nResponse:\n' + res;
+		$('#rtbcb-log-detail').text(content);
+		$('#rtbcb-log-modal').show();
+	});
+	$('#rtbcb-close-log').on('click', function(){
+		$('#rtbcb-log-modal').hide();
+	});
 });
 </script>
 

--- a/admin/calculations-page.php
+++ b/admin/calculations-page.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Calculation info admin page for Real Treasury Business Case Builder plugin.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Calculation info admin page for Real Treasury Business Case Builder plugin.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
@@ -13,60 +13,60 @@ $bank_fee   = get_option( 'rtbcb_bank_fee_baseline', 0 );
 ?>
 
 <div class="wrap">
-    <h1><?php echo esc_html__( 'Calculation Info', 'rtbcb' ); ?></h1>
+	<h1><?php echo esc_html__( 'Calculation Info', 'rtbcb' ); ?></h1>
 
-    <h2><?php echo esc_html__( 'Current Settings', 'rtbcb' ); ?></h2>
-    <ul>
-        <li><?php printf( esc_html__( 'Labor Cost Per Hour: %s', 'rtbcb' ), esc_html( number_format_i18n( $labor_cost, 2 ) ) ); ?></li>
-        <li><?php printf( esc_html__( 'Bank Fee Baseline: %s', 'rtbcb' ), esc_html( number_format_i18n( $bank_fee, 2 ) ) ); ?></li>
-    </ul>
+	<h2><?php echo esc_html__( 'Current Settings', 'rtbcb' ); ?></h2>
+	<ul>
+		<li><?php printf( esc_html__( 'Labor Cost Per Hour: %s', 'rtbcb' ), esc_html( number_format_i18n( $labor_cost, 2 ) ) ); ?></li>
+		<li><?php printf( esc_html__( 'Bank Fee Baseline: %s', 'rtbcb' ), esc_html( number_format_i18n( $bank_fee, 2 ) ) ); ?></li>
+	</ul>
 
-    <h2><?php echo esc_html__( 'Formulas', 'rtbcb' ); ?></h2>
-    <table class="widefat striped">
-        <thead>
-            <tr>
-                <th><?php echo esc_html__( 'Calculation', 'rtbcb' ); ?></th>
-                <th><?php echo esc_html__( 'Formula', 'rtbcb' ); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td><?php echo esc_html__( 'Labor Savings', 'rtbcb' ); ?></td>
-                <td><?php echo esc_html__( '(Hours Reconciliation + Hours Cash Positioning) * 52 * Labor Cost Per Hour * 0.30 * Scenario Multiplier', 'rtbcb' ); ?></td>
-            </tr>
-            <tr>
-                <td><?php echo esc_html__( 'Bank Fee Savings', 'rtbcb' ); ?></td>
-                <td><?php echo esc_html__( 'Number of Banks * Bank Fee Baseline * 0.08 * Scenario Multiplier', 'rtbcb' ); ?></td>
-            </tr>
-            <tr>
-                <td><?php echo esc_html__( 'Error Reduction', 'rtbcb' ); ?></td>
-                <td><?php echo esc_html__( 'Base Error Cost * 0.25 * Scenario Multiplier', 'rtbcb' ); ?></td>
-            </tr>
-        </tbody>
-    </table>
+	<h2><?php echo esc_html__( 'Formulas', 'rtbcb' ); ?></h2>
+	<table class="widefat striped">
+		<thead>
+			<tr>
+				<th><?php echo esc_html__( 'Calculation', 'rtbcb' ); ?></th>
+				<th><?php echo esc_html__( 'Formula', 'rtbcb' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><?php echo esc_html__( 'Labor Savings', 'rtbcb' ); ?></td>
+				<td><?php echo esc_html__( '(Hours Reconciliation + Hours Cash Positioning) * 52 * Labor Cost Per Hour * 0.30 * Scenario Multiplier', 'rtbcb' ); ?></td>
+			</tr>
+			<tr>
+				<td><?php echo esc_html__( 'Bank Fee Savings', 'rtbcb' ); ?></td>
+				<td><?php echo esc_html__( 'Number of Banks * Bank Fee Baseline * 0.08 * Scenario Multiplier', 'rtbcb' ); ?></td>
+			</tr>
+			<tr>
+				<td><?php echo esc_html__( 'Error Reduction', 'rtbcb' ); ?></td>
+				<td><?php echo esc_html__( 'Base Error Cost * 0.25 * Scenario Multiplier', 'rtbcb' ); ?></td>
+			</tr>
+		</tbody>
+	</table>
 
-    <h2><?php echo esc_html__( 'Industry Commentary Test', 'rtbcb' ); ?></h2>
-    <p>
-        <label for="rtbcb-commentary-industry"><?php esc_html_e( 'Industry', 'rtbcb' ); ?></label>
-        <select id="rtbcb-commentary-industry">
-            <option value=""><?php esc_html_e( 'Select your industry...', 'rtbcb' ); ?></option>
-            <option value="manufacturing"><?php esc_html_e( 'Manufacturing', 'rtbcb' ); ?></option>
-            <option value="retail"><?php esc_html_e( 'Retail &amp; E-commerce', 'rtbcb' ); ?></option>
-            <option value="healthcare"><?php esc_html_e( 'Healthcare', 'rtbcb' ); ?></option>
-            <option value="technology"><?php esc_html_e( 'Technology', 'rtbcb' ); ?></option>
-            <option value="financial_services"><?php esc_html_e( 'Financial Services', 'rtbcb' ); ?></option>
-            <option value="energy"><?php esc_html_e( 'Energy &amp; Utilities', 'rtbcb' ); ?></option>
-            <option value="real_estate"><?php esc_html_e( 'Real Estate', 'rtbcb' ); ?></option>
-            <option value="professional_services"><?php esc_html_e( 'Professional Services', 'rtbcb' ); ?></option>
-            <option value="transportation"><?php esc_html_e( 'Transportation &amp; Logistics', 'rtbcb' ); ?></option>
-            <option value="education"><?php esc_html_e( 'Education', 'rtbcb' ); ?></option>
-            <option value="government"><?php esc_html_e( 'Government', 'rtbcb' ); ?></option>
-            <option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
-        </select>
-        <button type="button" id="rtbcb-generate-commentary" class="button" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rtbcb_test_commentary' ) ); ?>">
-            <?php esc_html_e( 'Generate Commentary', 'rtbcb' ); ?>
-        </button>
-    </p>
-    <div id="rtbcb-commentary-results"></div>
+	<h2><?php echo esc_html__( 'Industry Commentary Test', 'rtbcb' ); ?></h2>
+	<p>
+		<label for="rtbcb-commentary-industry"><?php esc_html_e( 'Industry', 'rtbcb' ); ?></label>
+		<select id="rtbcb-commentary-industry">
+			<option value=""><?php esc_html_e( 'Select your industry...', 'rtbcb' ); ?></option>
+			<option value="manufacturing"><?php esc_html_e( 'Manufacturing', 'rtbcb' ); ?></option>
+			<option value="retail"><?php esc_html_e( 'Retail &amp; E-commerce', 'rtbcb' ); ?></option>
+			<option value="healthcare"><?php esc_html_e( 'Healthcare', 'rtbcb' ); ?></option>
+			<option value="technology"><?php esc_html_e( 'Technology', 'rtbcb' ); ?></option>
+			<option value="financial_services"><?php esc_html_e( 'Financial Services', 'rtbcb' ); ?></option>
+			<option value="energy"><?php esc_html_e( 'Energy &amp; Utilities', 'rtbcb' ); ?></option>
+			<option value="real_estate"><?php esc_html_e( 'Real Estate', 'rtbcb' ); ?></option>
+			<option value="professional_services"><?php esc_html_e( 'Professional Services', 'rtbcb' ); ?></option>
+			<option value="transportation"><?php esc_html_e( 'Transportation &amp; Logistics', 'rtbcb' ); ?></option>
+			<option value="education"><?php esc_html_e( 'Education', 'rtbcb' ); ?></option>
+			<option value="government"><?php esc_html_e( 'Government', 'rtbcb' ); ?></option>
+			<option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
+		</select>
+		<button type="button" id="rtbcb-generate-commentary" class="button" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rtbcb_test_commentary' ) ); ?>">
+			<?php esc_html_e( 'Generate Commentary', 'rtbcb' ); ?>
+		</button>
+	</p>
+	<div id="rtbcb-commentary-results"></div>
 </div>
 

--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -1,114 +1,114 @@
 <?php
 /**
- * Enhanced admin functionality for Real Treasury Business Case Builder plugin.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Enhanced admin functionality for Real Treasury Business Case Builder plugin.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Enhanced admin class with full feature integration.
- */
+	* Enhanced admin class with full feature integration.
+	*/
 class RTBCB_Admin {
-    /**
-     * Constructor.
-     */
-    public function __construct() {
-        add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
-        add_action( 'admin_init', [ $this, 'register_settings' ] );
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
-        add_action( 'admin_notices', [ $this, 'maybe_show_timeout_notice' ] );
-        add_action( 'admin_notices', [ $this, 'maybe_show_bypass_notice' ] );
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		add_action( 'admin_init', [ $this, 'register_settings' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+		add_action( 'admin_notices', [ $this, 'maybe_show_timeout_notice' ] );
+		add_action( 'admin_notices', [ $this, 'maybe_show_bypass_notice' ] );
 
-        // AJAX handlers
-        add_action( 'wp_ajax_rtbcb_test_connection', [ $this, 'test_api_connection' ] );
-        add_action( 'wp_ajax_rtbcb_rebuild_index', [ $this, 'rebuild_rag_index' ] );
-        add_action( 'wp_ajax_rtbcb_export_leads', [ $this, 'export_leads_csv' ] );
-        add_action( 'wp_ajax_rtbcb_delete_lead', [ $this, 'delete_lead' ] );
-        add_action( 'wp_ajax_rtbcb_bulk_action_leads', [ $this, 'bulk_action_leads' ] );
-        add_action( 'wp_ajax_rtbcb_run_tests', [ $this, 'run_integration_tests' ] );
-        add_action( 'wp_ajax_rtbcb_test_api', [ $this, 'ajax_test_api' ] );
-        add_action( 'wp_ajax_rtbcb_sync_to_local', [ $this, 'sync_to_local' ] );
-        add_action( 'wp_ajax_nopriv_rtbcb_sync_to_local', [ $this, 'sync_to_local' ] );
-        add_action( 'wp_ajax_rtbcb_test_commentary', [ $this, 'ajax_test_commentary' ] );
-        add_action( 'wp_ajax_rtbcb_test_company_overview', [ $this, 'ajax_test_company_overview' ] );
-        add_action( 'wp_ajax_rtbcb_test_industry_overview', [ $this, 'ajax_test_industry_overview' ] );
-        add_action( 'wp_ajax_rtbcb_test_real_treasury_overview', [ $this, 'ajax_test_real_treasury_overview' ] );
-        add_action( 'wp_ajax_rtbcb_test_maturity_model', [ $this, 'ajax_test_maturity_model' ] );
-        add_action( 'wp_ajax_rtbcb_test_rag_market_analysis', [ $this, 'ajax_test_rag_market_analysis' ] );
-        add_action( 'wp_ajax_rtbcb_test_value_proposition', [ $this, 'ajax_test_value_proposition' ] );
-        add_action( 'wp_ajax_rtbcb_get_company_data', [ $this, 'ajax_get_company_data' ] );
-        add_action( 'wp_ajax_rtbcb_test_estimated_benefits', [ $this, 'ajax_test_estimated_benefits' ] );
-        add_action( 'wp_ajax_rtbcb_save_test_results', [ $this, 'ajax_save_test_results' ] );
-        add_action( 'wp_ajax_rtbcb_set_test_company', [ $this, 'ajax_set_test_company' ] );
-        add_action( 'wp_ajax_rtbcb_test_calculate_roi', [ $this, 'ajax_test_calculate_roi' ] );
-        add_action( 'wp_ajax_rtbcb_test_portal', [ $this, 'ajax_test_portal' ] );
-        add_action( 'wp_ajax_rtbcb_test_rag', [ $this, 'ajax_test_rag' ] );
-        add_action( 'wp_ajax_rtbcb_test_data_enrichment', [ $this, 'ajax_test_data_enrichment' ] );
-        add_action( 'wp_ajax_rtbcb_test_data_storage', [ $this, 'ajax_test_data_storage' ] );
-        add_action( 'wp_ajax_rtbcb_test_report_assembly', [ $this, 'ajax_test_report_assembly' ] );
-        add_action( 'wp_ajax_rtbcb_test_tracking_script', [ $this, 'ajax_test_tracking_script' ] );
-        add_action( 'wp_ajax_rtbcb_test_follow_up_email', [ $this, 'ajax_test_follow_up_email' ] );
-        add_action( 'wp_ajax_rtbcb_get_phase_completion', [ $this, 'ajax_get_phase_completion' ] );
-        add_action( 'wp_ajax_rtbcb_get_section_config', [ $this, 'ajax_get_section_config' ] );
-        add_action( 'wp_ajax_rtbcb_get_test_summary_html', [ $this, 'ajax_get_test_summary_html' ] );
-        add_action( 'wp_ajax_rtbcb_generate_comprehensive_analysis', [ $this, 'ajax_generate_comprehensive_analysis' ] );
-        add_action( 'wp_ajax_rtbcb_get_analysis_status', [ $this, 'ajax_get_analysis_status' ] );
-        add_action( 'wp_ajax_rtbcb_clear_analysis_data', [ $this, 'ajax_clear_analysis_data' ] );
-        add_action( 'wp_ajax_rtbcb_delete_log', [ $this, 'ajax_delete_log' ] );
+		// AJAX handlers
+		add_action( 'wp_ajax_rtbcb_test_connection', [ $this, 'test_api_connection' ] );
+		add_action( 'wp_ajax_rtbcb_rebuild_index', [ $this, 'rebuild_rag_index' ] );
+		add_action( 'wp_ajax_rtbcb_export_leads', [ $this, 'export_leads_csv' ] );
+		add_action( 'wp_ajax_rtbcb_delete_lead', [ $this, 'delete_lead' ] );
+		add_action( 'wp_ajax_rtbcb_bulk_action_leads', [ $this, 'bulk_action_leads' ] );
+		add_action( 'wp_ajax_rtbcb_run_tests', [ $this, 'run_integration_tests' ] );
+		add_action( 'wp_ajax_rtbcb_test_api', [ $this, 'ajax_test_api' ] );
+		add_action( 'wp_ajax_rtbcb_sync_to_local', [ $this, 'sync_to_local' ] );
+		add_action( 'wp_ajax_nopriv_rtbcb_sync_to_local', [ $this, 'sync_to_local' ] );
+		add_action( 'wp_ajax_rtbcb_test_commentary', [ $this, 'ajax_test_commentary' ] );
+		add_action( 'wp_ajax_rtbcb_test_company_overview', [ $this, 'ajax_test_company_overview' ] );
+		add_action( 'wp_ajax_rtbcb_test_industry_overview', [ $this, 'ajax_test_industry_overview' ] );
+		add_action( 'wp_ajax_rtbcb_test_real_treasury_overview', [ $this, 'ajax_test_real_treasury_overview' ] );
+		add_action( 'wp_ajax_rtbcb_test_maturity_model', [ $this, 'ajax_test_maturity_model' ] );
+		add_action( 'wp_ajax_rtbcb_test_rag_market_analysis', [ $this, 'ajax_test_rag_market_analysis' ] );
+		add_action( 'wp_ajax_rtbcb_test_value_proposition', [ $this, 'ajax_test_value_proposition' ] );
+		add_action( 'wp_ajax_rtbcb_get_company_data', [ $this, 'ajax_get_company_data' ] );
+		add_action( 'wp_ajax_rtbcb_test_estimated_benefits', [ $this, 'ajax_test_estimated_benefits' ] );
+		add_action( 'wp_ajax_rtbcb_save_test_results', [ $this, 'ajax_save_test_results' ] );
+		add_action( 'wp_ajax_rtbcb_set_test_company', [ $this, 'ajax_set_test_company' ] );
+		add_action( 'wp_ajax_rtbcb_test_calculate_roi', [ $this, 'ajax_test_calculate_roi' ] );
+		add_action( 'wp_ajax_rtbcb_test_portal', [ $this, 'ajax_test_portal' ] );
+		add_action( 'wp_ajax_rtbcb_test_rag', [ $this, 'ajax_test_rag' ] );
+		add_action( 'wp_ajax_rtbcb_test_data_enrichment', [ $this, 'ajax_test_data_enrichment' ] );
+		add_action( 'wp_ajax_rtbcb_test_data_storage', [ $this, 'ajax_test_data_storage' ] );
+		add_action( 'wp_ajax_rtbcb_test_report_assembly', [ $this, 'ajax_test_report_assembly' ] );
+		add_action( 'wp_ajax_rtbcb_test_tracking_script', [ $this, 'ajax_test_tracking_script' ] );
+		add_action( 'wp_ajax_rtbcb_test_follow_up_email', [ $this, 'ajax_test_follow_up_email' ] );
+		add_action( 'wp_ajax_rtbcb_get_phase_completion', [ $this, 'ajax_get_phase_completion' ] );
+		add_action( 'wp_ajax_rtbcb_get_section_config', [ $this, 'ajax_get_section_config' ] );
+		add_action( 'wp_ajax_rtbcb_get_test_summary_html', [ $this, 'ajax_get_test_summary_html' ] );
+		add_action( 'wp_ajax_rtbcb_generate_comprehensive_analysis', [ $this, 'ajax_generate_comprehensive_analysis' ] );
+		add_action( 'wp_ajax_rtbcb_get_analysis_status', [ $this, 'ajax_get_analysis_status' ] );
+		add_action( 'wp_ajax_rtbcb_clear_analysis_data', [ $this, 'ajax_clear_analysis_data' ] );
+		add_action( 'wp_ajax_rtbcb_delete_log', [ $this, 'ajax_delete_log' ] );
 		add_action( 'wp_ajax_rtbcb_clear_logs', [ $this, 'ajax_clear_logs' ] );
 		add_action( 'wp_ajax_rtbcb_get_workflow_history', [ $this, 'ajax_get_workflow_history' ] );
 		add_action( 'wp_ajax_rtbcb_clear_workflow_history', [ $this, 'ajax_clear_workflow_history' ] );
 		add_action( 'update_option_rtbcb_openai_api_key', [ $this, 'clear_openai_models_cache' ], 10, 2 );
 	}
 
-    /**
-     * Enqueue admin assets.
-     *
-     * @param string $hook Page hook.
-     * @return void
-     */
-    public function enqueue_admin_assets( $hook ) {
-        $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
-        if ( strpos( $hook, 'rtbcb' ) === false && strpos( $page, 'rtbcb' ) === false ) {
-            return;
+	/**
+	 * Enqueue admin assets.
+	 *
+	 * @param string $hook Page hook.
+	 * @return void
+	 */
+	public function enqueue_admin_assets( $hook ) {
+		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+		if ( strpos( $hook, 'rtbcb' ) === false && strpos( $page, 'rtbcb' ) === false ) {
+			return;
 	}
 
-        $deps          = [ 'jquery' ];
-        $enable_charts = RTBCB_Settings::get_setting( 'enable_charts', true );
-        if ( $enable_charts ) {
-            wp_enqueue_script( 'chart-js', RTBCB_URL . 'public/js/chart.min.js', [], '3.9.1', true );
-            $deps[] = 'chart-js';
-        }
-        wp_enqueue_script(
-            'rtbcb-admin',
-            RTBCB_URL . 'admin/js/rtbcb-admin.js',
-            $deps,
-            RTBCB_VERSION,
-            true
-        );
-        wp_enqueue_style(
-            'rtbcb-admin',
-            RTBCB_URL . 'admin/css/rtbcb-admin.css',
-            [],
-            RTBCB_VERSION
-        );
+		$deps          = [ 'jquery' ];
+		$enable_charts = RTBCB_Settings::get_setting( 'enable_charts', true );
+		if ( $enable_charts ) {
+			wp_enqueue_script( 'chart-js', RTBCB_URL . 'public/js/chart.min.js', [], '3.9.1', true );
+			$deps[] = 'chart-js';
+		}
+		wp_enqueue_script(
+			'rtbcb-admin',
+			RTBCB_URL . 'admin/js/rtbcb-admin.js',
+			$deps,
+			RTBCB_VERSION,
+			true
+		);
+		wp_enqueue_style(
+			'rtbcb-admin',
+			RTBCB_URL . 'admin/css/rtbcb-admin.css',
+			[],
+			RTBCB_VERSION
+		);
 
-        if ( 'rtbcb-workflow-visualizer' === $page ) {
-            wp_enqueue_script(
-                'rtbcb-workflow-visualizer',
-                RTBCB_URL . 'admin/js/workflow-visualizer.js',
-                [ 'jquery' ],
-                RTBCB_VERSION,
-                true
-            );
-            wp_localize_script(
-                'rtbcb-workflow-visualizer',
-                'rtbcbWorkflow',
-                [
-                    'ajax_url' => admin_url( 'admin-ajax.php' ),
-                    'nonce'    => wp_create_nonce( 'rtbcb_workflow_visualizer' ),
+		if ( 'rtbcb-workflow-visualizer' === $page ) {
+			wp_enqueue_script(
+				'rtbcb-workflow-visualizer',
+				RTBCB_URL . 'admin/js/workflow-visualizer.js',
+				[ 'jquery' ],
+				RTBCB_VERSION,
+				true
+			);
+			wp_localize_script(
+				'rtbcb-workflow-visualizer',
+				'rtbcbWorkflow',
+				[
+					'ajax_url' => admin_url( 'admin-ajax.php' ),
+					'nonce'    => wp_create_nonce( 'rtbcb_workflow_visualizer' ),
 					'strings'  => [
 						'refresh_success' => __( 'Workflow history refreshed', 'rtbcb' ),
 						'clear_success'   => __( 'Workflow history cleared', 'rtbcb' ),
@@ -118,475 +118,475 @@ class RTBCB_Admin {
 						'unknown_lead'    => __( 'Unknown Lead', 'rtbcb' ),
 						'not_run'         => __( 'Not run', 'rtbcb' ),
 					],
-                ]
-            );
+				]
+			);
 	}
 
-        $company_data = [];
-        if ( function_exists( 'rtbcb_get_current_company' ) ) {
-            $raw_company = rtbcb_get_current_company();
-            if ( is_array( $raw_company ) ) {
-                $company_data = [
-                    'name'           => isset( $raw_company['name'] ) ? sanitize_text_field( $raw_company['name'] ) : '',
-                    'summary'        => isset( $raw_company['summary'] ) ? sanitize_textarea_field( $raw_company['summary'] ) : '',
-                    'industry'       => isset( $raw_company['industry'] ) ? sanitize_text_field( $raw_company['industry'] ) : '',
-                    'size'           => isset( $raw_company['size'] ) ? sanitize_text_field( $raw_company['size'] ) : '',
-                    'geography'      => isset( $raw_company['geography'] ) ? sanitize_text_field( $raw_company['geography'] ) : '',
-                    'business_model' => isset( $raw_company['business_model'] ) ? sanitize_text_field( $raw_company['business_model'] ) : '',
-                    'revenue'        => isset( $raw_company['revenue'] ) ? floatval( $raw_company['revenue'] ) : 0,
-                    'staff_count'    => isset( $raw_company['staff_count'] ) ? intval( $raw_company['staff_count'] ) : 0,
-                    'efficiency'     => isset( $raw_company['efficiency'] ) ? floatval( $raw_company['efficiency'] ) : 0,
-                ];
+		$company_data = [];
+		if ( function_exists( 'rtbcb_get_current_company' ) ) {
+			$raw_company = rtbcb_get_current_company();
+			if ( is_array( $raw_company ) ) {
+				$company_data = [
+					'name'           => isset( $raw_company['name'] ) ? sanitize_text_field( $raw_company['name'] ) : '',
+					'summary'        => isset( $raw_company['summary'] ) ? sanitize_textarea_field( $raw_company['summary'] ) : '',
+					'industry'       => isset( $raw_company['industry'] ) ? sanitize_text_field( $raw_company['industry'] ) : '',
+					'size'           => isset( $raw_company['size'] ) ? sanitize_text_field( $raw_company['size'] ) : '',
+					'geography'      => isset( $raw_company['geography'] ) ? sanitize_text_field( $raw_company['geography'] ) : '',
+					'business_model' => isset( $raw_company['business_model'] ) ? sanitize_text_field( $raw_company['business_model'] ) : '',
+					'revenue'        => isset( $raw_company['revenue'] ) ? floatval( $raw_company['revenue'] ) : 0,
+					'staff_count'    => isset( $raw_company['staff_count'] ) ? intval( $raw_company['staff_count'] ) : 0,
+					'efficiency'     => isset( $raw_company['efficiency'] ) ? floatval( $raw_company['efficiency'] ) : 0,
+				];
 
-                $company_data['focus_areas'] = isset( $raw_company['focus_areas'] )
-                    ? array_filter( array_map( 'sanitize_text_field', (array) $raw_company['focus_areas'] ) )
-                    : [];
-                $company_data['complexity']  = isset( $raw_company['complexity'] ) ? sanitize_text_field( $raw_company['complexity'] ) : '';
-                $company_data['challenges']  = isset( $raw_company['challenges'] )
-                    ? array_filter( array_map( 'sanitize_text_field', (array) $raw_company['challenges'] ) )
-                    : [];
-            }
-        }
+				$company_data['focus_areas'] = isset( $raw_company['focus_areas'] )
+					? array_filter( array_map( 'sanitize_text_field', (array) $raw_company['focus_areas'] ) )
+					: [];
+				$company_data['complexity']  = isset( $raw_company['complexity'] ) ? sanitize_text_field( $raw_company['complexity'] ) : '';
+				$company_data['challenges']  = isset( $raw_company['challenges'] )
+					? array_filter( array_map( 'sanitize_text_field', (array) $raw_company['challenges'] ) )
+					: [];
+			}
+		}
 
-        $sections_js = [];
-        if ( function_exists( 'rtbcb_get_dashboard_sections' ) ) {
-            $test_results = get_option( 'rtbcb_test_results', [] );
-            $raw_sections = rtbcb_get_dashboard_sections( $test_results );
-            foreach ( $raw_sections as $id => $section ) {
-                $section_data = [
-                    'id'        => sanitize_key( $id ),
-                    'label'     => isset( $section['label'] ) ? sanitize_text_field( $section['label'] ) : '',
-                    'option'    => isset( $section['option'] ) ? sanitize_key( $section['option'] ) : '',
-                    'requires'  => isset( $section['requires'] ) ? array_map( 'sanitize_key', (array) $section['requires'] ) : [],
-                    'phase'     => isset( $section['phase'] ) ? (int) $section['phase'] : 0,
-                    'completed' => ! empty( $section['completed'] ),
-                ];
-                if ( ! empty( $section['action'] ) ) {
-                    $action = sanitize_key( $section['action'] );
-                    $section_data['action'] = $action;
-                    $section_data['nonce']  = wp_create_nonce( $action );
-                }
-                $sections_js[] = $section_data;
-            }
-        }
+		$sections_js = [];
+		if ( function_exists( 'rtbcb_get_dashboard_sections' ) ) {
+			$test_results = get_option( 'rtbcb_test_results', [] );
+			$raw_sections = rtbcb_get_dashboard_sections( $test_results );
+			foreach ( $raw_sections as $id => $section ) {
+				$section_data = [
+					'id'        => sanitize_key( $id ),
+					'label'     => isset( $section['label'] ) ? sanitize_text_field( $section['label'] ) : '',
+					'option'    => isset( $section['option'] ) ? sanitize_key( $section['option'] ) : '',
+					'requires'  => isset( $section['requires'] ) ? array_map( 'sanitize_key', (array) $section['requires'] ) : [],
+					'phase'     => isset( $section['phase'] ) ? (int) $section['phase'] : 0,
+					'completed' => ! empty( $section['completed'] ),
+				];
+				if ( ! empty( $section['action'] ) ) {
+					$action = sanitize_key( $section['action'] );
+					$section_data['action'] = $action;
+					$section_data['nonce']  = wp_create_nonce( $action );
+				}
+				$sections_js[] = $section_data;
+			}
+		}
 
-        wp_localize_script( 'rtbcb-admin', 'rtbcbAdmin', [
-            'ajax_url'                   => admin_url( 'admin-ajax.php' ),
-            'nonce'                      => wp_create_nonce( 'rtbcb_nonce' ),
-            'company_overview_nonce'     => wp_create_nonce( 'rtbcb_test_company_overview' ),
-            'maturity_model_nonce'       => wp_create_nonce( 'rtbcb_test_maturity_model' ),
-            'rag_market_analysis_nonce'  => wp_create_nonce( 'rtbcb_test_rag_market_analysis' ),
-            'value_proposition_nonce'    => wp_create_nonce( 'rtbcb_test_value_proposition' ),
-            'industry_overview_nonce'    => wp_create_nonce( 'rtbcb_test_industry_overview' ),
-            'benefits_estimate_nonce'    => wp_create_nonce( 'rtbcb_test_estimated_benefits' ),
-            'test_dashboard_nonce'       => wp_create_nonce( 'rtbcb_test_dashboard' ),
-            'roi_nonce'                  => wp_create_nonce( 'rtbcb_test_calculate_roi' ),
-            'real_treasury_overview_nonce' => wp_create_nonce( 'rtbcb_test_real_treasury_overview' ),
-            'category_recommendation_nonce' => wp_create_nonce( 'rtbcb_test_category_recommendation' ),
-            'report_assembly_nonce'      => wp_create_nonce( 'rtbcb_test_report_assembly' ),
-            'tracking_script_nonce'      => wp_create_nonce( 'rtbcb_test_tracking_script' ),
-            'follow_up_email_nonce'      => wp_create_nonce( 'rtbcb_test_follow_up_email' ),
-            'page'                       => $page,
-            'company'                    => $company_data,
-            'sections'                   => $sections_js,
-            'strings'                    => [
-                'confirm_delete'      => __( 'Are you sure you want to delete this lead?', 'rtbcb' ),
-                'confirm_bulk_delete' => __( 'Are you sure you want to delete the selected leads?', 'rtbcb' ),
-                'processing'          => __( 'Processing...', 'rtbcb' ),
-                'error'               => __( 'An error occurred. Please try again.', 'rtbcb' ),
-                'testing'             => __( 'Testing...', 'rtbcb' ),
-                'generating'          => __( 'Generating...', 'rtbcb' ),
-                'copied'              => __( 'Copied to clipboard.', 'rtbcb' ),
-                'queued'              => __( 'Queued', 'rtbcb' ),
-                'running'             => __( 'Running', 'rtbcb' ),
-                'passed'              => __( 'Passed', 'rtbcb' ),
-                'failed'              => __( 'Failed', 'rtbcb' ),
-                'copy_debug'          => __( 'Copy Debug Info', 'rtbcb' ),
-                'retry'               => __( 'Retry', 'rtbcb' ),
-                'view'                => __( 'View', 'rtbcb' ),
-                'rerun'               => __( 'Re-run', 'rtbcb' ),
-                'company_required'    => __( 'Company name is required.', 'rtbcb' ),
-                'completion'          => __( 'Completion %', 'rtbcb' ),
-                'starting_tests'      => __( 'Starting tests...', 'rtbcb' ),
-                'all_sections_done'   => __( 'All sections completed', 'rtbcb' ),
-            ],
-        ] );
+		wp_localize_script( 'rtbcb-admin', 'rtbcbAdmin', [
+			'ajax_url'                   => admin_url( 'admin-ajax.php' ),
+			'nonce'                      => wp_create_nonce( 'rtbcb_nonce' ),
+			'company_overview_nonce'     => wp_create_nonce( 'rtbcb_test_company_overview' ),
+			'maturity_model_nonce'       => wp_create_nonce( 'rtbcb_test_maturity_model' ),
+			'rag_market_analysis_nonce'  => wp_create_nonce( 'rtbcb_test_rag_market_analysis' ),
+			'value_proposition_nonce'    => wp_create_nonce( 'rtbcb_test_value_proposition' ),
+			'industry_overview_nonce'    => wp_create_nonce( 'rtbcb_test_industry_overview' ),
+			'benefits_estimate_nonce'    => wp_create_nonce( 'rtbcb_test_estimated_benefits' ),
+			'test_dashboard_nonce'       => wp_create_nonce( 'rtbcb_test_dashboard' ),
+			'roi_nonce'                  => wp_create_nonce( 'rtbcb_test_calculate_roi' ),
+			'real_treasury_overview_nonce' => wp_create_nonce( 'rtbcb_test_real_treasury_overview' ),
+			'category_recommendation_nonce' => wp_create_nonce( 'rtbcb_test_category_recommendation' ),
+			'report_assembly_nonce'      => wp_create_nonce( 'rtbcb_test_report_assembly' ),
+			'tracking_script_nonce'      => wp_create_nonce( 'rtbcb_test_tracking_script' ),
+			'follow_up_email_nonce'      => wp_create_nonce( 'rtbcb_test_follow_up_email' ),
+			'page'                       => $page,
+			'company'                    => $company_data,
+			'sections'                   => $sections_js,
+			'strings'                    => [
+				'confirm_delete'      => __( 'Are you sure you want to delete this lead?', 'rtbcb' ),
+				'confirm_bulk_delete' => __( 'Are you sure you want to delete the selected leads?', 'rtbcb' ),
+				'processing'          => __( 'Processing...', 'rtbcb' ),
+				'error'               => __( 'An error occurred. Please try again.', 'rtbcb' ),
+				'testing'             => __( 'Testing...', 'rtbcb' ),
+				'generating'          => __( 'Generating...', 'rtbcb' ),
+				'copied'              => __( 'Copied to clipboard.', 'rtbcb' ),
+				'queued'              => __( 'Queued', 'rtbcb' ),
+				'running'             => __( 'Running', 'rtbcb' ),
+				'passed'              => __( 'Passed', 'rtbcb' ),
+				'failed'              => __( 'Failed', 'rtbcb' ),
+				'copy_debug'          => __( 'Copy Debug Info', 'rtbcb' ),
+				'retry'               => __( 'Retry', 'rtbcb' ),
+				'view'                => __( 'View', 'rtbcb' ),
+				'rerun'               => __( 'Re-run', 'rtbcb' ),
+				'company_required'    => __( 'Company name is required.', 'rtbcb' ),
+				'completion'          => __( 'Completion %', 'rtbcb' ),
+				'starting_tests'      => __( 'Starting tests...', 'rtbcb' ),
+				'all_sections_done'   => __( 'All sections completed', 'rtbcb' ),
+			],
+		] );
 
-    }
+	}
 
-    /**
-     * Register admin menu and submenus.
-     *
-     * @return void
-     */
-    public function add_admin_menu() {
-        add_menu_page(
-            __( 'Business Case Builder', 'rtbcb' ),
-            __( 'Real Treasury', 'rtbcb' ),
-            'manage_options',
-            'rtbcb-dashboard',
-            [ $this, 'render_dashboard' ],
-            'dashicons-calculator',
-            30
-        );
+	/**
+	 * Register admin menu and submenus.
+	 *
+	 * @return void
+	 */
+	public function add_admin_menu() {
+		add_menu_page(
+			__( 'Business Case Builder', 'rtbcb' ),
+			__( 'Real Treasury', 'rtbcb' ),
+			'manage_options',
+			'rtbcb-dashboard',
+			[ $this, 'render_dashboard' ],
+			'dashicons-calculator',
+			30
+		);
 
-        add_submenu_page(
-            'rtbcb-dashboard',
-            __( 'Dashboard', 'rtbcb' ),
-            __( 'Dashboard', 'rtbcb' ),
-            'manage_options',
-            'rtbcb-dashboard',
-            [ $this, 'render_dashboard' ]
-        );
+		add_submenu_page(
+			'rtbcb-dashboard',
+			__( 'Dashboard', 'rtbcb' ),
+			__( 'Dashboard', 'rtbcb' ),
+			'manage_options',
+			'rtbcb-dashboard',
+			[ $this, 'render_dashboard' ]
+		);
 
-        add_submenu_page(
-            'rtbcb-dashboard',
-            __( 'Settings', 'rtbcb' ),
-            __( 'Settings', 'rtbcb' ),
-            'manage_options',
-            'rtbcb-settings',
-            [ $this, 'render_settings' ]
-        );
+		add_submenu_page(
+			'rtbcb-dashboard',
+			__( 'Settings', 'rtbcb' ),
+			__( 'Settings', 'rtbcb' ),
+			'manage_options',
+			'rtbcb-settings',
+			[ $this, 'render_settings' ]
+		);
 
-        add_submenu_page(
-            'rtbcb-dashboard',
-            __( 'Leads', 'rtbcb' ),
-            __( 'Leads', 'rtbcb' ),
-            'manage_options',
-            'rtbcb-leads',
-            [ $this, 'render_leads' ]
-        );
+		add_submenu_page(
+			'rtbcb-dashboard',
+			__( 'Leads', 'rtbcb' ),
+			__( 'Leads', 'rtbcb' ),
+			'manage_options',
+			'rtbcb-leads',
+			[ $this, 'render_leads' ]
+		);
 
-        add_submenu_page(
-            'rtbcb-dashboard',
-            __( 'Analytics', 'rtbcb' ),
-            __( 'Analytics', 'rtbcb' ),
-            'manage_options',
-            'rtbcb-analytics',
-            [ $this, 'render_analytics' ]
-        );
+		add_submenu_page(
+			'rtbcb-dashboard',
+			__( 'Analytics', 'rtbcb' ),
+			__( 'Analytics', 'rtbcb' ),
+			'manage_options',
+			'rtbcb-analytics',
+			[ $this, 'render_analytics' ]
+		);
 
-        add_submenu_page(
-            'rtbcb-dashboard',
-            __( 'Calculation Info', 'rtbcb' ),
-            __( 'Calculation Info', 'rtbcb' ),
-            'manage_options',
-            'rtbcb-calculations',
-            [ $this, 'render_calculation_info' ]
-        );
+		add_submenu_page(
+			'rtbcb-dashboard',
+			__( 'Calculation Info', 'rtbcb' ),
+			__( 'Calculation Info', 'rtbcb' ),
+			'manage_options',
+			'rtbcb-calculations',
+			[ $this, 'render_calculation_info' ]
+		);
 
-        add_submenu_page(
-            'rtbcb-dashboard',
-            __( 'Test Dashboard', 'rtbcb' ),
-            __( 'Test Dashboard', 'rtbcb' ),
-            'manage_options',
-            'rtbcb-test-dashboard',
-            [ $this, 'render_test_dashboard' ]
-        );
+		add_submenu_page(
+			'rtbcb-dashboard',
+			__( 'Test Dashboard', 'rtbcb' ),
+			__( 'Test Dashboard', 'rtbcb' ),
+			'manage_options',
+			'rtbcb-test-dashboard',
+			[ $this, 'render_test_dashboard' ]
+		);
 
-        add_submenu_page(
-            'rtbcb-dashboard',
-            __( 'API Logs', 'rtbcb' ),
-            __( 'API Logs', 'rtbcb' ),
-            'manage_options',
-            'rtbcb-api-logs',
-            [ $this, 'render_api_logs' ]
-        );
+		add_submenu_page(
+			'rtbcb-dashboard',
+			__( 'API Logs', 'rtbcb' ),
+			__( 'API Logs', 'rtbcb' ),
+			'manage_options',
+			'rtbcb-api-logs',
+			[ $this, 'render_api_logs' ]
+		);
 
-        add_submenu_page(
-            'rtbcb-dashboard',
-            __( 'Workflow Visualizer', 'rtbcb' ),
-            __( 'Workflow Visualizer', 'rtbcb' ),
-            'manage_options',
-            'rtbcb-workflow-visualizer',
-            [ $this, 'render_workflow_visualizer' ]
-        );
+		add_submenu_page(
+			'rtbcb-dashboard',
+			__( 'Workflow Visualizer', 'rtbcb' ),
+			__( 'Workflow Visualizer', 'rtbcb' ),
+			'manage_options',
+			'rtbcb-workflow-visualizer',
+			[ $this, 'render_workflow_visualizer' ]
+		);
 
-    }
+	}
 
-    /**
-     * Render enhanced dashboard with statistics.
-     *
-     * @return void
-    */
-    public function render_dashboard() {
-        $stats = RTBCB_Leads::get_cached_statistics();
-        $recent_leads_data = RTBCB_Leads::get_all_leads( [ 'per_page' => 5, 'orderby' => 'created_at', 'order' => 'DESC' ] );
+	/**
+	 * Render enhanced dashboard with statistics.
+	 *
+	 * @return void
+	*/
+	public function render_dashboard() {
+		$stats = RTBCB_Leads::get_cached_statistics();
+		$recent_leads_data = RTBCB_Leads::get_all_leads( [ 'per_page' => 5, 'orderby' => 'created_at', 'order' => 'DESC' ] );
 
-        include RTBCB_DIR . 'admin/dashboard-page.php';
-    }
+		include RTBCB_DIR . 'admin/dashboard-page.php';
+	}
 
-    /**
-     * Render settings page.
-     *
-     * @return void
-     */
-    public function render_settings() {
-        include RTBCB_DIR . 'admin/settings-page.php';
-    }
+	/**
+	 * Render settings page.
+	 *
+	 * @return void
+	 */
+	public function render_settings() {
+		include RTBCB_DIR . 'admin/settings-page.php';
+	}
 
-    /**
-     * Render enhanced leads page with filtering and export.
-     *
-     * @return void
-     */
-    public function render_leads() {
-        $page = isset( $_GET['paged'] ) ? intval( wp_unslash( $_GET['paged'] ) ) : 1;
-        $search = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
-        $category = isset( $_GET['category'] ) ? sanitize_text_field( wp_unslash( $_GET['category'] ) ) : '';
-        $date_from = isset( $_GET['date_from'] ) ? sanitize_text_field( wp_unslash( $_GET['date_from'] ) ) : '';
-        $date_to = isset( $_GET['date_to'] ) ? sanitize_text_field( wp_unslash( $_GET['date_to'] ) ) : '';
+	/**
+	 * Render enhanced leads page with filtering and export.
+	 *
+	 * @return void
+	 */
+	public function render_leads() {
+		$page = isset( $_GET['paged'] ) ? intval( wp_unslash( $_GET['paged'] ) ) : 1;
+		$search = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
+		$category = isset( $_GET['category'] ) ? sanitize_text_field( wp_unslash( $_GET['category'] ) ) : '';
+		$date_from = isset( $_GET['date_from'] ) ? sanitize_text_field( wp_unslash( $_GET['date_from'] ) ) : '';
+		$date_to = isset( $_GET['date_to'] ) ? sanitize_text_field( wp_unslash( $_GET['date_to'] ) ) : '';
 
-        $orderby = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'created_at';
-        $allowed_orderby = [ 'email', 'created_at' ];
-        if ( ! in_array( $orderby, $allowed_orderby, true ) ) {
-            $orderby = 'created_at';
-        }
+		$orderby = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'created_at';
+		$allowed_orderby = [ 'email', 'created_at' ];
+		if ( ! in_array( $orderby, $allowed_orderby, true ) ) {
+			$orderby = 'created_at';
+		}
 
-        $order = isset( $_GET['order'] ) ? sanitize_key( wp_unslash( $_GET['order'] ) ) : 'DESC';
-        $order = strtoupper( $order );
-        if ( ! in_array( $order, [ 'ASC', 'DESC' ], true ) ) {
-            $order = 'DESC';
-        }
+		$order = isset( $_GET['order'] ) ? sanitize_key( wp_unslash( $_GET['order'] ) ) : 'DESC';
+		$order = strtoupper( $order );
+		if ( ! in_array( $order, [ 'ASC', 'DESC' ], true ) ) {
+			$order = 'DESC';
+		}
 
-        $args = [
-            'page'      => $page,
-            'search'    => $search,
-            'category'  => $category,
-            'date_from' => $date_from,
-            'date_to'   => $date_to,
-            'orderby'   => $orderby,
-            'order'     => $order,
-        ];
+		$args = [
+			'page'      => $page,
+			'search'    => $search,
+			'category'  => $category,
+			'date_from' => $date_from,
+			'date_to'   => $date_to,
+			'orderby'   => $orderby,
+			'order'     => $order,
+		];
 
-        $leads_data = RTBCB_Leads::get_all_leads( $args );
-        $categories = RTBCB_Category_Recommender::get_all_categories();
-        if ( ! is_array( $categories ) ) {
-            $categories = [];
-        }
+		$leads_data = RTBCB_Leads::get_all_leads( $args );
+		$categories = RTBCB_Category_Recommender::get_all_categories();
+		if ( ! is_array( $categories ) ) {
+			$categories = [];
+		}
 
-        include RTBCB_DIR . 'admin/leads-page-enhanced.php';
-    }
+		include RTBCB_DIR . 'admin/leads-page-enhanced.php';
+	}
 
-    /**
-     * Render analytics page with charts and insights.
-     *
-     * @return void
-     */
-    public function render_analytics() {
-        $stats = RTBCB_Leads::get_cached_statistics();
-        $monthly_trends = $this->get_monthly_trends();
-        
-        include RTBCB_DIR . 'admin/analytics-page.php';
-    }
+	/**
+	 * Render analytics page with charts and insights.
+	 *
+	 * @return void
+	 */
+	public function render_analytics() {
+		$stats = RTBCB_Leads::get_cached_statistics();
+		$monthly_trends = $this->get_monthly_trends();
+		
+		include RTBCB_DIR . 'admin/analytics-page.php';
+	}
 
-    /**
-     * Render calculation info page.
-     *
-     * @return void
-     */
-    public function render_calculation_info() {
-        include RTBCB_DIR . 'admin/calculations-page.php';
-    }
+	/**
+	 * Render calculation info page.
+	 *
+	 * @return void
+	 */
+	public function render_calculation_info() {
+		include RTBCB_DIR . 'admin/calculations-page.php';
+	}
 
-    /**
-     * Render test dashboard page.
-     *
-     * @return void
-     */
-    public function render_test_dashboard() {
-        $test_results   = get_option( 'rtbcb_test_results', [] );
-        $openai_key     = get_option( 'rtbcb_openai_api_key', '' );
-        $openai_status  = empty( $openai_key ) ? false : true;
-        $portal_active   = $this->check_portal_integration();
-        $rag_health_info = $this->check_rag_health();
-        $rag_health      = ( 'healthy' === ( $rag_health_info['status'] ?? '' ) );
-        $last_indexed   = get_option( 'rtbcb_last_indexed', '' );
-        $vendor_count   = $this->get_vendor_count();
+	/**
+	 * Render test dashboard page.
+	 *
+	 * @return void
+	 */
+	public function render_test_dashboard() {
+		$test_results   = get_option( 'rtbcb_test_results', [] );
+		$openai_key     = get_option( 'rtbcb_openai_api_key', '' );
+		$openai_status  = empty( $openai_key ) ? false : true;
+		$portal_active   = $this->check_portal_integration();
+		$rag_health_info = $this->check_rag_health();
+		$rag_health      = ( 'healthy' === ( $rag_health_info['status'] ?? '' ) );
+		$last_indexed   = get_option( 'rtbcb_last_indexed', '' );
+		$vendor_count   = $this->get_vendor_count();
 
-        include RTBCB_DIR . 'admin/test-dashboard-page.php';
-    }
+		include RTBCB_DIR . 'admin/test-dashboard-page.php';
+	}
 
-    /**
-     * Render API logs page.
-     *
-     * @return void
-     */
-    public function render_api_logs() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            return;
-        }
+	/**
+	 * Render API logs page.
+	 *
+	 * @return void
+	 */
+	public function render_api_logs() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
 
-        $paged     = isset( $_GET['paged'] ) ? intval( wp_unslash( $_GET['paged'] ) ) : 1;
-        $per_page  = 20;
-        $logs_data = RTBCB_API_Log::get_logs_paginated( $paged, $per_page );
-        $nonce     = wp_create_nonce( 'rtbcb_api_logs' );
+		$paged     = isset( $_GET['paged'] ) ? intval( wp_unslash( $_GET['paged'] ) ) : 1;
+		$per_page  = 20;
+		$logs_data = RTBCB_API_Log::get_logs_paginated( $paged, $per_page );
+		$nonce     = wp_create_nonce( 'rtbcb_api_logs' );
 
-        include RTBCB_DIR . 'admin/api-logs-page.php';
-    }
+		include RTBCB_DIR . 'admin/api-logs-page.php';
+	}
 
-    /**
-     * AJAX handler to save test results from dashboard.
-     *
-     * @return void
-     */
-    public function ajax_save_test_results() {
-        check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
+	/**
+	 * AJAX handler to save test results from dashboard.
+	 *
+	 * @return void
+	 */
+	public function ajax_save_test_results() {
+		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );
+		}
 
-        $results = isset( $_POST['results'] ) ? wp_unslash( $_POST['results'] ) : '';
-        $decoded = json_decode( $results, true );
-        if ( ! is_array( $decoded ) ) {
-            wp_send_json_error( [ 'message' => __( 'Invalid data format.', 'rtbcb' ) ] );
-        }
+		$results = isset( $_POST['results'] ) ? wp_unslash( $_POST['results'] ) : '';
+		$decoded = json_decode( $results, true );
+		if ( ! is_array( $decoded ) ) {
+			wp_send_json_error( [ 'message' => __( 'Invalid data format.', 'rtbcb' ) ] );
+		}
 
-        $sanitized = [];
-        foreach ( $decoded as $item ) {
-            $data = [];
-            if ( isset( $item['data'] ) && is_array( $item['data'] ) ) {
-                foreach ( $item['data'] as $key => $value ) {
-                    if ( is_scalar( $value ) ) {
-                        $data[ sanitize_key( $key ) ] = is_numeric( $value ) ? ( 0 + $value ) : sanitize_text_field( $value );
-                    }
-                }
-            }
+		$sanitized = [];
+		foreach ( $decoded as $item ) {
+			$data = [];
+			if ( isset( $item['data'] ) && is_array( $item['data'] ) ) {
+				foreach ( $item['data'] as $key => $value ) {
+					if ( is_scalar( $value ) ) {
+						$data[ sanitize_key( $key ) ] = is_numeric( $value ) ? ( 0 + $value ) : sanitize_text_field( $value );
+					}
+				}
+			}
 
-            $start_time = isset( $item['start_time'] ) ? sanitize_text_field( $item['start_time'] ) : '';
-            $end_time   = isset( $item['end_time'] ) ? sanitize_text_field( $item['end_time'] ) : '';
-            $duration   = isset( $item['duration'] ) ? floatval( $item['duration'] ) : 0;
+			$start_time = isset( $item['start_time'] ) ? sanitize_text_field( $item['start_time'] ) : '';
+			$end_time   = isset( $item['end_time'] ) ? sanitize_text_field( $item['end_time'] ) : '';
+			$duration   = isset( $item['duration'] ) ? floatval( $item['duration'] ) : 0;
 
-            $sanitized[] = [
-                'section'    => isset( $item['section'] ) ? sanitize_text_field( $item['section'] ) : '',
-                'status'     => isset( $item['status'] ) ? sanitize_text_field( $item['status'] ) : '',
-                'message'    => isset( $item['message'] ) ? sanitize_text_field( $item['message'] ) : '',
-                'timestamp'  => current_time( 'mysql' ),
-                'start_time' => $start_time,
-                'end_time'   => $end_time,
-                'duration'   => $duration,
-                'data'       => $data,
-            ];
-        }
+			$sanitized[] = [
+				'section'    => isset( $item['section'] ) ? sanitize_text_field( $item['section'] ) : '',
+				'status'     => isset( $item['status'] ) ? sanitize_text_field( $item['status'] ) : '',
+				'message'    => isset( $item['message'] ) ? sanitize_text_field( $item['message'] ) : '',
+				'timestamp'  => current_time( 'mysql' ),
+				'start_time' => $start_time,
+				'end_time'   => $end_time,
+				'duration'   => $duration,
+				'data'       => $data,
+			];
+		}
 
-        $existing    = get_option( 'rtbcb_test_results', [] );
-        $existing    = is_array( $existing ) ? $existing : [];
-        $combined    = array_merge( $sanitized, $existing );
-        $max_results = 10;
-        if ( count( $combined ) > $max_results ) {
-            $combined = array_slice( $combined, 0, $max_results );
-        }
+		$existing    = get_option( 'rtbcb_test_results', [] );
+		$existing    = is_array( $existing ) ? $existing : [];
+		$combined    = array_merge( $sanitized, $existing );
+		$max_results = 10;
+		if ( count( $combined ) > $max_results ) {
+			$combined = array_slice( $combined, 0, $max_results );
+		}
 
-        $updated = update_option( 'rtbcb_test_results', $combined );
+		$updated = update_option( 'rtbcb_test_results', $combined );
 
-        if ( false === $updated ) {
-            wp_send_json_error( [ 'message' => __( 'Failed to save test results.', 'rtbcb' ) ] );
-        }
+		if ( false === $updated ) {
+			wp_send_json_error( [ 'message' => __( 'Failed to save test results.', 'rtbcb' ) ] );
+		}
 
-        wp_send_json_success();
-    }
+		wp_send_json_success();
+	}
 
-    /**
-     * Register plugin settings.
-     *
-     * @return void
-     */
-    public function register_settings() {
-        register_setting( 'rtbcb_settings', 'rtbcb_settings', [ 'sanitize_callback' => [ $this, 'sanitize_settings' ] ] );
-        register_setting( 'rtbcb_settings', 'rtbcb_openai_api_key', [ 'sanitize_callback' => 'sanitize_text_field' ] );
-        register_setting( 'rtbcb_settings', 'rtbcb_mini_model', [ 'sanitize_callback' => 'sanitize_text_field' ] );
-        register_setting( 'rtbcb_settings', 'rtbcb_premium_model', [ 'sanitize_callback' => 'sanitize_text_field' ] );
-        register_setting( 'rtbcb_settings', 'rtbcb_advanced_model', [ 'sanitize_callback' => 'sanitize_text_field' ] );
-        register_setting( 'rtbcb_settings', 'rtbcb_embedding_model', [ 'sanitize_callback' => 'sanitize_text_field' ] );
-        register_setting( 'rtbcb_settings', 'rtbcb_labor_cost_per_hour', [ 'sanitize_callback' => 'floatval' ] );
-        register_setting( 'rtbcb_settings', 'rtbcb_bank_fee_baseline', [ 'sanitize_callback' => 'floatval' ] );
+	/**
+	 * Register plugin settings.
+	 *
+	 * @return void
+	 */
+	public function register_settings() {
+		register_setting( 'rtbcb_settings', 'rtbcb_settings', [ 'sanitize_callback' => [ $this, 'sanitize_settings' ] ] );
+		register_setting( 'rtbcb_settings', 'rtbcb_openai_api_key', [ 'sanitize_callback' => 'sanitize_text_field' ] );
+		register_setting( 'rtbcb_settings', 'rtbcb_mini_model', [ 'sanitize_callback' => 'sanitize_text_field' ] );
+		register_setting( 'rtbcb_settings', 'rtbcb_premium_model', [ 'sanitize_callback' => 'sanitize_text_field' ] );
+		register_setting( 'rtbcb_settings', 'rtbcb_advanced_model', [ 'sanitize_callback' => 'sanitize_text_field' ] );
+		register_setting( 'rtbcb_settings', 'rtbcb_embedding_model', [ 'sanitize_callback' => 'sanitize_text_field' ] );
+		register_setting( 'rtbcb_settings', 'rtbcb_labor_cost_per_hour', [ 'sanitize_callback' => 'floatval' ] );
+		register_setting( 'rtbcb_settings', 'rtbcb_bank_fee_baseline', [ 'sanitize_callback' => 'floatval' ] );
 		register_setting( 'rtbcb_settings', 'rtbcb_gpt5_timeout', [ 'sanitize_callback' => 'rtbcb_sanitize_api_timeout' ] );
-        register_setting( 'rtbcb_settings', 'rtbcb_gpt5_max_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_max_output_tokens' ] );
-        register_setting( 'rtbcb_settings', 'rtbcb_gpt5_min_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_min_output_tokens' ] );
-        register_setting( 'rtbcb_settings', 'rtbcb_fast_mode', [ 'sanitize_callback' => 'absint' ] );
-        register_setting( 'rtbcb_settings', 'rtbcb_disable_heavy_features', [ 'sanitize_callback' => 'absint' ] );
-    }
+		register_setting( 'rtbcb_settings', 'rtbcb_gpt5_max_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_max_output_tokens' ] );
+		register_setting( 'rtbcb_settings', 'rtbcb_gpt5_min_output_tokens', [ 'sanitize_callback' => 'rtbcb_sanitize_min_output_tokens' ] );
+		register_setting( 'rtbcb_settings', 'rtbcb_fast_mode', [ 'sanitize_callback' => 'absint' ] );
+		register_setting( 'rtbcb_settings', 'rtbcb_disable_heavy_features', [ 'sanitize_callback' => 'absint' ] );
+	}
 
-    /**
-     * Sanitize rtbcb_settings option.
-     *
-     * @param array $settings Settings array.
-     * @return array
-     */
-    public function sanitize_settings( $settings ) {
-        $settings = is_array( $settings ) ? $settings : [];
-        $settings['enable_ai_analysis'] = isset( $settings['enable_ai_analysis'] ) ? (bool) $settings['enable_ai_analysis'] : false;
-        $settings['enable_charts']      = isset( $settings['enable_charts'] ) ? (bool) $settings['enable_charts'] : false;
-        return $settings;
-    }
+	/**
+	 * Sanitize rtbcb_settings option.
+	 *
+	 * @param array $settings Settings array.
+	 * @return array
+	 */
+	public function sanitize_settings( $settings ) {
+		$settings = is_array( $settings ) ? $settings : [];
+		$settings['enable_ai_analysis'] = isset( $settings['enable_ai_analysis'] ) ? (bool) $settings['enable_ai_analysis'] : false;
+		$settings['enable_charts']      = isset( $settings['enable_charts'] ) ? (bool) $settings['enable_charts'] : false;
+		return $settings;
+	}
 
-    /**
-     * Export leads to CSV.
-     *
-     * @return void
-     */
-    public function export_leads_csv() {
-        check_ajax_referer( 'rtbcb_nonce', 'nonce' );
+	/**
+	 * Export leads to CSV.
+	 *
+	 * @return void
+	 */
+	public function export_leads_csv() {
+		check_ajax_referer( 'rtbcb_nonce', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
+		}
 
-        $filters = [
-            'search'    => sanitize_text_field( wp_unslash( $_POST['search'] ?? '' ) ),
-            'category'  => sanitize_text_field( wp_unslash( $_POST['category'] ?? '' ) ),
-            'date_from' => sanitize_text_field( wp_unslash( $_POST['date_from'] ?? '' ) ),
-            'date_to'   => sanitize_text_field( wp_unslash( $_POST['date_to'] ?? '' ) ),
-        ];
+		$filters = [
+			'search'    => sanitize_text_field( wp_unslash( $_POST['search'] ?? '' ) ),
+			'category'  => sanitize_text_field( wp_unslash( $_POST['category'] ?? '' ) ),
+			'date_from' => sanitize_text_field( wp_unslash( $_POST['date_from'] ?? '' ) ),
+			'date_to'   => sanitize_text_field( wp_unslash( $_POST['date_to'] ?? '' ) ),
+		];
 
-        $csv_content = RTBCB_Leads::export_to_csv( $filters );
-        $filename = 'rtbcb-leads-' . date( 'Y-m-d' ) . '.csv';
+		$csv_content = RTBCB_Leads::export_to_csv( $filters );
+		$filename = 'rtbcb-leads-' . date( 'Y-m-d' ) . '.csv';
 
-        wp_send_json_success( [
-            'content'  => $csv_content,
-            'filename' => $filename,
-        ] );
-    }
+		wp_send_json_success( [
+			'content'  => $csv_content,
+			'filename' => $filename,
+		] );
+	}
 
-    /**
-     * Delete a single lead.
-     *
-     * @return void
-     */
-    public function delete_lead() {
-        check_ajax_referer( 'rtbcb_nonce', 'nonce' );
+	/**
+	 * Delete a single lead.
+	 *
+	 * @return void
+	 */
+	public function delete_lead() {
+		check_ajax_referer( 'rtbcb_nonce', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
+		}
 
-        $lead_id = intval( wp_unslash( $_POST['lead_id'] ?? 0 ) );
-        
-        global $wpdb;
-        $table_name = $wpdb->prefix . 'rtbcb_leads';
-        
-        $result = $wpdb->delete( $table_name, [ 'id' => $lead_id ], [ '%d' ] );
+		$lead_id = intval( wp_unslash( $_POST['lead_id'] ?? 0 ) );
+		
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'rtbcb_leads';
+		
+		$result = $wpdb->delete( $table_name, [ 'id' => $lead_id ], [ '%d' ] );
 
-        if ( $result ) {
-            rtbcb_clear_report_cache();
-            wp_send_json_success( [ 'message' => __( 'Lead deleted successfully.', 'rtbcb' ) ] );
-        } else {
-            wp_send_json_error( [ 'message' => __( 'Failed to delete lead.', 'rtbcb' ) ] );
-        }
-    }
+		if ( $result ) {
+			rtbcb_clear_report_cache();
+			wp_send_json_success( [ 'message' => __( 'Lead deleted successfully.', 'rtbcb' ) ] );
+		} else {
+			wp_send_json_error( [ 'message' => __( 'Failed to delete lead.', 'rtbcb' ) ] );
+		}
+	}
 
-    /**
-     * Handle bulk actions on leads.
-     *
-     * @return void
-     */
-    public function bulk_action_leads() {
-        check_ajax_referer( 'rtbcb_nonce', 'nonce' );
+	/**
+	 * Handle bulk actions on leads.
+	 *
+	 * @return void
+	 */
+	public function bulk_action_leads() {
+		check_ajax_referer( 'rtbcb_nonce', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
+		}
 
 	$bulk_action = sanitize_text_field( wp_unslash( $_POST['bulk_action'] ?? '' ) );
 	$lead_ids_raw = wp_unslash( $_POST['lead_ids'] ?? [] );
@@ -597,43 +597,43 @@ class RTBCB_Admin {
 
 	$lead_ids = array_map( 'intval', (array) $lead_ids_raw );
 
-        if ( empty( $lead_ids ) ) {
-            wp_send_json_error( [ 'message' => __( 'No leads selected.', 'rtbcb' ) ] );
-        }
+		if ( empty( $lead_ids ) ) {
+			wp_send_json_error( [ 'message' => __( 'No leads selected.', 'rtbcb' ) ] );
+		}
 
-        global $wpdb;
-        $table_name = $wpdb->prefix . 'rtbcb_leads';
-        $placeholders = implode( ',', array_fill( 0, count( $lead_ids ), '%d' ) );
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'rtbcb_leads';
+		$placeholders = implode( ',', array_fill( 0, count( $lead_ids ), '%d' ) );
 
 	switch ( $bulk_action ) {
-            case 'delete':
-                $result = $wpdb->query( 
-                    $wpdb->prepare( 
-                        "DELETE FROM {$table_name} WHERE id IN ({$placeholders})", 
-                        $lead_ids 
-                    ) 
-                );
-                
-                if ( $result ) {
-                    rtbcb_clear_report_cache();
-                    wp_send_json_success( [
-                        'message' => sprintf( __( '%d leads deleted successfully.', 'rtbcb' ), $result )
-                    ] );
-                } else {
-                    wp_send_json_error( [ 'message' => __( 'Failed to delete leads.', 'rtbcb' ) ] );
-                }
-                break;
+			case 'delete':
+				$result = $wpdb->query( 
+					$wpdb->prepare( 
+						"DELETE FROM {$table_name} WHERE id IN ({$placeholders})", 
+						$lead_ids 
+					) 
+				);
+				
+				if ( $result ) {
+					rtbcb_clear_report_cache();
+					wp_send_json_success( [
+						'message' => sprintf( __( '%d leads deleted successfully.', 'rtbcb' ), $result )
+					] );
+				} else {
+					wp_send_json_error( [ 'message' => __( 'Failed to delete leads.', 'rtbcb' ) ] );
+				}
+				break;
 
-            default:
-                wp_send_json_error( [ 'message' => __( 'Invalid action.', 'rtbcb' ) ] );
-        }
-    }
+			default:
+				wp_send_json_error( [ 'message' => __( 'Invalid action.', 'rtbcb' ) ] );
+		}
+	}
 
-    /**
-     * Test the OpenAI API connection.
-     *
-     * @return void
-     */
+	/**
+	 * Test the OpenAI API connection.
+	 *
+	 * @return void
+	 */
 	public function test_api_connection() {
 		check_ajax_referer( 'rtbcb_nonce', 'nonce' );
 
@@ -651,15 +651,15 @@ class RTBCB_Admin {
 
 		if ( false === $response ) {
 			$response = wp_remote_get( 'https://api.openai.com/v1/models', [
-			    'headers' => [
-			        'Authorization' => 'Bearer ' . $api_key,
-			        'Content-Type'  => 'application/json',
-			    ],
-			    'timeout' => rtbcb_get_api_timeout(),
+				'headers' => [
+					'Authorization' => 'Bearer ' . $api_key,
+					'Content-Type'  => 'application/json',
+				],
+				'timeout' => rtbcb_get_api_timeout(),
 			] );
 
 			if ( ! is_wp_error( $response ) ) {
-			    wp_cache_set( $cache_key, $response, '', HOUR_IN_SECONDS );
+				wp_cache_set( $cache_key, $response, '', HOUR_IN_SECONDS );
 			}
 		}
 
@@ -675,16 +675,16 @@ class RTBCB_Admin {
 		wp_send_json_success( [ 'message' => __( 'Connection successful.', 'rtbcb' ) ] );
 	}
 
-    /**
-     * Clear cached OpenAI models when API settings change.
-     *
-     * @param string $old_value Old API key.
-     * @param string $value     New API key.
-     * @return void
-     */
+	/**
+	 * Clear cached OpenAI models when API settings change.
+	 *
+	 * @param string $old_value Old API key.
+	 * @param string $value     New API key.
+	 * @return void
+	 */
 	public function clear_openai_models_cache( $old_value, $value ) {
 		if ( $old_value !== $value ) {
-		    wp_cache_delete( 'rtbcb_openai_models' );
+			wp_cache_delete( 'rtbcb_openai_models' );
 		}
 	}
 
@@ -698,1174 +698,1174 @@ class RTBCB_Admin {
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( __( 'Permission denied', 'rtbcb' ) );
-        }
-
-        $result = RTBCB_API_Tester::test_connection();
-
-        if ( $result['success'] ) {
-            wp_send_json_success( $result );
-        }
-
-        wp_send_json_error( $result );
-    }
-
-    /**
-     * AJAX handler for industry commentary testing.
-     *
-     * @return void
-     */
-    public function ajax_test_commentary() {
-        check_ajax_referer( 'rtbcb_test_commentary', 'nonce' );
-
-        $industry = isset( $_POST['industry'] ) ? sanitize_text_field( wp_unslash( $_POST['industry'] ) ) : '';
-
-        if ( empty( $industry ) ) {
-            wp_send_json_error( [ 'message' => __( 'Invalid industry.', 'rtbcb' ) ] );
-        }
-
-        $start      = microtime( true );
-        $commentary = rtbcb_test_generate_industry_commentary( $industry );
-        $elapsed    = round( microtime( true ) - $start, 2 );
-
-        if ( is_wp_error( $commentary ) ) {
-            wp_send_json_error( [ 'message' => sanitize_text_field( $commentary->get_error_message() ) ] );
-        }
-
-        $word_count = str_word_count( $commentary );
-
-        wp_send_json_success(
-            [
-                'commentary' => sanitize_textarea_field( $commentary ),
-                'word_count' => $word_count,
-                'elapsed'    => $elapsed,
-                'generated'  => current_time( 'mysql' ),
-            ]
-        );
-    }
-
-    /**
-     * AJAX handler for company overview testing.
-     *
-     * Retrieves the company name from the request, stored options, or the
-     * currently selected company. Returns an error only if no name can be
-     * determined.
-     *
-     * @return void
-     */
-    public function ajax_test_company_overview() {
-        check_ajax_referer( 'rtbcb_test_company_overview', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        }
-
-        $company_name = isset( $_POST['company_name'] ) ?
-            sanitize_text_field( wp_unslash( $_POST['company_name'] ) ) : '';
-
-        if ( '' === $company_name ) {
-            $stored_data = get_option( 'rtbcb_company_data', [] );
-            if ( is_array( $stored_data ) && ! empty( $stored_data['name'] ) ) {
-                $company_name = sanitize_text_field( $stored_data['name'] );
-            }
-        }
-
-        if ( '' === $company_name ) {
-            $current_company = rtbcb_get_current_company();
-            if ( is_array( $current_company ) && ! empty( $current_company['name'] ) ) {
-                $company_name = sanitize_text_field( $current_company['name'] );
-            }
-        }
-
-        if ( '' === $company_name ) {
-            wp_send_json_error( [ 'message' => __( 'Company name is required.', 'rtbcb' ) ] );
-        }
-
-        $start_time = microtime( true );
-
-        try {
-            $overview = rtbcb_test_generate_company_overview( $company_name );
-
-            if ( is_wp_error( $overview ) ) {
-                wp_send_json_error( [
-                    'message' => $overview->get_error_message(),
-                ] );
-            }
-
-            $analysis        = $overview['analysis'] ?? '';
-            $recommendations = array_map( 'sanitize_text_field', $overview['recommendations'] ?? [] );
-            $references      = array_map( 'esc_url_raw', $overview['references'] ?? [] );
-            $metrics         = is_array( $overview['metrics'] ?? null ) ? $overview['metrics'] : [];
-            $revenue         = floatval( $metrics['revenue'] ?? 0 );
-            $staff_count     = intval( $metrics['staff_count'] ?? 0 );
-            $efficiency      = floatval( $metrics['baseline_efficiency'] ?? 0 );
-
-            $word_count   = str_word_count( wp_strip_all_tags( $analysis ) );
-            $elapsed_time = microtime( true ) - $start_time;
-
-            $existing = rtbcb_get_current_company();
-            $company_data = [
-                'name'            => $company_name,
-                'summary'         => sanitize_textarea_field( wp_strip_all_tags( $analysis ) ),
-                'recommendations' => $recommendations,
-                'references'      => $references,
-                'generated_at'    => current_time( 'mysql' ),
-                'focus_areas'     => array_map( 'sanitize_text_field', (array) ( $existing['focus_areas'] ?? [] ) ),
-                'industry'        => isset( $existing['industry'] ) ? sanitize_text_field( $existing['industry'] ) : '',
-                'size'            => isset( $existing['size'] ) ? sanitize_text_field( $existing['size'] ) : '',
-                'revenue'         => $revenue,
-                'staff_count'     => $staff_count,
-                'efficiency'      => $efficiency,
-            ];
-
-            update_option( 'rtbcb_current_company', $company_data );
-            $stored = get_option( 'rtbcb_company_data', [] );
-            if ( ! is_array( $stored ) ) {
-                $stored = [];
-            }
-            $stored['name']        = $company_name;
-            $stored['revenue']     = $revenue;
-            $stored['staff_count'] = $staff_count;
-            $stored['efficiency']  = $efficiency;
-            update_option( 'rtbcb_company_data', $stored );
-
-            wp_send_json_success(
-                [
-                    'message'         => __( 'Company overview generated.', 'rtbcb' ),
-                    'overview'        => wp_kses_post( $analysis ),
-                    'word_count'      => $word_count,
-                    'elapsed'         => round( $elapsed_time, 2 ),
-                    'generated'       => current_time( 'mysql' ),
-                    'recommendations' => $recommendations,
-                    'references'      => $references,
-                    'focus_areas'     => $company_data['focus_areas'],
-                    'industry'        => $company_data['industry'],
-                    'size'            => $company_data['size'],
-                    'metrics'         => [
-                        'revenue'     => $revenue,
-                        'staff_count' => $staff_count,
-                        'efficiency'  => $efficiency,
-                    ],
-                ]
-            );
-
-        } catch ( Exception $e ) {
-            error_log( 'RTBCB Company Overview Error: ' . $e->getMessage() );
-            wp_send_json_error( [
-                'message' => __( 'An error occurred while generating the overview.', 'rtbcb' ),
-            ] );
-        }
-    }
-
-    /**
-     * AJAX handler for industry overview testing.
-     *
-     * @return void
-     */
-    public function ajax_test_industry_overview() {
-        check_ajax_referer( 'rtbcb_test_industry_overview', 'nonce' );
-        $raw_data     = isset( $_POST['company_data'] ) ? wp_unslash( $_POST['company_data'] ) : '';
-        $company_data = json_decode( $raw_data, true );
-
-        if ( empty( $company_data ) || ! is_array( $company_data ) ) {
-            $company_data = rtbcb_get_current_company();
-
-            if ( empty( $company_data ) || ! is_array( $company_data ) ) {
-                wp_send_json_error( [ 'message' => __( 'Invalid company data.', 'rtbcb' ) ] );
-            }
-        }
-
-        $start    = microtime( true );
-        $overview = rtbcb_test_generate_industry_overview( $company_data );
-        $elapsed  = round( microtime( true ) - $start, 2 );
-
-        if ( is_wp_error( $overview ) ) {
-            wp_send_json_error( [ 'message' => sanitize_text_field( $overview->get_error_message() ) ] );
-        }
-
-        $word_count = str_word_count( $overview );
-
-        wp_send_json_success(
-            [
-                'overview'   => sanitize_textarea_field( $overview ),
-                'word_count' => $word_count,
-                'elapsed'    => $elapsed,
-                'generated'  => current_time( 'mysql' ),
-            ]
-        );
-    }
-
-    /**
-     * AJAX handler for maturity model testing.
-     *
-     * @return void
-     */
-    public function ajax_test_maturity_model() {
-        check_ajax_referer( 'rtbcb_test_maturity_model', 'nonce' );
-
-        $company = rtbcb_get_current_company();
-        $result  = rtbcb_test_generate_maturity_model( $company );
-        if ( is_wp_error( $result ) ) {
-            wp_send_json_error( [ 'message' => $result->get_error_message() ] );
-        }
-
-        update_option( 'rtbcb_maturity_model', $result['narrative'] );
-
-        wp_send_json_success(
-            [
-                'assessment' => sanitize_textarea_field( $result['narrative'] ),
-                'level'      => sanitize_text_field( $result['level'] ),
-                'generated'  => current_time( 'mysql' ),
-                'word_count' => str_word_count( $result['narrative'] ),
-            ]
-        );
-    }
-
-    /**
-     * AJAX handler for RAG market analysis testing.
-     *
-     * @return void
-     */
-    public function ajax_test_rag_market_analysis() {
-        check_ajax_referer( 'rtbcb_test_rag_market_analysis', 'nonce' );
-
-        $company = rtbcb_get_current_company();
-        $terms   = [];
-
-        if ( ! empty( $company['industry'] ) ) {
-            $terms[] = sanitize_text_field( $company['industry'] );
-        }
-
-        if ( ! empty( $company['focus_areas'] ) && is_array( $company['focus_areas'] ) ) {
-            $terms = array_merge( $terms, array_map( 'sanitize_text_field', $company['focus_areas'] ) );
-        }
-
-        if ( empty( $terms ) && ! empty( $company['summary'] ) ) {
-            $terms[] = sanitize_text_field( wp_trim_words( $company['summary'], 5, '' ) );
-        }
-
-        if ( empty( $terms ) ) {
-            wp_send_json_error( [ 'message' => __( 'Company data required for query.', 'rtbcb' ) ] );
-        }
-
-        $query   = sanitize_text_field( implode( ' ', $terms ) );
-        $vendors = rtbcb_test_rag_market_analysis( $query );
-        if ( is_wp_error( $vendors ) ) {
-            wp_send_json_error( [ 'message' => $vendors->get_error_message() ] );
-        }
-
-        update_option( 'rtbcb_rag_market_analysis', $vendors );
-
-        wp_send_json_success(
-            [
-                'vendors'   => array_map( 'sanitize_text_field', $vendors ),
-                'generated' => current_time( 'mysql' ),
-            ]
-        );
-    }
-
-    /**
-     * AJAX handler for value proposition testing.
-     *
-     * @return void
-     */
-    public function ajax_test_value_proposition() {
-        check_ajax_referer( 'rtbcb_test_value_proposition', 'nonce' );
-
-        $company = rtbcb_get_current_company();
-        $paragraph = rtbcb_test_generate_value_proposition( $company );
-        if ( is_wp_error( $paragraph ) ) {
-            wp_send_json_error( [ 'message' => $paragraph->get_error_message() ] );
-        }
-
-        update_option( 'rtbcb_value_proposition', $paragraph );
-
-        wp_send_json_success(
-            [
-                'paragraph' => sanitize_textarea_field( $paragraph ),
-                'word_count'=> str_word_count( $paragraph ),
-                'generated' => current_time( 'mysql' ),
-            ]
-        );
-    }
-
-    /**
-     * AJAX handler for treasury tech overview testing.
-     *
-     * @return void
-     */
-    /**
-     * AJAX handler for real treasury overview testing.
-     *
-     * @return void
-     */
-    public function ajax_test_real_treasury_overview() {
-        check_ajax_referer( 'rtbcb_test_real_treasury_overview', 'nonce' );
-        
-        $include_portal = isset( $_POST['include_portal'] ) ? (bool) intval( wp_unslash( $_POST['include_portal'] ) ) : false;
-        $categories     = isset( $_POST['categories'] ) ? (array) wp_unslash( $_POST['categories'] ) : [];
-        $categories     = array_filter( array_map( 'sanitize_text_field', $categories ) );
-
-        $inputs     = rtbcb_get_sample_inputs();
-        $challenges = array_map( 'sanitize_text_field', $inputs['pain_points'] ?? [] );
-
-        $company = rtbcb_get_current_company();
-        if ( ! is_array( $company ) ) {
-            $company = [];
-        }
-
-        if ( ! empty( $challenges ) ) {
-            $existing_challenges   = isset( $company['challenges'] ) ? (array) $company['challenges'] : [];
-            $merged_challenges     = array_values( array_unique( array_merge( $existing_challenges, $challenges ) ) );
-            $company['challenges'] = array_filter( array_map( 'sanitize_text_field', $merged_challenges ) );
-        }
-
-        if ( ! empty( $categories ) ) {
-            $existing_categories   = isset( $company['categories'] ) ? (array) $company['categories'] : [];
-            $merged_categories     = array_values( array_unique( array_merge( $existing_categories, $categories ) ) );
-            $company['categories'] = array_filter( array_map( 'sanitize_text_field', $merged_categories ) );
-        }
-
-        update_option( 'rtbcb_current_company', $company );
-
-        $start    = microtime( true );
-        $overview = rtbcb_test_generate_real_treasury_overview( $include_portal, $categories );
-        $elapsed  = round( microtime( true ) - $start, 2 );
-
-        if ( is_wp_error( $overview ) ) {
-            wp_send_json_error( [ 'message' => sanitize_text_field( $overview->get_error_message() ) ] );
-        }
-
-        $word_count = str_word_count( $overview );
-
-        wp_send_json_success(
-            [
-                'overview'   => sanitize_textarea_field( $overview ),
-                'word_count' => $word_count,
-                'elapsed'    => $elapsed,
-                'generated'  => current_time( 'mysql' ),
-            ]
-        );
-    }
-
-    /**
-     * AJAX handler to retrieve stored company data.
-     *
-     * @return void
-     */
-    public function ajax_get_company_data() {
-        check_ajax_referer( 'rtbcb_test_real_treasury_overview', 'nonce' );
-
-        $inputs  = rtbcb_get_sample_inputs();
-        $summary = rtbcb_test_generate_company_overview( $inputs['company_name'] );
-        if ( is_wp_error( $summary ) ) {
-            wp_send_json_error( [ 'message' => sanitize_text_field( $summary->get_error_message() ) ] );
-        }
-
-        $analysis        = $summary['analysis'] ?? '';
-        $recommendations = array_map( 'sanitize_text_field', $summary['recommendations'] ?? [] );
-        $references      = array_map( 'esc_url_raw', $summary['references'] ?? [] );
-
-        wp_send_json_success(
-            [
-                'summary'        => sanitize_textarea_field( $analysis ),
-                'recommendations'=> $recommendations,
-                'references'     => $references,
-                'challenges'     => array_map( 'sanitize_text_field', $inputs['pain_points'] ?? [] ),
-            ]
-        );
-    }
-
-    /**
-     * AJAX handler for testing estimated benefits.
-     *
-     * @return void
-     */
-    /**
-     * AJAX handler to generate estimated benefits.
-     *
-     * Stores sanitized results to mark the section complete.
-     *
-     * @return void
-     */
-    public function ajax_test_estimated_benefits() {
-        check_ajax_referer( 'rtbcb_test_estimated_benefits', 'nonce' );
-
-        $company_data = [];
-
-        if ( isset( $_POST['company_data'] ) && is_array( $_POST['company_data'] ) ) {
-            $company_data = [
-                'revenue'     => isset( $_POST['company_data']['revenue'] ) ? floatval( wp_unslash( $_POST['company_data']['revenue'] ) ) : 0,
-                'staff_count' => isset( $_POST['company_data']['staff_count'] ) ? intval( wp_unslash( $_POST['company_data']['staff_count'] ) ) : 0,
-                'efficiency'  => isset( $_POST['company_data']['efficiency'] ) ? floatval( wp_unslash( $_POST['company_data']['efficiency'] ) ) : 0,
-            ];
-        }
-
-        if ( empty( $company_data ) && function_exists( 'rtbcb_get_current_company' ) ) {
-            $current = rtbcb_get_current_company();
-            if ( is_array( $current ) ) {
-                $company_data = [
-                    'revenue'     => isset( $current['revenue'] ) ? floatval( $current['revenue'] ) : 0,
-                    'staff_count' => isset( $current['staff_count'] ) ? intval( $current['staff_count'] ) : 0,
-                    'efficiency'  => isset( $current['efficiency'] ) ? floatval( $current['efficiency'] ) : 0,
-                ];
-            }
-        }
-
-        $category = isset( $_POST['recommended_category'] ) ? sanitize_text_field( wp_unslash( $_POST['recommended_category'] ) ) : '';
-        if ( empty( $category ) ) {
-            $stored_category = get_option( 'rtbcb_last_recommended_category', '' );
-            if ( ! empty( $stored_category ) ) {
-                $category = sanitize_text_field( $stored_category );
-            }
-        }
-
-        if ( empty( $company_data ) ) {
-            wp_send_json_error( [ 'message' => __( 'Company data is required to estimate benefits.', 'rtbcb' ) ] );
-        }
-
-        if ( empty( $category ) ) {
-            wp_send_json_error( [ 'message' => __( 'Recommended category is required to estimate benefits.', 'rtbcb' ) ] );
-        }
-
-        $estimate = rtbcb_test_generate_benefits_estimate( $company_data, $category );
-
-        if ( is_wp_error( $estimate ) ) {
-            wp_send_json_error( [ 'message' => sanitize_text_field( $estimate->get_error_message() ) ] );
-        }
-
-        $sanitize_recursive = function ( $data ) use ( &$sanitize_recursive ) {
-            $sanitized = [];
-            foreach ( (array) $data as $key => $value ) {
-                $clean_key = sanitize_key( $key );
-                if ( is_array( $value ) ) {
-                    $sanitized[ $clean_key ] = $sanitize_recursive( $value );
-                } elseif ( is_numeric( $value ) ) {
-                    $sanitized[ $clean_key ] = floatval( $value );
-                } else {
-                    $sanitized[ $clean_key ] = sanitize_text_field( $value );
-                }
-            }
-
-            return $sanitized;
-        };
-
-        $sanitized_estimate = $sanitize_recursive( $estimate );
-        update_option( 'rtbcb_estimated_benefits', $sanitized_estimate );
-
-        wp_send_json_success( [ 'estimate' => $sanitized_estimate ] );
-    }
-
-    /**
-     * AJAX handler to calculate ROI from sample inputs.
-     *
-     * @return void
-     */
-    public function ajax_test_calculate_roi() {
-        check_ajax_referer( 'rtbcb_test_calculate_roi', 'nonce' );
-
-        $roi_inputs = isset( $_POST['roi_inputs'] ) && is_array( $_POST['roi_inputs'] )
-            ? rtbcb_sanitize_form_data( wp_unslash( $_POST['roi_inputs'] ) )
-            : rtbcb_get_sample_inputs();
-
-        $start         = microtime( true );
-        $roi           = RTBCB_Calculator::calculate_roi( $roi_inputs );
-        $recommendation = RTBCB_Category_Recommender::recommend_category( $roi_inputs );
-        $roi           = RTBCB_Calculator::calculate_category_refined_roi( $roi_inputs, $recommendation['category_info'] );
-        $elapsed       = round( microtime( true ) - $start, 2 );
-
-        if ( empty( $roi ) || is_wp_error( $roi ) ) {
-            wp_send_json_error( [ 'message' => __( 'Unable to calculate ROI.', 'rtbcb' ) ] );
-        }
-
-        wp_send_json_success(
-            [
-                'roi'       => $roi,
-                'word_count'=> 0,
-                'elapsed'   => $elapsed,
-                'generated' => current_time( 'mysql' ),
-            ]
-        );
-    }
-
-    /**
-     * AJAX handler for data enrichment testing.
-     *
-     * @return void
-     */
-    public function ajax_test_data_enrichment() {
-        check_ajax_referer( 'rtbcb_test_data_enrichment', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        }
-
-        $inputs   = rtbcb_get_sample_inputs();
-        $roi_data = [
-            'base' => [
-                'labor_savings'        => 1000,
-                'fee_savings'          => 500,
-                'error_reduction'      => 250,
-                'total_annual_benefit' => 1750,
-                'roi_percentage'       => 150,
-                'assumptions'          => [],
-            ],
-        ];
-
-        $llm      = new RTBCB_LLM();
-        $analysis = $llm->generate_business_case( $inputs, $roi_data );
-
-        if ( is_wp_error( $analysis ) ) {
-            wp_send_json_error( [ 'message' => sanitize_text_field( $analysis->get_error_message() ) ] );
-        }
-
-        update_option( 'rtbcb_data_enrichment', $analysis );
-
-        wp_send_json_success( [ 'analysis' => $analysis ] );
-    }
-
-    /**
-     * AJAX handler for data storage testing.
-     *
-     * @return void
-     */
-    public function ajax_test_data_storage() {
-        check_ajax_referer( 'rtbcb_test_data_storage', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        }
-
-        RTBCB_DB::init();
-
-        $email   = 'test+' . wp_rand( 1000, 9999 ) . '@example.com';
-        $lead_id = RTBCB_Leads::save_lead(
-            [
-                'email'        => $email,
-                'company_size' => 'medium',
-                'industry'     => 'finance',
-            ]
-        );
-
-        if ( ! $lead_id ) {
-            wp_send_json_error( [ 'message' => __( 'Failed to save lead.', 'rtbcb' ) ] );
-        }
-
-        $lead = RTBCB_Leads::get_lead_by_email( $email );
-
-        if ( ! $lead ) {
-            wp_send_json_error( [ 'message' => __( 'Failed to retrieve lead.', 'rtbcb' ) ] );
-        }
-
-        update_option( 'rtbcb_data_storage', $lead );
-
-        wp_send_json_success(
-            [
-                'lead_id'    => intval( $lead_id ),
-                'lead_email' => sanitize_email( $lead['email'] ),
-            ]
-        );
-    }
-
-    /**
-     * AJAX handler for report assembly testing.
-     *
-     * @return void
-     */
-    public function ajax_test_report_assembly() {
-        check_ajax_referer( 'rtbcb_test_report_assembly', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        }
-
-        $summary = rtbcb_test_generate_executive_summary();
-
-        if ( is_wp_error( $summary ) ) {
-            wp_send_json_error( [ 'message' => $summary->get_error_message() ] );
-        }
-
-        $combined = $summary['strategic_positioning'] . ' ' .
-            implode( ' ', $summary['key_value_drivers'] ) . ' ' .
-            $summary['executive_recommendation'];
-        $word_count = str_word_count( wp_strip_all_tags( $combined ) );
-
-        wp_send_json_success(
-            [
-                'summary'   => $summary,
-                'word_count'=> $word_count,
-                'generated' => current_time( 'mysql' ),
-            ]
-        );
-    }
-
-    /**
-     * AJAX handler for tracking script testing.
-     *
-     * @return void
-     */
-    public function ajax_test_tracking_script() {
-        check_ajax_referer( 'rtbcb_test_tracking_script', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        }
-
-        update_option( 'rtbcb_tracking_script', [ 'verified' => true, 'timestamp' => current_time( 'mysql' ) ] );
-
-        $result   = [
-            'section'   => 'rtbcb-test-tracking-script',
-            'status'    => 'success',
-            'message'   => __( 'Tracking event captured.', 'rtbcb' ),
-            'timestamp' => current_time( 'mysql' ),
-        ];
-        $existing = get_option( 'rtbcb_test_results', [] );
-        $existing = is_array( $existing ) ? $existing : [];
-        array_unshift( $existing, $result );
-        $existing = array_slice( $existing, 0, 10 );
-        update_option( 'rtbcb_test_results', $existing );
-
-        wp_send_json_success( [ 'message' => __( 'Tracking event captured.', 'rtbcb' ) ] );
-    }
-
-    /**
-     * AJAX handler for follow-up email testing.
-     *
-     * @return void
-     */
-    public function ajax_test_follow_up_email() {
-        check_ajax_referer( 'rtbcb_test_follow_up_email', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        }
-
-        $queue   = get_option( 'rtbcb_follow_up_queue', [] );
-        $queue   = is_array( $queue ) ? $queue : [];
-        $email   = 'lead+' . wp_rand( 1000, 9999 ) . '@example.com';
-        $message = __( 'Thanks for reviewing your business case. Let us know if you have questions.', 'rtbcb' );
-
-        $entry = [
-            'email'     => sanitize_email( $email ),
-            'message'   => sanitize_text_field( $message ),
-            'queued_at' => current_time( 'mysql' ),
-        ];
-        $queue[] = $entry;
-        update_option( 'rtbcb_follow_up_queue', $queue );
-
-        $result   = [
-            'section'   => 'rtbcb-test-follow-up-email',
-            'status'    => 'success',
-            'message'   => __( 'Follow-up email queued.', 'rtbcb' ),
-            'timestamp' => current_time( 'mysql' ),
-        ];
-        $existing = get_option( 'rtbcb_test_results', [] );
-        $existing = is_array( $existing ) ? $existing : [];
-        array_unshift( $existing, $result );
-        $existing = array_slice( $existing, 0, 10 );
-        update_option( 'rtbcb_test_results', $existing );
-
-        wp_send_json_success( [ 'queue' => $queue ] );
-    }
-
-    /**
-     * Rebuild the RAG index.
-     *
-     * @return void
-     */
-    public function rebuild_rag_index() {
-        check_ajax_referer( 'rtbcb_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
-        }
-
-        if ( ! class_exists( 'RTBCB_RAG' ) ) {
-            wp_send_json_error( [ 'message' => __( 'RAG system not available.', 'rtbcb' ) ] );
-        }
-
-        try {
-            $rag = new RTBCB_RAG();
-            $rag->rebuild_index();
-        } catch ( Exception $e ) {
-            wp_send_json_error( [ 'message' => sanitize_text_field( $e->getMessage() ) ] );
-        }
-
-        wp_send_json_success( [ 'message' => __( 'RAG index rebuilt successfully.', 'rtbcb' ) ] );
-    }
-
-    /**
-     * Run integration diagnostics.
-     *
-     * @return void
-     */
-    public function run_integration_tests() {
-        check_ajax_referer( 'rtbcb_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
-        }
-
-        $results = RTBCB_Tests::run_integration_tests();
-
-        wp_send_json_success( $results );
-    }
-
-    /**
-     * AJAX handler to set company name for tests.
-     *
-     * @return void
-     */
-    public function ajax_set_test_company() {
-        check_ajax_referer( 'rtbcb_set_test_company', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
-        }
-
-        $company_name = isset( $_POST['company_name'] ) ? sanitize_text_field( wp_unslash( $_POST['company_name'] ) ) : '';
-        if ( '' === $company_name ) {
-            wp_send_json_error( [ 'message' => __( 'Invalid company name.', 'rtbcb' ) ], 400 );
-        }
-
-        try {
-            $existing     = rtbcb_get_current_company();
-            $company_data = [
-                'name'            => $company_name,
-                'summary'         => '',
-                'recommendations' => [],
-                'references'      => [],
-                'generated_at'    => '',
-                'focus_areas'     => array_map( 'sanitize_text_field', (array) ( $existing['focus_areas'] ?? [] ) ),
-                'industry'        => isset( $existing['industry'] ) ? sanitize_text_field( $existing['industry'] ) : '',
-                'size'            => isset( $existing['size'] ) ? sanitize_text_field( $existing['size'] ) : '',
-                'revenue'         => 0,
-                'staff_count'     => 0,
-                'efficiency'      => 0,
-            ];
-
-            update_option( 'rtbcb_current_company', $company_data );
-
-            $stored = get_option( 'rtbcb_company_data', [] );
-            if ( ! is_array( $stored ) ) {
-                $stored = [];
-            }
-            $stored['name'] = $company_name;
-            update_option( 'rtbcb_company_data', $stored );
-
-            delete_option( 'rtbcb_test_results' );
-
-            wp_send_json_success(
-                [
-                    'message' => __( 'Company saved. Generating overview...', 'rtbcb' ),
-                    'name'    => $company_name,
-                ]
-            );
-        } catch ( Exception $e ) {
-            error_log( 'RTBCB Set Test Company Error: ' . $e->getMessage() );
-            wp_send_json_error(
-                [
-                    'message' => __( 'An error occurred while saving company data.', 'rtbcb' ),
-                ]
-            );
-        }
-    }
-
-    /**
-     * AJAX handler to test Portal integration.
-     *
-     * @return void
-     */
-    public function ajax_test_portal() {
-        check_ajax_referer( 'rtbcb_test_portal', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );
-        }
-
-        if ( ! $this->check_portal_integration() ) {
-            wp_send_json_error( [ 'message' => __( 'Portal integration not active.', 'rtbcb' ) ] );
-        }
-
-        $vendor_count = $this->get_vendor_count();
-
-        wp_send_json_success( [ 'vendor_count' => intval( $vendor_count ) ] );
-    }
-
-    /**
-     * AJAX handler to test RAG index health.
-     *
-     * @return void
-     */
-    public function ajax_test_rag() {
-        check_ajax_referer( 'rtbcb_test_rag', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );
-        }
-
-        $health = $this->check_rag_health();
-
-        if ( 'healthy' !== ( $health['status'] ?? '' ) ) {
-            $message = isset( $health['message'] ) ? sanitize_text_field( $health['message'] ) : __( 'RAG index needs attention.', 'rtbcb' );
-            wp_send_json_error(
-                [
-                    'status'  => sanitize_text_field( $health['status'] ?? '' ),
-                    'message' => $message,
-                ]
-            );
-        }
-
-        wp_send_json_success(
-            [
-                'status'        => 'healthy',
-                'indexed_items' => isset( $health['indexed_items'] ) ? intval( $health['indexed_items'] ) : 0,
-                'last_updated'  => isset( $health['last_updated'] ) ? sanitize_text_field( $health['last_updated'] ) : '',
-            ]
-        );
-    }
-
-    /**
-     * Sync portal data to the local site.
-     *
-     * @return void
-     */
-    public function sync_to_local() {
-        check_ajax_referer( 'rtbcb_sync_local', 'nonce' );
-
-        if ( is_user_logged_in() && ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
-        }
-
-        wp_send_json_success( [ 'message' => __( 'Data synchronized.', 'rtbcb' ) ] );
-    }
-
-    /**
-     * Get monthly trends data.
-     *
-     * @return array Monthly trends.
-     */
-    private function get_monthly_trends() {
-        global $wpdb;
-        $table_name = $wpdb->prefix . 'rtbcb_leads';
-
-        $results = $wpdb->get_results(
-            "SELECT 
-                DATE_FORMAT(created_at, '%Y-%m') as month,
-                COUNT(*) as leads,
-                AVG(roi_base) as avg_roi
-             FROM {$table_name} 
-             WHERE created_at >= DATE_SUB(NOW(), INTERVAL 12 MONTH)
-             GROUP BY DATE_FORMAT(created_at, '%Y-%m')
-             ORDER BY month",
-            ARRAY_A
-        );
-
-        return $results ?: [];
-    }
-
-    /**
-     * Check if Portal integration is active.
-     *
-     * @return bool
-     */
-    private function check_portal_integration() {
-        return (bool) ( has_filter( 'rt_portal_get_vendors' ) || has_filter( 'rt_portal_get_vendor_notes' ) );
-    }
-
-    /**
-     * Get vendor count from portal.
-     *
-     * @return int
-     */
-    private function get_vendor_count() {
-        $vendors = apply_filters( 'rt_portal_get_vendors', [] );
-        return is_array( $vendors ) ? count( $vendors ) : 0;
-    }
-
-    /**
-     * Check RAG index health.
-     *
-     * @return array Health status.
-     */
-    private function check_rag_health() {
-        global $wpdb;
-        $table_name = $wpdb->prefix . 'rtbcb_rag_index';
-
-        $table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
-        if ( $table_exists !== $table_name ) {
-            return [
-                'status'        => 'missing',
-                'message'       => __( 'RAG index table missing. Use the rebuild button to create it.', 'rtbcb' ),
-                'indexed_items' => 0,
-                'last_updated'  => '',
-            ];
-        }
-
-        $count       = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table_name}" );
-        $last_updated = $wpdb->get_var( "SELECT MAX(updated_at) FROM {$table_name}" );
-
-        if ( $wpdb->last_error ) {
-            return [
-                'status'  => 'error',
-                'message' => sprintf( __( 'Database error: %s', 'rtbcb' ), $wpdb->last_error ),
-            ];
-        }
-
-        if ( 0 === $count ) {
-            return [
-                'status'        => 'empty',
-                'message'       => __( 'RAG index is empty. Rebuild the index to add data.', 'rtbcb' ),
-                'indexed_items' => 0,
-                'last_updated'  => $last_updated,
-            ];
-        }
-
-        return [
-            'status'        => 'healthy',
-            'indexed_items' => $count,
-            'last_updated'  => $last_updated,
-        ];
-    }
-
-    /**
-     * AJAX handler to fetch phase completion percentages.
-     *
-     * @return void
-     */
-    public function ajax_get_phase_completion() {
-        check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
-
-        $test_results = get_option( 'rtbcb_test_results', [] );
-        $sections     = rtbcb_get_dashboard_sections( $test_results );
-        $percentages  = rtbcb_calculate_phase_completion( $sections );
-
-        wp_send_json_success( [ 'percentages' => $percentages ] );
-    }
-
-    /**
-     * AJAX handler to fetch sanitized configuration for a section.
-     *
-     * @return void
-     */
-    public function ajax_get_section_config() {
-        check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
-
-        $section_id = isset( $_POST['section'] ) ? sanitize_key( wp_unslash( $_POST['section'] ) ) : '';
-        if ( '' === $section_id ) {
-            wp_send_json_error( [ 'message' => __( 'Invalid section.', 'rtbcb' ) ] );
-        }
-
-        $sections = rtbcb_get_dashboard_sections();
-        if ( ! isset( $sections[ $section_id ]['option'] ) ) {
-            wp_send_json_error( [ 'message' => __( 'Unknown section.', 'rtbcb' ) ] );
-        }
-
-        $option_name = sanitize_key( $sections[ $section_id ]['option'] );
-        $raw         = get_option( $option_name, [] );
-        $sanitized   = $this->sanitize_section_config( $raw );
-        $snippet     = wp_json_encode( $sanitized );
-        if ( strlen( $snippet ) > 200 ) {
-            $snippet = substr( $snippet, 0, 200 ) . '...';
-        }
-
-        wp_send_json_success( [ 'config' => $snippet ] );
-    }
-
-    /**
-     * AJAX handler to build test summary HTML.
-     *
-     * @return void
-     */
-    public function ajax_get_test_summary_html() {
-        check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );
-        }
-
-        $test_results = get_option( 'rtbcb_test_results', [] );
-        if ( empty( $test_results ) ) {
-            wp_send_json_error( [ 'message' => __( 'No test results found.', 'rtbcb' ) ] );
-        }
-
-        ob_start();
-        echo '<div class="rtbcb-summary-panel">';
-        echo '<table class="rtbcb-summary-table">';
-        echo '<thead><tr>';
-        echo '<th>' . esc_html__( 'Section', 'rtbcb' ) . '</th>';
-        echo '<th>' . esc_html__( 'Status', 'rtbcb' ) . '</th>';
-        echo '<th>' . esc_html__( 'Message', 'rtbcb' ) . '</th>';
-        echo '<th>' . esc_html__( 'Duration', 'rtbcb' ) . '</th>';
-        echo '<th>' . esc_html__( 'Finished', 'rtbcb' ) . '</th>';
-        echo '</tr></thead><tbody>';
-
-        foreach ( $test_results as $result ) {
-            $section  = isset( $result['section'] ) ? $result['section'] : '';
-            $status   = isset( $result['status'] ) ? $result['status'] : '';
-            $message  = isset( $result['message'] ) ? $result['message'] : '';
-            $duration = isset( $result['duration'] ) ? $result['duration'] : '';
-            $end_time = isset( $result['end_time'] ) ? $result['end_time'] : '';
-
-            echo '<tr>';
-            echo '<td>' . esc_html( $section ) . '</td>';
-            echo '<td>' . esc_html( $status ) . '</td>';
-            echo '<td>' . esc_html( $message ) . '</td>';
-            echo '<td>' . esc_html( $duration ) . '</td>';
-            echo '<td>' . esc_html( $end_time ) . '</td>';
-            echo '</tr>';
-        }
-
-        echo '</tbody></table></div>';
-
-        $html = ob_get_clean();
-
-        wp_send_json_success( [ 'html' => $html ] );
-    }
-
-    /**
-     * Recursively sanitize configuration data.
-     *
-     * @param mixed $data Configuration value.
-     * @return mixed
-     */
-    private function sanitize_section_config( $data ) {
-        if ( is_array( $data ) ) {
-            $clean = [];
-            foreach ( $data as $key => $value ) {
-                $clean[ sanitize_key( $key ) ] = $this->sanitize_section_config( $value );
-            }
-            return $clean;
-        }
-
-        if ( is_scalar( $data ) ) {
-            return sanitize_text_field( (string) $data );
-        }
-
-        return '';
-    }
-
-    /**
-     * AJAX handler to generate comprehensive analysis.
-     *
-     * @return void
-     */
-    public function ajax_generate_comprehensive_analysis() {
-        check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
-        $company_name = isset( $_POST['company_name'] ) ? sanitize_text_field( wp_unslash( $_POST['company_name'] ) ) : '';
-        if ( '' === $company_name ) {
-            $stored       = get_option( 'rtbcb_company_data', [] );
-            $company_name = isset( $stored['name'] ) ? sanitize_text_field( $stored['name'] ) : '';
-        }
-
-        if ( '' === $company_name ) {
-            wp_send_json_error( [ 'message' => __( 'Company name is required.', 'rtbcb' ) ] );
-        }
-
-        $job_id = rtbcb_queue_comprehensive_analysis( $company_name );
-        if ( is_wp_error( $job_id ) ) {
-            wp_send_json_error( [ 'message' => $job_id->get_error_message() ] );
-        }
-
-        wp_send_json_success( [ 'job_id' => $job_id ] );
-    }
-
-    /**
-     * Get status for a queued comprehensive analysis job.
-     *
-     * @return void
-     */
-    public function ajax_get_analysis_status() {
-        check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
-
-        $job_id = isset( $_GET['job_id'] ) ? sanitize_key( wp_unslash( $_GET['job_id'] ) ) : '';
-        if ( '' === $job_id ) {
-            wp_send_json_error( [ 'message' => __( 'Job ID is required.', 'rtbcb' ) ] );
-        }
-
-        $result = rtbcb_get_analysis_job_result( $job_id );
-        if ( null === $result ) {
-            wp_send_json_success( [ 'status' => 'pending' ] );
-        }
-
-        if ( empty( $result['success'] ) ) {
-            wp_send_json_error( [ 'message' => $result['message'] ?? __( 'Unknown error.', 'rtbcb' ) ] );
-        }
-
-        wp_send_json_success( array_merge( [ 'status' => 'completed' ], $result ) );
-    }
-
-    /**
-     * Clear stored comprehensive analysis data.
-     *
-     * @return void
-     */
-    public function ajax_clear_analysis_data() {
-        check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
-
-        $options = [
-            'rtbcb_current_company',
-            'rtbcb_industry_insights',
-            'rtbcb_maturity_model',
-            'rtbcb_rag_market_analysis',
-            'rtbcb_value_proposition',
-            'rtbcb_estimated_benefits',
-            'rtbcb_executive_summary',
-            'rtbcb_roadmap_plan',
-        ];
-
-        foreach ( $options as $opt ) {
-            delete_option( $opt );
-        }
-
-        wp_send_json_success( [ 'message' => __( 'Stored analysis data cleared.', 'rtbcb' ) ] );
-    }
-
-    /**
-     * AJAX handler for deleting a single log entry.
-     *
-     * @return void
-     */
-    public function ajax_delete_log() {
-        check_ajax_referer( 'rtbcb_api_logs', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );
-        }
-
-        $id = isset( $_POST['id'] ) ? intval( $_POST['id'] ) : 0;
-        if ( $id <= 0 ) {
-            wp_send_json_error( [ 'message' => __( 'Invalid log ID.', 'rtbcb' ) ] );
-        }
-
-        $deleted = RTBCB_API_Log::delete_log( $id );
-
-        if ( $deleted ) {
-            wp_send_json_success();
-        }
-
-        wp_send_json_error( [ 'message' => __( 'Failed to delete log.', 'rtbcb' ) ] );
-    }
-
-    /**
-     * AJAX handler for clearing all log entries.
-     *
-     * @return void
-     */
-    public function ajax_clear_logs() {
-        check_ajax_referer( 'rtbcb_api_logs', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );
-        }
-
-        RTBCB_API_Log::clear_logs();
-
-        wp_send_json_success();
-    }
-
-    public function render_workflow_visualizer() {
-            include RTBCB_DIR . 'admin/workflow-visualizer-page.php';
-    }
+		}
+
+		$result = RTBCB_API_Tester::test_connection();
+
+		if ( $result['success'] ) {
+			wp_send_json_success( $result );
+		}
+
+		wp_send_json_error( $result );
+	}
+
+	/**
+	 * AJAX handler for industry commentary testing.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_commentary() {
+		check_ajax_referer( 'rtbcb_test_commentary', 'nonce' );
+
+		$industry = isset( $_POST['industry'] ) ? sanitize_text_field( wp_unslash( $_POST['industry'] ) ) : '';
+
+		if ( empty( $industry ) ) {
+			wp_send_json_error( [ 'message' => __( 'Invalid industry.', 'rtbcb' ) ] );
+		}
+
+		$start      = microtime( true );
+		$commentary = rtbcb_test_generate_industry_commentary( $industry );
+		$elapsed    = round( microtime( true ) - $start, 2 );
+
+		if ( is_wp_error( $commentary ) ) {
+			wp_send_json_error( [ 'message' => sanitize_text_field( $commentary->get_error_message() ) ] );
+		}
+
+		$word_count = str_word_count( $commentary );
+
+		wp_send_json_success(
+			[
+				'commentary' => sanitize_textarea_field( $commentary ),
+				'word_count' => $word_count,
+				'elapsed'    => $elapsed,
+				'generated'  => current_time( 'mysql' ),
+			]
+		);
+	}
+
+	/**
+	 * AJAX handler for company overview testing.
+	 *
+	 * Retrieves the company name from the request, stored options, or the
+	 * currently selected company. Returns an error only if no name can be
+	 * determined.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_company_overview() {
+		check_ajax_referer( 'rtbcb_test_company_overview', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+		}
+
+		$company_name = isset( $_POST['company_name'] ) ?
+			sanitize_text_field( wp_unslash( $_POST['company_name'] ) ) : '';
+
+		if ( '' === $company_name ) {
+			$stored_data = get_option( 'rtbcb_company_data', [] );
+			if ( is_array( $stored_data ) && ! empty( $stored_data['name'] ) ) {
+				$company_name = sanitize_text_field( $stored_data['name'] );
+			}
+		}
+
+		if ( '' === $company_name ) {
+			$current_company = rtbcb_get_current_company();
+			if ( is_array( $current_company ) && ! empty( $current_company['name'] ) ) {
+				$company_name = sanitize_text_field( $current_company['name'] );
+			}
+		}
+
+		if ( '' === $company_name ) {
+			wp_send_json_error( [ 'message' => __( 'Company name is required.', 'rtbcb' ) ] );
+		}
+
+		$start_time = microtime( true );
+
+		try {
+			$overview = rtbcb_test_generate_company_overview( $company_name );
+
+			if ( is_wp_error( $overview ) ) {
+				wp_send_json_error( [
+					'message' => $overview->get_error_message(),
+				] );
+			}
+
+			$analysis        = $overview['analysis'] ?? '';
+			$recommendations = array_map( 'sanitize_text_field', $overview['recommendations'] ?? [] );
+			$references      = array_map( 'esc_url_raw', $overview['references'] ?? [] );
+			$metrics         = is_array( $overview['metrics'] ?? null ) ? $overview['metrics'] : [];
+			$revenue         = floatval( $metrics['revenue'] ?? 0 );
+			$staff_count     = intval( $metrics['staff_count'] ?? 0 );
+			$efficiency      = floatval( $metrics['baseline_efficiency'] ?? 0 );
+
+			$word_count   = str_word_count( wp_strip_all_tags( $analysis ) );
+			$elapsed_time = microtime( true ) - $start_time;
+
+			$existing = rtbcb_get_current_company();
+			$company_data = [
+				'name'            => $company_name,
+				'summary'         => sanitize_textarea_field( wp_strip_all_tags( $analysis ) ),
+				'recommendations' => $recommendations,
+				'references'      => $references,
+				'generated_at'    => current_time( 'mysql' ),
+				'focus_areas'     => array_map( 'sanitize_text_field', (array) ( $existing['focus_areas'] ?? [] ) ),
+				'industry'        => isset( $existing['industry'] ) ? sanitize_text_field( $existing['industry'] ) : '',
+				'size'            => isset( $existing['size'] ) ? sanitize_text_field( $existing['size'] ) : '',
+				'revenue'         => $revenue,
+				'staff_count'     => $staff_count,
+				'efficiency'      => $efficiency,
+			];
+
+			update_option( 'rtbcb_current_company', $company_data );
+			$stored = get_option( 'rtbcb_company_data', [] );
+			if ( ! is_array( $stored ) ) {
+				$stored = [];
+			}
+			$stored['name']        = $company_name;
+			$stored['revenue']     = $revenue;
+			$stored['staff_count'] = $staff_count;
+			$stored['efficiency']  = $efficiency;
+			update_option( 'rtbcb_company_data', $stored );
+
+			wp_send_json_success(
+				[
+					'message'         => __( 'Company overview generated.', 'rtbcb' ),
+					'overview'        => wp_kses_post( $analysis ),
+					'word_count'      => $word_count,
+					'elapsed'         => round( $elapsed_time, 2 ),
+					'generated'       => current_time( 'mysql' ),
+					'recommendations' => $recommendations,
+					'references'      => $references,
+					'focus_areas'     => $company_data['focus_areas'],
+					'industry'        => $company_data['industry'],
+					'size'            => $company_data['size'],
+					'metrics'         => [
+						'revenue'     => $revenue,
+						'staff_count' => $staff_count,
+						'efficiency'  => $efficiency,
+					],
+				]
+			);
+
+		} catch ( Exception $e ) {
+			error_log( 'RTBCB Company Overview Error: ' . $e->getMessage() );
+			wp_send_json_error( [
+				'message' => __( 'An error occurred while generating the overview.', 'rtbcb' ),
+			] );
+		}
+	}
+
+	/**
+	 * AJAX handler for industry overview testing.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_industry_overview() {
+		check_ajax_referer( 'rtbcb_test_industry_overview', 'nonce' );
+		$raw_data     = isset( $_POST['company_data'] ) ? wp_unslash( $_POST['company_data'] ) : '';
+		$company_data = json_decode( $raw_data, true );
+
+		if ( empty( $company_data ) || ! is_array( $company_data ) ) {
+			$company_data = rtbcb_get_current_company();
+
+			if ( empty( $company_data ) || ! is_array( $company_data ) ) {
+				wp_send_json_error( [ 'message' => __( 'Invalid company data.', 'rtbcb' ) ] );
+			}
+		}
+
+		$start    = microtime( true );
+		$overview = rtbcb_test_generate_industry_overview( $company_data );
+		$elapsed  = round( microtime( true ) - $start, 2 );
+
+		if ( is_wp_error( $overview ) ) {
+			wp_send_json_error( [ 'message' => sanitize_text_field( $overview->get_error_message() ) ] );
+		}
+
+		$word_count = str_word_count( $overview );
+
+		wp_send_json_success(
+			[
+				'overview'   => sanitize_textarea_field( $overview ),
+				'word_count' => $word_count,
+				'elapsed'    => $elapsed,
+				'generated'  => current_time( 'mysql' ),
+			]
+		);
+	}
+
+	/**
+	 * AJAX handler for maturity model testing.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_maturity_model() {
+		check_ajax_referer( 'rtbcb_test_maturity_model', 'nonce' );
+
+		$company = rtbcb_get_current_company();
+		$result  = rtbcb_test_generate_maturity_model( $company );
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( [ 'message' => $result->get_error_message() ] );
+		}
+
+		update_option( 'rtbcb_maturity_model', $result['narrative'] );
+
+		wp_send_json_success(
+			[
+				'assessment' => sanitize_textarea_field( $result['narrative'] ),
+				'level'      => sanitize_text_field( $result['level'] ),
+				'generated'  => current_time( 'mysql' ),
+				'word_count' => str_word_count( $result['narrative'] ),
+			]
+		);
+	}
+
+	/**
+	 * AJAX handler for RAG market analysis testing.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_rag_market_analysis() {
+		check_ajax_referer( 'rtbcb_test_rag_market_analysis', 'nonce' );
+
+		$company = rtbcb_get_current_company();
+		$terms   = [];
+
+		if ( ! empty( $company['industry'] ) ) {
+			$terms[] = sanitize_text_field( $company['industry'] );
+		}
+
+		if ( ! empty( $company['focus_areas'] ) && is_array( $company['focus_areas'] ) ) {
+			$terms = array_merge( $terms, array_map( 'sanitize_text_field', $company['focus_areas'] ) );
+		}
+
+		if ( empty( $terms ) && ! empty( $company['summary'] ) ) {
+			$terms[] = sanitize_text_field( wp_trim_words( $company['summary'], 5, '' ) );
+		}
+
+		if ( empty( $terms ) ) {
+			wp_send_json_error( [ 'message' => __( 'Company data required for query.', 'rtbcb' ) ] );
+		}
+
+		$query   = sanitize_text_field( implode( ' ', $terms ) );
+		$vendors = rtbcb_test_rag_market_analysis( $query );
+		if ( is_wp_error( $vendors ) ) {
+			wp_send_json_error( [ 'message' => $vendors->get_error_message() ] );
+		}
+
+		update_option( 'rtbcb_rag_market_analysis', $vendors );
+
+		wp_send_json_success(
+			[
+				'vendors'   => array_map( 'sanitize_text_field', $vendors ),
+				'generated' => current_time( 'mysql' ),
+			]
+		);
+	}
+
+	/**
+	 * AJAX handler for value proposition testing.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_value_proposition() {
+		check_ajax_referer( 'rtbcb_test_value_proposition', 'nonce' );
+
+		$company = rtbcb_get_current_company();
+		$paragraph = rtbcb_test_generate_value_proposition( $company );
+		if ( is_wp_error( $paragraph ) ) {
+			wp_send_json_error( [ 'message' => $paragraph->get_error_message() ] );
+		}
+
+		update_option( 'rtbcb_value_proposition', $paragraph );
+
+		wp_send_json_success(
+			[
+				'paragraph' => sanitize_textarea_field( $paragraph ),
+				'word_count'=> str_word_count( $paragraph ),
+				'generated' => current_time( 'mysql' ),
+			]
+		);
+	}
+
+	/**
+	 * AJAX handler for treasury tech overview testing.
+	 *
+	 * @return void
+	 */
+	/**
+	 * AJAX handler for real treasury overview testing.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_real_treasury_overview() {
+		check_ajax_referer( 'rtbcb_test_real_treasury_overview', 'nonce' );
+		
+		$include_portal = isset( $_POST['include_portal'] ) ? (bool) intval( wp_unslash( $_POST['include_portal'] ) ) : false;
+		$categories     = isset( $_POST['categories'] ) ? (array) wp_unslash( $_POST['categories'] ) : [];
+		$categories     = array_filter( array_map( 'sanitize_text_field', $categories ) );
+
+		$inputs     = rtbcb_get_sample_inputs();
+		$challenges = array_map( 'sanitize_text_field', $inputs['pain_points'] ?? [] );
+
+		$company = rtbcb_get_current_company();
+		if ( ! is_array( $company ) ) {
+			$company = [];
+		}
+
+		if ( ! empty( $challenges ) ) {
+			$existing_challenges   = isset( $company['challenges'] ) ? (array) $company['challenges'] : [];
+			$merged_challenges     = array_values( array_unique( array_merge( $existing_challenges, $challenges ) ) );
+			$company['challenges'] = array_filter( array_map( 'sanitize_text_field', $merged_challenges ) );
+		}
+
+		if ( ! empty( $categories ) ) {
+			$existing_categories   = isset( $company['categories'] ) ? (array) $company['categories'] : [];
+			$merged_categories     = array_values( array_unique( array_merge( $existing_categories, $categories ) ) );
+			$company['categories'] = array_filter( array_map( 'sanitize_text_field', $merged_categories ) );
+		}
+
+		update_option( 'rtbcb_current_company', $company );
+
+		$start    = microtime( true );
+		$overview = rtbcb_test_generate_real_treasury_overview( $include_portal, $categories );
+		$elapsed  = round( microtime( true ) - $start, 2 );
+
+		if ( is_wp_error( $overview ) ) {
+			wp_send_json_error( [ 'message' => sanitize_text_field( $overview->get_error_message() ) ] );
+		}
+
+		$word_count = str_word_count( $overview );
+
+		wp_send_json_success(
+			[
+				'overview'   => sanitize_textarea_field( $overview ),
+				'word_count' => $word_count,
+				'elapsed'    => $elapsed,
+				'generated'  => current_time( 'mysql' ),
+			]
+		);
+	}
+
+	/**
+	 * AJAX handler to retrieve stored company data.
+	 *
+	 * @return void
+	 */
+	public function ajax_get_company_data() {
+		check_ajax_referer( 'rtbcb_test_real_treasury_overview', 'nonce' );
+
+		$inputs  = rtbcb_get_sample_inputs();
+		$summary = rtbcb_test_generate_company_overview( $inputs['company_name'] );
+		if ( is_wp_error( $summary ) ) {
+			wp_send_json_error( [ 'message' => sanitize_text_field( $summary->get_error_message() ) ] );
+		}
+
+		$analysis        = $summary['analysis'] ?? '';
+		$recommendations = array_map( 'sanitize_text_field', $summary['recommendations'] ?? [] );
+		$references      = array_map( 'esc_url_raw', $summary['references'] ?? [] );
+
+		wp_send_json_success(
+			[
+				'summary'        => sanitize_textarea_field( $analysis ),
+				'recommendations'=> $recommendations,
+				'references'     => $references,
+				'challenges'     => array_map( 'sanitize_text_field', $inputs['pain_points'] ?? [] ),
+			]
+		);
+	}
+
+	/**
+	 * AJAX handler for testing estimated benefits.
+	 *
+	 * @return void
+	 */
+	/**
+	 * AJAX handler to generate estimated benefits.
+	 *
+	 * Stores sanitized results to mark the section complete.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_estimated_benefits() {
+		check_ajax_referer( 'rtbcb_test_estimated_benefits', 'nonce' );
+
+		$company_data = [];
+
+		if ( isset( $_POST['company_data'] ) && is_array( $_POST['company_data'] ) ) {
+			$company_data = [
+				'revenue'     => isset( $_POST['company_data']['revenue'] ) ? floatval( wp_unslash( $_POST['company_data']['revenue'] ) ) : 0,
+				'staff_count' => isset( $_POST['company_data']['staff_count'] ) ? intval( wp_unslash( $_POST['company_data']['staff_count'] ) ) : 0,
+				'efficiency'  => isset( $_POST['company_data']['efficiency'] ) ? floatval( wp_unslash( $_POST['company_data']['efficiency'] ) ) : 0,
+			];
+		}
+
+		if ( empty( $company_data ) && function_exists( 'rtbcb_get_current_company' ) ) {
+			$current = rtbcb_get_current_company();
+			if ( is_array( $current ) ) {
+				$company_data = [
+					'revenue'     => isset( $current['revenue'] ) ? floatval( $current['revenue'] ) : 0,
+					'staff_count' => isset( $current['staff_count'] ) ? intval( $current['staff_count'] ) : 0,
+					'efficiency'  => isset( $current['efficiency'] ) ? floatval( $current['efficiency'] ) : 0,
+				];
+			}
+		}
+
+		$category = isset( $_POST['recommended_category'] ) ? sanitize_text_field( wp_unslash( $_POST['recommended_category'] ) ) : '';
+		if ( empty( $category ) ) {
+			$stored_category = get_option( 'rtbcb_last_recommended_category', '' );
+			if ( ! empty( $stored_category ) ) {
+				$category = sanitize_text_field( $stored_category );
+			}
+		}
+
+		if ( empty( $company_data ) ) {
+			wp_send_json_error( [ 'message' => __( 'Company data is required to estimate benefits.', 'rtbcb' ) ] );
+		}
+
+		if ( empty( $category ) ) {
+			wp_send_json_error( [ 'message' => __( 'Recommended category is required to estimate benefits.', 'rtbcb' ) ] );
+		}
+
+		$estimate = rtbcb_test_generate_benefits_estimate( $company_data, $category );
+
+		if ( is_wp_error( $estimate ) ) {
+			wp_send_json_error( [ 'message' => sanitize_text_field( $estimate->get_error_message() ) ] );
+		}
+
+		$sanitize_recursive = function ( $data ) use ( &$sanitize_recursive ) {
+			$sanitized = [];
+			foreach ( (array) $data as $key => $value ) {
+				$clean_key = sanitize_key( $key );
+				if ( is_array( $value ) ) {
+					$sanitized[ $clean_key ] = $sanitize_recursive( $value );
+				} elseif ( is_numeric( $value ) ) {
+					$sanitized[ $clean_key ] = floatval( $value );
+				} else {
+					$sanitized[ $clean_key ] = sanitize_text_field( $value );
+				}
+			}
+
+			return $sanitized;
+		};
+
+		$sanitized_estimate = $sanitize_recursive( $estimate );
+		update_option( 'rtbcb_estimated_benefits', $sanitized_estimate );
+
+		wp_send_json_success( [ 'estimate' => $sanitized_estimate ] );
+	}
+
+	/**
+	 * AJAX handler to calculate ROI from sample inputs.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_calculate_roi() {
+		check_ajax_referer( 'rtbcb_test_calculate_roi', 'nonce' );
+
+		$roi_inputs = isset( $_POST['roi_inputs'] ) && is_array( $_POST['roi_inputs'] )
+			? rtbcb_sanitize_form_data( wp_unslash( $_POST['roi_inputs'] ) )
+			: rtbcb_get_sample_inputs();
+
+		$start         = microtime( true );
+		$roi           = RTBCB_Calculator::calculate_roi( $roi_inputs );
+		$recommendation = RTBCB_Category_Recommender::recommend_category( $roi_inputs );
+		$roi           = RTBCB_Calculator::calculate_category_refined_roi( $roi_inputs, $recommendation['category_info'] );
+		$elapsed       = round( microtime( true ) - $start, 2 );
+
+		if ( empty( $roi ) || is_wp_error( $roi ) ) {
+			wp_send_json_error( [ 'message' => __( 'Unable to calculate ROI.', 'rtbcb' ) ] );
+		}
+
+		wp_send_json_success(
+			[
+				'roi'       => $roi,
+				'word_count'=> 0,
+				'elapsed'   => $elapsed,
+				'generated' => current_time( 'mysql' ),
+			]
+		);
+	}
+
+	/**
+	 * AJAX handler for data enrichment testing.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_data_enrichment() {
+		check_ajax_referer( 'rtbcb_test_data_enrichment', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+		}
+
+		$inputs   = rtbcb_get_sample_inputs();
+		$roi_data = [
+			'base' => [
+				'labor_savings'        => 1000,
+				'fee_savings'          => 500,
+				'error_reduction'      => 250,
+				'total_annual_benefit' => 1750,
+				'roi_percentage'       => 150,
+				'assumptions'          => [],
+			],
+		];
+
+		$llm      = new RTBCB_LLM();
+		$analysis = $llm->generate_business_case( $inputs, $roi_data );
+
+		if ( is_wp_error( $analysis ) ) {
+			wp_send_json_error( [ 'message' => sanitize_text_field( $analysis->get_error_message() ) ] );
+		}
+
+		update_option( 'rtbcb_data_enrichment', $analysis );
+
+		wp_send_json_success( [ 'analysis' => $analysis ] );
+	}
+
+	/**
+	 * AJAX handler for data storage testing.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_data_storage() {
+		check_ajax_referer( 'rtbcb_test_data_storage', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+		}
+
+		RTBCB_DB::init();
+
+		$email   = 'test+' . wp_rand( 1000, 9999 ) . '@example.com';
+		$lead_id = RTBCB_Leads::save_lead(
+			[
+				'email'        => $email,
+				'company_size' => 'medium',
+				'industry'     => 'finance',
+			]
+		);
+
+		if ( ! $lead_id ) {
+			wp_send_json_error( [ 'message' => __( 'Failed to save lead.', 'rtbcb' ) ] );
+		}
+
+		$lead = RTBCB_Leads::get_lead_by_email( $email );
+
+		if ( ! $lead ) {
+			wp_send_json_error( [ 'message' => __( 'Failed to retrieve lead.', 'rtbcb' ) ] );
+		}
+
+		update_option( 'rtbcb_data_storage', $lead );
+
+		wp_send_json_success(
+			[
+				'lead_id'    => intval( $lead_id ),
+				'lead_email' => sanitize_email( $lead['email'] ),
+			]
+		);
+	}
+
+	/**
+	 * AJAX handler for report assembly testing.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_report_assembly() {
+		check_ajax_referer( 'rtbcb_test_report_assembly', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+		}
+
+		$summary = rtbcb_test_generate_executive_summary();
+
+		if ( is_wp_error( $summary ) ) {
+			wp_send_json_error( [ 'message' => $summary->get_error_message() ] );
+		}
+
+		$combined = $summary['strategic_positioning'] . ' ' .
+			implode( ' ', $summary['key_value_drivers'] ) . ' ' .
+			$summary['executive_recommendation'];
+		$word_count = str_word_count( wp_strip_all_tags( $combined ) );
+
+		wp_send_json_success(
+			[
+				'summary'   => $summary,
+				'word_count'=> $word_count,
+				'generated' => current_time( 'mysql' ),
+			]
+		);
+	}
+
+	/**
+	 * AJAX handler for tracking script testing.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_tracking_script() {
+		check_ajax_referer( 'rtbcb_test_tracking_script', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+		}
+
+		update_option( 'rtbcb_tracking_script', [ 'verified' => true, 'timestamp' => current_time( 'mysql' ) ] );
+
+		$result   = [
+			'section'   => 'rtbcb-test-tracking-script',
+			'status'    => 'success',
+			'message'   => __( 'Tracking event captured.', 'rtbcb' ),
+			'timestamp' => current_time( 'mysql' ),
+		];
+		$existing = get_option( 'rtbcb_test_results', [] );
+		$existing = is_array( $existing ) ? $existing : [];
+		array_unshift( $existing, $result );
+		$existing = array_slice( $existing, 0, 10 );
+		update_option( 'rtbcb_test_results', $existing );
+
+		wp_send_json_success( [ 'message' => __( 'Tracking event captured.', 'rtbcb' ) ] );
+	}
+
+	/**
+	 * AJAX handler for follow-up email testing.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_follow_up_email() {
+		check_ajax_referer( 'rtbcb_test_follow_up_email', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+		}
+
+		$queue   = get_option( 'rtbcb_follow_up_queue', [] );
+		$queue   = is_array( $queue ) ? $queue : [];
+		$email   = 'lead+' . wp_rand( 1000, 9999 ) . '@example.com';
+		$message = __( 'Thanks for reviewing your business case. Let us know if you have questions.', 'rtbcb' );
+
+		$entry = [
+			'email'     => sanitize_email( $email ),
+			'message'   => sanitize_text_field( $message ),
+			'queued_at' => current_time( 'mysql' ),
+		];
+		$queue[] = $entry;
+		update_option( 'rtbcb_follow_up_queue', $queue );
+
+		$result   = [
+			'section'   => 'rtbcb-test-follow-up-email',
+			'status'    => 'success',
+			'message'   => __( 'Follow-up email queued.', 'rtbcb' ),
+			'timestamp' => current_time( 'mysql' ),
+		];
+		$existing = get_option( 'rtbcb_test_results', [] );
+		$existing = is_array( $existing ) ? $existing : [];
+		array_unshift( $existing, $result );
+		$existing = array_slice( $existing, 0, 10 );
+		update_option( 'rtbcb_test_results', $existing );
+
+		wp_send_json_success( [ 'queue' => $queue ] );
+	}
+
+	/**
+	 * Rebuild the RAG index.
+	 *
+	 * @return void
+	 */
+	public function rebuild_rag_index() {
+		check_ajax_referer( 'rtbcb_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
+		}
+
+		if ( ! class_exists( 'RTBCB_RAG' ) ) {
+			wp_send_json_error( [ 'message' => __( 'RAG system not available.', 'rtbcb' ) ] );
+		}
+
+		try {
+			$rag = new RTBCB_RAG();
+			$rag->rebuild_index();
+		} catch ( Exception $e ) {
+			wp_send_json_error( [ 'message' => sanitize_text_field( $e->getMessage() ) ] );
+		}
+
+		wp_send_json_success( [ 'message' => __( 'RAG index rebuilt successfully.', 'rtbcb' ) ] );
+	}
+
+	/**
+	 * Run integration diagnostics.
+	 *
+	 * @return void
+	 */
+	public function run_integration_tests() {
+		check_ajax_referer( 'rtbcb_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
+		}
+
+		$results = RTBCB_Tests::run_integration_tests();
+
+		wp_send_json_success( $results );
+	}
+
+	/**
+	 * AJAX handler to set company name for tests.
+	 *
+	 * @return void
+	 */
+	public function ajax_set_test_company() {
+		check_ajax_referer( 'rtbcb_set_test_company', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
+		}
+
+		$company_name = isset( $_POST['company_name'] ) ? sanitize_text_field( wp_unslash( $_POST['company_name'] ) ) : '';
+		if ( '' === $company_name ) {
+			wp_send_json_error( [ 'message' => __( 'Invalid company name.', 'rtbcb' ) ], 400 );
+		}
+
+		try {
+			$existing     = rtbcb_get_current_company();
+			$company_data = [
+				'name'            => $company_name,
+				'summary'         => '',
+				'recommendations' => [],
+				'references'      => [],
+				'generated_at'    => '',
+				'focus_areas'     => array_map( 'sanitize_text_field', (array) ( $existing['focus_areas'] ?? [] ) ),
+				'industry'        => isset( $existing['industry'] ) ? sanitize_text_field( $existing['industry'] ) : '',
+				'size'            => isset( $existing['size'] ) ? sanitize_text_field( $existing['size'] ) : '',
+				'revenue'         => 0,
+				'staff_count'     => 0,
+				'efficiency'      => 0,
+			];
+
+			update_option( 'rtbcb_current_company', $company_data );
+
+			$stored = get_option( 'rtbcb_company_data', [] );
+			if ( ! is_array( $stored ) ) {
+				$stored = [];
+			}
+			$stored['name'] = $company_name;
+			update_option( 'rtbcb_company_data', $stored );
+
+			delete_option( 'rtbcb_test_results' );
+
+			wp_send_json_success(
+				[
+					'message' => __( 'Company saved. Generating overview...', 'rtbcb' ),
+					'name'    => $company_name,
+				]
+			);
+		} catch ( Exception $e ) {
+			error_log( 'RTBCB Set Test Company Error: ' . $e->getMessage() );
+			wp_send_json_error(
+				[
+					'message' => __( 'An error occurred while saving company data.', 'rtbcb' ),
+				]
+			);
+		}
+	}
+
+	/**
+	 * AJAX handler to test Portal integration.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_portal() {
+		check_ajax_referer( 'rtbcb_test_portal', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );
+		}
+
+		if ( ! $this->check_portal_integration() ) {
+			wp_send_json_error( [ 'message' => __( 'Portal integration not active.', 'rtbcb' ) ] );
+		}
+
+		$vendor_count = $this->get_vendor_count();
+
+		wp_send_json_success( [ 'vendor_count' => intval( $vendor_count ) ] );
+	}
+
+	/**
+	 * AJAX handler to test RAG index health.
+	 *
+	 * @return void
+	 */
+	public function ajax_test_rag() {
+		check_ajax_referer( 'rtbcb_test_rag', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );
+		}
+
+		$health = $this->check_rag_health();
+
+		if ( 'healthy' !== ( $health['status'] ?? '' ) ) {
+			$message = isset( $health['message'] ) ? sanitize_text_field( $health['message'] ) : __( 'RAG index needs attention.', 'rtbcb' );
+			wp_send_json_error(
+				[
+					'status'  => sanitize_text_field( $health['status'] ?? '' ),
+					'message' => $message,
+				]
+			);
+		}
+
+		wp_send_json_success(
+			[
+				'status'        => 'healthy',
+				'indexed_items' => isset( $health['indexed_items'] ) ? intval( $health['indexed_items'] ) : 0,
+				'last_updated'  => isset( $health['last_updated'] ) ? sanitize_text_field( $health['last_updated'] ) : '',
+			]
+		);
+	}
+
+	/**
+	 * Sync portal data to the local site.
+	 *
+	 * @return void
+	 */
+	public function sync_to_local() {
+		check_ajax_referer( 'rtbcb_sync_local', 'nonce' );
+
+		if ( is_user_logged_in() && ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
+		}
+
+		wp_send_json_success( [ 'message' => __( 'Data synchronized.', 'rtbcb' ) ] );
+	}
+
+	/**
+	 * Get monthly trends data.
+	 *
+	 * @return array Monthly trends.
+	 */
+	private function get_monthly_trends() {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'rtbcb_leads';
+
+		$results = $wpdb->get_results(
+			"SELECT 
+				DATE_FORMAT(created_at, '%Y-%m') as month,
+				COUNT(*) as leads,
+				AVG(roi_base) as avg_roi
+			 FROM {$table_name} 
+			 WHERE created_at >= DATE_SUB(NOW(), INTERVAL 12 MONTH)
+			 GROUP BY DATE_FORMAT(created_at, '%Y-%m')
+			 ORDER BY month",
+			ARRAY_A
+		);
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Check if Portal integration is active.
+	 *
+	 * @return bool
+	 */
+	private function check_portal_integration() {
+		return (bool) ( has_filter( 'rt_portal_get_vendors' ) || has_filter( 'rt_portal_get_vendor_notes' ) );
+	}
+
+	/**
+	 * Get vendor count from portal.
+	 *
+	 * @return int
+	 */
+	private function get_vendor_count() {
+		$vendors = apply_filters( 'rt_portal_get_vendors', [] );
+		return is_array( $vendors ) ? count( $vendors ) : 0;
+	}
+
+	/**
+	 * Check RAG index health.
+	 *
+	 * @return array Health status.
+	 */
+	private function check_rag_health() {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'rtbcb_rag_index';
+
+		$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
+		if ( $table_exists !== $table_name ) {
+			return [
+				'status'        => 'missing',
+				'message'       => __( 'RAG index table missing. Use the rebuild button to create it.', 'rtbcb' ),
+				'indexed_items' => 0,
+				'last_updated'  => '',
+			];
+		}
+
+		$count       = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table_name}" );
+		$last_updated = $wpdb->get_var( "SELECT MAX(updated_at) FROM {$table_name}" );
+
+		if ( $wpdb->last_error ) {
+			return [
+				'status'  => 'error',
+				'message' => sprintf( __( 'Database error: %s', 'rtbcb' ), $wpdb->last_error ),
+			];
+		}
+
+		if ( 0 === $count ) {
+			return [
+				'status'        => 'empty',
+				'message'       => __( 'RAG index is empty. Rebuild the index to add data.', 'rtbcb' ),
+				'indexed_items' => 0,
+				'last_updated'  => $last_updated,
+			];
+		}
+
+		return [
+			'status'        => 'healthy',
+			'indexed_items' => $count,
+			'last_updated'  => $last_updated,
+		];
+	}
+
+	/**
+	 * AJAX handler to fetch phase completion percentages.
+	 *
+	 * @return void
+	 */
+	public function ajax_get_phase_completion() {
+		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
+
+		$test_results = get_option( 'rtbcb_test_results', [] );
+		$sections     = rtbcb_get_dashboard_sections( $test_results );
+		$percentages  = rtbcb_calculate_phase_completion( $sections );
+
+		wp_send_json_success( [ 'percentages' => $percentages ] );
+	}
+
+	/**
+	 * AJAX handler to fetch sanitized configuration for a section.
+	 *
+	 * @return void
+	 */
+	public function ajax_get_section_config() {
+		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
+
+		$section_id = isset( $_POST['section'] ) ? sanitize_key( wp_unslash( $_POST['section'] ) ) : '';
+		if ( '' === $section_id ) {
+			wp_send_json_error( [ 'message' => __( 'Invalid section.', 'rtbcb' ) ] );
+		}
+
+		$sections = rtbcb_get_dashboard_sections();
+		if ( ! isset( $sections[ $section_id ]['option'] ) ) {
+			wp_send_json_error( [ 'message' => __( 'Unknown section.', 'rtbcb' ) ] );
+		}
+
+		$option_name = sanitize_key( $sections[ $section_id ]['option'] );
+		$raw         = get_option( $option_name, [] );
+		$sanitized   = $this->sanitize_section_config( $raw );
+		$snippet     = wp_json_encode( $sanitized );
+		if ( strlen( $snippet ) > 200 ) {
+			$snippet = substr( $snippet, 0, 200 ) . '...';
+		}
+
+		wp_send_json_success( [ 'config' => $snippet ] );
+	}
+
+	/**
+	 * AJAX handler to build test summary HTML.
+	 *
+	 * @return void
+	 */
+	public function ajax_get_test_summary_html() {
+		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );
+		}
+
+		$test_results = get_option( 'rtbcb_test_results', [] );
+		if ( empty( $test_results ) ) {
+			wp_send_json_error( [ 'message' => __( 'No test results found.', 'rtbcb' ) ] );
+		}
+
+		ob_start();
+		echo '<div class="rtbcb-summary-panel">';
+		echo '<table class="rtbcb-summary-table">';
+		echo '<thead><tr>';
+		echo '<th>' . esc_html__( 'Section', 'rtbcb' ) . '</th>';
+		echo '<th>' . esc_html__( 'Status', 'rtbcb' ) . '</th>';
+		echo '<th>' . esc_html__( 'Message', 'rtbcb' ) . '</th>';
+		echo '<th>' . esc_html__( 'Duration', 'rtbcb' ) . '</th>';
+		echo '<th>' . esc_html__( 'Finished', 'rtbcb' ) . '</th>';
+		echo '</tr></thead><tbody>';
+
+		foreach ( $test_results as $result ) {
+			$section  = isset( $result['section'] ) ? $result['section'] : '';
+			$status   = isset( $result['status'] ) ? $result['status'] : '';
+			$message  = isset( $result['message'] ) ? $result['message'] : '';
+			$duration = isset( $result['duration'] ) ? $result['duration'] : '';
+			$end_time = isset( $result['end_time'] ) ? $result['end_time'] : '';
+
+			echo '<tr>';
+			echo '<td>' . esc_html( $section ) . '</td>';
+			echo '<td>' . esc_html( $status ) . '</td>';
+			echo '<td>' . esc_html( $message ) . '</td>';
+			echo '<td>' . esc_html( $duration ) . '</td>';
+			echo '<td>' . esc_html( $end_time ) . '</td>';
+			echo '</tr>';
+		}
+
+		echo '</tbody></table></div>';
+
+		$html = ob_get_clean();
+
+		wp_send_json_success( [ 'html' => $html ] );
+	}
+
+	/**
+	 * Recursively sanitize configuration data.
+	 *
+	 * @param mixed $data Configuration value.
+	 * @return mixed
+	 */
+	private function sanitize_section_config( $data ) {
+		if ( is_array( $data ) ) {
+			$clean = [];
+			foreach ( $data as $key => $value ) {
+				$clean[ sanitize_key( $key ) ] = $this->sanitize_section_config( $value );
+			}
+			return $clean;
+		}
+
+		if ( is_scalar( $data ) ) {
+			return sanitize_text_field( (string) $data );
+		}
+
+		return '';
+	}
+
+	/**
+	 * AJAX handler to generate comprehensive analysis.
+	 *
+	 * @return void
+	 */
+	public function ajax_generate_comprehensive_analysis() {
+		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
+		$company_name = isset( $_POST['company_name'] ) ? sanitize_text_field( wp_unslash( $_POST['company_name'] ) ) : '';
+		if ( '' === $company_name ) {
+			$stored       = get_option( 'rtbcb_company_data', [] );
+			$company_name = isset( $stored['name'] ) ? sanitize_text_field( $stored['name'] ) : '';
+		}
+
+		if ( '' === $company_name ) {
+			wp_send_json_error( [ 'message' => __( 'Company name is required.', 'rtbcb' ) ] );
+		}
+
+		$job_id = rtbcb_queue_comprehensive_analysis( $company_name );
+		if ( is_wp_error( $job_id ) ) {
+			wp_send_json_error( [ 'message' => $job_id->get_error_message() ] );
+		}
+
+		wp_send_json_success( [ 'job_id' => $job_id ] );
+	}
+
+	/**
+	 * Get status for a queued comprehensive analysis job.
+	 *
+	 * @return void
+	 */
+	public function ajax_get_analysis_status() {
+		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
+
+		$job_id = isset( $_GET['job_id'] ) ? sanitize_key( wp_unslash( $_GET['job_id'] ) ) : '';
+		if ( '' === $job_id ) {
+			wp_send_json_error( [ 'message' => __( 'Job ID is required.', 'rtbcb' ) ] );
+		}
+
+		$result = rtbcb_get_analysis_job_result( $job_id );
+		if ( null === $result ) {
+			wp_send_json_success( [ 'status' => 'pending' ] );
+		}
+
+		if ( empty( $result['success'] ) ) {
+			wp_send_json_error( [ 'message' => $result['message'] ?? __( 'Unknown error.', 'rtbcb' ) ] );
+		}
+
+		wp_send_json_success( array_merge( [ 'status' => 'completed' ], $result ) );
+	}
+
+	/**
+	 * Clear stored comprehensive analysis data.
+	 *
+	 * @return void
+	 */
+	public function ajax_clear_analysis_data() {
+		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
+
+		$options = [
+			'rtbcb_current_company',
+			'rtbcb_industry_insights',
+			'rtbcb_maturity_model',
+			'rtbcb_rag_market_analysis',
+			'rtbcb_value_proposition',
+			'rtbcb_estimated_benefits',
+			'rtbcb_executive_summary',
+			'rtbcb_roadmap_plan',
+		];
+
+		foreach ( $options as $opt ) {
+			delete_option( $opt );
+		}
+
+		wp_send_json_success( [ 'message' => __( 'Stored analysis data cleared.', 'rtbcb' ) ] );
+	}
+
+	/**
+	 * AJAX handler for deleting a single log entry.
+	 *
+	 * @return void
+	 */
+	public function ajax_delete_log() {
+		check_ajax_referer( 'rtbcb_api_logs', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );
+		}
+
+		$id = isset( $_POST['id'] ) ? intval( $_POST['id'] ) : 0;
+		if ( $id <= 0 ) {
+			wp_send_json_error( [ 'message' => __( 'Invalid log ID.', 'rtbcb' ) ] );
+		}
+
+		$deleted = RTBCB_API_Log::delete_log( $id );
+
+		if ( $deleted ) {
+			wp_send_json_success();
+		}
+
+		wp_send_json_error( [ 'message' => __( 'Failed to delete log.', 'rtbcb' ) ] );
+	}
+
+	/**
+	 * AJAX handler for clearing all log entries.
+	 *
+	 * @return void
+	 */
+	public function ajax_clear_logs() {
+		check_ajax_referer( 'rtbcb_api_logs', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Unauthorized', 'rtbcb' ) ] );
+		}
+
+		RTBCB_API_Log::clear_logs();
+
+		wp_send_json_success();
+	}
+
+	public function render_workflow_visualizer() {
+			include RTBCB_DIR . 'admin/workflow-visualizer-page.php';
+	}
 
 	public function ajax_get_workflow_history() {
 		check_ajax_referer( 'rtbcb_workflow_visualizer', 'nonce' );
@@ -1950,59 +1950,59 @@ class RTBCB_Admin {
 		return $total / count( $history );
 	}
 
-        private function calculate_success_rate( $history ) {
-                if ( empty( $history ) ) {
-                        return 0;
-                }
-                $success = 0;
-                foreach ( $history as $item ) {
-                        if ( ! empty( $item['success'] ) ) {
-                                $success++;
-                        }
-                }
-                return ( $success / count( $history ) ) * 100;
-        }
+		private function calculate_success_rate( $history ) {
+				if ( empty( $history ) ) {
+						return 0;
+				}
+				$success = 0;
+				foreach ( $history as $item ) {
+						if ( ! empty( $item['success'] ) ) {
+								$success++;
+						}
+				}
+				return ( $success / count( $history ) ) * 100;
+		}
 
-        /**
-         * Display notice if PHP max execution time is lower than GPT-5 timeout.
-         *
-         * @return void
-         */
-        public function maybe_show_timeout_notice() {
-                $php_limit   = (int) ini_get( 'max_execution_time' );
-                $gpt_timeout = (int) get_option( 'rtbcb_gpt5_timeout' );
+		/**
+		 * Display notice if PHP max execution time is lower than GPT-5 timeout.
+		 *
+		 * @return void
+		 */
+		public function maybe_show_timeout_notice() {
+				$php_limit   = (int) ini_get( 'max_execution_time' );
+				$gpt_timeout = (int) get_option( 'rtbcb_gpt5_timeout' );
 
-                if ( $php_limit > 0 && $gpt_timeout > 0 && $php_limit < $gpt_timeout ) {
-                        $doc_url = esc_url( RTBCB_URL . 'docs/timeout-config.md' );
-                        echo '<div class="notice notice-warning is-dismissible"><p>';
-                        printf(
-                                wp_kses(
-                                        __( 'Your PHP max execution time (%1$s seconds) is lower than the GPT-5 timeout (%2$s seconds). <a href="%3$s" target="_blank">Learn how to increase it</a>.', 'rtbcb' ),
-                                        [
-                                                'a' => [
-                                                        'href'   => [],
-                                                        'target' => [],
-                                                ],
-                                        ]
-                                ),
-                                esc_html( (string) $php_limit ),
-                                esc_html( (string) $gpt_timeout ),
-                                $doc_url
-                        );
-                        echo '</p></div>';
-                }
-        }
+				if ( $php_limit > 0 && $gpt_timeout > 0 && $php_limit < $gpt_timeout ) {
+						$doc_url = esc_url( RTBCB_URL . 'docs/timeout-config.md' );
+						echo '<div class="notice notice-warning is-dismissible"><p>';
+						printf(
+								wp_kses(
+										__( 'Your PHP max execution time (%1$s seconds) is lower than the GPT-5 timeout (%2$s seconds). <a href="%3$s" target="_blank">Learn how to increase it</a>.', 'rtbcb' ),
+										[
+												'a' => [
+														'href'   => [],
+														'target' => [],
+												],
+										]
+								),
+								esc_html( (string) $php_limit ),
+								esc_html( (string) $gpt_timeout ),
+								$doc_url
+						);
+						echo '</p></div>';
+				}
+		}
 
 
-    /**
-     * Display notice when heavy features are disabled.
-     *
-     * @return void
-     */
-    public function maybe_show_bypass_notice() {
-        if ( get_option( 'rtbcb_disable_heavy_features', 0 ) ) {
-            echo '<div class="notice notice-warning"><p>' . esc_html__( 'Heavy AI features are temporarily disabled. Remove the rtbcb_disable_heavy_features option to restore full functionality.', 'rtbcb' ) . '</p></div>';
-        }
-    }
+	/**
+	 * Display notice when heavy features are disabled.
+	 *
+	 * @return void
+	 */
+	public function maybe_show_bypass_notice() {
+		if ( get_option( 'rtbcb_disable_heavy_features', 0 ) ) {
+			echo '<div class="notice notice-warning"><p>' . esc_html__( 'Heavy AI features are temporarily disabled. Remove the rtbcb_disable_heavy_features option to restore full functionality.', 'rtbcb' ) . '</p></div>';
+		}
+	}
 
 }

--- a/admin/dashboard-page.php
+++ b/admin/dashboard-page.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Enhanced Dashboard admin page for Real Treasury Business Case Builder plugin.
- */
+	* Enhanced Dashboard admin page for Real Treasury Business Case Builder plugin.
+	*/
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
@@ -26,694 +26,694 @@ $avg_roi = intval( $roi_stats['avg_base'] ?? 0 );
 ?>
 
 <div class="wrap rtbcb-admin-page rtbcb-dashboard">
-    <div class="rtbcb-dashboard-header">
-        <div class="rtbcb-dashboard-title">
-            <h1><?php echo esc_html__( 'Business Case Builder Dashboard', 'rtbcb' ); ?></h1>
-            <p class="rtbcb-dashboard-subtitle">
-                <?php esc_html_e( 'Monitor lead generation, analyze performance, and manage your treasury technology business case builder.', 'rtbcb' ); ?>
-            </p>
-        </div>
-        <div class="rtbcb-dashboard-actions">
-            <a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-leads' ) ); ?>" class="button button-primary">
-                <?php esc_html_e( 'View All Leads', 'rtbcb' ); ?>
-            </a>
-            <a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-analytics' ) ); ?>" class="button button-secondary">
-                <?php esc_html_e( 'Analytics', 'rtbcb' ); ?>
-            </a>
-        </div>
-    </div>
+	<div class="rtbcb-dashboard-header">
+		<div class="rtbcb-dashboard-title">
+			<h1><?php echo esc_html__( 'Business Case Builder Dashboard', 'rtbcb' ); ?></h1>
+			<p class="rtbcb-dashboard-subtitle">
+				<?php esc_html_e( 'Monitor lead generation, analyze performance, and manage your treasury technology business case builder.', 'rtbcb' ); ?>
+			</p>
+		</div>
+		<div class="rtbcb-dashboard-actions">
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-leads' ) ); ?>" class="button button-primary">
+				<?php esc_html_e( 'View All Leads', 'rtbcb' ); ?>
+			</a>
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-analytics' ) ); ?>" class="button button-secondary">
+				<?php esc_html_e( 'Analytics', 'rtbcb' ); ?>
+			</a>
+		</div>
+	</div>
 
-    <!-- System Status -->
-    <div class="rtbcb-system-status">
-        <h3><?php esc_html_e( 'System Status', 'rtbcb' ); ?></h3>
-        <div class="rtbcb-status-grid">
-            <div class="rtbcb-status-item <?php echo $api_key_valid ? 'rtbcb-status-good' : 'rtbcb-status-warning'; ?>">
-                <div class="rtbcb-status-icon">
-                    <span class="dashicons <?php echo $api_key_valid ? 'dashicons-yes-alt' : 'dashicons-warning'; ?>"></span>
-                </div>
-                <div class="rtbcb-status-content">
-                    <div class="rtbcb-status-label"><?php esc_html_e( 'OpenAI API', 'rtbcb' ); ?></div>
-                    <div class="rtbcb-status-value">
-                        <?php
-                        if ( ! $api_key_configured ) {
-                            esc_html_e( 'Not configured', 'rtbcb' );
-                        } elseif ( ! $api_key_valid ) {
-                            esc_html_e( 'Invalid key format', 'rtbcb' );
-                        } else {
-                            esc_html_e( 'Configured', 'rtbcb' );
-                        }
-                        ?>
-                    </div>
-                </div>
-                <?php if ( ! $api_key_valid ) : ?>
-                    <a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-settings' ) ); ?>" class="rtbcb-status-action">
-                        <?php esc_html_e( 'Configure', 'rtbcb' ); ?>
-                    </a>
-                <?php endif; ?>
-            </div>
+	<!-- System Status -->
+	<div class="rtbcb-system-status">
+		<h3><?php esc_html_e( 'System Status', 'rtbcb' ); ?></h3>
+		<div class="rtbcb-status-grid">
+			<div class="rtbcb-status-item <?php echo $api_key_valid ? 'rtbcb-status-good' : 'rtbcb-status-warning'; ?>">
+				<div class="rtbcb-status-icon">
+					<span class="dashicons <?php echo $api_key_valid ? 'dashicons-yes-alt' : 'dashicons-warning'; ?>"></span>
+				</div>
+				<div class="rtbcb-status-content">
+					<div class="rtbcb-status-label"><?php esc_html_e( 'OpenAI API', 'rtbcb' ); ?></div>
+					<div class="rtbcb-status-value">
+						<?php
+						if ( ! $api_key_configured ) {
+							esc_html_e( 'Not configured', 'rtbcb' );
+						} elseif ( ! $api_key_valid ) {
+							esc_html_e( 'Invalid key format', 'rtbcb' );
+						} else {
+							esc_html_e( 'Configured', 'rtbcb' );
+						}
+						?>
+					</div>
+				</div>
+				<?php if ( ! $api_key_valid ) : ?>
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-settings' ) ); ?>" class="rtbcb-status-action">
+						<?php esc_html_e( 'Configure', 'rtbcb' ); ?>
+					</a>
+				<?php endif; ?>
+			</div>
 
-            <div class="rtbcb-status-item <?php echo $portal_active ? 'rtbcb-status-good' : 'rtbcb-status-info'; ?>">
-                <div class="rtbcb-status-icon">
-                    <span class="dashicons <?php echo $portal_active ? 'dashicons-yes-alt' : 'dashicons-info'; ?>"></span>
-                </div>
-                <div class="rtbcb-status-content">
-                    <div class="rtbcb-status-label"><?php esc_html_e( 'Portal Integration', 'rtbcb' ); ?></div>
-                    <div class="rtbcb-status-value">
-                        <?php echo $portal_active ? esc_html__( 'Active', 'rtbcb' ) : esc_html__( 'Inactive', 'rtbcb' ); ?>
-                    </div>
-                </div>
-            </div>
+			<div class="rtbcb-status-item <?php echo $portal_active ? 'rtbcb-status-good' : 'rtbcb-status-info'; ?>">
+				<div class="rtbcb-status-icon">
+					<span class="dashicons <?php echo $portal_active ? 'dashicons-yes-alt' : 'dashicons-info'; ?>"></span>
+				</div>
+				<div class="rtbcb-status-content">
+					<div class="rtbcb-status-label"><?php esc_html_e( 'Portal Integration', 'rtbcb' ); ?></div>
+					<div class="rtbcb-status-value">
+						<?php echo $portal_active ? esc_html__( 'Active', 'rtbcb' ) : esc_html__( 'Inactive', 'rtbcb' ); ?>
+					</div>
+				</div>
+			</div>
 
-            <div class="rtbcb-status-item <?php echo ! empty( $last_indexed ) ? 'rtbcb-status-good' : 'rtbcb-status-warning'; ?>">
-                <div class="rtbcb-status-icon">
-                    <span class="dashicons <?php echo ! empty( $last_indexed ) ? 'dashicons-yes-alt' : 'dashicons-warning'; ?>"></span>
-                </div>
-                <div class="rtbcb-status-content">
-                    <div class="rtbcb-status-label"><?php esc_html_e( 'RAG Index', 'rtbcb' ); ?></div>
-                    <div class="rtbcb-status-value">
-                        <?php 
-                        if ( ! empty( $last_indexed ) ) {
-                            echo esc_html( human_time_diff( strtotime( $last_indexed ), current_time( 'timestamp' ) ) ) . ' ' . esc_html__( 'ago', 'rtbcb' );
-                        } else {
-                            esc_html_e( 'Never indexed', 'rtbcb' );
-                        }
-                        ?>
-                    </div>
-                </div>
-                <button type="button" id="rtbcb-rebuild-index" class="rtbcb-status-action">
-                    <?php esc_html_e( 'Rebuild', 'rtbcb' ); ?>
-                </button>
-            </div>
-        </div>
-    </div>
+			<div class="rtbcb-status-item <?php echo ! empty( $last_indexed ) ? 'rtbcb-status-good' : 'rtbcb-status-warning'; ?>">
+				<div class="rtbcb-status-icon">
+					<span class="dashicons <?php echo ! empty( $last_indexed ) ? 'dashicons-yes-alt' : 'dashicons-warning'; ?>"></span>
+				</div>
+				<div class="rtbcb-status-content">
+					<div class="rtbcb-status-label"><?php esc_html_e( 'RAG Index', 'rtbcb' ); ?></div>
+					<div class="rtbcb-status-value">
+						<?php 
+						if ( ! empty( $last_indexed ) ) {
+							echo esc_html( human_time_diff( strtotime( $last_indexed ), current_time( 'timestamp' ) ) ) . ' ' . esc_html__( 'ago', 'rtbcb' );
+						} else {
+							esc_html_e( 'Never indexed', 'rtbcb' );
+						}
+						?>
+					</div>
+				</div>
+				<button type="button" id="rtbcb-rebuild-index" class="rtbcb-status-action">
+					<?php esc_html_e( 'Rebuild', 'rtbcb' ); ?>
+				</button>
+			</div>
+		</div>
+	</div>
 
-    <!-- Key Metrics Overview -->
-    <div class="rtbcb-metrics-overview">
-        <div class="rtbcb-metric-large">
-            <div class="rtbcb-metric-icon">
-                <span class="dashicons dashicons-groups"></span>
-            </div>
-            <div class="rtbcb-metric-content">
-                <div class="rtbcb-metric-value"><?php echo esc_html( number_format( $total_leads ) ); ?></div>
-                <div class="rtbcb-metric-label"><?php esc_html_e( 'Total Leads Generated', 'rtbcb' ); ?></div>
-                <div class="rtbcb-metric-subtitle">
-                    <?php 
-                    printf( 
-                        esc_html__( '%d new leads this month', 'rtbcb' ),
-                        esc_html( $recent_leads )
-                    );
-                    ?>
-                </div>
-            </div>
-        </div>
+	<!-- Key Metrics Overview -->
+	<div class="rtbcb-metrics-overview">
+		<div class="rtbcb-metric-large">
+			<div class="rtbcb-metric-icon">
+				<span class="dashicons dashicons-groups"></span>
+			</div>
+			<div class="rtbcb-metric-content">
+				<div class="rtbcb-metric-value"><?php echo esc_html( number_format( $total_leads ) ); ?></div>
+				<div class="rtbcb-metric-label"><?php esc_html_e( 'Total Leads Generated', 'rtbcb' ); ?></div>
+				<div class="rtbcb-metric-subtitle">
+					<?php 
+					printf( 
+						esc_html__( '%d new leads this month', 'rtbcb' ),
+						esc_html( $recent_leads )
+					);
+					?>
+				</div>
+			</div>
+		</div>
 
-        <div class="rtbcb-metrics-grid">
-            <div class="rtbcb-metric-card">
-                <div class="rtbcb-metric-header">
-                    <span class="dashicons dashicons-chart-line"></span>
-                    <span><?php esc_html_e( 'Average ROI', 'rtbcb' ); ?></span>
-                </div>
-                <div class="rtbcb-metric-value">$<?php echo esc_html( number_format( $avg_roi ) ); ?></div>
-                <div class="rtbcb-metric-change rtbcb-metric-positive">
-                    <span class="dashicons dashicons-arrow-up-alt2"></span>
-                    <?php esc_html_e( 'Strong value proposition', 'rtbcb' ); ?>
-                </div>
-            </div>
+		<div class="rtbcb-metrics-grid">
+			<div class="rtbcb-metric-card">
+				<div class="rtbcb-metric-header">
+					<span class="dashicons dashicons-chart-line"></span>
+					<span><?php esc_html_e( 'Average ROI', 'rtbcb' ); ?></span>
+				</div>
+				<div class="rtbcb-metric-value">$<?php echo esc_html( number_format( $avg_roi ) ); ?></div>
+				<div class="rtbcb-metric-change rtbcb-metric-positive">
+					<span class="dashicons dashicons-arrow-up-alt2"></span>
+					<?php esc_html_e( 'Strong value proposition', 'rtbcb' ); ?>
+				</div>
+			</div>
 
-            <div class="rtbcb-metric-card">
-                <div class="rtbcb-metric-header">
-                    <span class="dashicons dashicons-calendar-alt"></span>
-                    <span><?php esc_html_e( 'Monthly Growth', 'rtbcb' ); ?></span>
-                </div>
-                <div class="rtbcb-metric-value"><?php echo esc_html( number_format( $conversion_rate, 1 ) ); ?>%</div>
-                <div class="rtbcb-metric-change">
-                    <?php esc_html_e( 'Lead generation rate', 'rtbcb' ); ?>
-                </div>
-            </div>
+			<div class="rtbcb-metric-card">
+				<div class="rtbcb-metric-header">
+					<span class="dashicons dashicons-calendar-alt"></span>
+					<span><?php esc_html_e( 'Monthly Growth', 'rtbcb' ); ?></span>
+				</div>
+				<div class="rtbcb-metric-value"><?php echo esc_html( number_format( $conversion_rate, 1 ) ); ?>%</div>
+				<div class="rtbcb-metric-change">
+					<?php esc_html_e( 'Lead generation rate', 'rtbcb' ); ?>
+				</div>
+			</div>
 
-            <div class="rtbcb-metric-card">
-                <div class="rtbcb-metric-header">
-                    <span class="dashicons dashicons-star-filled"></span>
-                    <span><?php esc_html_e( 'Top Category', 'rtbcb' ); ?></span>
-                </div>
-                <div class="rtbcb-metric-value">
-                    <?php 
-                    if ( ! empty( $category_stats ) ) {
-                        $top_category = array_reduce( $category_stats, function( $carry, $item ) {
-                            return ( ! $carry || $item['count'] > $carry['count'] ) ? $item : $carry;
-                        } );
-                        
-                        $categories = RTBCB_Category_Recommender::get_all_categories();
-                        $top_cat_info = $categories[ $top_category['recommended_category'] ] ?? [];
-                        echo esc_html( $top_cat_info['name'] ?? 'TMS' );
-                    } else {
-                        esc_html_e( 'N/A', 'rtbcb' );
-                    }
-                    ?>
-                </div>
-                <div class="rtbcb-metric-change">
-                    <?php esc_html_e( 'Most recommended', 'rtbcb' ); ?>
-                </div>
-            </div>
-        </div>
-    </div>
+			<div class="rtbcb-metric-card">
+				<div class="rtbcb-metric-header">
+					<span class="dashicons dashicons-star-filled"></span>
+					<span><?php esc_html_e( 'Top Category', 'rtbcb' ); ?></span>
+				</div>
+				<div class="rtbcb-metric-value">
+					<?php 
+					if ( ! empty( $category_stats ) ) {
+						$top_category = array_reduce( $category_stats, function( $carry, $item ) {
+							return ( ! $carry || $item['count'] > $carry['count'] ) ? $item : $carry;
+						} );
+						
+						$categories = RTBCB_Category_Recommender::get_all_categories();
+						$top_cat_info = $categories[ $top_category['recommended_category'] ] ?? [];
+						echo esc_html( $top_cat_info['name'] ?? 'TMS' );
+					} else {
+						esc_html_e( 'N/A', 'rtbcb' );
+					}
+					?>
+				</div>
+				<div class="rtbcb-metric-change">
+					<?php esc_html_e( 'Most recommended', 'rtbcb' ); ?>
+				</div>
+			</div>
+		</div>
+	</div>
 
-    <!-- Quick Insights and Recent Activity -->
-    <div class="rtbcb-dashboard-content">
-        <!-- Recent Leads -->
-        <div class="rtbcb-dashboard-section">
-            <div class="rtbcb-section-header">
-                <h3><?php esc_html_e( 'Recent Leads', 'rtbcb' ); ?></h3>
-                <a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-leads' ) ); ?>" class="rtbcb-section-link">
-                    <?php esc_html_e( 'View All', 'rtbcb' ); ?>
-                </a>
-            </div>
+	<!-- Quick Insights and Recent Activity -->
+	<div class="rtbcb-dashboard-content">
+		<!-- Recent Leads -->
+		<div class="rtbcb-dashboard-section">
+			<div class="rtbcb-section-header">
+				<h3><?php esc_html_e( 'Recent Leads', 'rtbcb' ); ?></h3>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-leads' ) ); ?>" class="rtbcb-section-link">
+					<?php esc_html_e( 'View All', 'rtbcb' ); ?>
+				</a>
+			</div>
 
-            <?php if ( ! empty( $leads ) ) : ?>
-                <div class="rtbcb-recent-leads">
-                    <?php foreach ( array_slice( $leads, 0, 5 ) as $lead ) : ?>
-                        <div class="rtbcb-lead-item">
-                            <div class="rtbcb-lead-avatar">
-                                <?php echo esc_html( strtoupper( substr( $lead['email'], 0, 1 ) ) ); ?>
-                            </div>
-                            <div class="rtbcb-lead-info">
-                                <div class="rtbcb-lead-email"><?php echo esc_html( $lead['email'] ); ?></div>
-                                <div class="rtbcb-lead-meta">
-                                    <span class="rtbcb-company-size"><?php echo esc_html( $lead['company_size'] ); ?></span>
-                                    <?php if ( $lead['roi_base'] > 0 ) : ?>
-                                        <span class="rtbcb-lead-separator">•</span>
-                                        <span class="rtbcb-roi">$<?php echo esc_html( number_format( $lead['roi_base'] ) ); ?> ROI</span>
-                                    <?php endif; ?>
-                                </div>
-                            </div>
-                            <div class="rtbcb-lead-time">
-                                <?php echo esc_html( human_time_diff( strtotime( $lead['created_at'] ), current_time( 'timestamp' ) ) ); ?> <?php esc_html_e( 'ago', 'rtbcb' ); ?>
-                            </div>
-                        </div>
-                    <?php endforeach; ?>
-                </div>
-            <?php else : ?>
-                <div class="rtbcb-empty-state">
-                    <span class="dashicons dashicons-email-alt"></span>
-                    <p><?php esc_html_e( 'No leads yet. Share your business case builder to start generating leads!', 'rtbcb' ); ?></p>
-                </div>
-            <?php endif; ?>
-        </div>
+			<?php if ( ! empty( $leads ) ) : ?>
+				<div class="rtbcb-recent-leads">
+					<?php foreach ( array_slice( $leads, 0, 5 ) as $lead ) : ?>
+						<div class="rtbcb-lead-item">
+							<div class="rtbcb-lead-avatar">
+								<?php echo esc_html( strtoupper( substr( $lead['email'], 0, 1 ) ) ); ?>
+							</div>
+							<div class="rtbcb-lead-info">
+								<div class="rtbcb-lead-email"><?php echo esc_html( $lead['email'] ); ?></div>
+								<div class="rtbcb-lead-meta">
+									<span class="rtbcb-company-size"><?php echo esc_html( $lead['company_size'] ); ?></span>
+									<?php if ( $lead['roi_base'] > 0 ) : ?>
+										<span class="rtbcb-lead-separator">•</span>
+										<span class="rtbcb-roi">$<?php echo esc_html( number_format( $lead['roi_base'] ) ); ?> ROI</span>
+									<?php endif; ?>
+								</div>
+							</div>
+							<div class="rtbcb-lead-time">
+								<?php echo esc_html( human_time_diff( strtotime( $lead['created_at'] ), current_time( 'timestamp' ) ) ); ?> <?php esc_html_e( 'ago', 'rtbcb' ); ?>
+							</div>
+						</div>
+					<?php endforeach; ?>
+				</div>
+			<?php else : ?>
+				<div class="rtbcb-empty-state">
+					<span class="dashicons dashicons-email-alt"></span>
+					<p><?php esc_html_e( 'No leads yet. Share your business case builder to start generating leads!', 'rtbcb' ); ?></p>
+				</div>
+			<?php endif; ?>
+		</div>
 
-        <!-- Quick Actions -->
-        <div class="rtbcb-dashboard-section">
-            <div class="rtbcb-section-header">
-                <h3><?php esc_html_e( 'Quick Actions', 'rtbcb' ); ?></h3>
-            </div>
+		<!-- Quick Actions -->
+		<div class="rtbcb-dashboard-section">
+			<div class="rtbcb-section-header">
+				<h3><?php esc_html_e( 'Quick Actions', 'rtbcb' ); ?></h3>
+			</div>
 
-            <div class="rtbcb-quick-actions">
-                <a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-settings' ) ); ?>" class="rtbcb-action-card">
-                    <div class="rtbcb-action-icon">
-                        <span class="dashicons dashicons-admin-generic"></span>
-                    </div>
-                    <div class="rtbcb-action-content">
-                        <h4><?php esc_html_e( 'Settings', 'rtbcb' ); ?></h4>
-                        <p><?php esc_html_e( 'Configure API keys and ROI assumptions', 'rtbcb' ); ?></p>
-                    </div>
-                </a>
+			<div class="rtbcb-quick-actions">
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-settings' ) ); ?>" class="rtbcb-action-card">
+					<div class="rtbcb-action-icon">
+						<span class="dashicons dashicons-admin-generic"></span>
+					</div>
+					<div class="rtbcb-action-content">
+						<h4><?php esc_html_e( 'Settings', 'rtbcb' ); ?></h4>
+						<p><?php esc_html_e( 'Configure API keys and ROI assumptions', 'rtbcb' ); ?></p>
+					</div>
+				</a>
 
-                <button type="button" id="rtbcb-test-api" class="rtbcb-action-card">
-                    <div class="rtbcb-action-icon">
-                        <span class="dashicons dashicons-cloud"></span>
-                    </div>
-                    <div class="rtbcb-action-content">
-                        <h4><?php esc_html_e( 'Test API', 'rtbcb' ); ?></h4>
-                        <p><?php esc_html_e( 'Verify OpenAI connection', 'rtbcb' ); ?></p>
-                    </div>
-                </button>
+				<button type="button" id="rtbcb-test-api" class="rtbcb-action-card">
+					<div class="rtbcb-action-icon">
+						<span class="dashicons dashicons-cloud"></span>
+					</div>
+					<div class="rtbcb-action-content">
+						<h4><?php esc_html_e( 'Test API', 'rtbcb' ); ?></h4>
+						<p><?php esc_html_e( 'Verify OpenAI connection', 'rtbcb' ); ?></p>
+					</div>
+				</button>
 
-                <a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-analytics' ) ); ?>" class="rtbcb-action-card">
-                    <div class="rtbcb-action-icon">
-                        <span class="dashicons dashicons-chart-area"></span>
-                    </div>
-                    <div class="rtbcb-action-content">
-                        <h4><?php esc_html_e( 'Analytics', 'rtbcb' ); ?></h4>
-                        <p><?php esc_html_e( 'View detailed reports and insights', 'rtbcb' ); ?></p>
-                    </div>
-                </a>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-analytics' ) ); ?>" class="rtbcb-action-card">
+					<div class="rtbcb-action-icon">
+						<span class="dashicons dashicons-chart-area"></span>
+					</div>
+					<div class="rtbcb-action-content">
+						<h4><?php esc_html_e( 'Analytics', 'rtbcb' ); ?></h4>
+						<p><?php esc_html_e( 'View detailed reports and insights', 'rtbcb' ); ?></p>
+					</div>
+				</a>
 
-                <button type="button" id="rtbcb-export-data" class="rtbcb-action-card">
-                    <div class="rtbcb-action-icon">
-                        <span class="dashicons dashicons-download"></span>
-                    </div>
-                    <div class="rtbcb-action-content">
-                        <h4><?php esc_html_e( 'Export Data', 'rtbcb' ); ?></h4>
-                        <p><?php esc_html_e( 'Download leads as CSV', 'rtbcb' ); ?></p>
-                    </div>
-                </button>
-            </div>
-        </div>
-    </div>
+				<button type="button" id="rtbcb-export-data" class="rtbcb-action-card">
+					<div class="rtbcb-action-icon">
+						<span class="dashicons dashicons-download"></span>
+					</div>
+					<div class="rtbcb-action-content">
+						<h4><?php esc_html_e( 'Export Data', 'rtbcb' ); ?></h4>
+						<p><?php esc_html_e( 'Download leads as CSV', 'rtbcb' ); ?></p>
+					</div>
+				</button>
+			</div>
+		</div>
+	</div>
 
-    <!-- Category Distribution Summary -->
-    <?php if ( ! empty( $category_stats ) ) : ?>
-        <div class="rtbcb-dashboard-section rtbcb-section-full">
-            <div class="rtbcb-section-header">
-                <h3><?php esc_html_e( 'Category Distribution', 'rtbcb' ); ?></h3>
-                <a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-analytics' ) ); ?>" class="rtbcb-section-link">
-                    <?php esc_html_e( 'Detailed Analytics', 'rtbcb' ); ?>
-                </a>
-            </div>
+	<!-- Category Distribution Summary -->
+	<?php if ( ! empty( $category_stats ) ) : ?>
+		<div class="rtbcb-dashboard-section rtbcb-section-full">
+			<div class="rtbcb-section-header">
+				<h3><?php esc_html_e( 'Category Distribution', 'rtbcb' ); ?></h3>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-analytics' ) ); ?>" class="rtbcb-section-link">
+					<?php esc_html_e( 'Detailed Analytics', 'rtbcb' ); ?>
+				</a>
+			</div>
 
-            <div class="rtbcb-category-summary">
-                <?php foreach ( $category_stats as $stat ) : ?>
-                    <?php 
-                    $categories = RTBCB_Category_Recommender::get_all_categories();
-                    $cat_info = $categories[ $stat['recommended_category'] ] ?? [];
-                    $cat_name = $cat_info['name'] ?? ucfirst( str_replace( '_', ' ', $stat['recommended_category'] ) );
-                    $percentage = $total_leads > 0 ? ( $stat['count'] / $total_leads ) * 100 : 0;
-                    ?>
-                    <div class="rtbcb-category-item">
-                        <div class="rtbcb-category-header">
-                            <span class="rtbcb-category-name"><?php echo esc_html( $cat_name ); ?></span>
-                            <span class="rtbcb-category-count"><?php echo esc_html( $stat['count'] ); ?> leads</span>
-                        </div>
-                        <div class="rtbcb-category-bar">
-                            <div class="rtbcb-category-fill rtbcb-cat-<?php echo esc_attr( $stat['recommended_category'] ); ?>" 
-                                 style="width: <?php echo esc_attr( $percentage ); ?>%"></div>
-                        </div>
-                        <div class="rtbcb-category-percentage"><?php echo esc_html( number_format( $percentage, 1 ) ); ?>%</div>
-                    </div>
-                <?php endforeach; ?>
-            </div>
-        </div>
-    <?php endif; ?>
+			<div class="rtbcb-category-summary">
+				<?php foreach ( $category_stats as $stat ) : ?>
+					<?php 
+					$categories = RTBCB_Category_Recommender::get_all_categories();
+					$cat_info = $categories[ $stat['recommended_category'] ] ?? [];
+					$cat_name = $cat_info['name'] ?? ucfirst( str_replace( '_', ' ', $stat['recommended_category'] ) );
+					$percentage = $total_leads > 0 ? ( $stat['count'] / $total_leads ) * 100 : 0;
+					?>
+					<div class="rtbcb-category-item">
+						<div class="rtbcb-category-header">
+							<span class="rtbcb-category-name"><?php echo esc_html( $cat_name ); ?></span>
+							<span class="rtbcb-category-count"><?php echo esc_html( $stat['count'] ); ?> leads</span>
+						</div>
+						<div class="rtbcb-category-bar">
+							<div class="rtbcb-category-fill rtbcb-cat-<?php echo esc_attr( $stat['recommended_category'] ); ?>" 
+								 style="width: <?php echo esc_attr( $percentage ); ?>%"></div>
+						</div>
+						<div class="rtbcb-category-percentage"><?php echo esc_html( number_format( $percentage, 1 ) ); ?>%</div>
+					</div>
+				<?php endforeach; ?>
+			</div>
+		</div>
+	<?php endif; ?>
 </div>
 
 <style>
 /* Dashboard specific styles */
 .rtbcb-dashboard {
-    background: #f1f1f1;
-    margin: 0 -20px -20px -2px;
-    padding: 20px;
+	background: #f1f1f1;
+	margin: 0 -20px -20px -2px;
+	padding: 20px;
 }
 
 .rtbcb-dashboard-header {
-    background: white;
-    padding: 30px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    margin-bottom: 30px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+	background: white;
+	padding: 30px;
+	border-radius: 8px;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+	margin-bottom: 30px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 }
 
 .rtbcb-dashboard-title h1 {
-    margin: 0 0 8px 0;
-    color: #1f2937;
-    font-size: 28px;
+	margin: 0 0 8px 0;
+	color: #1f2937;
+	font-size: 28px;
 }
 
 .rtbcb-dashboard-subtitle {
-    margin: 0;
-    color: #6b7280;
-    font-size: 16px;
+	margin: 0;
+	color: #6b7280;
+	font-size: 16px;
 }
 
 .rtbcb-dashboard-actions {
-    display: flex;
-    gap: 12px;
+	display: flex;
+	gap: 12px;
 }
 
 /* System Status */
 .rtbcb-system-status {
-    background: white;
-    padding: 24px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    margin-bottom: 30px;
+	background: white;
+	padding: 24px;
+	border-radius: 8px;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+	margin-bottom: 30px;
 }
 
 .rtbcb-system-status h3 {
-    margin: 0 0 20px 0;
-    color: #1f2937;
+	margin: 0 0 20px 0;
+	color: #1f2937;
 }
 
 .rtbcb-status-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 16px;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+	gap: 16px;
 }
 
 .rtbcb-status-item {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 16px;
-    background: #f9fafb;
-    border-radius: 6px;
-    border-left: 4px solid #d1d5db;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 16px;
+	background: #f9fafb;
+	border-radius: 6px;
+	border-left: 4px solid #d1d5db;
 }
 
 .rtbcb-status-good {
-    background: #ecfdf5;
-    border-left-color: #059669;
+	background: #ecfdf5;
+	border-left-color: #059669;
 }
 
 .rtbcb-status-warning {
-    background: #fef3c7;
-    border-left-color: #d97706;
+	background: #fef3c7;
+	border-left-color: #d97706;
 }
 
 .rtbcb-status-info {
-    background: #eff6ff;
-    border-left-color: #2563eb;
+	background: #eff6ff;
+	border-left-color: #2563eb;
 }
 
 .rtbcb-status-icon {
-    color: #6b7280;
-    font-size: 20px;
+	color: #6b7280;
+	font-size: 20px;
 }
 
 .rtbcb-status-good .rtbcb-status-icon {
-    color: #059669;
+	color: #059669;
 }
 
 .rtbcb-status-warning .rtbcb-status-icon {
-    color: #d97706;
+	color: #d97706;
 }
 
 .rtbcb-status-info .rtbcb-status-icon {
-    color: #2563eb;
+	color: #2563eb;
 }
 
 .rtbcb-status-content {
-    flex: 1;
+	flex: 1;
 }
 
 .rtbcb-status-label {
-    font-weight: 600;
-    color: #374151;
-    margin-bottom: 2px;
+	font-weight: 600;
+	color: #374151;
+	margin-bottom: 2px;
 }
 
 .rtbcb-status-value {
-    font-size: 14px;
-    color: #6b7280;
+	font-size: 14px;
+	color: #6b7280;
 }
 
 .rtbcb-status-action {
-    background: none;
-    border: 1px solid #d1d5db;
-    padding: 6px 12px;
-    border-radius: 4px;
-    font-size: 12px;
-    color: #374151;
-    text-decoration: none;
-    cursor: pointer;
+	background: none;
+	border: 1px solid #d1d5db;
+	padding: 6px 12px;
+	border-radius: 4px;
+	font-size: 12px;
+	color: #374151;
+	text-decoration: none;
+	cursor: pointer;
 }
 
 .rtbcb-status-action:hover {
-    background: #f3f4f6;
+	background: #f3f4f6;
 }
 
 /* Metrics Overview */
 .rtbcb-metrics-overview {
-    display: grid;
-    grid-template-columns: 1fr 2fr;
-    gap: 20px;
-    margin-bottom: 30px;
+	display: grid;
+	grid-template-columns: 1fr 2fr;
+	gap: 20px;
+	margin-bottom: 30px;
 }
 
 .rtbcb-metric-large {
-    background: linear-gradient(135deg, #7216f4, #8f47f6);
-    color: white;
-    padding: 30px;
-    border-radius: 8px;
-    display: flex;
-    align-items: center;
-    gap: 20px;
+	background: linear-gradient(135deg, #7216f4, #8f47f6);
+	color: white;
+	padding: 30px;
+	border-radius: 8px;
+	display: flex;
+	align-items: center;
+	gap: 20px;
 }
 
 .rtbcb-metric-large .rtbcb-metric-icon {
-    width: 60px;
-    height: 60px;
-    background: rgba(255,255,255,0.2);
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 30px;
+	width: 60px;
+	height: 60px;
+	background: rgba(255,255,255,0.2);
+	border-radius: 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 30px;
 }
 
 .rtbcb-metric-large .rtbcb-metric-value {
-    font-size: 36px;
-    font-weight: 700;
-    margin-bottom: 8px;
+	font-size: 36px;
+	font-weight: 700;
+	margin-bottom: 8px;
 }
 
 .rtbcb-metric-large .rtbcb-metric-label {
-    font-size: 16px;
-    opacity: 0.9;
-    margin-bottom: 4px;
+	font-size: 16px;
+	opacity: 0.9;
+	margin-bottom: 4px;
 }
 
 .rtbcb-metric-large .rtbcb-metric-subtitle {
-    font-size: 14px;
-    opacity: 0.7;
+	font-size: 14px;
+	opacity: 0.7;
 }
 
 .rtbcb-metrics-grid {
-    display: grid;
-    gap: 20px;
+	display: grid;
+	gap: 20px;
 }
 
 .rtbcb-metric-card {
-    background: white;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+	background: white;
+	padding: 20px;
+	border-radius: 8px;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .rtbcb-metric-header {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 12px;
-    color: #6b7280;
-    font-size: 14px;
-    font-weight: 500;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 12px;
+	color: #6b7280;
+	font-size: 14px;
+	font-weight: 500;
 }
 
 .rtbcb-metric-card .rtbcb-metric-value {
-    font-size: 24px;
-    font-weight: 700;
-    color: #1f2937;
-    margin-bottom: 8px;
+	font-size: 24px;
+	font-weight: 700;
+	color: #1f2937;
+	margin-bottom: 8px;
 }
 
 .rtbcb-metric-change {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 12px;
-    color: #6b7280;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 12px;
+	color: #6b7280;
 }
 
 .rtbcb-metric-positive {
-    color: #059669;
+	color: #059669;
 }
 
 /* Dashboard Content */
 .rtbcb-dashboard-content {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 20px;
-    margin-bottom: 30px;
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 20px;
+	margin-bottom: 30px;
 }
 
 .rtbcb-dashboard-section {
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    overflow: hidden;
+	background: white;
+	border-radius: 8px;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+	overflow: hidden;
 }
 
 .rtbcb-section-full {
-    grid-column: 1 / -1;
+	grid-column: 1 / -1;
 }
 
 .rtbcb-section-header {
-    padding: 20px 24px;
-    border-bottom: 1px solid #f3f4f6;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+	padding: 20px 24px;
+	border-bottom: 1px solid #f3f4f6;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 }
 
 .rtbcb-section-header h3 {
-    margin: 0;
-    color: #1f2937;
-    font-size: 18px;
+	margin: 0;
+	color: #1f2937;
+	font-size: 18px;
 }
 
 .rtbcb-section-link {
-    color: #7216f4;
-    text-decoration: none;
-    font-size: 14px;
-    font-weight: 500;
+	color: #7216f4;
+	text-decoration: none;
+	font-size: 14px;
+	font-weight: 500;
 }
 
 .rtbcb-section-link:hover {
-    text-decoration: underline;
+	text-decoration: underline;
 }
 
 /* Recent Leads */
 .rtbcb-recent-leads {
-    padding: 0 24px 24px;
+	padding: 0 24px 24px;
 }
 
 .rtbcb-lead-item {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 12px 0;
-    border-bottom: 1px solid #f3f4f6;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 12px 0;
+	border-bottom: 1px solid #f3f4f6;
 }
 
 .rtbcb-lead-item:last-child {
-    border-bottom: none;
+	border-bottom: none;
 }
 
 .rtbcb-lead-avatar {
-    width: 40px;
-    height: 40px;
-    background: #7216f4;
-    color: white;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: 600;
-    font-size: 14px;
+	width: 40px;
+	height: 40px;
+	background: #7216f4;
+	color: white;
+	border-radius: 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-weight: 600;
+	font-size: 14px;
 }
 
 .rtbcb-lead-info {
-    flex: 1;
+	flex: 1;
 }
 
 .rtbcb-lead-email {
-    font-weight: 500;
-    color: #1f2937;
-    margin-bottom: 2px;
+	font-weight: 500;
+	color: #1f2937;
+	margin-bottom: 2px;
 }
 
 .rtbcb-lead-meta {
-    font-size: 12px;
-    color: #6b7280;
+	font-size: 12px;
+	color: #6b7280;
 }
 
 .rtbcb-lead-separator {
-    margin: 0 4px;
+	margin: 0 4px;
 }
 
 .rtbcb-roi {
-    color: #059669;
-    font-weight: 500;
+	color: #059669;
+	font-weight: 500;
 }
 
 .rtbcb-lead-time {
-    font-size: 12px;
-    color: #9ca3af;
+	font-size: 12px;
+	color: #9ca3af;
 }
 
 /* Quick Actions */
 .rtbcb-quick-actions {
-    padding: 24px;
-    display: grid;
-    gap: 16px;
+	padding: 24px;
+	display: grid;
+	gap: 16px;
 }
 
 .rtbcb-action-card {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 16px;
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    border-radius: 6px;
-    text-decoration: none;
-    color: inherit;
-    cursor: pointer;
-    transition: all 0.2s ease;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 16px;
+	background: #f9fafb;
+	border: 1px solid #e5e7eb;
+	border-radius: 6px;
+	text-decoration: none;
+	color: inherit;
+	cursor: pointer;
+	transition: all 0.2s ease;
 }
 
 .rtbcb-action-card:hover {
-    background: #f3f4f6;
-    border-color: #d1d5db;
-    transform: translateY(-1px);
+	background: #f3f4f6;
+	border-color: #d1d5db;
+	transform: translateY(-1px);
 }
 
 .rtbcb-action-icon {
-    width: 40px;
-    height: 40px;
-    background: #7216f4;
-    color: white;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 16px;
+	width: 40px;
+	height: 40px;
+	background: #7216f4;
+	color: white;
+	border-radius: 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 16px;
 }
 
 .rtbcb-action-content h4 {
-    margin: 0 0 4px 0;
-    color: #1f2937;
-    font-size: 14px;
-    font-weight: 600;
+	margin: 0 0 4px 0;
+	color: #1f2937;
+	font-size: 14px;
+	font-weight: 600;
 }
 
 .rtbcb-action-content p {
-    margin: 0;
-    color: #6b7280;
-    font-size: 12px;
+	margin: 0;
+	color: #6b7280;
+	font-size: 12px;
 }
 
 /* Category Summary */
 .rtbcb-category-summary {
-    padding: 24px;
-    display: grid;
-    gap: 16px;
+	padding: 24px;
+	display: grid;
+	gap: 16px;
 }
 
 .rtbcb-category-item {
-    display: grid;
-    gap: 8px;
+	display: grid;
+	gap: 8px;
 }
 
 .rtbcb-category-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 }
 
 .rtbcb-category-name {
-    font-weight: 600;
-    color: #1f2937;
+	font-weight: 600;
+	color: #1f2937;
 }
 
 .rtbcb-category-count {
-    font-size: 14px;
-    color: #6b7280;
+	font-size: 14px;
+	color: #6b7280;
 }
 
 .rtbcb-category-bar {
-    width: 100%;
-    height: 8px;
-    background: #f3f4f6;
-    border-radius: 4px;
-    overflow: hidden;
+	width: 100%;
+	height: 8px;
+	background: #f3f4f6;
+	border-radius: 4px;
+	overflow: hidden;
 }
 
 .rtbcb-category-fill {
-    height: 100%;
-    border-radius: 4px;
+	height: 100%;
+	border-radius: 4px;
 }
 
 .rtbcb-cat-cash_tools { background: #7216f4; }
@@ -721,47 +721,47 @@ $avg_roi = intval( $roi_stats['avg_base'] ?? 0 );
 .rtbcb-cat-trms { background: #c77dff; }
 
 .rtbcb-category-percentage {
-    text-align: right;
-    font-size: 12px;
-    color: #6b7280;
-    font-weight: 500;
+	text-align: right;
+	font-size: 12px;
+	color: #6b7280;
+	font-weight: 500;
 }
 
 .rtbcb-empty-state {
-    padding: 40px 24px;
-    text-align: center;
-    color: #9ca3af;
+	padding: 40px 24px;
+	text-align: center;
+	color: #9ca3af;
 }
 
 .rtbcb-empty-state .dashicons {
-    font-size: 48px;
-    margin-bottom: 16px;
-    display: block;
+	font-size: 48px;
+	margin-bottom: 16px;
+	display: block;
 }
 
 @media (max-width: 1200px) {
-    .rtbcb-metrics-overview {
-        grid-template-columns: 1fr;
-    }
-    
-    .rtbcb-dashboard-content {
-        grid-template-columns: 1fr;
-    }
+	.rtbcb-metrics-overview {
+		grid-template-columns: 1fr;
+	}
+	
+	.rtbcb-dashboard-content {
+		grid-template-columns: 1fr;
+	}
 }
 
 @media (max-width: 768px) {
-    .rtbcb-dashboard-header {
-        flex-direction: column;
-        gap: 20px;
-        align-items: stretch;
-    }
-    
-    .rtbcb-dashboard-actions {
-        justify-content: center;
-    }
-    
-    .rtbcb-status-grid {
-        grid-template-columns: 1fr;
-    }
+	.rtbcb-dashboard-header {
+		flex-direction: column;
+		gap: 20px;
+		align-items: stretch;
+	}
+	
+	.rtbcb-dashboard-actions {
+		justify-content: center;
+	}
+	
+	.rtbcb-status-grid {
+		grid-template-columns: 1fr;
+	}
 }
 </style>

--- a/admin/leads-page-enhanced.php
+++ b/admin/leads-page-enhanced.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Enhanced Leads admin page for Real Treasury Business Case Builder plugin.
- */
+	* Enhanced Leads admin page for Real Treasury Business Case Builder plugin.
+	*/
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
@@ -15,317 +15,317 @@ $order   = isset( $order ) ? sanitize_key( $order ) : 'DESC';
 ?>
 
 <div class="wrap rtbcb-admin-page">
-    <div class="rtbcb-admin-header">
-        <h1 class="wp-heading-inline">
-            <?php echo esc_html__( 'Leads Management', 'rtbcb' ); ?>
-            <span class="rtbcb-count-badge"><?php echo esc_html( number_format( $total_leads ) ); ?></span>
-        </h1>
-        <div class="rtbcb-admin-actions">
-            <button id="rtbcb-export-leads" class="button button-secondary">
-                <span class="dashicons dashicons-download"></span>
-                <?php esc_html_e( 'Export CSV', 'rtbcb' ); ?>
-            </button>
-        </div>
-    </div>
+	<div class="rtbcb-admin-header">
+		<h1 class="wp-heading-inline">
+			<?php echo esc_html__( 'Leads Management', 'rtbcb' ); ?>
+			<span class="rtbcb-count-badge"><?php echo esc_html( number_format( $total_leads ) ); ?></span>
+		</h1>
+		<div class="rtbcb-admin-actions">
+			<button id="rtbcb-export-leads" class="button button-secondary">
+				<span class="dashicons dashicons-download"></span>
+				<?php esc_html_e( 'Export CSV', 'rtbcb' ); ?>
+			</button>
+		</div>
+	</div>
 
-    <!-- Filters -->
-    <div class="rtbcb-filters">
-        <form method="get" action="">
-            <input type="hidden" name="page" value="rtbcb-leads" />
-            
-            <div class="rtbcb-filter-row">
-                <div class="rtbcb-filter-group">
-                    <label for="search"><?php esc_html_e( 'Search Email:', 'rtbcb' ); ?></label>
-                    <input type="text" id="search" name="search" value="<?php echo esc_attr( $search ); ?>" placeholder="<?php esc_attr_e( 'Enter email address...', 'rtbcb' ); ?>" />
-                </div>
-                
-                <div class="rtbcb-filter-group">
-                    <label for="category"><?php esc_html_e( 'Category:', 'rtbcb' ); ?></label>
-                    <select id="category" name="category">
-                        <option value=""><?php esc_html_e( 'All Categories', 'rtbcb' ); ?></option>
-                        <?php foreach ( $categories as $key => $cat_info ) : ?>
-                            <option value="<?php echo esc_attr( $key ); ?>" <?php selected( $category, $key ); ?>>
-                                <?php echo esc_html( $cat_info['name'] ); ?>
-                            </option>
-                        <?php endforeach; ?>
-                    </select>
-                </div>
-                
-                <div class="rtbcb-filter-group">
-                    <label for="date_from"><?php esc_html_e( 'From Date:', 'rtbcb' ); ?></label>
-                    <input type="date" id="date_from" name="date_from" value="<?php echo esc_attr( $date_from ); ?>" />
-                </div>
-                
-                <div class="rtbcb-filter-group">
-                    <label for="date_to"><?php esc_html_e( 'To Date:', 'rtbcb' ); ?></label>
-                    <input type="date" id="date_to" name="date_to" value="<?php echo esc_attr( $date_to ); ?>" />
-                </div>
-                
-                <div class="rtbcb-filter-actions">
-                    <button type="submit" class="button button-primary"><?php esc_html_e( 'Filter', 'rtbcb' ); ?></button>
-                    <a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-leads' ) ); ?>" class="button button-secondary"><?php esc_html_e( 'Clear', 'rtbcb' ); ?></a>
-                </div>
-            </div>
-        </form>
-    </div>
+	<!-- Filters -->
+	<div class="rtbcb-filters">
+		<form method="get" action="">
+			<input type="hidden" name="page" value="rtbcb-leads" />
+			
+			<div class="rtbcb-filter-row">
+				<div class="rtbcb-filter-group">
+					<label for="search"><?php esc_html_e( 'Search Email:', 'rtbcb' ); ?></label>
+					<input type="text" id="search" name="search" value="<?php echo esc_attr( $search ); ?>" placeholder="<?php esc_attr_e( 'Enter email address...', 'rtbcb' ); ?>" />
+				</div>
+				
+				<div class="rtbcb-filter-group">
+					<label for="category"><?php esc_html_e( 'Category:', 'rtbcb' ); ?></label>
+					<select id="category" name="category">
+						<option value=""><?php esc_html_e( 'All Categories', 'rtbcb' ); ?></option>
+						<?php foreach ( $categories as $key => $cat_info ) : ?>
+							<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $category, $key ); ?>>
+								<?php echo esc_html( $cat_info['name'] ); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+				</div>
+				
+				<div class="rtbcb-filter-group">
+					<label for="date_from"><?php esc_html_e( 'From Date:', 'rtbcb' ); ?></label>
+					<input type="date" id="date_from" name="date_from" value="<?php echo esc_attr( $date_from ); ?>" />
+				</div>
+				
+				<div class="rtbcb-filter-group">
+					<label for="date_to"><?php esc_html_e( 'To Date:', 'rtbcb' ); ?></label>
+					<input type="date" id="date_to" name="date_to" value="<?php echo esc_attr( $date_to ); ?>" />
+				</div>
+				
+				<div class="rtbcb-filter-actions">
+					<button type="submit" class="button button-primary"><?php esc_html_e( 'Filter', 'rtbcb' ); ?></button>
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-leads' ) ); ?>" class="button button-secondary"><?php esc_html_e( 'Clear', 'rtbcb' ); ?></a>
+				</div>
+			</div>
+		</form>
+	</div>
 
-    <!-- Bulk Actions -->
-    <div class="rtbcb-bulk-actions">
-        <form id="rtbcb-bulk-form">
-            <select id="rtbcb-bulk-action">
-                <option value=""><?php esc_html_e( 'Bulk Actions', 'rtbcb' ); ?></option>
-                <option value="delete"><?php esc_html_e( 'Delete', 'rtbcb' ); ?></option>
-            </select>
-            <button type="submit" class="button button-secondary" disabled><?php esc_html_e( 'Apply', 'rtbcb' ); ?></button>
-        </form>
-    </div>
+	<!-- Bulk Actions -->
+	<div class="rtbcb-bulk-actions">
+		<form id="rtbcb-bulk-form">
+			<select id="rtbcb-bulk-action">
+				<option value=""><?php esc_html_e( 'Bulk Actions', 'rtbcb' ); ?></option>
+				<option value="delete"><?php esc_html_e( 'Delete', 'rtbcb' ); ?></option>
+			</select>
+			<button type="submit" class="button button-secondary" disabled><?php esc_html_e( 'Apply', 'rtbcb' ); ?></button>
+		</form>
+	</div>
 
-    <!-- Leads Table -->
-    <?php if ( ! empty( $leads ) ) : ?>
-        <div class="rtbcb-table-container">
-            <table class="wp-list-table widefat fixed striped">
-                <thead>
-                    <tr>
-                        <td class="manage-column column-cb check-column">
-                            <input type="checkbox" id="rtbcb-select-all" />
-                        </td>
-                        <th class="manage-column column-email column-primary">
-                            <a href="<?php echo esc_url( add_query_arg( [ 'orderby' => 'email', 'order' => ( 'email' === $orderby && 'ASC' === strtoupper( $order ) ) ? 'DESC' : 'ASC' ] ) ); ?>">
-                                <?php esc_html_e( 'Email', 'rtbcb' ); ?>
-                                <?php if ( 'email' === $orderby ) : ?>
-                                    <span class="sorting-indicator"></span>
-                                <?php endif; ?>
-                            </a>
-                        </th>
-                        <th class="manage-column column-company-name"><?php esc_html_e( 'Company', 'rtbcb' ); ?></th>
-                        <th class="manage-column column-company-size"><?php esc_html_e( 'Company Size', 'rtbcb' ); ?></th>
-                        <th class="manage-column column-category"><?php esc_html_e( 'Recommended Category', 'rtbcb' ); ?></th>
-                        <th class="manage-column column-roi"><?php esc_html_e( 'Base ROI', 'rtbcb' ); ?></th>
-                        <th class="manage-column column-date">
-                            <a href="<?php echo esc_url( add_query_arg( [ 'orderby' => 'created_at', 'order' => ( 'created_at' === $orderby && 'ASC' === strtoupper( $order ) ) ? 'DESC' : 'ASC' ] ) ); ?>">
-                                <?php esc_html_e( 'Date', 'rtbcb' ); ?>
-                                <?php if ( 'created_at' === $orderby ) : ?>
-                                    <span class="sorting-indicator"></span>
-                                <?php endif; ?>
-                            </a>
-                        </th>
-                        <th class="manage-column column-actions"><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ( $leads as $lead ) : ?>
-                        <tr data-lead-id="<?php echo esc_attr( $lead['id'] ); ?>">
-                            <th scope="row" class="check-column">
-                                <input type="checkbox" class="rtbcb-lead-checkbox" value="<?php echo esc_attr( $lead['id'] ); ?>" />
-                            </th>
-                            <td class="column-email column-primary" data-colname="<?php esc_attr_e( 'Email', 'rtbcb' ); ?>">
-                                <strong><?php echo esc_html( $lead['email'] ); ?></strong>
-                                <div class="row-actions">
-                                    <span class="view">
-                                        <a href="#" class="rtbcb-view-lead" data-lead-id="<?php echo esc_attr( $lead['id'] ); ?>">
-                                            <?php esc_html_e( 'View Details', 'rtbcb' ); ?>
-                                        </a> |
-                                    </span>
-                                    <span class="delete">
-                                        <a href="#" class="rtbcb-delete-lead submitdelete" data-lead-id="<?php echo esc_attr( $lead['id'] ); ?>">
-                                            <?php esc_html_e( 'Delete', 'rtbcb' ); ?>
-                                        </a>
-                                    </span>
-                                </div>
-                                <button type="button" class="toggle-row"><span class="screen-reader-text"><?php esc_html_e( 'Show more details', 'rtbcb' ); ?></span></button>
-                            </td>
-                            <td class="column-company-name" data-colname="<?php esc_attr_e( 'Company', 'rtbcb' ); ?>">
-                                <?php if ( ! empty( $lead['company_name'] ) ) : ?>
-                                    <?php echo esc_html( $lead['company_name'] ); ?>
-                                <?php else : ?>
-                                    <span class="rtbcb-no-data"><?php esc_html_e( 'No data', 'rtbcb' ); ?></span>
-                                <?php endif; ?>
-                            </td>
-                            <td class="column-company-size" data-colname="<?php esc_attr_e( 'Company Size', 'rtbcb' ); ?>">
-                                <span class="rtbcb-company-size-badge rtbcb-size-<?php echo esc_attr( sanitize_title( $lead['company_size'] ) ); ?>">
-                                    <?php echo esc_html( $lead['company_size'] ); ?>
-                                </span>
-                            </td>
-                            <td class="column-category" data-colname="<?php esc_attr_e( 'Category', 'rtbcb' ); ?>">
-                                <?php if ( ! empty( $lead['recommended_category'] ) ) : ?>
-                                    <?php 
-                                    $cat_info = $categories[ $lead['recommended_category'] ] ?? [];
-                                    $cat_name = $cat_info['name'] ?? ucfirst( str_replace( '_', ' ', $lead['recommended_category'] ) );
-                                    ?>
-                                    <span class="rtbcb-category-badge rtbcb-cat-<?php echo esc_attr( $lead['recommended_category'] ); ?>">
-                                        <?php echo esc_html( $cat_name ); ?>
-                                    </span>
-                                <?php else : ?>
-                                    <span class="rtbcb-no-data"><?php esc_html_e( 'Not categorized', 'rtbcb' ); ?></span>
-                                <?php endif; ?>
-                            </td>
-                            <td class="column-roi" data-colname="<?php esc_attr_e( 'ROI', 'rtbcb' ); ?>">
-                                <?php if ( $lead['roi_base'] > 0 ) : ?>
-                                    <span class="rtbcb-roi-amount">$<?php echo esc_html( number_format( $lead['roi_base'] ) ); ?></span>
-                                <?php else : ?>
-                                    <span class="rtbcb-no-data"><?php esc_html_e( 'No data', 'rtbcb' ); ?></span>
-                                <?php endif; ?>
-                            </td>
-                            <td class="column-date" data-colname="<?php esc_attr_e( 'Date', 'rtbcb' ); ?>">
-                                <span title="<?php echo esc_attr( $lead['created_at'] ); ?>">
-                                    <?php echo esc_html( human_time_diff( strtotime( $lead['created_at'] ), current_time( 'timestamp' ) ) ); ?> <?php esc_html_e( 'ago', 'rtbcb' ); ?>
-                                </span>
-                            </td>
-                            <td class="column-actions" data-colname="<?php esc_attr_e( 'Actions', 'rtbcb' ); ?>">
-                                <div class="rtbcb-action-buttons">
-                                    <button type="button" class="button button-small rtbcb-view-lead" data-lead-id="<?php echo esc_attr( $lead['id'] ); ?>">
-                                        <span class="dashicons dashicons-visibility"></span>
-                                        <?php esc_html_e( 'View', 'rtbcb' ); ?>
-                                    </button>
-                                </div>
-                            </td>
-                        </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
-        </div>
+	<!-- Leads Table -->
+	<?php if ( ! empty( $leads ) ) : ?>
+		<div class="rtbcb-table-container">
+			<table class="wp-list-table widefat fixed striped">
+				<thead>
+					<tr>
+						<td class="manage-column column-cb check-column">
+							<input type="checkbox" id="rtbcb-select-all" />
+						</td>
+						<th class="manage-column column-email column-primary">
+							<a href="<?php echo esc_url( add_query_arg( [ 'orderby' => 'email', 'order' => ( 'email' === $orderby && 'ASC' === strtoupper( $order ) ) ? 'DESC' : 'ASC' ] ) ); ?>">
+								<?php esc_html_e( 'Email', 'rtbcb' ); ?>
+								<?php if ( 'email' === $orderby ) : ?>
+									<span class="sorting-indicator"></span>
+								<?php endif; ?>
+							</a>
+						</th>
+						<th class="manage-column column-company-name"><?php esc_html_e( 'Company', 'rtbcb' ); ?></th>
+						<th class="manage-column column-company-size"><?php esc_html_e( 'Company Size', 'rtbcb' ); ?></th>
+						<th class="manage-column column-category"><?php esc_html_e( 'Recommended Category', 'rtbcb' ); ?></th>
+						<th class="manage-column column-roi"><?php esc_html_e( 'Base ROI', 'rtbcb' ); ?></th>
+						<th class="manage-column column-date">
+							<a href="<?php echo esc_url( add_query_arg( [ 'orderby' => 'created_at', 'order' => ( 'created_at' === $orderby && 'ASC' === strtoupper( $order ) ) ? 'DESC' : 'ASC' ] ) ); ?>">
+								<?php esc_html_e( 'Date', 'rtbcb' ); ?>
+								<?php if ( 'created_at' === $orderby ) : ?>
+									<span class="sorting-indicator"></span>
+								<?php endif; ?>
+							</a>
+						</th>
+						<th class="manage-column column-actions"><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php foreach ( $leads as $lead ) : ?>
+						<tr data-lead-id="<?php echo esc_attr( $lead['id'] ); ?>">
+							<th scope="row" class="check-column">
+								<input type="checkbox" class="rtbcb-lead-checkbox" value="<?php echo esc_attr( $lead['id'] ); ?>" />
+							</th>
+							<td class="column-email column-primary" data-colname="<?php esc_attr_e( 'Email', 'rtbcb' ); ?>">
+								<strong><?php echo esc_html( $lead['email'] ); ?></strong>
+								<div class="row-actions">
+									<span class="view">
+										<a href="#" class="rtbcb-view-lead" data-lead-id="<?php echo esc_attr( $lead['id'] ); ?>">
+											<?php esc_html_e( 'View Details', 'rtbcb' ); ?>
+										</a> |
+									</span>
+									<span class="delete">
+										<a href="#" class="rtbcb-delete-lead submitdelete" data-lead-id="<?php echo esc_attr( $lead['id'] ); ?>">
+											<?php esc_html_e( 'Delete', 'rtbcb' ); ?>
+										</a>
+									</span>
+								</div>
+								<button type="button" class="toggle-row"><span class="screen-reader-text"><?php esc_html_e( 'Show more details', 'rtbcb' ); ?></span></button>
+							</td>
+							<td class="column-company-name" data-colname="<?php esc_attr_e( 'Company', 'rtbcb' ); ?>">
+								<?php if ( ! empty( $lead['company_name'] ) ) : ?>
+									<?php echo esc_html( $lead['company_name'] ); ?>
+								<?php else : ?>
+									<span class="rtbcb-no-data"><?php esc_html_e( 'No data', 'rtbcb' ); ?></span>
+								<?php endif; ?>
+							</td>
+							<td class="column-company-size" data-colname="<?php esc_attr_e( 'Company Size', 'rtbcb' ); ?>">
+								<span class="rtbcb-company-size-badge rtbcb-size-<?php echo esc_attr( sanitize_title( $lead['company_size'] ) ); ?>">
+									<?php echo esc_html( $lead['company_size'] ); ?>
+								</span>
+							</td>
+							<td class="column-category" data-colname="<?php esc_attr_e( 'Category', 'rtbcb' ); ?>">
+								<?php if ( ! empty( $lead['recommended_category'] ) ) : ?>
+									<?php 
+									$cat_info = $categories[ $lead['recommended_category'] ] ?? [];
+									$cat_name = $cat_info['name'] ?? ucfirst( str_replace( '_', ' ', $lead['recommended_category'] ) );
+									?>
+									<span class="rtbcb-category-badge rtbcb-cat-<?php echo esc_attr( $lead['recommended_category'] ); ?>">
+										<?php echo esc_html( $cat_name ); ?>
+									</span>
+								<?php else : ?>
+									<span class="rtbcb-no-data"><?php esc_html_e( 'Not categorized', 'rtbcb' ); ?></span>
+								<?php endif; ?>
+							</td>
+							<td class="column-roi" data-colname="<?php esc_attr_e( 'ROI', 'rtbcb' ); ?>">
+								<?php if ( $lead['roi_base'] > 0 ) : ?>
+									<span class="rtbcb-roi-amount">$<?php echo esc_html( number_format( $lead['roi_base'] ) ); ?></span>
+								<?php else : ?>
+									<span class="rtbcb-no-data"><?php esc_html_e( 'No data', 'rtbcb' ); ?></span>
+								<?php endif; ?>
+							</td>
+							<td class="column-date" data-colname="<?php esc_attr_e( 'Date', 'rtbcb' ); ?>">
+								<span title="<?php echo esc_attr( $lead['created_at'] ); ?>">
+									<?php echo esc_html( human_time_diff( strtotime( $lead['created_at'] ), current_time( 'timestamp' ) ) ); ?> <?php esc_html_e( 'ago', 'rtbcb' ); ?>
+								</span>
+							</td>
+							<td class="column-actions" data-colname="<?php esc_attr_e( 'Actions', 'rtbcb' ); ?>">
+								<div class="rtbcb-action-buttons">
+									<button type="button" class="button button-small rtbcb-view-lead" data-lead-id="<?php echo esc_attr( $lead['id'] ); ?>">
+										<span class="dashicons dashicons-visibility"></span>
+										<?php esc_html_e( 'View', 'rtbcb' ); ?>
+									</button>
+								</div>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+		</div>
 
-        <!-- Pagination -->
-        <?php if ( $total_pages > 1 ) : ?>
-            <div class="rtbcb-pagination">
-                <?php
-                $pagination_args = [
-                    'base'      => add_query_arg( 'paged', '%#%' ),
-                    'format'    => '',
-                    'current'   => $current_page,
-                    'total'     => $total_pages,
-                    'prev_text' => '&laquo; ' . __( 'Previous', 'rtbcb' ),
-                    'next_text' => __( 'Next', 'rtbcb' ) . ' &raquo;',
-                ];
-                echo wp_kses_post( paginate_links( $pagination_args ) );
-                ?>
-            </div>
-        <?php endif; ?>
+		<!-- Pagination -->
+		<?php if ( $total_pages > 1 ) : ?>
+			<div class="rtbcb-pagination">
+				<?php
+				$pagination_args = [
+					'base'      => add_query_arg( 'paged', '%#%' ),
+					'format'    => '',
+					'current'   => $current_page,
+					'total'     => $total_pages,
+					'prev_text' => '&laquo; ' . __( 'Previous', 'rtbcb' ),
+					'next_text' => __( 'Next', 'rtbcb' ) . ' &raquo;',
+				];
+				echo wp_kses_post( paginate_links( $pagination_args ) );
+				?>
+			</div>
+		<?php endif; ?>
 
-    <?php else : ?>
-        <div class="rtbcb-no-data">
-            <div class="rtbcb-no-data-icon">
-                <span class="dashicons dashicons-email-alt"></span>
-            </div>
-            <h3><?php esc_html_e( 'No leads found', 'rtbcb' ); ?></h3>
-            <p><?php esc_html_e( 'No one has completed the business case form yet, or your current filters don\'t match any leads.', 'rtbcb' ); ?></p>
-            <?php if ( ! empty( array_filter( [ $search, $category, $date_from, $date_to ] ) ) ) : ?>
-                <a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-leads' ) ); ?>" class="button button-primary">
-                    <?php esc_html_e( 'Clear Filters', 'rtbcb' ); ?>
-                </a>
-            <?php endif; ?>
-        </div>
-    <?php endif; ?>
+	<?php else : ?>
+		<div class="rtbcb-no-data">
+			<div class="rtbcb-no-data-icon">
+				<span class="dashicons dashicons-email-alt"></span>
+			</div>
+			<h3><?php esc_html_e( 'No leads found', 'rtbcb' ); ?></h3>
+			<p><?php esc_html_e( 'No one has completed the business case form yet, or your current filters don\'t match any leads.', 'rtbcb' ); ?></p>
+			<?php if ( ! empty( array_filter( [ $search, $category, $date_from, $date_to ] ) ) ) : ?>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-leads' ) ); ?>" class="button button-primary">
+					<?php esc_html_e( 'Clear Filters', 'rtbcb' ); ?>
+				</a>
+			<?php endif; ?>
+		</div>
+	<?php endif; ?>
 </div>
 
 <!-- Lead Details Modal -->
 <div id="rtbcb-lead-modal" class="rtbcb-modal" style="display: none;">
-    <div class="rtbcb-modal-content">
-        <div class="rtbcb-modal-header">
-            <h2><?php esc_html_e( 'Lead Details', 'rtbcb' ); ?></h2>
-            <button type="button" class="rtbcb-modal-close">&times;</button>
-        </div>
-        <div class="rtbcb-modal-body">
-            <div id="rtbcb-lead-details">
-                <!-- Lead details will be loaded here via AJAX -->
-            </div>
-        </div>
-    </div>
+	<div class="rtbcb-modal-content">
+		<div class="rtbcb-modal-header">
+			<h2><?php esc_html_e( 'Lead Details', 'rtbcb' ); ?></h2>
+			<button type="button" class="rtbcb-modal-close">&times;</button>
+		</div>
+		<div class="rtbcb-modal-body">
+			<div id="rtbcb-lead-details">
+				<!-- Lead details will be loaded here via AJAX -->
+			</div>
+		</div>
+	</div>
 </div>
 
 <style>
 /* Page-specific styles */
 .rtbcb-admin-page {
-    background: #f1f1f1;
-    margin: 0 -20px -20px -2px;
-    padding: 20px;
+	background: #f1f1f1;
+	margin: 0 -20px -20px -2px;
+	padding: 20px;
 }
 
 .rtbcb-admin-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
-    background: white;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 20px;
+	background: white;
+	padding: 20px;
+	border-radius: 8px;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .rtbcb-count-badge {
-    background: var(--primary-purple, #7216f4);
-    color: white;
-    padding: 4px 8px;
-    border-radius: 12px;
-    font-size: 12px;
-    font-weight: normal;
-    margin-left: 8px;
+	background: var(--primary-purple, #7216f4);
+	color: white;
+	padding: 4px 8px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: normal;
+	margin-left: 8px;
 }
 
 .rtbcb-filters {
-    background: white;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    margin-bottom: 20px;
+	background: white;
+	padding: 20px;
+	border-radius: 8px;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+	margin-bottom: 20px;
 }
 
 .rtbcb-filter-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
-    align-items: end;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+	align-items: end;
 }
 
 .rtbcb-filter-group {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    min-width: 150px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-width: 150px;
 }
 
 .rtbcb-filter-group label {
-    font-weight: 600;
-    font-size: 12px;
-    color: #666;
+	font-weight: 600;
+	font-size: 12px;
+	color: #666;
 }
 
 .rtbcb-filter-actions {
-    display: flex;
-    gap: 8px;
-    align-items: end;
+	display: flex;
+	gap: 8px;
+	align-items: end;
 }
 
 .rtbcb-bulk-actions {
-    background: white;
-    padding: 12px 20px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    margin-bottom: 20px;
+	background: white;
+	padding: 12px 20px;
+	border-radius: 8px;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+	margin-bottom: 20px;
 }
 
 .rtbcb-bulk-actions form {
-    display: flex;
-    align-items: center;
-    gap: 8px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
 }
 
 .rtbcb-table-container {
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    overflow: hidden;
+	background: white;
+	border-radius: 8px;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+	overflow: hidden;
 }
 
 .rtbcb-company-size-badge,
 .rtbcb-category-badge {
-    display: inline-block;
-    padding: 4px 8px;
-    border-radius: 12px;
-    font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
+	display: inline-block;
+	padding: 4px 8px;
+	border-radius: 12px;
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
 }
 
 .rtbcb-size-50m { background: #dbeafe; color: #1e40af; }
@@ -338,142 +338,142 @@ $order   = isset( $order ) ? sanitize_key( $order ) : 'DESC';
 .rtbcb-cat-trms { background: #fef2f2; color: #991b1b; }
 
 .rtbcb-roi-amount {
-    font-weight: 600;
-    color: #059669;
+	font-weight: 600;
+	color: #059669;
 }
 
 .rtbcb-no-data {
-    color: #9ca3af;
-    font-style: italic;
+	color: #9ca3af;
+	font-style: italic;
 }
 
 .rtbcb-action-buttons {
-    display: flex;
-    gap: 4px;
+	display: flex;
+	gap: 4px;
 }
 
 .rtbcb-no-data {
-    text-align: center;
-    padding: 60px 20px;
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+	text-align: center;
+	padding: 60px 20px;
+	background: white;
+	border-radius: 8px;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .rtbcb-no-data-icon {
-    font-size: 48px;
-    color: #d1d5db;
-    margin-bottom: 16px;
+	font-size: 48px;
+	color: #d1d5db;
+	margin-bottom: 16px;
 }
 
 .rtbcb-pagination {
-    display: flex;
-    justify-content: center;
-    margin-top: 20px;
+	display: flex;
+	justify-content: center;
+	margin-top: 20px;
 }
 
 /* Modal Styles */
 .rtbcb-modal {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0,0,0,0.7);
-    z-index: 100000;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background: rgba(0,0,0,0.7);
+	z-index: 100000;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .rtbcb-modal-content {
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 20px 60px rgba(0,0,0,0.3);
-    max-width: 600px;
-    width: 90%;
-    max-height: 80vh;
-    overflow: hidden;
+	background: white;
+	border-radius: 8px;
+	box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+	max-width: 600px;
+	width: 90%;
+	max-height: 80vh;
+	overflow: hidden;
 }
 
 .rtbcb-modal-header {
-    padding: 20px;
-    border-bottom: 1px solid #e5e7eb;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+	padding: 20px;
+	border-bottom: 1px solid #e5e7eb;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 }
 
 .rtbcb-modal-header h2 {
-    margin: 0;
-    color: #111827;
+	margin: 0;
+	color: #111827;
 }
 
 .rtbcb-modal-close {
-    background: none;
-    border: none;
-    font-size: 24px;
-    cursor: pointer;
-    color: #6b7280;
-    padding: 0;
-    width: 32px;
-    height: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 4px;
+	background: none;
+	border: none;
+	font-size: 24px;
+	cursor: pointer;
+	color: #6b7280;
+	padding: 0;
+	width: 32px;
+	height: 32px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 4px;
 }
 
 .rtbcb-modal-close:hover {
-    background: #f3f4f6;
-    color: #374151;
+	background: #f3f4f6;
+	color: #374151;
 }
 
 .rtbcb-modal-body {
-    padding: 20px;
-    overflow-y: auto;
-    max-height: calc(80vh - 120px);
+	padding: 20px;
+	overflow-y: auto;
+	max-height: calc(80vh - 120px);
 }
 
 .rtbcb-lead-detail-grid {
-    display: grid;
-    gap: 16px;
+	display: grid;
+	gap: 16px;
 }
 
 .rtbcb-detail-item {
-    display: grid;
-    grid-template-columns: 120px 1fr;
-    gap: 12px;
-    align-items: center;
+	display: grid;
+	grid-template-columns: 120px 1fr;
+	gap: 12px;
+	align-items: center;
 }
 
 .rtbcb-detail-item label {
-    font-weight: 600;
-    color: #374151;
+	font-weight: 600;
+	color: #374151;
 }
 
 .rtbcb-detail-item span {
-    color: #111827;
+	color: #111827;
 }
 
 @media (max-width: 768px) {
-    .rtbcb-admin-header {
-        flex-direction: column;
-        gap: 16px;
-        align-items: stretch;
-    }
-    
-    .rtbcb-filter-row {
-        flex-direction: column;
-    }
-    
-    .rtbcb-filter-group {
-        min-width: auto;
-    }
-    
-    .rtbcb-detail-item {
-        grid-template-columns: 1fr;
-        gap: 4px;
-    }
+	.rtbcb-admin-header {
+		flex-direction: column;
+		gap: 16px;
+		align-items: stretch;
+	}
+	
+	.rtbcb-filter-row {
+		flex-direction: column;
+	}
+	
+	.rtbcb-filter-group {
+		min-width: auto;
+	}
+	
+	.rtbcb-detail-item {
+		grid-template-columns: 1fr;
+		gap: 4px;
+	}
 }
 </style>

--- a/admin/partials/dashboard-connectivity.php
+++ b/admin/partials/dashboard-connectivity.php
@@ -1,283 +1,283 @@
 <?php
 /**
- * Dashboard connectivity status and tests.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Dashboard connectivity status and tests.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 ?>
 <div class="card">
-    <h2 class="title"><?php esc_html_e( 'Connectivity Tests & Status', 'rtbcb' ); ?></h2>
-    <table class="widefat striped">
-        <tbody>
-            <tr>
-                <th><?php esc_html_e( 'OpenAI API Key', 'rtbcb' ); ?></th>
-                <td><?php echo $openai_status ? esc_html__( 'Configured', 'rtbcb' ) : esc_html__( 'Missing', 'rtbcb' ); ?></td>
-            </tr>
-            <tr>
-                <th><?php esc_html_e( 'Portal Integration', 'rtbcb' ); ?></th>
-                <td><?php echo $portal_active ? esc_html__( 'Active', 'rtbcb' ) : esc_html__( 'Inactive', 'rtbcb' ); ?></td>
-            </tr>
-            <tr>
-                <th><?php esc_html_e( 'RAG Index', 'rtbcb' ); ?></th>
-                <td><?php echo $rag_health ? esc_html__( 'Healthy', 'rtbcb' ) : esc_html__( 'Needs attention', 'rtbcb' ); ?></td>
-            </tr>
-            <tr>
-                <th><?php esc_html_e( 'Last RAG Index', 'rtbcb' ); ?></th>
-                <td>
-                    <?php
-                    if ( ! empty( $last_indexed ) ) {
-                        echo esc_html( $last_indexed );
-                    } else {
-                        esc_html_e( 'Never', 'rtbcb' );
-                    }
-                    ?>
-                </td>
-            </tr>
-            <tr>
-                <th><?php esc_html_e( 'Vendor Count', 'rtbcb' ); ?></th>
-                <td><?php echo esc_html( intval( $vendor_count ) ); ?></td>
-            </tr>
-        </tbody>
-    </table>
-    <p class="submit">
-        <button type="button" id="rtbcb-test-openai" class="button"><?php esc_html_e( 'Test OpenAI API', 'rtbcb' ); ?></button>
-        <button type="button" id="rtbcb-test-portal" class="button"><?php esc_html_e( 'Test Portal Connection', 'rtbcb' ); ?></button>
-        <button type="button" id="rtbcb-test-rag" class="button"><?php esc_html_e( 'Test RAG Index', 'rtbcb' ); ?></button>
-        <button type="button" id="rtbcb-rebuild-rag" class="button"><?php esc_html_e( 'Rebuild RAG Index', 'rtbcb' ); ?></button>
-    </p>
-    <form id="rtbcb-sync-local-form" class="submit">
-        <?php wp_nonce_field( 'rtbcb_sync_local', 'rtbcb_sync_local_nonce' ); ?>
-        <button type="button" class="button" id="rtbcb-sync-to-local">
-            <?php esc_html_e( 'Sync to Local', 'rtbcb' ); ?>
-        </button>
-    </form>
-    <p id="rtbcb-connectivity-status"></p>
+	<h2 class="title"><?php esc_html_e( 'Connectivity Tests & Status', 'rtbcb' ); ?></h2>
+	<table class="widefat striped">
+		<tbody>
+			<tr>
+				<th><?php esc_html_e( 'OpenAI API Key', 'rtbcb' ); ?></th>
+				<td><?php echo $openai_status ? esc_html__( 'Configured', 'rtbcb' ) : esc_html__( 'Missing', 'rtbcb' ); ?></td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Portal Integration', 'rtbcb' ); ?></th>
+				<td><?php echo $portal_active ? esc_html__( 'Active', 'rtbcb' ) : esc_html__( 'Inactive', 'rtbcb' ); ?></td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'RAG Index', 'rtbcb' ); ?></th>
+				<td><?php echo $rag_health ? esc_html__( 'Healthy', 'rtbcb' ) : esc_html__( 'Needs attention', 'rtbcb' ); ?></td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Last RAG Index', 'rtbcb' ); ?></th>
+				<td>
+					<?php
+					if ( ! empty( $last_indexed ) ) {
+						echo esc_html( $last_indexed );
+					} else {
+						esc_html_e( 'Never', 'rtbcb' );
+					}
+					?>
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Vendor Count', 'rtbcb' ); ?></th>
+				<td><?php echo esc_html( intval( $vendor_count ) ); ?></td>
+			</tr>
+		</tbody>
+	</table>
+	<p class="submit">
+		<button type="button" id="rtbcb-test-openai" class="button"><?php esc_html_e( 'Test OpenAI API', 'rtbcb' ); ?></button>
+		<button type="button" id="rtbcb-test-portal" class="button"><?php esc_html_e( 'Test Portal Connection', 'rtbcb' ); ?></button>
+		<button type="button" id="rtbcb-test-rag" class="button"><?php esc_html_e( 'Test RAG Index', 'rtbcb' ); ?></button>
+		<button type="button" id="rtbcb-rebuild-rag" class="button"><?php esc_html_e( 'Rebuild RAG Index', 'rtbcb' ); ?></button>
+	</p>
+	<form id="rtbcb-sync-local-form" class="submit">
+		<?php wp_nonce_field( 'rtbcb_sync_local', 'rtbcb_sync_local_nonce' ); ?>
+		<button type="button" class="button" id="rtbcb-sync-to-local">
+			<?php esc_html_e( 'Sync to Local', 'rtbcb' ); ?>
+		</button>
+	</form>
+	<p id="rtbcb-connectivity-status"></p>
 
-    <?php include RTBCB_DIR . 'admin/partials/dashboard-test-results.php'; ?>
+	<?php include RTBCB_DIR . 'admin/partials/dashboard-test-results.php'; ?>
 </div>
 <script>
 (function($){
-    function escHtml(text) {
-        return $('<div />').text(text).html();
-    }
+	function escHtml(text) {
+		return $('<div />').text(text).html();
+	}
 
-    function renderStatus($el, message, success){
-        var cls = success ? 'notice notice-success' : 'notice notice-error';
-        $el.html('<div class="' + cls + '"><p>' + message + '</p></div>');
-    }
+	function renderStatus($el, message, success){
+		var cls = success ? 'notice notice-success' : 'notice notice-error';
+		$el.html('<div class="' + cls + '"><p>' + message + '</p></div>');
+	}
 
-    $('#rtbcb-test-openai').on('click', function(){
-        var $btn = $(this);
-        var original = $btn.text();
-        var $status = $('#rtbcb-connectivity-status');
-        $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
-        $.ajax({
-            url: ajaxurl,
-            method: 'POST',
-            data: {
-                action: 'rtbcb_test_api',
-                nonce: '<?php echo wp_create_nonce( 'rtbcb_test_api' ); ?>'
-            },
-            async: false,
-            success: function(response){
-                if (response.success) {
-                    renderStatus($status, response.data.message || '<?php echo esc_js( __( 'Connection successful.', 'rtbcb' ) ); ?>', true);
-                } else {
-                    renderStatus($status, response.data.message || '<?php echo esc_js( __( 'Connection failed.', 'rtbcb' ) ); ?>', false);
-                }
-            },
-            error: function(){
-                renderStatus($status, '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);
-            },
-            complete: function(){
-                $btn.prop('disabled', false).text(original);
-            }
-        });
-    });
+	$('#rtbcb-test-openai').on('click', function(){
+		var $btn = $(this);
+		var original = $btn.text();
+		var $status = $('#rtbcb-connectivity-status');
+		$btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
+		$.ajax({
+			url: ajaxurl,
+			method: 'POST',
+			data: {
+				action: 'rtbcb_test_api',
+				nonce: '<?php echo wp_create_nonce( 'rtbcb_test_api' ); ?>'
+			},
+			async: false,
+			success: function(response){
+				if (response.success) {
+					renderStatus($status, response.data.message || '<?php echo esc_js( __( 'Connection successful.', 'rtbcb' ) ); ?>', true);
+				} else {
+					renderStatus($status, response.data.message || '<?php echo esc_js( __( 'Connection failed.', 'rtbcb' ) ); ?>', false);
+				}
+			},
+			error: function(){
+				renderStatus($status, '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);
+			},
+			complete: function(){
+				$btn.prop('disabled', false).text(original);
+			}
+		});
+	});
 
-    $('#rtbcb-test-portal').on('click', function(){
-        var $btn = $(this);
-        var original = $btn.text();
-        var $status = $('#rtbcb-connectivity-status');
-        $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
-        $.ajax({
-            url: ajaxurl,
-            method: 'POST',
-            data: {
-                action: 'rtbcb_test_portal',
-                nonce: '<?php echo wp_create_nonce( 'rtbcb_test_portal' ); ?>'
-            },
-            async: false,
-            success: function(response){
-                if (response.success) {
-                    var msg = response.data && response.data.vendor_count !== undefined ? '<?php echo esc_js( __( 'Vendor count:', 'rtbcb' ) ); ?> ' + response.data.vendor_count : (response.data.message || '<?php echo esc_js( __( 'Portal test successful.', 'rtbcb' ) ); ?>');
-                    renderStatus($status, msg, true);
-                } else {
-                    renderStatus($status, (response.data && response.data.message) ? response.data.message : '<?php echo esc_js( __( 'Test failed.', 'rtbcb' ) ); ?>', false);
-                }
-            },
-            error: function(){
-                renderStatus($status, '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);
-            },
-            complete: function(){
-                $btn.prop('disabled', false).text(original);
-            }
-        });
-    });
+	$('#rtbcb-test-portal').on('click', function(){
+		var $btn = $(this);
+		var original = $btn.text();
+		var $status = $('#rtbcb-connectivity-status');
+		$btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
+		$.ajax({
+			url: ajaxurl,
+			method: 'POST',
+			data: {
+				action: 'rtbcb_test_portal',
+				nonce: '<?php echo wp_create_nonce( 'rtbcb_test_portal' ); ?>'
+			},
+			async: false,
+			success: function(response){
+				if (response.success) {
+					var msg = response.data && response.data.vendor_count !== undefined ? '<?php echo esc_js( __( 'Vendor count:', 'rtbcb' ) ); ?> ' + response.data.vendor_count : (response.data.message || '<?php echo esc_js( __( 'Portal test successful.', 'rtbcb' ) ); ?>');
+					renderStatus($status, msg, true);
+				} else {
+					renderStatus($status, (response.data && response.data.message) ? response.data.message : '<?php echo esc_js( __( 'Test failed.', 'rtbcb' ) ); ?>', false);
+				}
+			},
+			error: function(){
+				renderStatus($status, '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);
+			},
+			complete: function(){
+				$btn.prop('disabled', false).text(original);
+			}
+		});
+	});
 
-    $('#rtbcb-test-rag').on('click', function(){
-        var $btn = $(this);
-        var original = $btn.text();
-        var $status = $('#rtbcb-connectivity-status');
-        $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
-        $.ajax({
-            url: ajaxurl,
-            method: 'POST',
-            data: {
-                action: 'rtbcb_test_rag',
-                nonce: '<?php echo wp_create_nonce( 'rtbcb_test_rag' ); ?>'
-            },
-            success: function(response){
-                if (response.success) {
-                    var ragMsg = response.data && response.data.status ? escHtml(response.data.status) : '<?php echo esc_js( esc_html__( 'RAG index healthy.', 'rtbcb' ) ); ?>';
+	$('#rtbcb-test-rag').on('click', function(){
+		var $btn = $(this);
+		var original = $btn.text();
+		var $status = $('#rtbcb-connectivity-status');
+		$btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
+		$.ajax({
+			url: ajaxurl,
+			method: 'POST',
+			data: {
+				action: 'rtbcb_test_rag',
+				nonce: '<?php echo wp_create_nonce( 'rtbcb_test_rag' ); ?>'
+			},
+			success: function(response){
+				if (response.success) {
+					var ragMsg = response.data && response.data.status ? escHtml(response.data.status) : '<?php echo esc_js( esc_html__( 'RAG index healthy.', 'rtbcb' ) ); ?>';
 
-                    if (response.data) {
-                        if (typeof response.data.indexed_items !== 'undefined') {
-                            ragMsg += '<br><?php echo esc_js( esc_html__( 'Indexed items:', 'rtbcb' ) ); ?> ' + escHtml(response.data.indexed_items);
-                        }
+					if (response.data) {
+						if (typeof response.data.indexed_items !== 'undefined') {
+							ragMsg += '<br><?php echo esc_js( esc_html__( 'Indexed items:', 'rtbcb' ) ); ?> ' + escHtml(response.data.indexed_items);
+						}
 
-                        if (response.data.last_updated) {
-                            ragMsg += '<br><?php echo esc_js( esc_html__( 'Last updated:', 'rtbcb' ) ); ?> ' + escHtml(response.data.last_updated);
-                        }
-                    }
+						if (response.data.last_updated) {
+							ragMsg += '<br><?php echo esc_js( esc_html__( 'Last updated:', 'rtbcb' ) ); ?> ' + escHtml(response.data.last_updated);
+						}
+					}
 
-                    renderStatus($status, ragMsg, true);
-                } else {
-                    var errMsg = (response.data && response.data.message) ? escHtml(response.data.message) : '<?php echo esc_js( esc_html__( 'Test failed.', 'rtbcb' ) ); ?>';
-                    renderStatus($status, errMsg, false);
-                }
-            },
-            error: function(){
-                renderStatus($status, '<?php echo esc_js( esc_html__( 'Request failed.', 'rtbcb' ) ); ?>', false);
-            },
-            complete: function(){
-                $btn.prop('disabled', false).text(original);
-            }
-        });
-    });
+					renderStatus($status, ragMsg, true);
+				} else {
+					var errMsg = (response.data && response.data.message) ? escHtml(response.data.message) : '<?php echo esc_js( esc_html__( 'Test failed.', 'rtbcb' ) ); ?>';
+					renderStatus($status, errMsg, false);
+				}
+			},
+			error: function(){
+				renderStatus($status, '<?php echo esc_js( esc_html__( 'Request failed.', 'rtbcb' ) ); ?>', false);
+			},
+			complete: function(){
+				$btn.prop('disabled', false).text(original);
+			}
+		});
+	});
 
-    $('#rtbcb-rebuild-rag').on('click', function(){
-        var $btn = $(this);
-        var original = $btn.text();
-        var $status = $('#rtbcb-connectivity-status');
-        $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Rebuilding...', 'rtbcb' ) ); ?>');
-        $.ajax({
-            url: ajaxurl,
-            method: 'POST',
-            data: {
-                action: 'rtbcb_rebuild_index',
-                nonce: '<?php echo wp_create_nonce( 'rtbcb_nonce' ); ?>'
-            },
-            success: function(response){
-                if (response.success) {
-                    var msg = (response.data && response.data.message) ? escHtml(response.data.message) : '<?php echo esc_js( esc_html__( 'RAG index rebuilt successfully.', 'rtbcb' ) ); ?>';
-                    renderStatus($status, msg, true);
-                } else {
-                    var err = (response.data && response.data.message) ? escHtml(response.data.message) : '<?php echo esc_js( esc_html__( 'Rebuild failed.', 'rtbcb' ) ); ?>';
-                    renderStatus($status, err, false);
-                }
-            },
-            error: function(){
-                renderStatus($status, '<?php echo esc_js( esc_html__( 'Request failed.', 'rtbcb' ) ); ?>', false);
-            },
-            complete: function(){
-                $btn.prop('disabled', false).text(original);
-            }
-        });
-    });
+	$('#rtbcb-rebuild-rag').on('click', function(){
+		var $btn = $(this);
+		var original = $btn.text();
+		var $status = $('#rtbcb-connectivity-status');
+		$btn.prop('disabled', true).text('<?php echo esc_js( __( 'Rebuilding...', 'rtbcb' ) ); ?>');
+		$.ajax({
+			url: ajaxurl,
+			method: 'POST',
+			data: {
+				action: 'rtbcb_rebuild_index',
+				nonce: '<?php echo wp_create_nonce( 'rtbcb_nonce' ); ?>'
+			},
+			success: function(response){
+				if (response.success) {
+					var msg = (response.data && response.data.message) ? escHtml(response.data.message) : '<?php echo esc_js( esc_html__( 'RAG index rebuilt successfully.', 'rtbcb' ) ); ?>';
+					renderStatus($status, msg, true);
+				} else {
+					var err = (response.data && response.data.message) ? escHtml(response.data.message) : '<?php echo esc_js( esc_html__( 'Rebuild failed.', 'rtbcb' ) ); ?>';
+					renderStatus($status, err, false);
+				}
+			},
+			error: function(){
+				renderStatus($status, '<?php echo esc_js( esc_html__( 'Request failed.', 'rtbcb' ) ); ?>', false);
+			},
+			complete: function(){
+				$btn.prop('disabled', false).text(original);
+			}
+		});
+	});
 
-    $('#rtbcb-set-company').on('click', function(){
-        var $btn = $(this);
-        var original = $btn.text();
-        var $status = $('#rtbcb-connectivity-status');
-        var $companyInput = $('#rtbcb-company-name');
-        var name = $companyInput.val().trim();
+	$('#rtbcb-set-company').on('click', function(){
+		var $btn = $(this);
+		var original = $btn.text();
+		var $status = $('#rtbcb-connectivity-status');
+		var $companyInput = $('#rtbcb-company-name');
+		var name = $companyInput.val().trim();
 
-        if (!name) {
-            renderStatus($status, '<?php echo esc_js( __( 'Please enter a company name.', 'rtbcb' ) ); ?>', false);
-            $companyInput.focus();
-            return;
-        }
+		if (!name) {
+			renderStatus($status, '<?php echo esc_js( __( 'Please enter a company name.', 'rtbcb' ) ); ?>', false);
+			$companyInput.focus();
+			return;
+		}
 
-        var $spinner = $('<span class="spinner is-active"></span>').insertAfter($btn);
-        $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Saving...', 'rtbcb' ) ); ?>');
+		var $spinner = $('<span class="spinner is-active"></span>').insertAfter($btn);
+		$btn.prop('disabled', true).text('<?php echo esc_js( __( 'Saving...', 'rtbcb' ) ); ?>');
 
-        $.ajax({
-            url: ajaxurl,
-            method: 'POST',
-            timeout: rtbcb_ajax.timeout,
-            data: {
-                action: 'rtbcb_set_test_company',
-                nonce: $('#rtbcb_set_test_company_nonce').val(),
-                company_name: name
-            },
-            success: function(response){
-                if (response.success) {
-                    renderStatus($status, escHtml(response.data.message), true);
-                    $('#rtbcb-test-results-summary tbody').html('<tr><td colspan="7"><?php echo esc_js( __( 'No test results found.', 'rtbcb' ) ); ?></td></tr>');
-                    generateOverview(name, original, $btn, $spinner, $status);
-                } else {
-                    renderStatus($status, (response.data && response.data.message) ? escHtml(response.data.message) : '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);
-                    $btn.prop('disabled', false).text(original);
-                    $spinner.remove();
-                }
-            },
-            error: function(xhr, textStatus){
-                var msg = '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>';
-                if (textStatus === 'timeout') {
-                    msg = '<?php echo esc_js( __( 'Request timed out.', 'rtbcb' ) ); ?>';
-                }
-                renderStatus($status, msg, false);
-                $btn.prop('disabled', false).text(original);
-                $spinner.remove();
-            }
-        });
-    });
+		$.ajax({
+			url: ajaxurl,
+			method: 'POST',
+			timeout: rtbcb_ajax.timeout,
+			data: {
+				action: 'rtbcb_set_test_company',
+				nonce: $('#rtbcb_set_test_company_nonce').val(),
+				company_name: name
+			},
+			success: function(response){
+				if (response.success) {
+					renderStatus($status, escHtml(response.data.message), true);
+					$('#rtbcb-test-results-summary tbody').html('<tr><td colspan="7"><?php echo esc_js( __( 'No test results found.', 'rtbcb' ) ); ?></td></tr>');
+					generateOverview(name, original, $btn, $spinner, $status);
+				} else {
+					renderStatus($status, (response.data && response.data.message) ? escHtml(response.data.message) : '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>', false);
+					$btn.prop('disabled', false).text(original);
+					$spinner.remove();
+				}
+			},
+			error: function(xhr, textStatus){
+				var msg = '<?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?>';
+				if (textStatus === 'timeout') {
+					msg = '<?php echo esc_js( __( 'Request timed out.', 'rtbcb' ) ); ?>';
+				}
+				renderStatus($status, msg, false);
+				$btn.prop('disabled', false).text(original);
+				$spinner.remove();
+			}
+		});
+	});
 
-    function generateOverview(name, original, $btn, $spinner, $status){
-        $btn.text('<?php echo esc_js( __( 'Generating overview...', 'rtbcb' ) ); ?>');
+	function generateOverview(name, original, $btn, $spinner, $status){
+		$btn.text('<?php echo esc_js( __( 'Generating overview...', 'rtbcb' ) ); ?>');
 
-        $.ajax({
-            url: ajaxurl,
-            method: 'POST',
-            timeout: rtbcb_ajax.timeout,
-            data: {
-                action: 'rtbcb_generate_company_overview',
-                nonce: '<?php echo wp_create_nonce( 'rtbcb_test_company_overview' ); ?>',
-                company_name: name
-            },
-            success: function(response){
-                if (response.success) {
-                    renderStatus($status, '<?php echo esc_js( __( 'Company overview generated.', 'rtbcb' ) ); ?>', true);
-                } else {
-                    var msg = (response.data && response.data.message) ? escHtml(response.data.message) : '<?php echo esc_js( __( 'Overview generation failed.', 'rtbcb' ) ); ?>';
-                    renderStatus($status, msg, false);
-                }
-            },
-            error: function(xhr, textStatus){
-                var msg = '<?php echo esc_js( __( 'Overview request failed.', 'rtbcb' ) ); ?>';
-                if (textStatus === 'timeout') {
-                    msg = '<?php echo esc_js( __( 'Overview request timed out.', 'rtbcb' ) ); ?>';
-                }
-                renderStatus($status, msg, false);
-            },
-            complete: function(){
-                $btn.prop('disabled', false).text(original);
-                $spinner.remove();
-            }
-        });
-    }
+		$.ajax({
+			url: ajaxurl,
+			method: 'POST',
+			timeout: rtbcb_ajax.timeout,
+			data: {
+				action: 'rtbcb_generate_company_overview',
+				nonce: '<?php echo wp_create_nonce( 'rtbcb_test_company_overview' ); ?>',
+				company_name: name
+			},
+			success: function(response){
+				if (response.success) {
+					renderStatus($status, '<?php echo esc_js( __( 'Company overview generated.', 'rtbcb' ) ); ?>', true);
+				} else {
+					var msg = (response.data && response.data.message) ? escHtml(response.data.message) : '<?php echo esc_js( __( 'Overview generation failed.', 'rtbcb' ) ); ?>';
+					renderStatus($status, msg, false);
+				}
+			},
+			error: function(xhr, textStatus){
+				var msg = '<?php echo esc_js( __( 'Overview request failed.', 'rtbcb' ) ); ?>';
+				if (textStatus === 'timeout') {
+					msg = '<?php echo esc_js( __( 'Overview request timed out.', 'rtbcb' ) ); ?>';
+				}
+				renderStatus($status, msg, false);
+			},
+			complete: function(){
+				$btn.prop('disabled', false).text(original);
+				$spinner.remove();
+			}
+		});
+	}
 })(jQuery);
 </script>

--- a/admin/partials/dashboard-test-results.php
+++ b/admin/partials/dashboard-test-results.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Dashboard recent test results.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Dashboard recent test results.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 $max_results  = 10;
 $recent_results = [];
 if ( ! empty( $test_results ) && is_array( $test_results ) ) {
-    $recent_results = array_slice( $test_results, 0, $max_results );
+	$recent_results = array_slice( $test_results, 0, $max_results );
 }
 
 $sections     = rtbcb_get_dashboard_sections( $test_results );
@@ -19,89 +19,89 @@ $sections     = rtbcb_get_dashboard_sections( $test_results );
 <h2 class="title"><?php esc_html_e( 'Recent Test Results', 'rtbcb' ); ?></h2>
 <div class="rtbcb-results-table-wrapper">
 <table class="widefat striped rtbcb-test-results-table" id="rtbcb-test-results-summary">
-    <thead>
-        <tr>
-            <th><?php esc_html_e( 'Section', 'rtbcb' ); ?></th>
-            <th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
-            <th><?php esc_html_e( 'Message', 'rtbcb' ); ?></th>
-            <th><?php esc_html_e( 'Word Count', 'rtbcb' ); ?></th>
-            <th><?php esc_html_e( 'Elapsed (s)', 'rtbcb' ); ?></th>
-            <th><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
-            <th><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
-        </tr>
-    </thead>
-    <tbody>
-    <?php if ( ! empty( $recent_results ) ) : ?>
-        <?php foreach ( $recent_results as $result ) : ?>
-            <?php
-            $section_id = isset( $result['section'] ) ? sanitize_text_field( $result['section'] ) : '';
-            $section_label = '';
-            if ( isset( $sections[ $section_id ] ) ) {
-                $section_label = $sections[ $section_id ]['label'];
-            } else {
-                foreach ( $sections as $id => $section ) {
-                    if ( $section['label'] === $section_id ) {
-                        $section_label = $section['label'];
-                        $section_id    = $id;
-                        break;
-                    }
-                }
-                if ( '' === $section_label ) {
-                    $section_label = $section_id;
-                }
-            }
+	<thead>
+		<tr>
+			<th><?php esc_html_e( 'Section', 'rtbcb' ); ?></th>
+			<th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
+			<th><?php esc_html_e( 'Message', 'rtbcb' ); ?></th>
+			<th><?php esc_html_e( 'Word Count', 'rtbcb' ); ?></th>
+			<th><?php esc_html_e( 'Elapsed (s)', 'rtbcb' ); ?></th>
+			<th><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
+			<th><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
+		</tr>
+	</thead>
+	<tbody>
+	<?php if ( ! empty( $recent_results ) ) : ?>
+		<?php foreach ( $recent_results as $result ) : ?>
+			<?php
+			$section_id = isset( $result['section'] ) ? sanitize_text_field( $result['section'] ) : '';
+			$section_label = '';
+			if ( isset( $sections[ $section_id ] ) ) {
+				$section_label = $sections[ $section_id ]['label'];
+			} else {
+				foreach ( $sections as $id => $section ) {
+					if ( $section['label'] === $section_id ) {
+						$section_label = $section['label'];
+						$section_id    = $id;
+						break;
+					}
+				}
+				if ( '' === $section_label ) {
+					$section_label = $section_id;
+				}
+			}
 
-            $word_count = '';
-            if ( isset( $result['word_count'] ) ) {
-                $word_count = (int) $result['word_count'];
-            } elseif ( isset( $result['data']['word_count'] ) ) {
-                $word_count = (int) $result['data']['word_count'];
-            }
+			$word_count = '';
+			if ( isset( $result['word_count'] ) ) {
+				$word_count = (int) $result['word_count'];
+			} elseif ( isset( $result['data']['word_count'] ) ) {
+				$word_count = (int) $result['data']['word_count'];
+			}
 
-            $elapsed = '';
-            if ( isset( $result['elapsed'] ) ) {
-                $elapsed = (float) $result['elapsed'];
-            } elseif ( isset( $result['data']['elapsed'] ) ) {
-                $elapsed = (float) $result['data']['elapsed'];
-            } elseif ( isset( $result['data']['elapsed_time'] ) ) {
-                $elapsed = (float) $result['data']['elapsed_time'];
-            }
-            ?>
-            <tr>
-                <td data-label="<?php echo esc_attr__( 'Section', 'rtbcb' ); ?>"><?php echo esc_html( $section_label ); ?></td>
-                <td data-label="<?php echo esc_attr__( 'Status', 'rtbcb' ); ?>"><?php echo esc_html( $result['status'] ); ?></td>
-                <td data-label="<?php echo esc_attr__( 'Message', 'rtbcb' ); ?>"><?php echo esc_html( $result['message'] ); ?></td>
-                <td class="rtbcb-word-count" data-label="<?php echo esc_attr__( 'Word Count', 'rtbcb' ); ?>"><?php echo '' !== $word_count ? esc_html( $word_count ) : esc_html__( 'N/A', 'rtbcb' ); ?></td>
-                <td class="rtbcb-elapsed" data-label="<?php echo esc_attr__( 'Elapsed (s)', 'rtbcb' ); ?>"><?php echo '' !== $elapsed ? esc_html( $elapsed ) : esc_html__( 'N/A', 'rtbcb' ); ?></td>
-                <td data-label="<?php echo esc_attr__( 'Timestamp', 'rtbcb' ); ?>"><?php echo esc_html( $result['timestamp'] ); ?></td>
-                <td class="rtbcb-actions" data-label="<?php echo esc_attr__( 'Actions', 'rtbcb' ); ?>">
-                    <?php if ( $section_id ) : ?>
-                        <a href="#<?php echo esc_attr( $section_id ); ?>" class="button button-secondary rtbcb-action rtbcb-jump-tab"><?php esc_html_e( 'View', 'rtbcb' ); ?></a>
-                        <a href="#" class="button button-secondary rtbcb-action rtbcb-rerun-test" data-section="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Re-run', 'rtbcb' ); ?></a>
-                    <?php endif; ?>
-                </td>
-            </tr>
-        <?php endforeach; ?>
-    <?php else : ?>
-        <tr>
-            <td colspan="7"><?php esc_html_e( 'No test results found.', 'rtbcb' ); ?></td>
-        </tr>
-    <?php endif; ?>
-    </tbody>
+			$elapsed = '';
+			if ( isset( $result['elapsed'] ) ) {
+				$elapsed = (float) $result['elapsed'];
+			} elseif ( isset( $result['data']['elapsed'] ) ) {
+				$elapsed = (float) $result['data']['elapsed'];
+			} elseif ( isset( $result['data']['elapsed_time'] ) ) {
+				$elapsed = (float) $result['data']['elapsed_time'];
+			}
+			?>
+			<tr>
+				<td data-label="<?php echo esc_attr__( 'Section', 'rtbcb' ); ?>"><?php echo esc_html( $section_label ); ?></td>
+				<td data-label="<?php echo esc_attr__( 'Status', 'rtbcb' ); ?>"><?php echo esc_html( $result['status'] ); ?></td>
+				<td data-label="<?php echo esc_attr__( 'Message', 'rtbcb' ); ?>"><?php echo esc_html( $result['message'] ); ?></td>
+				<td class="rtbcb-word-count" data-label="<?php echo esc_attr__( 'Word Count', 'rtbcb' ); ?>"><?php echo '' !== $word_count ? esc_html( $word_count ) : esc_html__( 'N/A', 'rtbcb' ); ?></td>
+				<td class="rtbcb-elapsed" data-label="<?php echo esc_attr__( 'Elapsed (s)', 'rtbcb' ); ?>"><?php echo '' !== $elapsed ? esc_html( $elapsed ) : esc_html__( 'N/A', 'rtbcb' ); ?></td>
+				<td data-label="<?php echo esc_attr__( 'Timestamp', 'rtbcb' ); ?>"><?php echo esc_html( $result['timestamp'] ); ?></td>
+				<td class="rtbcb-actions" data-label="<?php echo esc_attr__( 'Actions', 'rtbcb' ); ?>">
+					<?php if ( $section_id ) : ?>
+						<a href="#<?php echo esc_attr( $section_id ); ?>" class="button button-secondary rtbcb-action rtbcb-jump-tab"><?php esc_html_e( 'View', 'rtbcb' ); ?></a>
+						<a href="#" class="button button-secondary rtbcb-action rtbcb-rerun-test" data-section="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Re-run', 'rtbcb' ); ?></a>
+					<?php endif; ?>
+				</td>
+			</tr>
+		<?php endforeach; ?>
+	<?php else : ?>
+		<tr>
+			<td colspan="7"><?php esc_html_e( 'No test results found.', 'rtbcb' ); ?></td>
+		</tr>
+	<?php endif; ?>
+	</tbody>
 </table>
 </div>
 <script>
 (function($){
-    $('#rtbcb-test-results-summary').on('click', '.rtbcb-jump-tab', function(e){
-        e.preventDefault();
-        var target = $(this).attr('href');
-        $('#rtbcb-test-tabs a[href="' + target + '"]').trigger('click');
-    });
-    $('#rtbcb-test-results-summary').on('click', '.rtbcb-rerun-test', function(e){
-        e.preventDefault();
-        var section = $(this).data('section');
-        $('#rtbcb-test-tabs a[href="#' + section + '"]').trigger('click');
-        $('#' + section).find('form').first().trigger('submit');
-    });
+	$('#rtbcb-test-results-summary').on('click', '.rtbcb-jump-tab', function(e){
+		e.preventDefault();
+		var target = $(this).attr('href');
+		$('#rtbcb-test-tabs a[href="' + target + '"]').trigger('click');
+	});
+	$('#rtbcb-test-results-summary').on('click', '.rtbcb-rerun-test', function(e){
+		e.preventDefault();
+		var section = $(this).data('section');
+		$('#rtbcb-test-tabs a[href="#' + section + '"]').trigger('click');
+		$('#' + section).find('form').first().trigger('submit');
+	});
 })(jQuery);
 </script>

--- a/admin/partials/test-company-overview.php
+++ b/admin/partials/test-company-overview.php
@@ -1,81 +1,81 @@
 <?php
 /**
- * Partial for Test Company Overview section.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Partial for Test Company Overview section.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-company-overview', false ) ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 ?>
 <h2><?php esc_html_e( 'Test Company Overview', 'rtbcb' ); ?></h2>
 <p class="description"><?php esc_html_e( 'Generate a concise company profile using your configured AI model.', 'rtbcb' ); ?></p>
 <p class="rtbcb-data-source">
-    <span class="rtbcb-data-status rtbcb-status-company-overview">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
-    <a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
-        <?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
-    </a>
+	<span class="rtbcb-data-status rtbcb-status-company-overview">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
+	<a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
+		<?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
+	</a>
 </p>
 <?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-company-overview', $test_results ?? [] ); ?>
 <?php if ( $rtbcb_last ) : ?>
-    <div class="notice notice-info" role="status">
-        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
-        <p class="submit">
-            <button type="button" class="button" id="rtbcb-rerun-company-overview" data-section="rtbcb-test-company-overview">
-                <?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </div>
+	<div class="notice notice-info" role="status">
+		<p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+		<p class="submit">
+			<button type="button" class="button" id="rtbcb-rerun-company-overview" data-section="rtbcb-test-company-overview">
+				<?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</div>
 <?php endif; ?>
 <div class="card">
-    <h3 class="title"><?php esc_html_e( 'Generate Company Overview', 'rtbcb' ); ?></h3>
-    <p><?php esc_html_e( 'Use the company name set above to generate an AI-powered overview using the configured LLM.', 'rtbcb' ); ?></p>
-    <p class="submit">
-        <button type="button" id="rtbcb-generate-company-overview" class="button button-primary">
-            <?php esc_html_e( 'Generate Overview', 'rtbcb' ); ?>
-        </button>
-        <button type="button" id="rtbcb-clear-company-overview" class="button">
-            <?php esc_html_e( 'Clear', 'rtbcb' ); ?>
-        </button>
-    </p>
+	<h3 class="title"><?php esc_html_e( 'Generate Company Overview', 'rtbcb' ); ?></h3>
+	<p><?php esc_html_e( 'Use the company name set above to generate an AI-powered overview using the configured LLM.', 'rtbcb' ); ?></p>
+	<p class="submit">
+		<button type="button" id="rtbcb-generate-company-overview" class="button button-primary">
+			<?php esc_html_e( 'Generate Overview', 'rtbcb' ); ?>
+		</button>
+		<button type="button" id="rtbcb-clear-company-overview" class="button">
+			<?php esc_html_e( 'Clear', 'rtbcb' ); ?>
+		</button>
+	</p>
 </div>
 <div id="rtbcb-company-overview-card" class="rtbcb-result-card" style="display:none;">
-    <details>
-        <summary><?php esc_html_e( 'Generated Overview', 'rtbcb' ); ?></summary>
-        <div id="<?php echo esc_attr( 'rtbcb-company-overview-results' ); ?>"></div>
-        <div id="<?php echo esc_attr( 'rtbcb-company-overview-meta' ); ?>" class="rtbcb-meta"></div>
-        <p class="rtbcb-actions">
-            <button type="button" id="rtbcb-regenerate-company-overview" class="button">
-                <?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
-            </button>
-            <button type="button" id="rtbcb-copy-company-overview" class="button">
-                <?php esc_html_e( 'Copy to Clipboard', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </details>
+	<details>
+		<summary><?php esc_html_e( 'Generated Overview', 'rtbcb' ); ?></summary>
+		<div id="<?php echo esc_attr( 'rtbcb-company-overview-results' ); ?>"></div>
+		<div id="<?php echo esc_attr( 'rtbcb-company-overview-meta' ); ?>" class="rtbcb-meta"></div>
+		<p class="rtbcb-actions">
+			<button type="button" id="rtbcb-regenerate-company-overview" class="button">
+				<?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
+			</button>
+			<button type="button" id="rtbcb-copy-company-overview" class="button">
+				<?php esc_html_e( 'Copy to Clipboard', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</details>
 </div>
 <style>
 #rtbcb-company-overview-card details {
-    margin-top: 20px;
+	margin-top: 20px;
 }
 #rtbcb-company-overview-results div[style*="background"] {
-    white-space: pre-wrap;
-    line-height: 1.6;
+	white-space: pre-wrap;
+	line-height: 1.6;
 }
 #rtbcb-company-overview-meta {
-    margin-top: 10px;
+	margin-top: 10px;
 }
 </style>
 <script>
-    document.getElementById( 'rtbcb-rerun-company-overview' )?.addEventListener( 'click', function() {
-        document.getElementById( 'rtbcb-generate-company-overview' ).click();
-    });
+	document.getElementById( 'rtbcb-rerun-company-overview' )?.addEventListener( 'click', function() {
+		document.getElementById( 'rtbcb-generate-company-overview' ).click();
+	});
 </script>

--- a/admin/partials/test-data-enrichment.php
+++ b/admin/partials/test-data-enrichment.php
@@ -1,75 +1,75 @@
 <?php
 /**
- * Partial for Test Data Enrichment section.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Partial for Test Data Enrichment section.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-data-enrichment', false ) ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 ?>
 <h2><?php esc_html_e( 'Test Data Enrichment', 'rtbcb' ); ?></h2>
 <p class="description"><?php esc_html_e( 'Validate LLM-based enrichment using sample inputs.', 'rtbcb' ); ?></p>
 <?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-data-enrichment', $test_results ?? [] ); ?>
 <?php if ( $rtbcb_last ) : ?>
-    <div class="notice notice-info" role="status">
-        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
-        <p class="submit">
-            <button type="button" class="button" id="rtbcb-rerun-data-enrichment" data-section="rtbcb-test-data-enrichment">
-                <?php esc_html_e( 'Re-run', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </div>
+	<div class="notice notice-info" role="status">
+		<p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+		<p class="submit">
+			<button type="button" class="button" id="rtbcb-rerun-data-enrichment" data-section="rtbcb-test-data-enrichment">
+				<?php esc_html_e( 'Re-run', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</div>
 <?php endif; ?>
 <div class="card">
-    <h3 class="title"><?php esc_html_e( 'Run Data Enrichment', 'rtbcb' ); ?></h3>
-    <p><?php esc_html_e( 'Use the configured language model to enrich sample data.', 'rtbcb' ); ?></p>
-    <?php wp_nonce_field( 'rtbcb_test_data_enrichment', 'rtbcb_test_data_enrichment_nonce' ); ?>
-    <p class="submit">
-        <button type="button" id="rtbcb-run-data-enrichment" class="button button-primary">
-            <?php esc_html_e( 'Run Test', 'rtbcb' ); ?>
-        </button>
-    </p>
+	<h3 class="title"><?php esc_html_e( 'Run Data Enrichment', 'rtbcb' ); ?></h3>
+	<p><?php esc_html_e( 'Use the configured language model to enrich sample data.', 'rtbcb' ); ?></p>
+	<?php wp_nonce_field( 'rtbcb_test_data_enrichment', 'rtbcb_test_data_enrichment_nonce' ); ?>
+	<p class="submit">
+		<button type="button" id="rtbcb-run-data-enrichment" class="button button-primary">
+			<?php esc_html_e( 'Run Test', 'rtbcb' ); ?>
+		</button>
+	</p>
 </div>
 <div id="rtbcb-data-enrichment-result" class="rtbcb-result-card"></div>
 <script>
 (function($){
-    $('#rtbcb-run-data-enrichment, #rtbcb-rerun-data-enrichment').on('click', function(e){
-        e.preventDefault();
-        var nonce = $('#rtbcb_test_data_enrichment_nonce').val();
-        var $btn = $('#rtbcb-run-data-enrichment');
-        var original = $btn.text();
-        $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
-        $('#rtbcb-data-enrichment-result').html('');
-        $.ajax({
-            url: ajaxurl,
-            method: 'POST',
-            data: {
-                action: 'rtbcb_test_data_enrichment',
-                nonce: nonce
-            },
-            success: function(response){
-                if (response.success) {
-                    $('#rtbcb-data-enrichment-result').html('<pre>'+JSON.stringify(response.data.analysis, null, 2)+'</pre>');
-                } else {
-                    $('#rtbcb-data-enrichment-result').html('<div class="notice notice-error"><p>'+ (response.data && response.data.message ? response.data.message : '<?php echo esc_js( __( 'Test failed.', 'rtbcb' ) ); ?>') +'</p></div>');
-                }
-            },
-            error: function(){
-                $('#rtbcb-data-enrichment-result').html('<div class="notice notice-error"><p><?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?></p></div>');
-            },
-            complete: function(){
-                $btn.prop('disabled', false).text(original);
-            }
-        });
-    });
+	$('#rtbcb-run-data-enrichment, #rtbcb-rerun-data-enrichment').on('click', function(e){
+		e.preventDefault();
+		var nonce = $('#rtbcb_test_data_enrichment_nonce').val();
+		var $btn = $('#rtbcb-run-data-enrichment');
+		var original = $btn.text();
+		$btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
+		$('#rtbcb-data-enrichment-result').html('');
+		$.ajax({
+			url: ajaxurl,
+			method: 'POST',
+			data: {
+				action: 'rtbcb_test_data_enrichment',
+				nonce: nonce
+			},
+			success: function(response){
+				if (response.success) {
+					$('#rtbcb-data-enrichment-result').html('<pre>'+JSON.stringify(response.data.analysis, null, 2)+'</pre>');
+				} else {
+					$('#rtbcb-data-enrichment-result').html('<div class="notice notice-error"><p>'+ (response.data && response.data.message ? response.data.message : '<?php echo esc_js( __( 'Test failed.', 'rtbcb' ) ); ?>') +'</p></div>');
+				}
+			},
+			error: function(){
+				$('#rtbcb-data-enrichment-result').html('<div class="notice notice-error"><p><?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?></p></div>');
+			},
+			complete: function(){
+				$btn.prop('disabled', false).text(original);
+			}
+		});
+	});
 })(jQuery);
 </script>

--- a/admin/partials/test-data-storage.php
+++ b/admin/partials/test-data-storage.php
@@ -1,74 +1,74 @@
 <?php
 /**
- * Partial for Test Data Storage section.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Partial for Test Data Storage section.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-data-storage', false ) ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 ?>
 <h2><?php esc_html_e( 'Test Data Storage', 'rtbcb' ); ?></h2>
 <p class="description"><?php esc_html_e( 'Verify saving and retrieving records using the plugin database layer.', 'rtbcb' ); ?></p>
 <?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-data-storage', $test_results ?? [] ); ?>
 <?php if ( $rtbcb_last ) : ?>
-    <div class="notice notice-info" role="status">
-        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
-        <p class="submit">
-            <button type="button" class="button" id="rtbcb-rerun-data-storage" data-section="rtbcb-test-data-storage">
-                <?php esc_html_e( 'Re-run', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </div>
+	<div class="notice notice-info" role="status">
+		<p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+		<p class="submit">
+			<button type="button" class="button" id="rtbcb-rerun-data-storage" data-section="rtbcb-test-data-storage">
+				<?php esc_html_e( 'Re-run', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</div>
 <?php endif; ?>
 <div class="card">
-    <h3 class="title"><?php esc_html_e( 'Run Data Storage Test', 'rtbcb' ); ?></h3>
-    <?php wp_nonce_field( 'rtbcb_test_data_storage', 'rtbcb_test_data_storage_nonce' ); ?>
-    <p class="submit">
-        <button type="button" id="rtbcb-run-data-storage" class="button button-primary">
-            <?php esc_html_e( 'Run Test', 'rtbcb' ); ?>
-        </button>
-    </p>
+	<h3 class="title"><?php esc_html_e( 'Run Data Storage Test', 'rtbcb' ); ?></h3>
+	<?php wp_nonce_field( 'rtbcb_test_data_storage', 'rtbcb_test_data_storage_nonce' ); ?>
+	<p class="submit">
+		<button type="button" id="rtbcb-run-data-storage" class="button button-primary">
+			<?php esc_html_e( 'Run Test', 'rtbcb' ); ?>
+		</button>
+	</p>
 </div>
 <div id="rtbcb-data-storage-result" class="rtbcb-result-card"></div>
 <script>
 (function($){
-    $('#rtbcb-run-data-storage, #rtbcb-rerun-data-storage').on('click', function(e){
-        e.preventDefault();
-        var nonce = $('#rtbcb_test_data_storage_nonce').val();
-        var $btn = $('#rtbcb-run-data-storage');
-        var original = $btn.text();
-        $btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
-        $('#rtbcb-data-storage-result').html('');
-        $.ajax({
-            url: ajaxurl,
-            method: 'POST',
-            data: {
-                action: 'rtbcb_test_data_storage',
-                nonce: nonce
-            },
-            success: function(response){
-                if (response.success) {
-                    $('#rtbcb-data-storage-result').html('<div class="notice notice-success"><p><?php echo esc_js( __( 'Lead saved with ID:', 'rtbcb' ) ); ?> '+response.data.lead_id+'</p></div>');
-                } else {
-                    $('#rtbcb-data-storage-result').html('<div class="notice notice-error"><p>'+ (response.data && response.data.message ? response.data.message : '<?php echo esc_js( __( 'Test failed.', 'rtbcb' ) ); ?>') +'</p></div>');
-                }
-            },
-            error: function(){
-                $('#rtbcb-data-storage-result').html('<div class="notice notice-error"><p><?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?></p></div>');
-            },
-            complete: function(){
-                $btn.prop('disabled', false).text(original);
-            }
-        });
-    });
+	$('#rtbcb-run-data-storage, #rtbcb-rerun-data-storage').on('click', function(e){
+		e.preventDefault();
+		var nonce = $('#rtbcb_test_data_storage_nonce').val();
+		var $btn = $('#rtbcb-run-data-storage');
+		var original = $btn.text();
+		$btn.prop('disabled', true).text('<?php echo esc_js( __( 'Testing...', 'rtbcb' ) ); ?>');
+		$('#rtbcb-data-storage-result').html('');
+		$.ajax({
+			url: ajaxurl,
+			method: 'POST',
+			data: {
+				action: 'rtbcb_test_data_storage',
+				nonce: nonce
+			},
+			success: function(response){
+				if (response.success) {
+					$('#rtbcb-data-storage-result').html('<div class="notice notice-success"><p><?php echo esc_js( __( 'Lead saved with ID:', 'rtbcb' ) ); ?> '+response.data.lead_id+'</p></div>');
+				} else {
+					$('#rtbcb-data-storage-result').html('<div class="notice notice-error"><p>'+ (response.data && response.data.message ? response.data.message : '<?php echo esc_js( __( 'Test failed.', 'rtbcb' ) ); ?>') +'</p></div>');
+				}
+			},
+			error: function(){
+				$('#rtbcb-data-storage-result').html('<div class="notice notice-error"><p><?php echo esc_js( __( 'Request failed.', 'rtbcb' ) ); ?></p></div>');
+			},
+			complete: function(){
+				$btn.prop('disabled', false).text(original);
+			}
+		});
+	});
 })(jQuery);
 </script>

--- a/admin/partials/test-estimated-benefits.php
+++ b/admin/partials/test-estimated-benefits.php
@@ -1,27 +1,27 @@
 <?php
 /**
- * Partial for Test Estimated Benefits section.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Partial for Test Estimated Benefits section.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-estimated-benefits', false ) ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 
 $company = rtbcb_get_current_company();
 if ( empty( $company ) ) {
 $overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
-    echo '<div class="notice notice-error"><p>' . sprintf(
-        esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
-        '<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'
-    ) . '</p></div>';
-    return;
+	echo '<div class="notice notice-error"><p>' . sprintf(
+		esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
+		'<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'
+	) . '</p></div>';
+	return;
 }
 
 $company_data         = $company;
@@ -31,66 +31,66 @@ $categories           = RTBCB_Category_Recommender::get_all_categories();
 <h2><?php esc_html_e( 'Test Estimated Benefits', 'rtbcb' ); ?></h2>
 <p class="description"><?php esc_html_e( 'Estimate potential savings and efficiency gains based on company metrics.', 'rtbcb' ); ?></p>
 <p class="rtbcb-data-source">
-    <span class="rtbcb-data-status rtbcb-status-financial-analysis">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
-    <a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
-        <?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
-    </a>
+	<span class="rtbcb-data-status rtbcb-status-financial-analysis">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
+	<a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
+		<?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
+	</a>
 </p>
 <?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-estimated-benefits', $test_results ?? [] ); ?>
 <?php if ( $rtbcb_last ) : ?>
-    <div class="notice notice-info" role="status">
-        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
-        <p class="submit">
-            <button type="button" class="button" id="rtbcb-rerun-benefits" data-section="rtbcb-test-estimated-benefits">
-                <?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </div>
+	<div class="notice notice-info" role="status">
+		<p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+		<p class="submit">
+			<button type="button" class="button" id="rtbcb-rerun-benefits" data-section="rtbcb-test-estimated-benefits">
+				<?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</div>
 <?php endif; ?>
 <form id="rtbcb-benefits-estimate-form">
-    <table class="form-table">
-        <tr>
-            <th scope="row"><?php esc_html_e( 'Company Annual Revenue', 'rtbcb' ); ?></th>
-            <td><?php echo esc_html( $company_data['revenue'] ?? '' ); ?></td>
-        </tr>
-        <tr>
-            <th scope="row"><?php esc_html_e( 'Treasury Staff Count', 'rtbcb' ); ?></th>
-            <td><?php echo esc_html( $company_data['staff_count'] ?? '' ); ?></td>
-        </tr>
-        <tr>
-            <th scope="row"><?php esc_html_e( 'Current Process Efficiency', 'rtbcb' ); ?></th>
-            <td><?php echo esc_html( $company_data['efficiency'] ?? '' ); ?></td>
-        </tr>
-        <tr>
-            <th scope="row">
-                <label for="rtbcb-test-category"><?php esc_html_e( 'Category', 'rtbcb' ); ?></label>
-            </th>
-            <td>
-                <select id="rtbcb-test-category">
-                    <?php foreach ( $categories as $key => $label ) : ?>
-                        <option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $recommended_category ); ?>><?php echo esc_html( $label ); ?></option>
-                    <?php endforeach; ?>
-                </select>
-                <?php wp_nonce_field( 'rtbcb_test_estimated_benefits', 'rtbcb_test_estimated_benefits_nonce' ); ?>
-            </td>
-        </tr>
-    </table>
-    <p class="submit">
-        <button type="submit" id="rtbcb-generate-benefits-estimate" class="button button-primary">
-            <?php esc_html_e( 'Generate Estimate', 'rtbcb' ); ?>
-        </button>
-    </p>
+	<table class="form-table">
+		<tr>
+			<th scope="row"><?php esc_html_e( 'Company Annual Revenue', 'rtbcb' ); ?></th>
+			<td><?php echo esc_html( $company_data['revenue'] ?? '' ); ?></td>
+		</tr>
+		<tr>
+			<th scope="row"><?php esc_html_e( 'Treasury Staff Count', 'rtbcb' ); ?></th>
+			<td><?php echo esc_html( $company_data['staff_count'] ?? '' ); ?></td>
+		</tr>
+		<tr>
+			<th scope="row"><?php esc_html_e( 'Current Process Efficiency', 'rtbcb' ); ?></th>
+			<td><?php echo esc_html( $company_data['efficiency'] ?? '' ); ?></td>
+		</tr>
+		<tr>
+			<th scope="row">
+				<label for="rtbcb-test-category"><?php esc_html_e( 'Category', 'rtbcb' ); ?></label>
+			</th>
+			<td>
+				<select id="rtbcb-test-category">
+					<?php foreach ( $categories as $key => $label ) : ?>
+						<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $recommended_category ); ?>><?php echo esc_html( $label ); ?></option>
+					<?php endforeach; ?>
+				</select>
+				<?php wp_nonce_field( 'rtbcb_test_estimated_benefits', 'rtbcb_test_estimated_benefits_nonce' ); ?>
+			</td>
+		</tr>
+	</table>
+	<p class="submit">
+		<button type="submit" id="rtbcb-generate-benefits-estimate" class="button button-primary">
+			<?php esc_html_e( 'Generate Estimate', 'rtbcb' ); ?>
+		</button>
+	</p>
 </form>
 <div id="rtbcb-benefits-estimate-card" class="rtbcb-result-card">
-    <details>
-        <summary><?php esc_html_e( 'Estimated Benefits', 'rtbcb' ); ?></summary>
-        <div id="rtbcb-benefits-estimate-results"></div>
-    </details>
+	<details>
+		<summary><?php esc_html_e( 'Estimated Benefits', 'rtbcb' ); ?></summary>
+		<div id="rtbcb-benefits-estimate-results"></div>
+	</details>
 </div>
 <script>
 document.getElementById( 'rtbcb-rerun-benefits' )?.addEventListener( 'click', function() {
-    jQuery( '#rtbcb-benefits-estimate-form' ).trigger( 'submit' );
+	jQuery( '#rtbcb-benefits-estimate-form' ).trigger( 'submit' );
 });
 </script>

--- a/admin/partials/test-follow-up-email.php
+++ b/admin/partials/test-follow-up-email.php
@@ -1,17 +1,17 @@
 <?php
 /**
- * Follow-up email queue test.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Follow-up email queue test.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-follow-up-email', false ) ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 
 ?>
@@ -20,26 +20,26 @@ if ( ! rtbcb_require_completed_steps( 'rtbcb-test-follow-up-email', false ) ) {
 
 <?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-follow-up-email', $test_results ?? [] ); ?>
 <?php if ( $rtbcb_last ) : ?>
-    <div class="notice notice-info" role="status">
-        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
-        <p class="submit">
-            <button type="button" class="button" id="rtbcb-rerun-follow-up" data-section="rtbcb-test-follow-up-email">
-                <?php esc_html_e( 'Re-run', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </div>
+	<div class="notice notice-info" role="status">
+		<p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+		<p class="submit">
+			<button type="button" class="button" id="rtbcb-rerun-follow-up" data-section="rtbcb-test-follow-up-email">
+				<?php esc_html_e( 'Re-run', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</div>
 <?php endif; ?>
 
 <div class="card">
-    <h3 class="title"><?php esc_html_e( 'Follow-up Email Queue', 'rtbcb' ); ?></h3>
-    <p><?php esc_html_e( 'Trigger personalized follow-up emails and inspect queued messages.', 'rtbcb' ); ?></p>
-    <?php wp_nonce_field( 'rtbcb_test_follow_up_email', 'rtbcb_test_follow_up_email_nonce' ); ?>
-    <p class="submit">
-        <button type="button" id="rtbcb-run-follow-up" class="button button-primary" data-section="rtbcb-test-follow-up-email">
-            <?php esc_html_e( 'Queue Email', 'rtbcb' ); ?>
-        </button>
-    </p>
+	<h3 class="title"><?php esc_html_e( 'Follow-up Email Queue', 'rtbcb' ); ?></h3>
+	<p><?php esc_html_e( 'Trigger personalized follow-up emails and inspect queued messages.', 'rtbcb' ); ?></p>
+	<?php wp_nonce_field( 'rtbcb_test_follow_up_email', 'rtbcb_test_follow_up_email_nonce' ); ?>
+	<p class="submit">
+		<button type="button" id="rtbcb-run-follow-up" class="button button-primary" data-section="rtbcb-test-follow-up-email">
+			<?php esc_html_e( 'Queue Email', 'rtbcb' ); ?>
+		</button>
+	</p>
 </div>
 <div id="rtbcb-follow-up-result" class="rtbcb-result-card"></div>

--- a/admin/partials/test-industry-overview.php
+++ b/admin/partials/test-industry-overview.php
@@ -1,28 +1,28 @@
 <?php
 /**
- * Partial for Test Industry Overview section.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Partial for Test Industry Overview section.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 $allowed = rtbcb_require_completed_steps( 'rtbcb-test-industry-overview', false );
 if ( ! $allowed ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 
 $company = rtbcb_get_current_company();
 if ( empty( $company ) ) {
 $overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
-    echo '<div class="notice notice-error"><p>' . sprintf(
-        esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
-        '<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'
-    ) . '</p></div>';
-    return;
+	echo '<div class="notice notice-error"><p>' . sprintf(
+		esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
+		'<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'
+	) . '</p></div>';
+	return;
 }
 
 $company_name = isset( $company['name'] ) ? sanitize_text_field( $company['name'] ) : '';
@@ -33,59 +33,59 @@ $company_size = isset( $company['size'] ) ? sanitize_text_field( $company['size'
 <h2><?php esc_html_e( 'Test Industry Overview', 'rtbcb' ); ?></h2>
 <p class="description"><?php esc_html_e( 'Generate insights about the company\'s industry to inform later recommendations.', 'rtbcb' ); ?></p>
 <p class="rtbcb-data-source">
-    <span class="rtbcb-data-status rtbcb-status-industry-analysis">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
-    <a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
-        <?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
-    </a>
+	<span class="rtbcb-data-status rtbcb-status-industry-analysis">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
+	<a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
+		<?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
+	</a>
 </p>
 <?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-industry-overview', $test_results ?? [] ); ?>
 <?php if ( $rtbcb_last ) : ?>
-    <div class="notice notice-info" role="status">
-        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
-        <p class="submit">
-            <button type="button" class="button" id="rtbcb-rerun-industry-overview" data-section="rtbcb-test-industry-overview">
-                <?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </div>
+	<div class="notice notice-info" role="status">
+		<p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+		<p class="submit">
+			<button type="button" class="button" id="rtbcb-rerun-industry-overview" data-section="rtbcb-test-industry-overview">
+				<?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</div>
 <?php endif; ?>
 <?php if ( ! empty( $company_name ) ) : ?>
-    <h3><?php echo esc_html( $company_name ); ?></h3>
-    <?php if ( ! empty( $company_sum ) ) : ?>
-        <p><?php echo esc_html( $company_sum ); ?></p>
-    <?php endif; ?>
+	<h3><?php echo esc_html( $company_name ); ?></h3>
+	<?php if ( ! empty( $company_sum ) ) : ?>
+		<p><?php echo esc_html( $company_sum ); ?></p>
+	<?php endif; ?>
 <?php endif; ?>
 <form id="rtbcb-industry-overview-form">
-    <input type="hidden" id="rtbcb-company-size" value="<?php echo esc_attr( $company_size ); ?>" />
-    <table class="form-table">
-        <tr>
-            <th scope="row">
-                <label for="rtbcb-industry-name"><?php esc_html_e( 'Industry Name', 'rtbcb' ); ?></label>
-            </th>
-            <td>
-                <input type="text" id="rtbcb-industry-name" class="regular-text" value="<?php echo esc_attr( $company_ind ); ?>" />
-                <p class="description"><?php esc_html_e( 'Override if needed.', 'rtbcb' ); ?></p>
-                <?php wp_nonce_field( 'rtbcb_test_industry_overview', 'nonce' ); ?>
-            </td>
-        </tr>
-    </table>
-    <p class="submit">
-        <button type="submit" class="button button-primary"><?php esc_html_e( 'Generate Overview', 'rtbcb' ); ?></button>
-        <button type="button" id="rtbcb-clear-results" class="button"><?php esc_html_e( 'Clear Results', 'rtbcb' ); ?></button>
-    </p>
+	<input type="hidden" id="rtbcb-company-size" value="<?php echo esc_attr( $company_size ); ?>" />
+	<table class="form-table">
+		<tr>
+			<th scope="row">
+				<label for="rtbcb-industry-name"><?php esc_html_e( 'Industry Name', 'rtbcb' ); ?></label>
+			</th>
+			<td>
+				<input type="text" id="rtbcb-industry-name" class="regular-text" value="<?php echo esc_attr( $company_ind ); ?>" />
+				<p class="description"><?php esc_html_e( 'Override if needed.', 'rtbcb' ); ?></p>
+				<?php wp_nonce_field( 'rtbcb_test_industry_overview', 'nonce' ); ?>
+			</td>
+		</tr>
+	</table>
+	<p class="submit">
+		<button type="submit" class="button button-primary"><?php esc_html_e( 'Generate Overview', 'rtbcb' ); ?></button>
+		<button type="button" id="rtbcb-clear-results" class="button"><?php esc_html_e( 'Clear Results', 'rtbcb' ); ?></button>
+	</p>
 </form>
 <div id="rtbcb-industry-overview-card" class="rtbcb-result-card">
-    <details>
-        <summary><?php esc_html_e( 'Generated Overview', 'rtbcb' ); ?></summary>
-        <div id="<?php echo esc_attr( 'rtbcb-industry-overview-results' ); ?>">
-            <div id="<?php echo esc_attr( 'rtbcb-industry-overview-meta' ); ?>" class="rtbcb-meta"></div>
-        </div>
-    </details>
+	<details>
+		<summary><?php esc_html_e( 'Generated Overview', 'rtbcb' ); ?></summary>
+		<div id="<?php echo esc_attr( 'rtbcb-industry-overview-results' ); ?>">
+			<div id="<?php echo esc_attr( 'rtbcb-industry-overview-meta' ); ?>" class="rtbcb-meta"></div>
+		</div>
+	</details>
 </div>
 <script>
 document.getElementById( 'rtbcb-rerun-industry-overview' )?.addEventListener( 'click', function() {
-    jQuery( '#rtbcb-industry-overview-form' ).trigger( 'submit' );
+	jQuery( '#rtbcb-industry-overview-form' ).trigger( 'submit' );
 });
 </script>

--- a/admin/partials/test-maturity-model.php
+++ b/admin/partials/test-maturity-model.php
@@ -1,76 +1,76 @@
 <?php
 /**
- * Partial for Test Maturity Model section.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Partial for Test Maturity Model section.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-maturity-model', false ) ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 
 ?>
 <h2><?php esc_html_e( 'Test Maturity Model', 'rtbcb' ); ?></h2>
 <p class="description"><?php esc_html_e( 'Assess treasury maturity based on company data.', 'rtbcb' ); ?></p>
 <p class="rtbcb-data-source">
-    <span class="rtbcb-data-status rtbcb-status-treasury-maturity">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
-    <a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
-        <?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
-    </a>
+	<span class="rtbcb-data-status rtbcb-status-treasury-maturity">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
+	<a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
+		<?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
+	</a>
 </p>
 <?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-maturity-model', $test_results ?? [] ); ?>
 <?php if ( $rtbcb_last ) : ?>
-    <div class="notice notice-info" role="status">
-        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
-        <p class="submit">
-            <button type="button" class="button" id="rtbcb-rerun-maturity-model" data-section="rtbcb-test-maturity-model">
-                <?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </div>
+	<div class="notice notice-info" role="status">
+		<p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+		<p class="submit">
+			<button type="button" class="button" id="rtbcb-rerun-maturity-model" data-section="rtbcb-test-maturity-model">
+				<?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</div>
 <?php endif; ?>
 <div class="card">
-    <h3 class="title"><?php esc_html_e( 'Generate Assessment', 'rtbcb' ); ?></h3>
-    <?php wp_nonce_field( 'rtbcb_test_maturity_model', 'rtbcb_test_maturity_model_nonce' ); ?>
-    <p class="submit">
-        <button type="button" id="rtbcb-generate-maturity-model" class="button button-primary">
-            <?php esc_html_e( 'Assess Maturity', 'rtbcb' ); ?>
-        </button>
-    </p>
+	<h3 class="title"><?php esc_html_e( 'Generate Assessment', 'rtbcb' ); ?></h3>
+	<?php wp_nonce_field( 'rtbcb_test_maturity_model', 'rtbcb_test_maturity_model_nonce' ); ?>
+	<p class="submit">
+		<button type="button" id="rtbcb-generate-maturity-model" class="button button-primary">
+			<?php esc_html_e( 'Assess Maturity', 'rtbcb' ); ?>
+		</button>
+	</p>
 </div>
 <div id="rtbcb-maturity-model-card" class="rtbcb-result-card" style="display:none;">
-    <details>
-        <summary><?php esc_html_e( 'Assessment', 'rtbcb' ); ?></summary>
-        <div id="rtbcb-maturity-model-results"></div>
-    </details>
+	<details>
+		<summary><?php esc_html_e( 'Assessment', 'rtbcb' ); ?></summary>
+		<div id="rtbcb-maturity-model-results"></div>
+	</details>
 </div>
 <script>
-    jQuery('#rtbcb-generate-maturity-model').on('click', function(){
-        const btn = jQuery(this);
-        const original = rtbcbTestUtils.showLoading(btn);
-        jQuery.post(ajaxurl, {
-            action: 'rtbcb_test_maturity_model',
-            nonce: jQuery('#rtbcb_test_maturity_model_nonce').val()
-        }).done(function(response){
-            if (response.success) {
-                const data = response.data;
-                rtbcbTestUtils.renderSuccess(jQuery('#rtbcb-maturity-model-results'), data.assessment, null, data);
-            jQuery('#rtbcb-maturity-model-card').show();
-        } else {
-            rtbcbTestUtils.renderError(jQuery('#rtbcb-maturity-model-results'), response.data.message);
-        }
-    }).always(function(){
-        rtbcbTestUtils.hideLoading(btn, original);
-    });
- });
- document.getElementById('rtbcb-rerun-maturity-model')?.addEventListener('click', function(){
-    document.getElementById('rtbcb-generate-maturity-model').click();
- });
+	jQuery('#rtbcb-generate-maturity-model').on('click', function(){
+		const btn = jQuery(this);
+		const original = rtbcbTestUtils.showLoading(btn);
+		jQuery.post(ajaxurl, {
+			action: 'rtbcb_test_maturity_model',
+			nonce: jQuery('#rtbcb_test_maturity_model_nonce').val()
+		}).done(function(response){
+			if (response.success) {
+				const data = response.data;
+				rtbcbTestUtils.renderSuccess(jQuery('#rtbcb-maturity-model-results'), data.assessment, null, data);
+			jQuery('#rtbcb-maturity-model-card').show();
+		} else {
+			rtbcbTestUtils.renderError(jQuery('#rtbcb-maturity-model-results'), response.data.message);
+		}
+	}).always(function(){
+		rtbcbTestUtils.hideLoading(btn, original);
+	});
+	});
+	document.getElementById('rtbcb-rerun-maturity-model')?.addEventListener('click', function(){
+	document.getElementById('rtbcb-generate-maturity-model').click();
+	});
 </script>

--- a/admin/partials/test-rag-market-analysis.php
+++ b/admin/partials/test-rag-market-analysis.php
@@ -1,78 +1,78 @@
 <?php
 /**
- * Partial for Test RAG Market Analysis section.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Partial for Test RAG Market Analysis section.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-rag-market-analysis', false ) ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 
 ?>
 <h2><?php esc_html_e( 'Test RAG Market Analysis', 'rtbcb' ); ?></h2>
 <p class="description"><?php esc_html_e( 'Run a retrieval-augmented query and view a vendor shortlist.', 'rtbcb' ); ?></p>
 <p class="rtbcb-data-source">
-    <span class="rtbcb-data-status rtbcb-status-market-analysis">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
-    <a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
-        <?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
-    </a>
+	<span class="rtbcb-data-status rtbcb-status-market-analysis">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
+	<a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
+		<?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
+	</a>
 </p>
 <?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-rag-market-analysis', $test_results ?? [] ); ?>
 <?php if ( $rtbcb_last ) : ?>
-    <div class="notice notice-info" role="status">
-        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
-        <p class="submit">
-            <button type="button" class="button" id="rtbcb-rerun-rag-market-analysis" data-section="rtbcb-test-rag-market-analysis">
-                <?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </div>
+	<div class="notice notice-info" role="status">
+		<p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+		<p class="submit">
+			<button type="button" class="button" id="rtbcb-rerun-rag-market-analysis" data-section="rtbcb-test-rag-market-analysis">
+				<?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</div>
 <?php endif; ?>
 <div class="card">
-    <h3 class="title"><?php esc_html_e( 'Run Market Analysis', 'rtbcb' ); ?></h3>
-    <?php wp_nonce_field( 'rtbcb_test_rag_market_analysis', 'rtbcb_test_rag_market_analysis_nonce' ); ?>
-    <p class="submit">
-        <button type="button" id="rtbcb-run-rag-analysis" class="button button-primary">
-            <?php esc_html_e( 'Run Analysis', 'rtbcb' ); ?>
-        </button>
-    </p>
+	<h3 class="title"><?php esc_html_e( 'Run Market Analysis', 'rtbcb' ); ?></h3>
+	<?php wp_nonce_field( 'rtbcb_test_rag_market_analysis', 'rtbcb_test_rag_market_analysis_nonce' ); ?>
+	<p class="submit">
+		<button type="button" id="rtbcb-run-rag-analysis" class="button button-primary">
+			<?php esc_html_e( 'Run Analysis', 'rtbcb' ); ?>
+		</button>
+	</p>
 </div>
 <div id="rtbcb-rag-market-analysis-card" class="rtbcb-result-card" style="display:none;">
-    <details>
-        <summary><?php esc_html_e( 'Vendor Shortlist', 'rtbcb' ); ?></summary>
-        <ul id="rtbcb-rag-market-analysis-results"></ul>
-    </details>
+	<details>
+		<summary><?php esc_html_e( 'Vendor Shortlist', 'rtbcb' ); ?></summary>
+		<ul id="rtbcb-rag-market-analysis-results"></ul>
+	</details>
 </div>
 <script>
-    jQuery('#rtbcb-run-rag-analysis').on('click', function(){
-        const btn = jQuery(this);
-        const original = rtbcbTestUtils.showLoading(btn);
-        jQuery.post(ajaxurl, {
-            action: 'rtbcb_test_rag_market_analysis',
-            nonce: jQuery('#rtbcb_test_rag_market_analysis_nonce').val()
-        }).done(function(response){
-            if (response.success) {
-                const list = jQuery('#rtbcb-rag-market-analysis-results').empty();
-                response.data.vendors.forEach(function(v){
-                list.append('<li>' + v + '</li>');
-            });
-            jQuery('#rtbcb-rag-market-analysis-card').show();
-        } else {
-            rtbcbTestUtils.renderError(jQuery('#rtbcb-rag-market-analysis-results'), response.data.message);
-        }
-    }).always(function(){
-        rtbcbTestUtils.hideLoading(btn, original);
-    });
- });
- document.getElementById('rtbcb-rerun-rag-market-analysis')?.addEventListener('click', function(){
-    document.getElementById('rtbcb-run-rag-analysis').click();
- });
+	jQuery('#rtbcb-run-rag-analysis').on('click', function(){
+		const btn = jQuery(this);
+		const original = rtbcbTestUtils.showLoading(btn);
+		jQuery.post(ajaxurl, {
+			action: 'rtbcb_test_rag_market_analysis',
+			nonce: jQuery('#rtbcb_test_rag_market_analysis_nonce').val()
+		}).done(function(response){
+			if (response.success) {
+				const list = jQuery('#rtbcb-rag-market-analysis-results').empty();
+				response.data.vendors.forEach(function(v){
+				list.append('<li>' + v + '</li>');
+			});
+			jQuery('#rtbcb-rag-market-analysis-card').show();
+		} else {
+			rtbcbTestUtils.renderError(jQuery('#rtbcb-rag-market-analysis-results'), response.data.message);
+		}
+	}).always(function(){
+		rtbcbTestUtils.hideLoading(btn, original);
+	});
+	});
+	document.getElementById('rtbcb-rerun-rag-market-analysis')?.addEventListener('click', function(){
+	document.getElementById('rtbcb-run-rag-analysis').click();
+	});
 </script>

--- a/admin/partials/test-real-treasury-overview.php
+++ b/admin/partials/test-real-treasury-overview.php
@@ -1,119 +1,119 @@
 <?php
 /**
- * Partial for Test Real Treasury Overview section.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Partial for Test Real Treasury Overview section.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-real-treasury-overview', false ) ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 
 $company = rtbcb_get_current_company();
 if ( empty( $company ) ) {
 $overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
-    echo '<div class="notice notice-error"><p>' . sprintf(
-        esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
-        '<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'
-    ) . '</p></div>';
-    return;
+	echo '<div class="notice notice-error"><p>' . sprintf(
+		esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
+		'<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'
+	) . '</p></div>';
+	return;
 }
 ?>
 <h2><?php esc_html_e( 'Test Real Treasury Overview Generation', 'rtbcb' ); ?></h2>
 <p class="description"><?php esc_html_e( 'Create a tailored treasury overview based on company data and selected options.', 'rtbcb' ); ?></p>
 <?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-real-treasury-overview', $test_results ?? [] ); ?>
 <?php if ( $rtbcb_last ) : ?>
-    <div class="notice notice-info" role="status">
-        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
-        <p class="submit">
-            <button type="button" class="button" id="rtbcb-rerun-real-treasury" data-section="rtbcb-test-real-treasury-overview">
-                <?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </div>
+	<div class="notice notice-info" role="status">
+		<p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+		<p class="submit">
+			<button type="button" class="button" id="rtbcb-rerun-real-treasury" data-section="rtbcb-test-real-treasury-overview">
+				<?php esc_html_e( 'Regenerate', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</div>
 <?php endif; ?>
 <div class="card">
-    <h3 class="title"><?php esc_html_e( 'Generate Real Treasury Overview', 'rtbcb' ); ?></h3>
-    <p><?php esc_html_e( 'Configure options and generate an overview.', 'rtbcb' ); ?></p>
+	<h3 class="title"><?php esc_html_e( 'Generate Real Treasury Overview', 'rtbcb' ); ?></h3>
+	<p><?php esc_html_e( 'Configure options and generate an overview.', 'rtbcb' ); ?></p>
 
-    <h3><?php esc_html_e( 'Company Summary', 'rtbcb' ); ?></h3>
-    <p id="rtbcb-company-summary"></p>
+	<h3><?php esc_html_e( 'Company Summary', 'rtbcb' ); ?></h3>
+	<p id="rtbcb-company-summary"></p>
 
-    <h3><?php esc_html_e( 'Identified Challenges', 'rtbcb' ); ?></h3>
-    <ul id="rtbcb-company-challenges"></ul>
+	<h3><?php esc_html_e( 'Identified Challenges', 'rtbcb' ); ?></h3>
+	<ul id="rtbcb-company-challenges"></ul>
 
-    <table class="form-table">
-        <tr>
-            <th scope="row">
-                <label for="rtbcb-include-portal"><?php esc_html_e( 'Include Portal Data', 'rtbcb' ); ?></label>
-            </th>
-            <td>
-                <label>
-                    <input type="checkbox" id="rtbcb-include-portal" />
-                    <?php esc_html_e( 'Include Portal Data', 'rtbcb' ); ?>
-                </label>
-            </td>
-        </tr>
-        <tr>
-            <th scope="row">
-                <label for="rtbcb-override-categories"><?php esc_html_e( 'Override Categories', 'rtbcb' ); ?></label>
-            </th>
-            <td>
-                <label>
-                    <input type="checkbox" id="rtbcb-override-categories" />
-                    <?php esc_html_e( 'Specify vendor categories', 'rtbcb' ); ?>
-                </label>
-                <select id="rtbcb-vendor-categories" multiple size="5" style="display:none;">
-                    <option value="tms"><?php esc_html_e( 'TMS', 'rtbcb' ); ?></option>
-                    <option value="cash_management"><?php esc_html_e( 'Cash Management', 'rtbcb' ); ?></option>
-                    <option value="payments"><?php esc_html_e( 'Payments', 'rtbcb' ); ?></option>
-                    <option value="liquidity"><?php esc_html_e( 'Liquidity', 'rtbcb' ); ?></option>
-                    <option value="risk_management"><?php esc_html_e( 'Risk Management', 'rtbcb' ); ?></option>
-                </select>
-            </td>
-        </tr>
-    </table>
+	<table class="form-table">
+		<tr>
+			<th scope="row">
+				<label for="rtbcb-include-portal"><?php esc_html_e( 'Include Portal Data', 'rtbcb' ); ?></label>
+			</th>
+			<td>
+				<label>
+					<input type="checkbox" id="rtbcb-include-portal" />
+					<?php esc_html_e( 'Include Portal Data', 'rtbcb' ); ?>
+				</label>
+			</td>
+		</tr>
+		<tr>
+			<th scope="row">
+				<label for="rtbcb-override-categories"><?php esc_html_e( 'Override Categories', 'rtbcb' ); ?></label>
+			</th>
+			<td>
+				<label>
+					<input type="checkbox" id="rtbcb-override-categories" />
+					<?php esc_html_e( 'Specify vendor categories', 'rtbcb' ); ?>
+				</label>
+				<select id="rtbcb-vendor-categories" multiple size="5" style="display:none;">
+					<option value="tms"><?php esc_html_e( 'TMS', 'rtbcb' ); ?></option>
+					<option value="cash_management"><?php esc_html_e( 'Cash Management', 'rtbcb' ); ?></option>
+					<option value="payments"><?php esc_html_e( 'Payments', 'rtbcb' ); ?></option>
+					<option value="liquidity"><?php esc_html_e( 'Liquidity', 'rtbcb' ); ?></option>
+					<option value="risk_management"><?php esc_html_e( 'Risk Management', 'rtbcb' ); ?></option>
+				</select>
+			</td>
+		</tr>
+	</table>
 
-    <?php wp_nonce_field( 'rtbcb_test_real_treasury_overview', 'rtbcb_test_real_treasury_overview_nonce' ); ?>
+	<?php wp_nonce_field( 'rtbcb_test_real_treasury_overview', 'rtbcb_test_real_treasury_overview_nonce' ); ?>
 
-    <p class="submit">
-        <button type="button" id="rtbcb-generate-real-treasury-overview" class="button button-primary">
-            <?php esc_html_e( 'Generate Real Treasury Overview', 'rtbcb' ); ?>
-        </button>
-        <button type="button" id="rtbcb-clear-real-treasury-overview" class="button">
-            <?php esc_html_e( 'Clear Results', 'rtbcb' ); ?>
-        </button>
-    </p>
-    </div>
+	<p class="submit">
+		<button type="button" id="rtbcb-generate-real-treasury-overview" class="button button-primary">
+			<?php esc_html_e( 'Generate Real Treasury Overview', 'rtbcb' ); ?>
+		</button>
+		<button type="button" id="rtbcb-clear-real-treasury-overview" class="button">
+			<?php esc_html_e( 'Clear Results', 'rtbcb' ); ?>
+		</button>
+	</p>
+	</div>
 <div id="rtbcb-real-treasury-overview-card" class="rtbcb-result-card" style="display:none;">
-    <details>
-        <summary><?php esc_html_e( 'Generated Overview', 'rtbcb' ); ?></summary>
-        <div id="rtbcb-real-treasury-overview-results"></div>
-        <div id="rtbcb-real-treasury-overview-meta" class="rtbcb-meta"></div>
-        <p class="rtbcb-actions">
-            <button type="button" id="rtbcb-regenerate-real-treasury-overview" class="button"><?php esc_html_e( 'Regenerate', 'rtbcb' ); ?></button>
-            <button type="button" id="rtbcb-copy-real-treasury-overview" class="button"><?php esc_html_e( 'Copy', 'rtbcb' ); ?></button>
-        </p>
-    </details>
+	<details>
+		<summary><?php esc_html_e( 'Generated Overview', 'rtbcb' ); ?></summary>
+		<div id="rtbcb-real-treasury-overview-results"></div>
+		<div id="rtbcb-real-treasury-overview-meta" class="rtbcb-meta"></div>
+		<p class="rtbcb-actions">
+			<button type="button" id="rtbcb-regenerate-real-treasury-overview" class="button"><?php esc_html_e( 'Regenerate', 'rtbcb' ); ?></button>
+			<button type="button" id="rtbcb-copy-real-treasury-overview" class="button"><?php esc_html_e( 'Copy', 'rtbcb' ); ?></button>
+		</p>
+	</details>
 </div>
 <style>
 #rtbcb-real-treasury-overview-card details {
-    margin-top: 20px;
+	margin-top: 20px;
 }
 #rtbcb-real-treasury-overview-results div[style*="background"] {
-    white-space: pre-wrap;
-    line-height: 1.6;
+	white-space: pre-wrap;
+	line-height: 1.6;
 }
 </style>
 <script>
-    document.getElementById( 'rtbcb-rerun-real-treasury' )?.addEventListener( 'click', function() {
-        document.getElementById( 'rtbcb-generate-real-treasury-overview' ).click();
-    });
+	document.getElementById( 'rtbcb-rerun-real-treasury' )?.addEventListener( 'click', function() {
+		document.getElementById( 'rtbcb-generate-real-treasury-overview' ).click();
+	});
 </script>

--- a/admin/partials/test-report-assembly.php
+++ b/admin/partials/test-report-assembly.php
@@ -1,53 +1,53 @@
 <?php
 /**
- * Report assembly and delivery test section.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Report assembly and delivery test section.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 $allowed = rtbcb_require_completed_steps( 'rtbcb-test-report-assembly', false );
 if ( ! $allowed ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 
 $summary = get_option( 'rtbcb_executive_summary', [] );
 ?>
 <h2><?php esc_html_e( 'Report Assembly & Delivery', 'rtbcb' ); ?></h2>
 <p class="description">
-    <?php esc_html_e( 'Generate an executive summary to verify report assembly.', 'rtbcb' ); ?>
+	<?php esc_html_e( 'Generate an executive summary to verify report assembly.', 'rtbcb' ); ?>
 </p>
 <p class="rtbcb-data-source">
-    <span class="rtbcb-data-status rtbcb-status-executive-summary">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
-    <a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
-        <?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
-    </a>
+	<span class="rtbcb-data-status rtbcb-status-executive-summary">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
+	<a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
+		<?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
+	</a>
 </p>
 <div class="card">
-    <h3 class="title"><?php esc_html_e( 'Executive Summary', 'rtbcb' ); ?></h3>
-    <form id="rtbcb-report-assembly-form">
-        <?php wp_nonce_field( 'rtbcb_test_report_assembly', 'nonce' ); ?>
-        <p class="submit">
-            <button type="submit" class="button button-primary">
-                <?php esc_html_e( 'Generate Summary', 'rtbcb' ); ?>
-            </button>
-            <button type="button" id="rtbcb-clear-report-summary" class="button">
-                <?php esc_html_e( 'Clear', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </form>
-    <div id="rtbcb-report-assembly-results">
-        <?php if ( ! empty( $summary ) ) : ?>
-            <pre><?php echo esc_html( wp_json_encode( $summary, JSON_PRETTY_PRINT ) ); ?></pre>
-        <?php endif; ?>
-    </div>
+	<h3 class="title"><?php esc_html_e( 'Executive Summary', 'rtbcb' ); ?></h3>
+	<form id="rtbcb-report-assembly-form">
+		<?php wp_nonce_field( 'rtbcb_test_report_assembly', 'nonce' ); ?>
+		<p class="submit">
+			<button type="submit" class="button button-primary">
+				<?php esc_html_e( 'Generate Summary', 'rtbcb' ); ?>
+			</button>
+			<button type="button" id="rtbcb-clear-report-summary" class="button">
+				<?php esc_html_e( 'Clear', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</form>
+	<div id="rtbcb-report-assembly-results">
+		<?php if ( ! empty( $summary ) ) : ?>
+			<pre><?php echo esc_html( wp_json_encode( $summary, JSON_PRETTY_PRINT ) ); ?></pre>
+		<?php endif; ?>
+	</div>
 </div>
 <script>
 document.getElementById('rtbcb-clear-report-summary')?.addEventListener('click', function() {
-    document.getElementById('rtbcb-report-assembly-results').innerHTML = '';
+	document.getElementById('rtbcb-report-assembly-results').innerHTML = '';
 });
 </script>

--- a/admin/partials/test-roadmap-generator.php
+++ b/admin/partials/test-roadmap-generator.php
@@ -1,40 +1,40 @@
 <?php
 /**
- * Partial for Test Roadmap Generator section.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Partial for Test Roadmap Generator section.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-roadmap-generator', false ) ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 
 $company = rtbcb_get_current_company();
 if ( empty( $company ) ) {
-    $overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
-    echo '<div class="notice notice-error"><p>' . sprintf(
-        esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
-        '<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'
-    ) . '</p></div>';
-    return;
+	$overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
+	echo '<div class="notice notice-error"><p>' . sprintf(
+		esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
+		'<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'
+	) . '</p></div>';
+	return;
 }
 
 $roadmap = [];
 
 if ( isset( $_POST['rtbcb_generate_roadmap'] ) && check_admin_referer( 'rtbcb_generate_roadmap', 'rtbcb_generate_roadmap_nonce' ) ) {
-    $rec = RTBCB_Category_Recommender::recommend_category( $company );
-    update_option( 'rtbcb_last_recommended_category', $rec['recommended'] );
-    $features = $rec['category_info']['features'] ?? [];
-    $chunks   = array_chunk( $features, ceil( count( $features ) / 3 ) );
-    foreach ( $chunks as $index => $items ) {
-        $roadmap[ $index + 1 ] = array_map( 'sanitize_text_field', $items );
-    }
-    update_option( 'rtbcb_roadmap_plan', $roadmap );
+	$rec = RTBCB_Category_Recommender::recommend_category( $company );
+	update_option( 'rtbcb_last_recommended_category', $rec['recommended'] );
+	$features = $rec['category_info']['features'] ?? [];
+	$chunks   = array_chunk( $features, ceil( count( $features ) / 3 ) );
+	foreach ( $chunks as $index => $items ) {
+		$roadmap[ $index + 1 ] = array_map( 'sanitize_text_field', $items );
+	}
+	update_option( 'rtbcb_roadmap_plan', $roadmap );
 }
 
 $roadmap = ! empty( $roadmap ) ? $roadmap : get_option( 'rtbcb_roadmap_plan', [] );
@@ -42,26 +42,26 @@ $roadmap = ! empty( $roadmap ) ? $roadmap : get_option( 'rtbcb_roadmap_plan', []
 <h2><?php esc_html_e( 'Test Roadmap Generator', 'rtbcb' ); ?></h2>
 <p class="description"><?php esc_html_e( 'Build a multi-phase implementation roadmap based on the recommended category.', 'rtbcb' ); ?></p>
 <p class="rtbcb-data-source">
-    <span class="rtbcb-data-status rtbcb-status-implementation-roadmap">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
-    <a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
-        <?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
-    </a>
+	<span class="rtbcb-data-status rtbcb-status-implementation-roadmap">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
+	<a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
+		<?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
+	</a>
 </p>
 <form method="post">
-    <?php wp_nonce_field( 'rtbcb_generate_roadmap', 'rtbcb_generate_roadmap_nonce' ); ?>
-    <p class="submit">
-        <button type="submit" name="rtbcb_generate_roadmap" class="button button-primary"><?php esc_html_e( 'Generate Roadmap', 'rtbcb' ); ?></button>
-    </p>
+	<?php wp_nonce_field( 'rtbcb_generate_roadmap', 'rtbcb_generate_roadmap_nonce' ); ?>
+	<p class="submit">
+		<button type="submit" name="rtbcb_generate_roadmap" class="button button-primary"><?php esc_html_e( 'Generate Roadmap', 'rtbcb' ); ?></button>
+	</p>
 </form>
 <?php if ( ! empty( $roadmap ) ) : ?>
-    <div class="card">
-        <?php foreach ( $roadmap as $phase => $items ) : ?>
-            <h3><?php printf( esc_html__( 'Phase %d', 'rtbcb' ), intval( $phase ) ); ?></h3>
-            <ul>
-                <?php foreach ( $items as $item ) : ?>
-                    <li><?php echo esc_html( $item ); ?></li>
-                <?php endforeach; ?>
-            </ul>
-        <?php endforeach; ?>
-    </div>
+	<div class="card">
+		<?php foreach ( $roadmap as $phase => $items ) : ?>
+			<h3><?php printf( esc_html__( 'Phase %d', 'rtbcb' ), intval( $phase ) ); ?></h3>
+			<ul>
+				<?php foreach ( $items as $item ) : ?>
+					<li><?php echo esc_html( $item ); ?></li>
+				<?php endforeach; ?>
+			</ul>
+		<?php endforeach; ?>
+	</div>
 <?php endif; ?>

--- a/admin/partials/test-roi-calculator.php
+++ b/admin/partials/test-roi-calculator.php
@@ -1,36 +1,36 @@
 <?php
 /**
- * Partial for Test ROI Calculator section.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Partial for Test ROI Calculator section.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-roi-calculator', false ) ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 
 $company = rtbcb_get_current_company();
 if ( empty( $company ) ) {
-    $overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
-    echo '<div class="notice notice-error"><p>' . sprintf(
-        esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
-        '<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'
-    ) . '</p></div>';
-    return;
+	$overview_url = admin_url( 'admin.php?page=rtbcb-test-dashboard#rtbcb-phase1' );
+	echo '<div class="notice notice-error"><p>' . sprintf(
+		esc_html__( 'No company data found. Please run the %s first.', 'rtbcb' ),
+		'<a href="' . esc_url( $overview_url ) . '">' . esc_html__( 'Company Overview', 'rtbcb' ) . '</a>'
+	) . '</p></div>';
+	return;
 }
 
 $results = [];
 
 if ( isset( $_POST['rtbcb_calculate_roi'] ) && check_admin_referer( 'rtbcb_calculate_roi', 'rtbcb_calculate_roi_nonce' ) ) {
-    $results        = RTBCB_Calculator::calculate_roi( $company );
-    $recommendation = RTBCB_Category_Recommender::recommend_category( $company );
-    $results        = RTBCB_Calculator::calculate_category_refined_roi( $company, $recommendation['category_info'] );
-    update_option( 'rtbcb_roi_results', $results );
+	$results        = RTBCB_Calculator::calculate_roi( $company );
+	$recommendation = RTBCB_Category_Recommender::recommend_category( $company );
+	$results        = RTBCB_Calculator::calculate_category_refined_roi( $company, $recommendation['category_info'] );
+	update_option( 'rtbcb_roi_results', $results );
 }
 
 $results = ! empty( $results ) ? $results : get_option( 'rtbcb_roi_results', [] );
@@ -38,34 +38,34 @@ $results = ! empty( $results ) ? $results : get_option( 'rtbcb_roi_results', [] 
 <h2><?php esc_html_e( 'Test ROI Calculator', 'rtbcb' ); ?></h2>
 <p class="description"><?php esc_html_e( 'Calculate three-year ROI scenarios for the recommended solution.', 'rtbcb' ); ?></p>
 <p class="rtbcb-data-source">
-    <span class="rtbcb-data-status rtbcb-status-financial-analysis">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
-    <a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
-        <?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
-    </a>
+	<span class="rtbcb-data-status rtbcb-status-financial-analysis">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
+	<a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
+		<?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
+	</a>
 </p>
 <form method="post">
-    <?php wp_nonce_field( 'rtbcb_calculate_roi', 'rtbcb_calculate_roi_nonce' ); ?>
-    <p class="submit">
-        <button type="submit" name="rtbcb_calculate_roi" class="button button-primary"><?php esc_html_e( 'Calculate ROI', 'rtbcb' ); ?></button>
-    </p>
+	<?php wp_nonce_field( 'rtbcb_calculate_roi', 'rtbcb_calculate_roi_nonce' ); ?>
+	<p class="submit">
+		<button type="submit" name="rtbcb_calculate_roi" class="button button-primary"><?php esc_html_e( 'Calculate ROI', 'rtbcb' ); ?></button>
+	</p>
 </form>
 <?php if ( ! empty( $results ) ) : ?>
-    <table class="widefat striped">
-        <thead>
-            <tr>
-                <th><?php esc_html_e( 'Scenario', 'rtbcb' ); ?></th>
-                <th><?php esc_html_e( '3-Year Benefit', 'rtbcb' ); ?></th>
-                <th><?php esc_html_e( 'ROI %', 'rtbcb' ); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-        <?php foreach ( $results as $scenario => $data ) : ?>
-            <tr>
-                <td><?php echo esc_html( ucfirst( $scenario ) ); ?></td>
-                <td><?php echo esc_html( number_format_i18n( $data['total_annual_benefit'] * 3, 2 ) ); ?></td>
-                <td><?php echo esc_html( number_format_i18n( $data['roi_percentage'], 2 ) ); ?></td>
-            </tr>
-        <?php endforeach; ?>
-        </tbody>
-    </table>
+	<table class="widefat striped">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Scenario', 'rtbcb' ); ?></th>
+				<th><?php esc_html_e( '3-Year Benefit', 'rtbcb' ); ?></th>
+				<th><?php esc_html_e( 'ROI %', 'rtbcb' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+		<?php foreach ( $results as $scenario => $data ) : ?>
+			<tr>
+				<td><?php echo esc_html( ucfirst( $scenario ) ); ?></td>
+				<td><?php echo esc_html( number_format_i18n( $data['total_annual_benefit'] * 3, 2 ) ); ?></td>
+				<td><?php echo esc_html( number_format_i18n( $data['roi_percentage'], 2 ) ); ?></td>
+			</tr>
+		<?php endforeach; ?>
+		</tbody>
+	</table>
 <?php endif; ?>

--- a/admin/partials/test-tracking-script.php
+++ b/admin/partials/test-tracking-script.php
@@ -1,17 +1,17 @@
 <?php
 /**
- * Tracking script injection test.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Tracking script injection test.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-tracking-script', false ) ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 
 ?>
@@ -20,27 +20,27 @@ if ( ! rtbcb_require_completed_steps( 'rtbcb-test-tracking-script', false ) ) {
 
 <?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-tracking-script', $test_results ?? [] ); ?>
 <?php if ( $rtbcb_last ) : ?>
-    <div class="notice notice-info" role="status">
-        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
-        <p class="submit">
-            <button type="button" class="button" id="rtbcb-rerun-tracking-script" data-section="rtbcb-test-tracking-script">
-                <?php esc_html_e( 'Re-run', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </div>
+	<div class="notice notice-info" role="status">
+		<p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+		<p class="submit">
+			<button type="button" class="button" id="rtbcb-rerun-tracking-script" data-section="rtbcb-test-tracking-script">
+				<?php esc_html_e( 'Re-run', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</div>
 <?php endif; ?>
 
 <div class="card">
-    <h3 class="title"><?php esc_html_e( 'Tracking Script Injection', 'rtbcb' ); ?></h3>
-    <p><?php esc_html_e( 'Paste a tracking script snippet and verify it fires a test event.', 'rtbcb' ); ?></p>
-    <textarea id="rtbcb-tracking-snippet" class="large-text" rows="4" placeholder="<?php esc_attr_e( 'Paste script snippet…', 'rtbcb' ); ?>"></textarea>
-    <?php wp_nonce_field( 'rtbcb_test_tracking_script', 'rtbcb_test_tracking_script_nonce' ); ?>
-    <p class="submit">
-        <button type="button" id="rtbcb-run-tracking-script" class="button button-primary" data-section="rtbcb-test-tracking-script">
-            <?php esc_html_e( 'Inject &amp; Test', 'rtbcb' ); ?>
-        </button>
-    </p>
+	<h3 class="title"><?php esc_html_e( 'Tracking Script Injection', 'rtbcb' ); ?></h3>
+	<p><?php esc_html_e( 'Paste a tracking script snippet and verify it fires a test event.', 'rtbcb' ); ?></p>
+	<textarea id="rtbcb-tracking-snippet" class="large-text" rows="4" placeholder="<?php esc_attr_e( 'Paste script snippet…', 'rtbcb' ); ?>"></textarea>
+	<?php wp_nonce_field( 'rtbcb_test_tracking_script', 'rtbcb_test_tracking_script_nonce' ); ?>
+	<p class="submit">
+		<button type="button" id="rtbcb-run-tracking-script" class="button button-primary" data-section="rtbcb-test-tracking-script">
+			<?php esc_html_e( 'Inject &amp; Test', 'rtbcb' ); ?>
+		</button>
+	</p>
 </div>
 <div id="rtbcb-tracking-script-result" class="rtbcb-result-card"></div>

--- a/admin/partials/test-value-proposition.php
+++ b/admin/partials/test-value-proposition.php
@@ -1,76 +1,76 @@
 <?php
 /**
- * Partial for Test Value Proposition section.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Partial for Test Value Proposition section.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-value-proposition', false ) ) {
-    echo '<div class="notice notice-warning inline"><p>' .
-        esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
-        '</p></div>';
-    return;
+	echo '<div class="notice notice-warning inline"><p>' .
+		esc_html__( 'Please complete previous steps before accessing this section.', 'rtbcb' ) .
+		'</p></div>';
+	return;
 }
 
 ?>
 <h2><?php esc_html_e( 'Test Value Proposition', 'rtbcb' ); ?></h2>
 <p class="description"><?php esc_html_e( 'Generate a personalized opening paragraph for the report.', 'rtbcb' ); ?></p>
 <p class="rtbcb-data-source">
-    <span class="rtbcb-data-status rtbcb-status-value-proposition">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
-    <a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
-        <?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
-    </a>
+	<span class="rtbcb-data-status rtbcb-status-value-proposition">⚪ <?php esc_html_e( 'Generate new', 'rtbcb' ); ?></span>
+	<a href="#rtbcb-comprehensive-analysis" class="rtbcb-view-source" style="display:none;">
+		<?php esc_html_e( 'View Source Data', 'rtbcb' ); ?>
+	</a>
 </p>
 <?php $rtbcb_last = rtbcb_get_last_test_result( 'rtbcb-test-value-proposition', $test_results ?? [] ); ?>
 <?php if ( $rtbcb_last ) : ?>
-    <div class="notice notice-info" role="status">
-        <p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
-        <p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
-        <p class="submit">
-            <button type="button" class="button" id="rtbcb-rerun-value-proposition" data-section="rtbcb-test-value-proposition">
-                <?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </div>
+	<div class="notice notice-info" role="status">
+		<p><strong><?php esc_html_e( 'Status:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['status'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Message:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['message'] ); ?></p>
+		<p><strong><?php esc_html_e( 'Timestamp:', 'rtbcb' ); ?></strong> <?php echo esc_html( $rtbcb_last['timestamp'] ); ?></p>
+		<p class="submit">
+			<button type="button" class="button" id="rtbcb-rerun-value-proposition" data-section="rtbcb-test-value-proposition">
+				<?php esc_html_e( 'Regenerate This Section Only', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</div>
 <?php endif; ?>
 <div class="card">
-    <h3 class="title"><?php esc_html_e( 'Generate Value Proposition', 'rtbcb' ); ?></h3>
-    <?php wp_nonce_field( 'rtbcb_test_value_proposition', 'rtbcb_test_value_proposition_nonce' ); ?>
-    <p class="submit">
-        <button type="button" id="rtbcb-generate-value-proposition" class="button button-primary">
-            <?php esc_html_e( 'Generate', 'rtbcb' ); ?>
-        </button>
-    </p>
+	<h3 class="title"><?php esc_html_e( 'Generate Value Proposition', 'rtbcb' ); ?></h3>
+	<?php wp_nonce_field( 'rtbcb_test_value_proposition', 'rtbcb_test_value_proposition_nonce' ); ?>
+	<p class="submit">
+		<button type="button" id="rtbcb-generate-value-proposition" class="button button-primary">
+			<?php esc_html_e( 'Generate', 'rtbcb' ); ?>
+		</button>
+	</p>
 </div>
 <div id="rtbcb-value-proposition-card" class="rtbcb-result-card" style="display:none;">
-    <details>
-        <summary><?php esc_html_e( 'Opening Paragraph', 'rtbcb' ); ?></summary>
-        <div id="rtbcb-value-proposition-results"></div>
-    </details>
+	<details>
+		<summary><?php esc_html_e( 'Opening Paragraph', 'rtbcb' ); ?></summary>
+		<div id="rtbcb-value-proposition-results"></div>
+	</details>
 </div>
 <script>
-    jQuery('#rtbcb-generate-value-proposition').on('click', function(){
-        const btn = jQuery(this);
-        const original = rtbcbTestUtils.showLoading(btn);
-        jQuery.post(ajaxurl, {
-            action: 'rtbcb_test_value_proposition',
-            nonce: jQuery('#rtbcb_test_value_proposition_nonce').val()
-        }).done(function(response){
-            if (response.success) {
-                const data = response.data;
-                rtbcbTestUtils.renderSuccess(jQuery('#rtbcb-value-proposition-results'), data.paragraph, null, data);
-            jQuery('#rtbcb-value-proposition-card').show();
-        } else {
-            rtbcbTestUtils.renderError(jQuery('#rtbcb-value-proposition-results'), response.data.message);
-        }
-    }).always(function(){
-        rtbcbTestUtils.hideLoading(btn, original);
-    });
- });
- document.getElementById('rtbcb-rerun-value-proposition')?.addEventListener('click', function(){
-    document.getElementById('rtbcb-generate-value-proposition').click();
- });
+	jQuery('#rtbcb-generate-value-proposition').on('click', function(){
+		const btn = jQuery(this);
+		const original = rtbcbTestUtils.showLoading(btn);
+		jQuery.post(ajaxurl, {
+			action: 'rtbcb_test_value_proposition',
+			nonce: jQuery('#rtbcb_test_value_proposition_nonce').val()
+		}).done(function(response){
+			if (response.success) {
+				const data = response.data;
+				rtbcbTestUtils.renderSuccess(jQuery('#rtbcb-value-proposition-results'), data.paragraph, null, data);
+			jQuery('#rtbcb-value-proposition-card').show();
+		} else {
+			rtbcbTestUtils.renderError(jQuery('#rtbcb-value-proposition-results'), response.data.message);
+		}
+	}).always(function(){
+		rtbcbTestUtils.hideLoading(btn, original);
+	});
+	});
+	document.getElementById('rtbcb-rerun-value-proposition')?.addEventListener('click', function(){
+	document.getElementById('rtbcb-generate-value-proposition').click();
+	});
 </script>

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Settings admin page for Real Treasury Business Case Builder plugin.
- */
+	* Settings admin page for Real Treasury Business Case Builder plugin.
+	*/
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
@@ -22,180 +22,180 @@ $enable_ai_analysis = isset( $feature_settings['enable_ai_analysis'] ) ? (bool) 
 $enable_charts      = isset( $feature_settings['enable_charts'] ) ? (bool) $feature_settings['enable_charts'] : true;
 
 $chat_models = [
-    'gpt-5'             => 'gpt-5',
-    'gpt-5-mini'        => 'gpt-5-mini',
-    'gpt-5-nano'        => 'gpt-5-nano',
-    'gpt-5-chat-latest' => 'gpt-5-chat-latest',
-    'gpt-4o-mini'       => 'gpt-4o-mini',
-    'gpt-4o'            => 'gpt-4o',
-    'o1-mini'           => 'o1-mini',
-    'o1-preview'        => 'o1-preview',
+	'gpt-5'             => 'gpt-5',
+	'gpt-5-mini'        => 'gpt-5-mini',
+	'gpt-5-nano'        => 'gpt-5-nano',
+	'gpt-5-chat-latest' => 'gpt-5-chat-latest',
+	'gpt-4o-mini'       => 'gpt-4o-mini',
+	'gpt-4o'            => 'gpt-4o',
+	'o1-mini'           => 'o1-mini',
+	'o1-preview'        => 'o1-preview',
 ];
 
 $embedding_models = [
-    'text-embedding-3-small' => 'text-embedding-3-small',
-    'text-embedding-3-large' => 'text-embedding-3-large',
+	'text-embedding-3-small' => 'text-embedding-3-small',
+	'text-embedding-3-large' => 'text-embedding-3-large',
 ];
 ?>
 
 <?php if ( ! rtbcb_has_openai_api_key() ) : ?>
-    <div class="notice notice-warning is-dismissible">
-        <p><?php echo esc_html__( 'OpenAI API key is missing. Please enter a valid key to enable AI features.', 'rtbcb' ); ?></p>
-    </div>
+	<div class="notice notice-warning is-dismissible">
+		<p><?php echo esc_html__( 'OpenAI API key is missing. Please enter a valid key to enable AI features.', 'rtbcb' ); ?></p>
+	</div>
 <?php endif; ?>
 
 <div class="wrap">
-    <h1><?php echo esc_html__( 'Business Case Builder Settings', 'rtbcb' ); ?></h1>
-    <form action="options.php" method="post">
-        <?php settings_fields( 'rtbcb_settings' ); ?>
-        <table class="form-table" role="presentation">
-            <tr>
-                <th scope="row">
-                    <label for="rtbcb_openai_api_key"><?php echo esc_html__( 'OpenAI API Key', 'rtbcb' ); ?></label>
-                </th>
-                <td>
-                    <input type="password" id="rtbcb_openai_api_key" name="rtbcb_openai_api_key" value="<?php echo esc_attr( $api_key ); ?>" class="regular-text" />
-                    <button type="button" class="button" id="rtbcb-toggle-api-key"><?php echo esc_html__( 'Show', 'rtbcb' ); ?></button>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row">
-                    <label for="rtbcb_mini_model"><?php echo esc_html__( 'Mini Model', 'rtbcb' ); ?></label>
-                </th>
-                <td>
-                    <select id="rtbcb_mini_model" name="rtbcb_mini_model">
-                        <?php foreach ( $chat_models as $value => $label ) : ?>
-                            <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $mini_model, $value ); ?>><?php echo esc_html( $label ); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row">
-                    <label for="rtbcb_premium_model"><?php echo esc_html__( 'Premium Model', 'rtbcb' ); ?></label>
-                </th>
-                <td>
-                    <select id="rtbcb_premium_model" name="rtbcb_premium_model">
-                        <?php foreach ( $chat_models as $value => $label ) : ?>
-                            <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $premium_model, $value ); ?>><?php echo esc_html( $label ); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row">
-                    <label for="rtbcb_advanced_model"><?php echo esc_html__( 'Advanced Model', 'rtbcb' ); ?></label>
-                </th>
-                <td>
-                    <select id="rtbcb_advanced_model" name="rtbcb_advanced_model">
-                        <?php foreach ( $chat_models as $value => $label ) : ?>
-                            <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $advanced_model, $value ); ?>><?php echo esc_html( $label ); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row">
-                    <label for="rtbcb_gpt5_timeout"><?php echo esc_html__( 'API Request Timeout (seconds)', 'rtbcb' ); ?></label>
-                </th>
-                <td>
-                    <input type="number" id="rtbcb_gpt5_timeout" name="rtbcb_gpt5_timeout" value="<?php echo esc_attr( $gpt5_timeout ); ?>" class="small-text" min="1" max="600" />
-                    <p class="description"><?php echo esc_html__( 'Maximum time to wait for OpenAI responses (default 300, max 600).', 'rtbcb' ); ?></p>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row">
-                    <label for="rtbcb_gpt5_min_output_tokens"><?php echo esc_html__( 'Min Output Tokens', 'rtbcb' ); ?></label>
-                </th>
-                <td>
-                    <input type="number" id="rtbcb_gpt5_min_output_tokens" name="rtbcb_gpt5_min_output_tokens" value="<?php echo esc_attr( $gpt5_min_output_tokens ); ?>" class="small-text" min="1" max="128000" />
-                    <p class="description"><?php echo esc_html__( 'Minimum tokens returned by OpenAI.', 'rtbcb' ); ?></p>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row">
-                    <label for="rtbcb_gpt5_max_output_tokens"><?php echo esc_html__( 'Max Output Tokens', 'rtbcb' ); ?></label>
-                </th>
-                <td>
-                    <input type="number" id="rtbcb_gpt5_max_output_tokens" name="rtbcb_gpt5_max_output_tokens" value="<?php echo esc_attr( $gpt5_max_output_tokens ); ?>" class="small-text" min="256" max="128000" />
-                    <p class="description"><?php echo esc_html__( 'Maximum tokens returned by OpenAI (max 128000).', 'rtbcb' ); ?></p>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row">
-                    <label for="rtbcb_embedding_model"><?php echo esc_html__( 'Embedding Model', 'rtbcb' ); ?></label>
-                </th>
-                <td>
-                    <select id="rtbcb_embedding_model" name="rtbcb_embedding_model">
-                        <?php foreach ( $embedding_models as $value => $label ) : ?>
-                            <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $embedding_model, $value ); ?>><?php echo esc_html( $label ); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row">
-                    <label for="rtbcb_labor_cost_per_hour"><?php echo esc_html__( 'Labor Cost Per Hour', 'rtbcb' ); ?></label>
-                </th>
-                <td>
-                    <input type="number" step="0.01" id="rtbcb_labor_cost_per_hour" name="rtbcb_labor_cost_per_hour" value="<?php echo esc_attr( $labor_cost ); ?>" class="regular-text" />
-                </td>
-            </tr>
-            <tr>
-                <th scope="row">
-                    <label for="rtbcb_bank_fee_baseline"><?php echo esc_html__( 'Bank Fee Baseline', 'rtbcb' ); ?></label>
-                </th>
-                <td>
-                    <input type="number" step="0.01" id="rtbcb_bank_fee_baseline" name="rtbcb_bank_fee_baseline" value="<?php echo esc_attr( $bank_fee ); ?>" class="regular-text" />
-                </td>
-            </tr>
-            <tr>
-                <th scope="row">
-                    <label for="rtbcb_fast_mode"><?php echo esc_html__( 'Fast Mode', 'rtbcb' ); ?></label>
-                </th>
-                <td>
-                    <input type="checkbox" id="rtbcb_fast_mode" name="rtbcb_fast_mode" value="1" <?php checked( 1, $fast_mode ); ?> />
-                    <p class="description"><?php echo esc_html__( 'Generate a basic ROI-only report without AI processing.', 'rtbcb' ); ?></p>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row">
-                    <label for="rtbcb_enable_ai_analysis"><?php echo esc_html__( 'Enable AI Analysis', 'rtbcb' ); ?></label>
-                </th>
-                <td>
-                    <input type="checkbox" id="rtbcb_enable_ai_analysis" name="rtbcb_settings[enable_ai_analysis]" value="1" <?php checked( $enable_ai_analysis ); ?> />
-                    <p class="description"><?php echo esc_html__( 'Use AI services for enhanced insights and recommendations.', 'rtbcb' ); ?></p>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row">
-                    <label for="rtbcb_enable_charts"><?php echo esc_html__( 'Enable Charts', 'rtbcb' ); ?></label>
-                </th>
-                <td>
-                    <input type="checkbox" id="rtbcb_enable_charts" name="rtbcb_settings[enable_charts]" value="1" <?php checked( $enable_charts ); ?> />
-                    <p class="description"><?php echo esc_html__( 'Display visual charts in reports and analytics.', 'rtbcb' ); ?></p>
-                </td>
-            </tr>
-        </table>
-        <?php submit_button(); ?>
-    </form>
+	<h1><?php echo esc_html__( 'Business Case Builder Settings', 'rtbcb' ); ?></h1>
+	<form action="options.php" method="post">
+		<?php settings_fields( 'rtbcb_settings' ); ?>
+		<table class="form-table" role="presentation">
+			<tr>
+				<th scope="row">
+					<label for="rtbcb_openai_api_key"><?php echo esc_html__( 'OpenAI API Key', 'rtbcb' ); ?></label>
+				</th>
+				<td>
+					<input type="password" id="rtbcb_openai_api_key" name="rtbcb_openai_api_key" value="<?php echo esc_attr( $api_key ); ?>" class="regular-text" />
+					<button type="button" class="button" id="rtbcb-toggle-api-key"><?php echo esc_html__( 'Show', 'rtbcb' ); ?></button>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="rtbcb_mini_model"><?php echo esc_html__( 'Mini Model', 'rtbcb' ); ?></label>
+				</th>
+				<td>
+					<select id="rtbcb_mini_model" name="rtbcb_mini_model">
+						<?php foreach ( $chat_models as $value => $label ) : ?>
+							<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $mini_model, $value ); ?>><?php echo esc_html( $label ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="rtbcb_premium_model"><?php echo esc_html__( 'Premium Model', 'rtbcb' ); ?></label>
+				</th>
+				<td>
+					<select id="rtbcb_premium_model" name="rtbcb_premium_model">
+						<?php foreach ( $chat_models as $value => $label ) : ?>
+							<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $premium_model, $value ); ?>><?php echo esc_html( $label ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="rtbcb_advanced_model"><?php echo esc_html__( 'Advanced Model', 'rtbcb' ); ?></label>
+				</th>
+				<td>
+					<select id="rtbcb_advanced_model" name="rtbcb_advanced_model">
+						<?php foreach ( $chat_models as $value => $label ) : ?>
+							<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $advanced_model, $value ); ?>><?php echo esc_html( $label ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="rtbcb_gpt5_timeout"><?php echo esc_html__( 'API Request Timeout (seconds)', 'rtbcb' ); ?></label>
+				</th>
+				<td>
+					<input type="number" id="rtbcb_gpt5_timeout" name="rtbcb_gpt5_timeout" value="<?php echo esc_attr( $gpt5_timeout ); ?>" class="small-text" min="1" max="600" />
+					<p class="description"><?php echo esc_html__( 'Maximum time to wait for OpenAI responses (default 300, max 600).', 'rtbcb' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="rtbcb_gpt5_min_output_tokens"><?php echo esc_html__( 'Min Output Tokens', 'rtbcb' ); ?></label>
+				</th>
+				<td>
+					<input type="number" id="rtbcb_gpt5_min_output_tokens" name="rtbcb_gpt5_min_output_tokens" value="<?php echo esc_attr( $gpt5_min_output_tokens ); ?>" class="small-text" min="1" max="128000" />
+					<p class="description"><?php echo esc_html__( 'Minimum tokens returned by OpenAI.', 'rtbcb' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="rtbcb_gpt5_max_output_tokens"><?php echo esc_html__( 'Max Output Tokens', 'rtbcb' ); ?></label>
+				</th>
+				<td>
+					<input type="number" id="rtbcb_gpt5_max_output_tokens" name="rtbcb_gpt5_max_output_tokens" value="<?php echo esc_attr( $gpt5_max_output_tokens ); ?>" class="small-text" min="256" max="128000" />
+					<p class="description"><?php echo esc_html__( 'Maximum tokens returned by OpenAI (max 128000).', 'rtbcb' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="rtbcb_embedding_model"><?php echo esc_html__( 'Embedding Model', 'rtbcb' ); ?></label>
+				</th>
+				<td>
+					<select id="rtbcb_embedding_model" name="rtbcb_embedding_model">
+						<?php foreach ( $embedding_models as $value => $label ) : ?>
+							<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $embedding_model, $value ); ?>><?php echo esc_html( $label ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="rtbcb_labor_cost_per_hour"><?php echo esc_html__( 'Labor Cost Per Hour', 'rtbcb' ); ?></label>
+				</th>
+				<td>
+					<input type="number" step="0.01" id="rtbcb_labor_cost_per_hour" name="rtbcb_labor_cost_per_hour" value="<?php echo esc_attr( $labor_cost ); ?>" class="regular-text" />
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="rtbcb_bank_fee_baseline"><?php echo esc_html__( 'Bank Fee Baseline', 'rtbcb' ); ?></label>
+				</th>
+				<td>
+					<input type="number" step="0.01" id="rtbcb_bank_fee_baseline" name="rtbcb_bank_fee_baseline" value="<?php echo esc_attr( $bank_fee ); ?>" class="regular-text" />
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="rtbcb_fast_mode"><?php echo esc_html__( 'Fast Mode', 'rtbcb' ); ?></label>
+				</th>
+				<td>
+					<input type="checkbox" id="rtbcb_fast_mode" name="rtbcb_fast_mode" value="1" <?php checked( 1, $fast_mode ); ?> />
+					<p class="description"><?php echo esc_html__( 'Generate a basic ROI-only report without AI processing.', 'rtbcb' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="rtbcb_enable_ai_analysis"><?php echo esc_html__( 'Enable AI Analysis', 'rtbcb' ); ?></label>
+				</th>
+				<td>
+					<input type="checkbox" id="rtbcb_enable_ai_analysis" name="rtbcb_settings[enable_ai_analysis]" value="1" <?php checked( $enable_ai_analysis ); ?> />
+					<p class="description"><?php echo esc_html__( 'Use AI services for enhanced insights and recommendations.', 'rtbcb' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="rtbcb_enable_charts"><?php echo esc_html__( 'Enable Charts', 'rtbcb' ); ?></label>
+				</th>
+				<td>
+					<input type="checkbox" id="rtbcb_enable_charts" name="rtbcb_settings[enable_charts]" value="1" <?php checked( $enable_charts ); ?> />
+					<p class="description"><?php echo esc_html__( 'Display visual charts in reports and analytics.', 'rtbcb' ); ?></p>
+				</td>
+			</tr>
+		</table>
+		<?php submit_button(); ?>
+	</form>
 </div>
 
 <script type="text/javascript">
 ( function() {
-    var toggleButton = document.getElementById( 'rtbcb-toggle-api-key' );
-    var apiInput = document.getElementById( 'rtbcb_openai_api_key' );
-    if ( toggleButton && apiInput ) {
-        toggleButton.addEventListener( 'click', function() {
-            if ( 'password' === apiInput.type ) {
-                apiInput.type = 'text';
-                toggleButton.textContent = '<?php echo esc_js( __( 'Hide', 'rtbcb' ) ); ?>';
-            } else {
-                apiInput.type = 'password';
-                toggleButton.textContent = '<?php echo esc_js( __( 'Show', 'rtbcb' ) ); ?>';
-            }
-        } );
-    }
+	var toggleButton = document.getElementById( 'rtbcb-toggle-api-key' );
+	var apiInput = document.getElementById( 'rtbcb_openai_api_key' );
+	if ( toggleButton && apiInput ) {
+		toggleButton.addEventListener( 'click', function() {
+			if ( 'password' === apiInput.type ) {
+				apiInput.type = 'text';
+				toggleButton.textContent = '<?php echo esc_js( __( 'Hide', 'rtbcb' ) ); ?>';
+			} else {
+				apiInput.type = 'password';
+				toggleButton.textContent = '<?php echo esc_js( __( 'Show', 'rtbcb' ) ); ?>';
+			}
+		} );
+	}
 } )();
 </script>
 

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Test Dashboard admin page.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Test Dashboard admin page.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 defined( 'ABSPATH' ) || exit;
 $company_data   = get_option( 'rtbcb_company_data', [] );
 $company_name   = isset( $company_data['name'] ) ? sanitize_text_field( $company_data['name'] ) : '';
@@ -12,160 +12,160 @@ $sections      = rtbcb_get_dashboard_sections( $test_results );
 $total_sections = count( $sections );
 ?>
 <div class="wrap rtbcb-admin-page">
-    <h1><?php esc_html_e( 'Treasury Report Section Testing Dashboard', 'rtbcb' ); ?></h1>
-    <?php rtbcb_render_start_new_analysis_button(); ?>
-    <div class="card">
-        <h2 class="title"><?php esc_html_e( 'Run All Tests', 'rtbcb' ); ?></h2>
-        <p>
-            <label for="rtbcb-company-name"><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></label>
-            <input type="text" id="rtbcb-company-name" class="regular-text" value="<?php echo esc_attr( $company_name ); ?>" />
-            <button type="button" id="rtbcb-set-company" class="button"><?php esc_html_e( 'Set Company', 'rtbcb' ); ?></button>
-            <?php wp_nonce_field( 'rtbcb_set_test_company', 'rtbcb_set_test_company_nonce' ); ?>
-        </p>
-        <p class="description"><?php esc_html_e( 'Run the complete test suite. Individual test tools will be available after completion.', 'rtbcb' ); ?></p>
-        <p class="submit">
-            <button type="button" id="rtbcb-test-all-sections" class="button button-primary">
-                <?php esc_html_e( 'Run All Tests', 'rtbcb' ); ?>
-            </button>
-            <?php wp_nonce_field( 'rtbcb_test_dashboard', 'rtbcb_test_dashboard_nonce' ); ?>
-        </p>
-        <progress id="rtbcb-test-progress" class="rtbcb-test-progress" max="<?php echo esc_attr( $total_sections ); ?>" value="0" role="progressbar" aria-valuemin="0" aria-valuemax="<?php echo esc_attr( $total_sections ); ?>" aria-valuenow="0" aria-label="<?php esc_attr_e( 'Test progress', 'rtbcb' ); ?>"></progress>
-        <p id="rtbcb-test-status" role="status" aria-live="polite"></p>
-        <p id="rtbcb-test-step"></p>
-        <pre id="rtbcb-test-config" class="rtbcb-config-snippet"></pre>
-    </div>
+	<h1><?php esc_html_e( 'Treasury Report Section Testing Dashboard', 'rtbcb' ); ?></h1>
+	<?php rtbcb_render_start_new_analysis_button(); ?>
+	<div class="card">
+		<h2 class="title"><?php esc_html_e( 'Run All Tests', 'rtbcb' ); ?></h2>
+		<p>
+			<label for="rtbcb-company-name"><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></label>
+			<input type="text" id="rtbcb-company-name" class="regular-text" value="<?php echo esc_attr( $company_name ); ?>" />
+			<button type="button" id="rtbcb-set-company" class="button"><?php esc_html_e( 'Set Company', 'rtbcb' ); ?></button>
+			<?php wp_nonce_field( 'rtbcb_set_test_company', 'rtbcb_set_test_company_nonce' ); ?>
+		</p>
+		<p class="description"><?php esc_html_e( 'Run the complete test suite. Individual test tools will be available after completion.', 'rtbcb' ); ?></p>
+		<p class="submit">
+			<button type="button" id="rtbcb-test-all-sections" class="button button-primary">
+				<?php esc_html_e( 'Run All Tests', 'rtbcb' ); ?>
+			</button>
+			<?php wp_nonce_field( 'rtbcb_test_dashboard', 'rtbcb_test_dashboard_nonce' ); ?>
+		</p>
+		<progress id="rtbcb-test-progress" class="rtbcb-test-progress" max="<?php echo esc_attr( $total_sections ); ?>" value="0" role="progressbar" aria-valuemin="0" aria-valuemax="<?php echo esc_attr( $total_sections ); ?>" aria-valuenow="0" aria-label="<?php esc_attr_e( 'Test progress', 'rtbcb' ); ?>"></progress>
+		<p id="rtbcb-test-status" role="status" aria-live="polite"></p>
+		<p id="rtbcb-test-step"></p>
+		<pre id="rtbcb-test-config" class="rtbcb-config-snippet"></pre>
+	</div>
 
-    <div id="rtbcb-comprehensive-analysis" class="card" style="display:none;">
-        <h2 class="title"><?php esc_html_e( 'Comprehensive Analysis Results', 'rtbcb' ); ?></h2>
-        <div id="rtbcb-comprehensive-results"></div>
-        <div id="rtbcb-usage-map-wrapper" style="display:none;">
-            <table id="rtbcb-usage-map"></table>
-        </div>
-        <p class="rtbcb-actions">
-            <button type="button" id="rtbcb-regenerate-analysis" class="button">
-                <?php esc_html_e( 'Regenerate Full Analysis', 'rtbcb' ); ?>
-            </button>
-            <button type="button" id="rtbcb-export-analysis" class="button">
-                <?php esc_html_e( 'Export Results', 'rtbcb' ); ?>
-            </button>
-            <button type="button" id="rtbcb-show-usage-map" class="button">
-                <?php esc_html_e( 'Show Usage Map', 'rtbcb' ); ?>
-            </button>
-            <button type="button" id="rtbcb-clear-analysis" class="button">
-                <?php esc_html_e( 'Clear All Stored Data', 'rtbcb' ); ?>
-            </button>
-        </p>
-    </div>
+	<div id="rtbcb-comprehensive-analysis" class="card" style="display:none;">
+		<h2 class="title"><?php esc_html_e( 'Comprehensive Analysis Results', 'rtbcb' ); ?></h2>
+		<div id="rtbcb-comprehensive-results"></div>
+		<div id="rtbcb-usage-map-wrapper" style="display:none;">
+			<table id="rtbcb-usage-map"></table>
+		</div>
+		<p class="rtbcb-actions">
+			<button type="button" id="rtbcb-regenerate-analysis" class="button">
+				<?php esc_html_e( 'Regenerate Full Analysis', 'rtbcb' ); ?>
+			</button>
+			<button type="button" id="rtbcb-export-analysis" class="button">
+				<?php esc_html_e( 'Export Results', 'rtbcb' ); ?>
+			</button>
+			<button type="button" id="rtbcb-show-usage-map" class="button">
+				<?php esc_html_e( 'Show Usage Map', 'rtbcb' ); ?>
+			</button>
+			<button type="button" id="rtbcb-clear-analysis" class="button">
+				<?php esc_html_e( 'Clear All Stored Data', 'rtbcb' ); ?>
+			</button>
+		</p>
+	</div>
 
-    <?php
-    $phases   = [
-        1 => [
-            'label'       => __( 'Phase 1: Data Collection & Enrichment', 'rtbcb' ),
-            'description' => __( 'Gather company information and enrich it for analysis.', 'rtbcb' ),
-        ],
-        2 => [
-            'label'       => __( 'Phase 2: Analysis & Content Generation', 'rtbcb' ),
-            'description' => __( 'Generate insights and draft report content.', 'rtbcb' ),
-        ],
-        3 => [
-            'label'       => __( 'Phase 3: ROI & Strategic Recommendation', 'rtbcb' ),
-            'description' => __( 'Build the business case and recommendations.', 'rtbcb' ),
-        ],
-        4 => [
-            'label'       => __( 'Phase 4: Report Assembly & Delivery', 'rtbcb' ),
-            'description' => __( 'Assemble results into a sharable report.', 'rtbcb' ),
-        ],
-        5 => [
-            'label'       => __( 'Phase 5: Post-Delivery Engagement', 'rtbcb' ),
-            'description' => __( 'Engage recipients and track interactions.', 'rtbcb' ),
-        ],
-    ];
-    $sections_by_phase = [];
-    foreach ( $sections as $id => $section ) {
-        $phase = isset( $section['phase'] ) ? (int) $section['phase'] : 0;
-        if ( $phase ) {
-            $sections_by_phase[ $phase ][ $id ] = $section;
-        }
-    }
-    $phase_keys        = array_keys( $phases );
-    $phase_percentages = rtbcb_calculate_phase_completion( $sections, $phase_keys );
-    ?>
-    <div class="card rtbcb-progress-card">
-        <h2 class="title"><?php esc_html_e( 'Analysis Progress', 'rtbcb' ); ?></h2>
-        <div id="rtbcb-progress-steps" class="rtbcb-progress-steps">
-            <?php foreach ( $phases as $phase_num => $phase ) : ?>
-                <div class="rtbcb-progress-phase" data-phase="<?php echo esc_attr( $phase_num ); ?>">
-                    <button type="button" class="rtbcb-phase-toggle" aria-expanded="false" aria-controls="rtbcb-phase-content-<?php echo esc_attr( $phase_num ); ?>">
-                        <span class="rtbcb-phase-label"><?php echo esc_html( $phase['label'] ); ?></span>
-                        <span class="rtbcb-phase-percent"><?php echo esc_html( $phase_percentages[ $phase_num ] ); ?>%</span>
-                    </button>
-                    <div id="rtbcb-phase-content-<?php echo esc_attr( $phase_num ); ?>" class="rtbcb-phase-content">
-                        <span class="rtbcb-phase-desc"><?php echo esc_html( $phase['description'] ); ?></span>
-                        <?php if ( ! empty( $sections_by_phase[ $phase_num ] ) ) : ?>
-                            <?php foreach ( $sections_by_phase[ $phase_num ] as $id => $section ) : ?>
-                                <?php $done = ! empty( $section['completed'] ); ?>
-                                <div class="rtbcb-section-item <?php echo $done ? 'completed' : 'pending'; ?>" data-completed="<?php echo $done ? '1' : '0'; ?>">
-                                    <span class="rtbcb-section-label"><?php echo esc_html( $section['label'] ); ?></span>
-                                    <span class="rtbcb-section-status"><?php echo $done ? esc_html__( '✓ Tested', 'rtbcb' ) : esc_html__( '⚪ Pending', 'rtbcb' ); ?></span>
-                                </div>
-                            <?php endforeach; ?>
-                        <?php else : ?>
-                            <p class="rtbcb-no-tests"><?php esc_html_e( 'No tests yet.', 'rtbcb' ); ?></p>
-                        <?php endif; ?>
-                    </div>
-                </div>
-            <?php endforeach; ?>
-        </div>
-    </div>
+	<?php
+	$phases   = [
+		1 => [
+			'label'       => __( 'Phase 1: Data Collection & Enrichment', 'rtbcb' ),
+			'description' => __( 'Gather company information and enrich it for analysis.', 'rtbcb' ),
+		],
+		2 => [
+			'label'       => __( 'Phase 2: Analysis & Content Generation', 'rtbcb' ),
+			'description' => __( 'Generate insights and draft report content.', 'rtbcb' ),
+		],
+		3 => [
+			'label'       => __( 'Phase 3: ROI & Strategic Recommendation', 'rtbcb' ),
+			'description' => __( 'Build the business case and recommendations.', 'rtbcb' ),
+		],
+		4 => [
+			'label'       => __( 'Phase 4: Report Assembly & Delivery', 'rtbcb' ),
+			'description' => __( 'Assemble results into a sharable report.', 'rtbcb' ),
+		],
+		5 => [
+			'label'       => __( 'Phase 5: Post-Delivery Engagement', 'rtbcb' ),
+			'description' => __( 'Engage recipients and track interactions.', 'rtbcb' ),
+		],
+	];
+	$sections_by_phase = [];
+	foreach ( $sections as $id => $section ) {
+		$phase = isset( $section['phase'] ) ? (int) $section['phase'] : 0;
+		if ( $phase ) {
+			$sections_by_phase[ $phase ][ $id ] = $section;
+		}
+	}
+	$phase_keys        = array_keys( $phases );
+	$phase_percentages = rtbcb_calculate_phase_completion( $sections, $phase_keys );
+	?>
+	<div class="card rtbcb-progress-card">
+		<h2 class="title"><?php esc_html_e( 'Analysis Progress', 'rtbcb' ); ?></h2>
+		<div id="rtbcb-progress-steps" class="rtbcb-progress-steps">
+			<?php foreach ( $phases as $phase_num => $phase ) : ?>
+				<div class="rtbcb-progress-phase" data-phase="<?php echo esc_attr( $phase_num ); ?>">
+					<button type="button" class="rtbcb-phase-toggle" aria-expanded="false" aria-controls="rtbcb-phase-content-<?php echo esc_attr( $phase_num ); ?>">
+						<span class="rtbcb-phase-label"><?php echo esc_html( $phase['label'] ); ?></span>
+						<span class="rtbcb-phase-percent"><?php echo esc_html( $phase_percentages[ $phase_num ] ); ?>%</span>
+					</button>
+					<div id="rtbcb-phase-content-<?php echo esc_attr( $phase_num ); ?>" class="rtbcb-phase-content">
+						<span class="rtbcb-phase-desc"><?php echo esc_html( $phase['description'] ); ?></span>
+						<?php if ( ! empty( $sections_by_phase[ $phase_num ] ) ) : ?>
+							<?php foreach ( $sections_by_phase[ $phase_num ] as $id => $section ) : ?>
+								<?php $done = ! empty( $section['completed'] ); ?>
+								<div class="rtbcb-section-item <?php echo $done ? 'completed' : 'pending'; ?>" data-completed="<?php echo $done ? '1' : '0'; ?>">
+									<span class="rtbcb-section-label"><?php echo esc_html( $section['label'] ); ?></span>
+									<span class="rtbcb-section-status"><?php echo $done ? esc_html__( '✓ Tested', 'rtbcb' ) : esc_html__( '⚪ Pending', 'rtbcb' ); ?></span>
+								</div>
+							<?php endforeach; ?>
+						<?php else : ?>
+							<p class="rtbcb-no-tests"><?php esc_html_e( 'No tests yet.', 'rtbcb' ); ?></p>
+						<?php endif; ?>
+					</div>
+				</div>
+			<?php endforeach; ?>
+		</div>
+	</div>
 
-    <script>
-    window.rtbcbAdmin = window.rtbcbAdmin || {};
-    window.rtbcbAdmin.phaseLabels = <?php echo wp_json_encode( wp_list_pluck( $phases, 'label' ) ); ?>;
-    window.rtbcbAdmin.phaseKeys = <?php echo wp_json_encode( $phase_keys ); ?>;
-    window.rtbcbAdmin.phaseCompletion = <?php echo wp_json_encode( $phase_percentages ); ?>;
-    </script>
+	<script>
+	window.rtbcbAdmin = window.rtbcbAdmin || {};
+	window.rtbcbAdmin.phaseLabels = <?php echo wp_json_encode( wp_list_pluck( $phases, 'label' ) ); ?>;
+	window.rtbcbAdmin.phaseKeys = <?php echo wp_json_encode( $phase_keys ); ?>;
+	window.rtbcbAdmin.phaseCompletion = <?php echo wp_json_encode( $phase_percentages ); ?>;
+	</script>
 
-    <?php include RTBCB_DIR . 'admin/partials/dashboard-connectivity.php'; ?>
+	<?php include RTBCB_DIR . 'admin/partials/dashboard-connectivity.php'; ?>
 
-    <div id="rtbcb-section-tests" style="display:none;">
-        <h2 class="title"><?php esc_html_e( 'Individual Test Tools', 'rtbcb' ); ?></h2>
-        <p><?php esc_html_e( 'These tools are optional and available after running all tests.', 'rtbcb' ); ?></p>
+	<div id="rtbcb-section-tests" style="display:none;">
+		<h2 class="title"><?php esc_html_e( 'Individual Test Tools', 'rtbcb' ); ?></h2>
+		<p><?php esc_html_e( 'These tools are optional and available after running all tests.', 'rtbcb' ); ?></p>
 
-        <h2 class="nav-tab-wrapper" id="rtbcb-test-tabs">
-            <a href="#rtbcb-phase1" class="nav-tab nav-tab-active"><?php echo esc_html( $phases[1]['label'] ); ?></a>
-            <a href="#rtbcb-phase2" class="nav-tab"><?php echo esc_html( $phases[2]['label'] ); ?></a>
-            <a href="#rtbcb-phase3" class="nav-tab"><?php echo esc_html( $phases[3]['label'] ); ?></a>
-            <a href="#rtbcb-phase4" class="nav-tab"><?php echo esc_html( $phases[4]['label'] ); ?></a>
-            <a href="#rtbcb-phase5" class="nav-tab"><?php echo esc_html( $phases[5]['label'] ); ?></a>
-        </h2>
+		<h2 class="nav-tab-wrapper" id="rtbcb-test-tabs">
+			<a href="#rtbcb-phase1" class="nav-tab nav-tab-active"><?php echo esc_html( $phases[1]['label'] ); ?></a>
+			<a href="#rtbcb-phase2" class="nav-tab"><?php echo esc_html( $phases[2]['label'] ); ?></a>
+			<a href="#rtbcb-phase3" class="nav-tab"><?php echo esc_html( $phases[3]['label'] ); ?></a>
+			<a href="#rtbcb-phase4" class="nav-tab"><?php echo esc_html( $phases[4]['label'] ); ?></a>
+			<a href="#rtbcb-phase5" class="nav-tab"><?php echo esc_html( $phases[5]['label'] ); ?></a>
+		</h2>
 
-        <div id="rtbcb-phase1" class="rtbcb-tab-panel" style="display:block;">
-            <?php include RTBCB_DIR . 'admin/partials/test-company-overview.php'; ?>
-            <?php include RTBCB_DIR . 'admin/partials/test-data-enrichment.php'; ?>
-            <?php include RTBCB_DIR . 'admin/partials/test-data-storage.php'; ?>
-        </div>
-        <div id="rtbcb-phase2" class="rtbcb-tab-panel" style="display:none;">
-            <?php include RTBCB_DIR . 'admin/partials/test-maturity-model.php'; ?>
-            <?php include RTBCB_DIR . 'admin/partials/test-rag-market-analysis.php'; ?>
-            <?php include RTBCB_DIR . 'admin/partials/test-value-proposition.php'; ?>
-            <?php include RTBCB_DIR . 'admin/partials/test-industry-overview.php'; ?>
-            <?php include RTBCB_DIR . 'admin/partials/test-real-treasury-overview.php'; ?>
-        </div>
-        <div id="rtbcb-phase3" class="rtbcb-tab-panel" style="display:none;">
-            <?php include RTBCB_DIR . 'admin/partials/test-roadmap-generator.php'; ?>
-            <?php include RTBCB_DIR . 'admin/partials/test-roi-calculator.php'; ?>
-            <?php include RTBCB_DIR . 'admin/partials/test-estimated-benefits.php'; ?>
-        </div>
-        <div id="rtbcb-phase4" class="rtbcb-tab-panel" style="display:none;">
-            <?php include RTBCB_DIR . 'admin/partials/test-report-assembly.php'; ?>
-        </div>
-        <div id="rtbcb-phase5" class="rtbcb-tab-panel" style="display:none;">
-            <?php include RTBCB_DIR . 'admin/partials/test-tracking-script.php'; ?>
-            <?php include RTBCB_DIR . 'admin/partials/test-follow-up-email.php'; ?>
-        </div>
-    </div>
+		<div id="rtbcb-phase1" class="rtbcb-tab-panel" style="display:block;">
+			<?php include RTBCB_DIR . 'admin/partials/test-company-overview.php'; ?>
+			<?php include RTBCB_DIR . 'admin/partials/test-data-enrichment.php'; ?>
+			<?php include RTBCB_DIR . 'admin/partials/test-data-storage.php'; ?>
+		</div>
+		<div id="rtbcb-phase2" class="rtbcb-tab-panel" style="display:none;">
+			<?php include RTBCB_DIR . 'admin/partials/test-maturity-model.php'; ?>
+			<?php include RTBCB_DIR . 'admin/partials/test-rag-market-analysis.php'; ?>
+			<?php include RTBCB_DIR . 'admin/partials/test-value-proposition.php'; ?>
+			<?php include RTBCB_DIR . 'admin/partials/test-industry-overview.php'; ?>
+			<?php include RTBCB_DIR . 'admin/partials/test-real-treasury-overview.php'; ?>
+		</div>
+		<div id="rtbcb-phase3" class="rtbcb-tab-panel" style="display:none;">
+			<?php include RTBCB_DIR . 'admin/partials/test-roadmap-generator.php'; ?>
+			<?php include RTBCB_DIR . 'admin/partials/test-roi-calculator.php'; ?>
+			<?php include RTBCB_DIR . 'admin/partials/test-estimated-benefits.php'; ?>
+		</div>
+		<div id="rtbcb-phase4" class="rtbcb-tab-panel" style="display:none;">
+			<?php include RTBCB_DIR . 'admin/partials/test-report-assembly.php'; ?>
+		</div>
+		<div id="rtbcb-phase5" class="rtbcb-tab-panel" style="display:none;">
+			<?php include RTBCB_DIR . 'admin/partials/test-tracking-script.php'; ?>
+			<?php include RTBCB_DIR . 'admin/partials/test-follow-up-email.php'; ?>
+		</div>
+	</div>
 
-    <script>
-    // Tabs handled in admin/js/rtbcb-admin.js
-    </script>
+	<script>
+	// Tabs handled in admin/js/rtbcb-admin.js
+	</script>
 </div>

--- a/admin/workflow-visualizer-page.php
+++ b/admin/workflow-visualizer-page.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Workflow Visualizer admin page.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Workflow Visualizer admin page.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 ?>

--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -2,56 +2,56 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * AJAX handlers for Business Case Builder.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* AJAX handlers for Business Case Builder.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 class RTBCB_Ajax {
 	/**
 	 * Generate comprehensive case via AJAX.
 	 *
 	 * @return void
 	 */
-        public static function generate_comprehensive_case() {
-                if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
-                        wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
-                        return;
-                }
+		public static function generate_comprehensive_case() {
+				if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
+						wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
+						return;
+				}
 
-                $user_inputs = self::collect_and_validate_user_inputs();
-                if ( is_wp_error( $user_inputs ) ) {
-                        wp_send_json_error( $user_inputs->get_error_message(), 400 );
-                        return;
-                }
+				$user_inputs = self::collect_and_validate_user_inputs();
+				if ( is_wp_error( $user_inputs ) ) {
+						wp_send_json_error( $user_inputs->get_error_message(), 400 );
+						return;
+				}
 
-                $job_id = RTBCB_Background_Job::enqueue( $user_inputs );
-                wp_send_json_success( [ 'job_id' => $job_id ] );
-        }
+				$job_id = RTBCB_Background_Job::enqueue( $user_inputs );
+				wp_send_json_success( [ 'job_id' => $job_id ] );
+		}
 
-        /**
-         * Stream business analysis chunks via AJAX.
-         *
-         * @return void
-         */
-        public static function stream_analysis() {
-                if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
-                        wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
-                        return;
-                }
+		/**
+		 * Stream business analysis chunks via AJAX.
+		 *
+		 * @return void
+		 */
+		public static function stream_analysis() {
+				if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
+						wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
+						return;
+				}
 
-                $user_inputs = self::collect_and_validate_user_inputs();
-                if ( is_wp_error( $user_inputs ) ) {
-                        wp_send_json_error( $user_inputs->get_error_message(), 400 );
-                        return;
-                }
+				$user_inputs = self::collect_and_validate_user_inputs();
+				if ( is_wp_error( $user_inputs ) ) {
+						wp_send_json_error( $user_inputs->get_error_message(), 400 );
+						return;
+				}
 
-                nocache_headers();
-                header( 'Content-Type: text/event-stream' );
-                header( 'Cache-Control: no-cache' );
-                header( 'Connection: keep-alive' );
+				nocache_headers();
+				header( 'Content-Type: text/event-stream' );
+				header( 'Cache-Control: no-cache' );
+				header( 'Connection: keep-alive' );
 
-                $scenarios      = RTBCB_Calculator::calculate_roi( $user_inputs );
-                $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+				$scenarios      = RTBCB_Calculator::calculate_roi( $user_inputs );
+				$recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
 
 $plugin = RTBCB_Main::instance();
 
@@ -72,12 +72,12 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 			return;
 		}
 
-                echo 'data: ' . wp_json_encode( [ 'type' => 'final', 'payload' => $result ] ) . "\n\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                if ( function_exists( 'flush' ) ) {
-                        flush();
-                }
-                exit;
-        }
+				echo 'data: ' . wp_json_encode( [ 'type' => 'final', 'payload' => $result ] ) . "\n\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				if ( function_exists( 'flush' ) ) {
+						flush();
+				}
+				exit;
+		}
 	/**
 	 * Process the basic ROI calculation step.
 	 *
@@ -101,11 +101,11 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 	 * @param array $user_inputs User inputs.
 	 * @return array|WP_Error Result data or error.
 	 */
-        public static function process_comprehensive_case( $user_inputs, $job_id = '' ) {
-               $request_start    = microtime( true );
-               $workflow_tracker = new RTBCB_Workflow_Tracker();
-               $bypass_heavy    = rtbcb_heavy_features_disabled();
-               $enable_ai        = ! $bypass_heavy && RTBCB_Settings::get_setting( 'enable_ai_analysis', true );
+		public static function process_comprehensive_case( $user_inputs, $job_id = '' ) {
+			   $request_start    = microtime( true );
+			   $workflow_tracker = new RTBCB_Workflow_Tracker();
+			   $bypass_heavy    = rtbcb_heavy_features_disabled();
+			   $enable_ai        = ! $bypass_heavy && RTBCB_Settings::get_setting( 'enable_ai_analysis', true );
 
 		add_action(
 			'rtbcb_llm_prompt_sent',
@@ -115,139 +115,139 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 		);
 
 		try {
-                        if ( $bypass_heavy ) {
-                                $workflow_tracker->add_warning( 'heavy_features_bypassed', __( 'AI features temporarily disabled.', 'rtbcb' ) );
-                                $workflow_tracker->start_step( 'ai_enrichment' );
-                                $enriched_profile = self::create_fallback_profile( $user_inputs );
-                                $workflow_tracker->complete_step( 'ai_enrichment', $enriched_profile );
-                                if ( $job_id ) {
-                                        RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enriched_profile' => $enriched_profile ] );
-                                }
+						if ( $bypass_heavy ) {
+								$workflow_tracker->add_warning( 'heavy_features_bypassed', __( 'AI features temporarily disabled.', 'rtbcb' ) );
+								$workflow_tracker->start_step( 'ai_enrichment' );
+								$enriched_profile = self::create_fallback_profile( $user_inputs );
+								$workflow_tracker->complete_step( 'ai_enrichment', $enriched_profile );
+								if ( $job_id ) {
+										RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enriched_profile' => $enriched_profile ] );
+								}
 
-                                $workflow_tracker->start_step( 'enhanced_roi_calculation' );
-                                $roi_scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
-                                $workflow_tracker->complete_step( 'enhanced_roi_calculation', $roi_scenarios );
-                                if ( $job_id ) {
-                                        RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enhanced_roi' => $roi_scenarios ] );
-                                }
+								$workflow_tracker->start_step( 'enhanced_roi_calculation' );
+								$roi_scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
+								$workflow_tracker->complete_step( 'enhanced_roi_calculation', $roi_scenarios );
+								if ( $job_id ) {
+										RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enhanced_roi' => $roi_scenarios ] );
+								}
 
-                                $workflow_tracker->start_step( 'intelligent_recommendations' );
-                                $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
-                                $workflow_tracker->complete_step( 'intelligent_recommendations', $recommendation );
-                                if ( $job_id ) {
-                                        RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'category' => $recommendation['recommended'] ] );
-                                }
+								$workflow_tracker->start_step( 'intelligent_recommendations' );
+								$recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+								$workflow_tracker->complete_step( 'intelligent_recommendations', $recommendation );
+								if ( $job_id ) {
+										RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'category' => $recommendation['recommended'] ] );
+								}
 
-                                $workflow_tracker->start_step( 'hybrid_rag_analysis' );
-                                $final_analysis = self::create_fallback_analysis( $enriched_profile, $roi_scenarios );
-                                $workflow_tracker->complete_step( 'hybrid_rag_analysis', $final_analysis );
-                                if ( $job_id ) {
-                                        RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'analysis' => $final_analysis ] );
-                                }
+								$workflow_tracker->start_step( 'hybrid_rag_analysis' );
+								$final_analysis = self::create_fallback_analysis( $enriched_profile, $roi_scenarios );
+								$workflow_tracker->complete_step( 'hybrid_rag_analysis', $final_analysis );
+								if ( $job_id ) {
+										RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'analysis' => $final_analysis ] );
+								}
 
-                                $chart_data = self::prepare_chart_data( $roi_scenarios );
+								$chart_data = self::prepare_chart_data( $roi_scenarios );
 
-                                $workflow_tracker->start_step( 'data_structuring' );
-                                $structured_report_data = self::structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $chart_data, $request_start );
-                                $workflow_tracker->complete_step( 'data_structuring', $structured_report_data );
-                                if ( $job_id ) {
-                                        RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'report_data' => $structured_report_data ] );
-                                }
+								$workflow_tracker->start_step( 'data_structuring' );
+								$structured_report_data = self::structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $chart_data, $request_start );
+								$workflow_tracker->complete_step( 'data_structuring', $structured_report_data );
+								if ( $job_id ) {
+										RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'report_data' => $structured_report_data ] );
+								}
 
-                                $lead_id    = self::save_lead_data_async( $user_inputs, $structured_report_data );
-                                $lead_email = ! empty( $user_inputs['email'] ) ? sanitize_email( $user_inputs['email'] ) : '';
+								$lead_id    = self::save_lead_data_async( $user_inputs, $structured_report_data );
+								$lead_email = ! empty( $user_inputs['email'] ) ? sanitize_email( $user_inputs['email'] ) : '';
 
-                                $debug_info           = $workflow_tracker->get_debug_info();
-                                $debug_info['lead_id'] = $lead_id;
-                                if ( $lead_email ) {
-                                        $debug_info['lead_email'] = $lead_email;
-                                }
-                                self::store_workflow_history( $debug_info, $lead_id, $lead_email );
+								$debug_info           = $workflow_tracker->get_debug_info();
+								$debug_info['lead_id'] = $lead_id;
+								if ( $lead_email ) {
+										$debug_info['lead_email'] = $lead_email;
+								}
+								self::store_workflow_history( $debug_info, $lead_id, $lead_email );
 
-                                return [
-                                        'report_data'   => $structured_report_data,
-                                        'workflow_info' => $debug_info,
-                                        'lead_id'       => $lead_id,
-                                        'analysis_type' => rtbcb_get_analysis_type(),
-                                ];
-                        }
-                        $workflow_tracker->start_step( 'ai_enrichment' );
-                        if ( $enable_ai ) {
-                                $enriched_profile = new WP_Error( 'llm_missing', 'LLM service unavailable.' );
-                                if ( class_exists( 'RTBCB_LLM' ) ) {
-                                        $llm = new RTBCB_LLM();
-                                        if ( method_exists( $llm, 'enrich_company_profile' ) ) {
-                                                $enriched_profile = $llm->enrich_company_profile( $user_inputs );
-                                        }
-                                }
-                                if ( is_wp_error( $enriched_profile ) ) {
-                                        $enriched_profile = self::create_fallback_profile( $user_inputs );
-                                        $workflow_tracker->add_warning( 'ai_enrichment_failed', $enriched_profile->get_error_message() );
-                                }
-                        } else {
-                                $enriched_profile = self::create_fallback_profile( $user_inputs );
-                                $workflow_tracker->add_warning( 'ai_enrichment_disabled', __( 'AI analysis disabled.', 'rtbcb' ) );
-                        }
-                        $workflow_tracker->complete_step( 'ai_enrichment', $enriched_profile );
-                        if ( $job_id ) {
-                                RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enriched_profile' => $enriched_profile ] );
-                        }
+								return [
+										'report_data'   => $structured_report_data,
+										'workflow_info' => $debug_info,
+										'lead_id'       => $lead_id,
+										'analysis_type' => rtbcb_get_analysis_type(),
+								];
+						}
+						$workflow_tracker->start_step( 'ai_enrichment' );
+						if ( $enable_ai ) {
+								$enriched_profile = new WP_Error( 'llm_missing', 'LLM service unavailable.' );
+								if ( class_exists( 'RTBCB_LLM' ) ) {
+										$llm = new RTBCB_LLM();
+										if ( method_exists( $llm, 'enrich_company_profile' ) ) {
+												$enriched_profile = $llm->enrich_company_profile( $user_inputs );
+										}
+								}
+								if ( is_wp_error( $enriched_profile ) ) {
+										$enriched_profile = self::create_fallback_profile( $user_inputs );
+										$workflow_tracker->add_warning( 'ai_enrichment_failed', $enriched_profile->get_error_message() );
+								}
+						} else {
+								$enriched_profile = self::create_fallback_profile( $user_inputs );
+								$workflow_tracker->add_warning( 'ai_enrichment_disabled', __( 'AI analysis disabled.', 'rtbcb' ) );
+						}
+						$workflow_tracker->complete_step( 'ai_enrichment', $enriched_profile );
+						if ( $job_id ) {
+								RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enriched_profile' => $enriched_profile ] );
+						}
 
 			$workflow_tracker->start_step( 'enhanced_roi_calculation' );
 			$enhanced_calculator = new RTBCB_Enhanced_Calculator();
 			$roi_scenarios       = $enhanced_calculator->calculate_enhanced_roi( $user_inputs, $enriched_profile );
-                        $workflow_tracker->complete_step( 'enhanced_roi_calculation', $roi_scenarios );
-                        if ( $job_id ) {
-                                RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enhanced_roi' => $roi_scenarios ] );
-                        }
+						$workflow_tracker->complete_step( 'enhanced_roi_calculation', $roi_scenarios );
+						if ( $job_id ) {
+								RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enhanced_roi' => $roi_scenarios ] );
+						}
 
-                        $workflow_tracker->start_step( 'intelligent_recommendations' );
-                        if ( $enable_ai ) {
-                                $intelligent_recommender = new RTBCB_Intelligent_Recommender();
-                                $recommendation          = $intelligent_recommender->recommend_with_ai_insights( $user_inputs, $enriched_profile );
-                        } else {
-                                $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
-                                $workflow_tracker->add_warning( 'intelligent_recommendations_disabled', __( 'AI analysis disabled.', 'rtbcb' ) );
-                        }
-                        $workflow_tracker->complete_step( 'intelligent_recommendations', $recommendation );
-                        if ( $job_id ) {
-                                RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'category' => $recommendation['recommended'] ] );
-                        }
+						$workflow_tracker->start_step( 'intelligent_recommendations' );
+						if ( $enable_ai ) {
+								$intelligent_recommender = new RTBCB_Intelligent_Recommender();
+								$recommendation          = $intelligent_recommender->recommend_with_ai_insights( $user_inputs, $enriched_profile );
+						} else {
+								$recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+								$workflow_tracker->add_warning( 'intelligent_recommendations_disabled', __( 'AI analysis disabled.', 'rtbcb' ) );
+						}
+						$workflow_tracker->complete_step( 'intelligent_recommendations', $recommendation );
+						if ( $job_id ) {
+								RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'category' => $recommendation['recommended'] ] );
+						}
 
-                        $workflow_tracker->start_step( 'hybrid_rag_analysis' );
-                        if ( $enable_ai ) {
-                                $rag_baseline = [];
-                                if ( class_exists( 'RTBCB_RAG' ) ) {
-                                        $rag          = new RTBCB_RAG();
-                                        $search_query = self::build_rag_search_query( $user_inputs, $enriched_profile );
-                                        $rag_baseline = $rag->search_similar( $search_query, 5 );
-                                }
-                                $final_analysis = new WP_Error( 'analysis_unavailable', 'Final analysis unavailable.' );
-                                if ( isset( $llm ) && method_exists( $llm, 'generate_strategic_analysis' ) ) {
-                                        $final_analysis = $llm->generate_strategic_analysis( $enriched_profile, $roi_scenarios, $recommendation, $rag_baseline );
-                                }
-                                if ( is_wp_error( $final_analysis ) ) {
-                                        $final_analysis = self::create_fallback_analysis( $enriched_profile, $roi_scenarios );
-                                        $workflow_tracker->add_warning( 'final_analysis_failed', $final_analysis->get_error_message() );
-                                }
-                        } else {
-                                $rag_baseline  = [];
-                                $final_analysis = self::create_fallback_analysis( $enriched_profile, $roi_scenarios );
-                                $workflow_tracker->add_warning( 'hybrid_rag_disabled', __( 'AI analysis disabled.', 'rtbcb' ) );
-                        }
-                       $workflow_tracker->complete_step( 'hybrid_rag_analysis', $final_analysis );
-                       if ( $job_id ) {
-                               RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'analysis' => $final_analysis ] );
-                       }
+						$workflow_tracker->start_step( 'hybrid_rag_analysis' );
+						if ( $enable_ai ) {
+								$rag_baseline = [];
+								if ( class_exists( 'RTBCB_RAG' ) ) {
+										$rag          = new RTBCB_RAG();
+										$search_query = self::build_rag_search_query( $user_inputs, $enriched_profile );
+										$rag_baseline = $rag->search_similar( $search_query, 5 );
+								}
+								$final_analysis = new WP_Error( 'analysis_unavailable', 'Final analysis unavailable.' );
+								if ( isset( $llm ) && method_exists( $llm, 'generate_strategic_analysis' ) ) {
+										$final_analysis = $llm->generate_strategic_analysis( $enriched_profile, $roi_scenarios, $recommendation, $rag_baseline );
+								}
+								if ( is_wp_error( $final_analysis ) ) {
+										$final_analysis = self::create_fallback_analysis( $enriched_profile, $roi_scenarios );
+										$workflow_tracker->add_warning( 'final_analysis_failed', $final_analysis->get_error_message() );
+								}
+						} else {
+								$rag_baseline  = [];
+								$final_analysis = self::create_fallback_analysis( $enriched_profile, $roi_scenarios );
+								$workflow_tracker->add_warning( 'hybrid_rag_disabled', __( 'AI analysis disabled.', 'rtbcb' ) );
+						}
+					   $workflow_tracker->complete_step( 'hybrid_rag_analysis', $final_analysis );
+					   if ( $job_id ) {
+							   RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'analysis' => $final_analysis ] );
+					   }
 
-                       $chart_data = self::prepare_chart_data( $roi_scenarios );
+					   $chart_data = self::prepare_chart_data( $roi_scenarios );
 
-                       $workflow_tracker->start_step( 'data_structuring' );
-                       $structured_report_data = self::structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $chart_data, $request_start );
-                        $workflow_tracker->complete_step( 'data_structuring', $structured_report_data );
-                        if ( $job_id ) {
-                                RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'report_data' => $structured_report_data ] );
-                        }
+					   $workflow_tracker->start_step( 'data_structuring' );
+					   $structured_report_data = self::structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $chart_data, $request_start );
+						$workflow_tracker->complete_step( 'data_structuring', $structured_report_data );
+						if ( $job_id ) {
+								RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'report_data' => $structured_report_data ] );
+						}
 
 			$lead_id    = self::save_lead_data_async( $user_inputs, $structured_report_data );
 			$lead_email = ! empty( $user_inputs['email'] ) ? sanitize_email( $user_inputs['email'] ) : '';
@@ -263,7 +263,7 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 				'report_data'   => $structured_report_data,
 				'workflow_info' => $debug_info,
 				'lead_id'       => $lead_id,
-                               'analysis_type' => rtbcb_get_analysis_type(),
+							   'analysis_type' => rtbcb_get_analysis_type(),
 			];
 		} catch ( Exception $e ) {
 			$workflow_tracker->add_error( 'exception', $e->getMessage() );
@@ -296,22 +296,22 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 			return;
 		}
 
-                $status = RTBCB_Background_Job::get_status( $job_id );
-                if ( is_wp_error( $status ) ) {
-                        $status = [
-                                'state'   => 'error',
-                                'message' => sanitize_text_field( $status->get_error_message() ),
-                        ];
-                }
+				$status = RTBCB_Background_Job::get_status( $job_id );
+				if ( is_wp_error( $status ) ) {
+						$status = [
+								'state'   => 'error',
+								'message' => sanitize_text_field( $status->get_error_message() ),
+						];
+				}
 
-                $response = [
-                        'status' => $status['state'] ?? '',
-                ];
+				$response = [
+						'status' => $status['state'] ?? '',
+				];
 
-                foreach ( $status as $field => $value ) {
-                        if ( in_array( $field, [ 'state', 'created', 'updated', 'result' ], true ) ) {
-                                continue;
-                        }
+				foreach ( $status as $field => $value ) {
+						if ( in_array( $field, [ 'state', 'created', 'updated', 'result' ], true ) ) {
+								continue;
+						}
 			if ( 'percent' === $field ) {
 				$response[ $field ] = floatval( $value );
 			} elseif ( 'download_url' === $field && is_string( $value ) ) {
@@ -321,11 +321,11 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 			} else {
 				$response[ $field ] = $value;
 			}
-                }
+				}
 
-                if ( isset( $status['result'] ) ) {
-                        if (
-                                'completed' === ( $response['status'] ?? '' ) &&
+				if ( isset( $status['result'] ) ) {
+						if (
+								'completed' === ( $response['status'] ?? '' ) &&
 				! empty( $status['result']['report_data'] )
 			) {
 				$result                  = $status['result'];
@@ -344,9 +344,9 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 		}
 
 		wp_send_json_success( $response );
-       }
+	   }
 
-       private static function collect_and_validate_user_inputs() {
+	   private static function collect_and_validate_user_inputs() {
 		$validator = new RTBCB_Validator();
 		$validated = $validator->validate( $_POST );
 
@@ -355,7 +355,7 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 		}
 
 		return $validated;
-       }
+	   }
 
 	private static function create_fallback_profile( $user_inputs ) {
 		return [
@@ -400,7 +400,7 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 			'metadata' => [
 				'company_name'   => $user_inputs['company_name'],
 				'analysis_date'  => current_time( 'Y-m-d' ),
-                               'analysis_type'  => rtbcb_get_analysis_type(),
+							   'analysis_type'  => rtbcb_get_analysis_type(),
 				'confidence_level' => $final_analysis['confidence_level'] ?? 0.85,
 				'processing_time' => microtime( true ) - $request_start,
 			],
@@ -417,13 +417,13 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 				'maturity_assessment' => $enriched_profile['maturity_assessment'] ?? [],
 				'competitive_position'=> $enriched_profile['competitive_position'] ?? [],
 			],
-                       'financial_analysis' => [
-                               'roi_scenarios'        => self::format_roi_scenarios( $roi_scenarios ),
-                               'investment_breakdown' => $final_analysis['financial_analysis']['investment_breakdown'] ?? [],
-                               'payback_analysis'     => $final_analysis['financial_analysis']['payback_analysis'] ?? [],
-                               'sensitivity_analysis' => $roi_scenarios['sensitivity_analysis'] ?? [],
-                               'chart_data'           => $chart_data,
-                       ],
+					   'financial_analysis' => [
+							   'roi_scenarios'        => self::format_roi_scenarios( $roi_scenarios ),
+							   'investment_breakdown' => $final_analysis['financial_analysis']['investment_breakdown'] ?? [],
+							   'payback_analysis'     => $final_analysis['financial_analysis']['payback_analysis'] ?? [],
+							   'sensitivity_analysis' => $roi_scenarios['sensitivity_analysis'] ?? [],
+							   'chart_data'           => $chart_data,
+					   ],
 			'technology_strategy' => [
 				'recommended_category' => $recommendation['recommended'],
 				'category_details'     => $recommendation['category_info'],
@@ -472,73 +472,73 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 		];
 	}
 
-        private static function save_lead_data_async( $user_inputs, $structured_report_data ) {
-                if ( class_exists( 'RTBCB_Leads' ) ) {
-                        $lead_data = array_merge( $user_inputs, [ 'report_data' => $structured_report_data ] );
-                        return RTBCB_Leads::save_lead( $lead_data );
-                }
-                return null;
-        }
+		private static function save_lead_data_async( $user_inputs, $structured_report_data ) {
+				if ( class_exists( 'RTBCB_Leads' ) ) {
+						$lead_data = array_merge( $user_inputs, [ 'report_data' => $structured_report_data ] );
+						return RTBCB_Leads::save_lead( $lead_data );
+				}
+				return null;
+		}
 
-       /**
-        * Prepare chart data for ROI visualization.
-        *
-        * @param array $roi_scenarios ROI scenarios.
-        * @return array Chart.js compatible data structure.
-        */
-       private static function prepare_chart_data( $roi_scenarios ) {
-               return [
-                       'labels'   => [
-                               __( 'Labor Savings', 'rtbcb' ),
-                               __( 'Fee Savings', 'rtbcb' ),
-                               __( 'Error Reduction', 'rtbcb' ),
-                               __( 'Total Benefit', 'rtbcb' ),
-                       ],
-                       'datasets' => [
-                               [
-                                       'label'           => __( 'Conservative', 'rtbcb' ),
-                                       'data'            => [
-                                               $roi_scenarios['conservative']['labor_savings'] ?? 0,
-                                               $roi_scenarios['conservative']['fee_savings'] ?? 0,
-                                               $roi_scenarios['conservative']['error_reduction'] ?? 0,
-                                               $roi_scenarios['conservative']['total_annual_benefit'] ?? 0,
-                                       ],
-                                       'backgroundColor' => 'rgba(239, 68, 68, 0.8)',
-                                       'borderColor'     => 'rgba(239, 68, 68, 1)',
-                                       'borderWidth'     => 1,
-                               ],
-                               [
-                                       'label'           => __( 'Base Case', 'rtbcb' ),
-                                       'data'            => [
-                                               $roi_scenarios['base']['labor_savings'] ?? 0,
-                                               $roi_scenarios['base']['fee_savings'] ?? 0,
-                                               $roi_scenarios['base']['error_reduction'] ?? 0,
-                                               $roi_scenarios['base']['total_annual_benefit'] ?? 0,
-                                       ],
-                                       'backgroundColor' => 'rgba(59, 130, 246, 0.8)',
-                                       'borderColor'     => 'rgba(59, 130, 246, 1)',
-                                       'borderWidth'     => 1,
-                               ],
-                               [
-                                       'label'           => __( 'Optimistic', 'rtbcb' ),
-                                       'data'            => [
-                                               $roi_scenarios['optimistic']['labor_savings'] ?? 0,
-                                               $roi_scenarios['optimistic']['fee_savings'] ?? 0,
-                                               $roi_scenarios['optimistic']['error_reduction'] ?? 0,
-                                               $roi_scenarios['optimistic']['total_annual_benefit'] ?? 0,
-                                       ],
-                                       'backgroundColor' => 'rgba(16, 185, 129, 0.8)',
-                                       'borderColor'     => 'rgba(16, 185, 129, 1)',
-                                       'borderWidth'     => 1,
-                               ],
-                       ],
-               ];
-       }
+	   /**
+		* Prepare chart data for ROI visualization.
+		*
+		* @param array $roi_scenarios ROI scenarios.
+		* @return array Chart.js compatible data structure.
+		*/
+	   private static function prepare_chart_data( $roi_scenarios ) {
+			   return [
+					   'labels'   => [
+							   __( 'Labor Savings', 'rtbcb' ),
+							   __( 'Fee Savings', 'rtbcb' ),
+							   __( 'Error Reduction', 'rtbcb' ),
+							   __( 'Total Benefit', 'rtbcb' ),
+					   ],
+					   'datasets' => [
+							   [
+									   'label'           => __( 'Conservative', 'rtbcb' ),
+									   'data'            => [
+											   $roi_scenarios['conservative']['labor_savings'] ?? 0,
+											   $roi_scenarios['conservative']['fee_savings'] ?? 0,
+											   $roi_scenarios['conservative']['error_reduction'] ?? 0,
+											   $roi_scenarios['conservative']['total_annual_benefit'] ?? 0,
+									   ],
+									   'backgroundColor' => 'rgba(239, 68, 68, 0.8)',
+									   'borderColor'     => 'rgba(239, 68, 68, 1)',
+									   'borderWidth'     => 1,
+							   ],
+							   [
+									   'label'           => __( 'Base Case', 'rtbcb' ),
+									   'data'            => [
+											   $roi_scenarios['base']['labor_savings'] ?? 0,
+											   $roi_scenarios['base']['fee_savings'] ?? 0,
+											   $roi_scenarios['base']['error_reduction'] ?? 0,
+											   $roi_scenarios['base']['total_annual_benefit'] ?? 0,
+									   ],
+									   'backgroundColor' => 'rgba(59, 130, 246, 0.8)',
+									   'borderColor'     => 'rgba(59, 130, 246, 1)',
+									   'borderWidth'     => 1,
+							   ],
+							   [
+									   'label'           => __( 'Optimistic', 'rtbcb' ),
+									   'data'            => [
+											   $roi_scenarios['optimistic']['labor_savings'] ?? 0,
+											   $roi_scenarios['optimistic']['fee_savings'] ?? 0,
+											   $roi_scenarios['optimistic']['error_reduction'] ?? 0,
+											   $roi_scenarios['optimistic']['total_annual_benefit'] ?? 0,
+									   ],
+									   'backgroundColor' => 'rgba(16, 185, 129, 0.8)',
+									   'borderColor'     => 'rgba(16, 185, 129, 1)',
+									   'borderWidth'     => 1,
+							   ],
+					   ],
+			   ];
+	   }
 
-       private static function calculate_business_case_strength( $roi_scenarios, $recommendation ) {
-               $base = $roi_scenarios['base']['total_annual_benefit'] ?? 0;
-               return $base > 0 ? 'strong' : 'weak';
-       }
+	   private static function calculate_business_case_strength( $roi_scenarios, $recommendation ) {
+			   $base = $roi_scenarios['base']['total_annual_benefit'] ?? 0;
+			   return $base > 0 ? 'strong' : 'weak';
+	   }
 
 	private static function format_roi_scenarios( $roi_scenarios ) {
 		return $roi_scenarios;

--- a/inc/class-rtbcb-api-tester.php
+++ b/inc/class-rtbcb-api-tester.php
@@ -2,115 +2,115 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * API connection testing utilities.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* API connection testing utilities.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 /**
- * Class RTBCB_API_Tester.
- */
+	* Class RTBCB_API_Tester.
+	*/
 class RTBCB_API_Tester {
-    /**
-     * Test OpenAI API connection.
-     *
-     * @param string $api_key Optional API key to test.
-     * @return array Test result.
-     */
-    public static function test_connection( $api_key = null ) {
-        $api_key = $api_key ?: rtbcb_get_openai_api_key();
+	/**
+	 * Test OpenAI API connection.
+	 *
+	 * @param string $api_key Optional API key to test.
+	 * @return array Test result.
+	 */
+	public static function test_connection( $api_key = null ) {
+		$api_key = $api_key ?: rtbcb_get_openai_api_key();
 
-        if ( empty( $api_key ) ) {
-            return [
-                'success' => false,
-                'message' => __( 'No API key configured.', 'rtbcb' ),
-                'details' => __( 'Please add your OpenAI API key in settings.', 'rtbcb' ),
-            ];
-        }
+		if ( empty( $api_key ) ) {
+			return [
+				'success' => false,
+				'message' => __( 'No API key configured.', 'rtbcb' ),
+				'details' => __( 'Please add your OpenAI API key in settings.', 'rtbcb' ),
+			];
+		}
 
-        if ( ! rtbcb_is_valid_openai_api_key( $api_key ) ) {
-            return [
-                'success' => false,
-                'message' => __( 'Invalid API key format.', 'rtbcb' ),
-                'details' => __( 'OpenAI API keys should start with "sk-".', 'rtbcb' ),
-            ];
-        }
+		if ( ! rtbcb_is_valid_openai_api_key( $api_key ) ) {
+			return [
+				'success' => false,
+				'message' => __( 'Invalid API key format.', 'rtbcb' ),
+				'details' => __( 'OpenAI API keys should start with "sk-".', 'rtbcb' ),
+			];
+		}
 
-        return self::test_completion( $api_key );
-    }
+		return self::test_completion( $api_key );
+	}
 
-    /**
-     * Test API with a simple completion request.
-     *
-     * @param string $api_key API key.
-     * @return array Test result.
-     */
-    private static function test_completion( $api_key ) {
-        $model  = get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) );
-        $config = rtbcb_get_gpt5_config();
+	/**
+	 * Test API with a simple completion request.
+	 *
+	 * @param string $api_key API key.
+	 * @return array Test result.
+	 */
+	private static function test_completion( $api_key ) {
+		$model  = get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) );
+		$config = rtbcb_get_gpt5_config();
 
-        $body = [
-            'model'             => rtbcb_normalize_model_name( $model ),
-            'input'             => 'Test connection - respond with exactly: "API connection successful"',
-            'max_output_tokens' => $config['max_output_tokens'],
-        ];
+		$body = [
+			'model'             => rtbcb_normalize_model_name( $model ),
+			'input'             => 'Test connection - respond with exactly: "API connection successful"',
+			'max_output_tokens' => $config['max_output_tokens'],
+		];
 
-        if ( rtbcb_model_supports_temperature( $model ) ) {
-            $body['temperature'] = 0.1;
-        }
+		if ( rtbcb_model_supports_temperature( $model ) ) {
+			$body['temperature'] = 0.1;
+		}
 
-        $timeout = rtbcb_get_api_timeout();
+		$timeout = rtbcb_get_api_timeout();
 
-        $args = [
-            'headers' => [
-                'Authorization' => 'Bearer ' . $api_key,
-                'Content-Type' => 'application/json',
-            ],
-            'body'    => wp_json_encode( $body ),
-            'timeout' => $timeout,
-        ];
+		$args = [
+			'headers' => [
+				'Authorization' => 'Bearer ' . $api_key,
+				'Content-Type' => 'application/json',
+			],
+			'body'    => wp_json_encode( $body ),
+			'timeout' => $timeout,
+		];
 
 $response = rtbcb_wp_remote_post_with_retry( 'https://api.openai.com/v1/responses', $args );
 
-        if ( is_wp_error( $response ) ) {
-            return [
-                'success' => false,
-                'message' => __( 'Connection failed.', 'rtbcb' ),
-                'details' => $response->get_error_message(),
-            ];
-        }
+		if ( is_wp_error( $response ) ) {
+			return [
+				'success' => false,
+				'message' => __( 'Connection failed.', 'rtbcb' ),
+				'details' => $response->get_error_message(),
+			];
+		}
 
-        $code = wp_remote_retrieve_response_code( $response );
-        if ( 200 !== $code ) {
-            $body    = wp_remote_retrieve_body( $response );
-            $decoded = json_decode( $body, true );
-            $error_message = $decoded['error']['message'] ?? 'Unknown error';
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $code ) {
+			$body    = wp_remote_retrieve_body( $response );
+			$decoded = json_decode( $body, true );
+			$error_message = $decoded['error']['message'] ?? 'Unknown error';
 
-            return [
-                'success' => false,
-                'message' => sprintf( __( 'API error (%d)', 'rtbcb' ), $code ),
-                'details' => $error_message,
-            ];
-        }
+			return [
+				'success' => false,
+				'message' => sprintf( __( 'API error (%d)', 'rtbcb' ), $code ),
+				'details' => $error_message,
+			];
+		}
 
-        $parsed      = rtbcb_parse_gpt5_response( $response );
-        $output_text = $parsed['output_text'];
+		$parsed      = rtbcb_parse_gpt5_response( $response );
+		$output_text = $parsed['output_text'];
 
-        if ( empty( $output_text ) ) {
-            return [
-                'success' => false,
-                'message' => __( 'Empty response from API.', 'rtbcb' ),
-                'details' => __( 'The API returned an empty response.', 'rtbcb' ),
-            ];
-        }
+		if ( empty( $output_text ) ) {
+			return [
+				'success' => false,
+				'message' => __( 'Empty response from API.', 'rtbcb' ),
+				'details' => __( 'The API returned an empty response.', 'rtbcb' ),
+			];
+		}
 
-        return [
-            'success' => true,
-            'message' => __( 'Connection successful.', 'rtbcb' ),
-            'response' => $output_text,
-            'details' => sprintf( __( 'Model: %s, Response length: %d characters', 'rtbcb' ),
-                $model, strlen( $output_text ) ),
-        ];
-    }
+		return [
+			'success' => true,
+			'message' => __( 'Connection successful.', 'rtbcb' ),
+			'response' => $output_text,
+			'details' => sprintf( __( 'Model: %s, Response length: %d characters', 'rtbcb' ),
+				$model, strlen( $output_text ) ),
+		];
+	}
 }
 

--- a/inc/class-rtbcb-background-job.php
+++ b/inc/class-rtbcb-background-job.php
@@ -2,20 +2,20 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Handles background job processing for case generation.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Handles background job processing for case generation.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 class RTBCB_Background_Job {
 /**
- * Update job status data and accumulate payload.
- *
- * @param string $job_id  Job identifier.
- * @param string $state   New job state.
- * @param array  $payload Additional fields such as step, percent, or partial results.
- * @return void
- */
+	* Update job status data and accumulate payload.
+	*
+	* @param string $job_id  Job identifier.
+	* @param string $state   New job state.
+	* @param array  $payload Additional fields such as step, percent, or partial results.
+	* @return void
+	*/
 public static function update_status( $job_id, $state, $payload = [] ) {
 $current = get_transient( $job_id );
 if ( ! is_array( $current ) ) {
@@ -43,19 +43,19 @@ $job_id = uniqid( 'rtbcb_job_', true );
 
 self::update_status( $job_id, 'queued' );
 
-                wp_schedule_single_event(
-                        time(),
-                        'rtbcb_process_job',
-                        [ $job_id, $user_inputs ]
-                );
+				wp_schedule_single_event(
+						time(),
+						'rtbcb_process_job',
+						[ $job_id, $user_inputs ]
+				);
 
 		// Trigger cron immediately in a non-blocking way.
 		if ( function_exists( 'spawn_cron' ) && ! wp_doing_cron() ) {
 			spawn_cron();
 		}
 
-                return $job_id;
-        }
+				return $job_id;
+		}
 
 	/**
 	 * Process a queued job.
@@ -166,11 +166,11 @@ if ( is_wp_error( $result ) ) {
 	}
 
 /**
- * Get job status data.
- *
- * @param string $job_id Job identifier.
- * @return array|WP_Error Job data or error.
- */
+	* Get job status data.
+	*
+	* @param string $job_id Job identifier.
+	* @return array|WP_Error Job data or error.
+	*/
 public static function get_status( $job_id ) {
 $data = get_transient( $job_id );
 self::cleanup();
@@ -183,10 +183,10 @@ return array_merge( $data, $payload );
 }
 
 /**
- * Cleanup expired, errored, or stale job transients.
- *
- * @return void
- */
+	* Cleanup expired, errored, or stale job transients.
+	*
+	* @return void
+	*/
 public static function cleanup() {
 global $wpdb;
 

--- a/inc/class-rtbcb-calculator.php
+++ b/inc/class-rtbcb-calculator.php
@@ -2,214 +2,214 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * ROI calculation utilities.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* ROI calculation utilities.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 /**
- * Class RTBCB_Calculator.
- *
- * Provides static ROI calculation helpers.
- */
+	* Class RTBCB_Calculator.
+	*
+	* Provides static ROI calculation helpers.
+	*/
 class RTBCB_Calculator {
-    /**
-     * Calculate ROI scenarios for given inputs.
-     *
-     * @param array $user_inputs User provided inputs.
-     * @param array $category    Optional category info.
-     * @return array
-     */
-    public static function calculate_roi( $user_inputs, $category = [] ) {
-        $settings      = RTBCB_Settings::get_all();
-        $industry_mult = self::get_industry_benchmark( $user_inputs['industry'] ?? '' );
+	/**
+	 * Calculate ROI scenarios for given inputs.
+	 *
+	 * @param array $user_inputs User provided inputs.
+	 * @param array $category    Optional category info.
+	 * @return array
+	 */
+	public static function calculate_roi( $user_inputs, $category = [] ) {
+		$settings      = RTBCB_Settings::get_all();
+		$industry_mult = self::get_industry_benchmark( $user_inputs['industry'] ?? '' );
 
-        $scenarios = [];
-        foreach ( [ 'conservative', 'base', 'optimistic' ] as $scenario ) {
-            $scenarios[ $scenario ] = self::calculate_scenario( $user_inputs, $settings, $category, $scenario, $industry_mult );
-        }
+		$scenarios = [];
+		foreach ( [ 'conservative', 'base', 'optimistic' ] as $scenario ) {
+			$scenarios[ $scenario ] = self::calculate_scenario( $user_inputs, $settings, $category, $scenario, $industry_mult );
+		}
 
-        return $scenarios;
-    }
+		return $scenarios;
+	}
 
-    /**
-     * Recalculate ROI scenarios using recommended category info.
-     *
-     * @param array $user_inputs User provided inputs.
-     * @param array $category    Category info from recommender.
-     * @return array
-     */
-    public static function calculate_category_refined_roi( $user_inputs, $category ) {
-        return self::calculate_roi( $user_inputs, $category );
-    }
+	/**
+	 * Recalculate ROI scenarios using recommended category info.
+	 *
+	 * @param array $user_inputs User provided inputs.
+	 * @param array $category    Category info from recommender.
+	 * @return array
+	 */
+	public static function calculate_category_refined_roi( $user_inputs, $category ) {
+		return self::calculate_roi( $user_inputs, $category );
+	}
 
-    /**
-     * Calculate ROI for a scenario.
-     *
-     * @param array  $inputs        User inputs.
-     * @param array  $settings      Plugin settings.
-     * @param array  $category      Recommended category info.
-     * @param string $scenario_type Scenario type.
-     * @param float  $industry_mult Industry benchmark multiplier.
-     * @return array
-     */
-    private static function calculate_scenario( $inputs, $settings, $category, $scenario_type, $industry_mult ) {
-        /**
-         * Filters the scenario multipliers used to adjust ROI calculations.
-         *
-         * @param array  $multipliers   Associative array of scenario multipliers.
-         * @param array  $inputs        User provided inputs.
-         * @param array  $settings      Plugin settings.
-         * @param array  $category      Recommended category info.
-         * @param string $scenario_type Scenario type.
-         * @param float  $industry_mult Industry benchmark multiplier.
-         */
-        $multipliers = apply_filters(
-            'rtbcb_roi_multipliers',
-            [
-                'conservative' => 0.8,
-                'base'         => 1.0,
-                'optimistic'   => 1.2,
-            ],
-            $inputs,
-            $settings,
-            $category,
-            $scenario_type,
-            $industry_mult
-        );
-        $multiplier  = $multipliers[ $scenario_type ];
+	/**
+	 * Calculate ROI for a scenario.
+	 *
+	 * @param array  $inputs        User inputs.
+	 * @param array  $settings      Plugin settings.
+	 * @param array  $category      Recommended category info.
+	 * @param string $scenario_type Scenario type.
+	 * @param float  $industry_mult Industry benchmark multiplier.
+	 * @return array
+	 */
+	private static function calculate_scenario( $inputs, $settings, $category, $scenario_type, $industry_mult ) {
+		/**
+		 * Filters the scenario multipliers used to adjust ROI calculations.
+		 *
+		 * @param array  $multipliers   Associative array of scenario multipliers.
+		 * @param array  $inputs        User provided inputs.
+		 * @param array  $settings      Plugin settings.
+		 * @param array  $category      Recommended category info.
+		 * @param string $scenario_type Scenario type.
+		 * @param float  $industry_mult Industry benchmark multiplier.
+		 */
+		$multipliers = apply_filters(
+			'rtbcb_roi_multipliers',
+			[
+				'conservative' => 0.8,
+				'base'         => 1.0,
+				'optimistic'   => 1.2,
+			],
+			$inputs,
+			$settings,
+			$category,
+			$scenario_type,
+			$industry_mult
+		);
+		$multiplier  = $multipliers[ $scenario_type ];
 
-        $labor_savings   = self::calculate_labor_savings( $inputs, $settings, $multiplier );
-        $fee_savings     = self::calculate_fee_savings( $inputs, $settings, $multiplier );
-        $error_reduction = self::calculate_error_reduction( $inputs, $settings, $multiplier );
+		$labor_savings   = self::calculate_labor_savings( $inputs, $settings, $multiplier );
+		$fee_savings     = self::calculate_fee_savings( $inputs, $settings, $multiplier );
+		$error_reduction = self::calculate_error_reduction( $inputs, $settings, $multiplier );
 
-        $total_annual_benefit = ( $labor_savings + $fee_savings + $error_reduction ) * $industry_mult;
+		$total_annual_benefit = ( $labor_savings + $fee_savings + $error_reduction ) * $industry_mult;
 
-        $min_roi = $category['roi_range'][0] ?? 0;
-        $max_roi = $category['roi_range'][1] ?? $total_annual_benefit;
-        $total_annual_benefit = max( $min_roi, min( $total_annual_benefit, $max_roi ) );
+		$min_roi = $category['roi_range'][0] ?? 0;
+		$max_roi = $category['roi_range'][1] ?? $total_annual_benefit;
+		$total_annual_benefit = max( $min_roi, min( $total_annual_benefit, $max_roi ) );
 
-        $avg_cost      = ( $min_roi + $max_roi ) / 2;
-        $roi_percentage = $avg_cost > 0 ? ( $total_annual_benefit / $avg_cost ) * 100 : 0;
+		$avg_cost      = ( $min_roi + $max_roi ) / 2;
+		$roi_percentage = $avg_cost > 0 ? ( $total_annual_benefit / $avg_cost ) * 100 : 0;
 
-        return [
-            'labor_savings'        => $labor_savings,
-            'fee_savings'          => $fee_savings,
-            'error_reduction'      => $error_reduction,
-            'total_annual_benefit' => $total_annual_benefit,
-            'roi_percentage'       => $roi_percentage,
-            'assumptions'          => self::get_scenario_assumptions( $scenario_type, $multiplier, $industry_mult ),
-        ];
-    }
+		return [
+			'labor_savings'        => $labor_savings,
+			'fee_savings'          => $fee_savings,
+			'error_reduction'      => $error_reduction,
+			'total_annual_benefit' => $total_annual_benefit,
+			'roi_percentage'       => $roi_percentage,
+			'assumptions'          => self::get_scenario_assumptions( $scenario_type, $multiplier, $industry_mult ),
+		];
+	}
 
-    /**
-     * Calculate labor cost savings.
-     *
-     * @param array $inputs     User inputs.
-     * @param array $settings   Plugin settings.
-     * @param float $multiplier Scenario multiplier.
-     *
-     * @return float Annual labor savings.
-     */
-    private static function calculate_labor_savings( $inputs, $settings, $multiplier ) {
-        $hourly_cost = isset( $settings['labor_cost_per_hour'] ) ? floatval( $settings['labor_cost_per_hour'] ) : 100;
-        $weekly_hours = ( isset( $inputs['hours_reconciliation'] ) ? floatval( $inputs['hours_reconciliation'] ) : 0 )
-            + ( isset( $inputs['hours_cash_positioning'] ) ? floatval( $inputs['hours_cash_positioning'] ) : 0 );
-        $efficiency   = 0.30 * $multiplier;
-        $hours_saved  = $weekly_hours * $efficiency;
+	/**
+	 * Calculate labor cost savings.
+	 *
+	 * @param array $inputs     User inputs.
+	 * @param array $settings   Plugin settings.
+	 * @param float $multiplier Scenario multiplier.
+	 *
+	 * @return float Annual labor savings.
+	 */
+	private static function calculate_labor_savings( $inputs, $settings, $multiplier ) {
+		$hourly_cost = isset( $settings['labor_cost_per_hour'] ) ? floatval( $settings['labor_cost_per_hour'] ) : 100;
+		$weekly_hours = ( isset( $inputs['hours_reconciliation'] ) ? floatval( $inputs['hours_reconciliation'] ) : 0 )
+			+ ( isset( $inputs['hours_cash_positioning'] ) ? floatval( $inputs['hours_cash_positioning'] ) : 0 );
+		$efficiency   = 0.30 * $multiplier;
+		$hours_saved  = $weekly_hours * $efficiency;
 
-        return $hours_saved * 52 * $hourly_cost;
-    }
+		return $hours_saved * 52 * $hourly_cost;
+	}
 
-    /**
-     * Calculate bank fee savings.
-     *
-     * @param array $inputs     User inputs.
-     * @param array $settings   Plugin settings.
-     * @param float $multiplier Scenario multiplier.
-     *
-     * @return float Annual fee savings.
-     */
-    private static function calculate_fee_savings( $inputs, $settings, $multiplier ) {
-        $num_banks = isset( $inputs['num_banks'] ) ? intval( $inputs['num_banks'] ) : 0;
-        $baseline  = isset( $settings['bank_fee_baseline'] ) ? floatval( $settings['bank_fee_baseline'] ) : 15000;
-        $rate      = 0.08 * $multiplier;
+	/**
+	 * Calculate bank fee savings.
+	 *
+	 * @param array $inputs     User inputs.
+	 * @param array $settings   Plugin settings.
+	 * @param float $multiplier Scenario multiplier.
+	 *
+	 * @return float Annual fee savings.
+	 */
+	private static function calculate_fee_savings( $inputs, $settings, $multiplier ) {
+		$num_banks = isset( $inputs['num_banks'] ) ? intval( $inputs['num_banks'] ) : 0;
+		$baseline  = isset( $settings['bank_fee_baseline'] ) ? floatval( $settings['bank_fee_baseline'] ) : 15000;
+		$rate      = 0.08 * $multiplier;
 
-        return $num_banks * $baseline * $rate;
-    }
+		return $num_banks * $baseline * $rate;
+	}
 
-    /**
-     * Calculate savings from error reduction.
-     *
-     * @param array $inputs     User inputs.
-     * @param array $settings   Plugin settings.
-     * @param float $multiplier Scenario multiplier.
-     *
-     * @return float Annual error reduction benefit.
-     */
-    private static function calculate_error_reduction( $inputs, $settings, $multiplier ) {
-        /**
-         * Filters the base error cost map used for calculating error reduction savings.
-         *
-         * @param array $cost_map   Map of company sizes to base error costs.
-         * @param array $inputs     User provided inputs.
-         * @param array $settings   Plugin settings.
-         * @param float $multiplier Scenario multiplier.
-         */
-        $cost_map = apply_filters(
-            'rtbcb_error_cost_map',
-            [
-                '<$50M'       => 25000,
-                '$50M-$500M'  => 75000,
-                '$500M-$2B'   => 200000,
-                '>$2B'        => 500000,
-            ],
-            $inputs,
-            $settings,
-            $multiplier
-        );
-        $company_size = isset( $inputs['company_size'] ) ? $inputs['company_size'] : '';
-        $base_cost    = isset( $cost_map[ $company_size ] ) ? $cost_map[ $company_size ] : 50000;
-        $reduction    = 0.25 * $multiplier;
+	/**
+	 * Calculate savings from error reduction.
+	 *
+	 * @param array $inputs     User inputs.
+	 * @param array $settings   Plugin settings.
+	 * @param float $multiplier Scenario multiplier.
+	 *
+	 * @return float Annual error reduction benefit.
+	 */
+	private static function calculate_error_reduction( $inputs, $settings, $multiplier ) {
+		/**
+		 * Filters the base error cost map used for calculating error reduction savings.
+		 *
+		 * @param array $cost_map   Map of company sizes to base error costs.
+		 * @param array $inputs     User provided inputs.
+		 * @param array $settings   Plugin settings.
+		 * @param float $multiplier Scenario multiplier.
+		 */
+		$cost_map = apply_filters(
+			'rtbcb_error_cost_map',
+			[
+				'<$50M'       => 25000,
+				'$50M-$500M'  => 75000,
+				'$500M-$2B'   => 200000,
+				'>$2B'        => 500000,
+			],
+			$inputs,
+			$settings,
+			$multiplier
+		);
+		$company_size = isset( $inputs['company_size'] ) ? $inputs['company_size'] : '';
+		$base_cost    = isset( $cost_map[ $company_size ] ) ? $cost_map[ $company_size ] : 50000;
+		$reduction    = 0.25 * $multiplier;
 
-        return $base_cost * $reduction;
-    }
+		return $base_cost * $reduction;
+	}
 
-    /**
-     * Get scenario assumptions.
-     *
-     * @param string $scenario_type Scenario key.
-     * @param float  $multiplier    Scenario multiplier.
-     * @param float  $industry_mult Industry multiplier.
-     *
-     * @return array Assumptions for the scenario.
-     */
-    private static function get_scenario_assumptions( $scenario_type, $multiplier, $industry_mult ) {
-        return [
-            'name'                  => ucfirst( $scenario_type ),
-            'efficiency_improvement'=> 0.30 * $multiplier,
-            'error_reduction'       => 0.25 * $multiplier,
-            'fee_reduction'         => 0.08 * $multiplier,
-            'industry_benchmark'    => $industry_mult,
-        ];
-    }
+	/**
+	 * Get scenario assumptions.
+	 *
+	 * @param string $scenario_type Scenario key.
+	 * @param float  $multiplier    Scenario multiplier.
+	 * @param float  $industry_mult Industry multiplier.
+	 *
+	 * @return array Assumptions for the scenario.
+	 */
+	private static function get_scenario_assumptions( $scenario_type, $multiplier, $industry_mult ) {
+		return [
+			'name'                  => ucfirst( $scenario_type ),
+			'efficiency_improvement'=> 0.30 * $multiplier,
+			'error_reduction'       => 0.25 * $multiplier,
+			'fee_reduction'         => 0.08 * $multiplier,
+			'industry_benchmark'    => $industry_mult,
+		];
+	}
 
-    /**
-     * Retrieve industry benchmark multiplier.
-     *
-     * @param string $industry Industry identifier.
-     * @return float Multiplier.
-     */
-    private static function get_industry_benchmark( $industry ) {
-        $benchmarks = [
-            'manufacturing' => 0.9,
-            'technology'    => 1.1,
-            'finance'       => 1.05,
-            'retail'        => 0.95,
-        ];
+	/**
+	 * Retrieve industry benchmark multiplier.
+	 *
+	 * @param string $industry Industry identifier.
+	 * @return float Multiplier.
+	 */
+	private static function get_industry_benchmark( $industry ) {
+		$benchmarks = [
+			'manufacturing' => 0.9,
+			'technology'    => 1.1,
+			'finance'       => 1.05,
+			'retail'        => 0.95,
+		];
 
-        $industry = strtolower( $industry );
+		$industry = strtolower( $industry );
 
-        return $benchmarks[ $industry ] ?? 1.0;
-    }
+		return $benchmarks[ $industry ] ?? 1.0;
+	}
 }

--- a/inc/class-rtbcb-category-recommender.php
+++ b/inc/class-rtbcb-category-recommender.php
@@ -2,14 +2,14 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Treasury tool category recommendation engine.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Treasury tool category recommendation engine.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 /**
- * Class RTBCB_Category_Recommender.
- */
+	* Class RTBCB_Category_Recommender.
+	*/
 class RTBCB_Category_Recommender {
 	/**
 	 * Category definitions with descriptions and criteria.
@@ -18,46 +18,46 @@ class RTBCB_Category_Recommender {
 	 */
 	public const CATEGORIES = [
 		'cash_tools' => [
-		    'name'        => 'Cash Management Tools',
-		    'description' => 'Basic cash visibility and forecasting solutions for simple treasury operations.',
-		    'features'    => [
-		        'Real-time cash positioning',
-		        'Basic cash forecasting',
-		        'Bank balance aggregation',
-		        'Simple reporting',
-		        'Excel-based workflows',
-		    ],
-		    'ideal_for'   => 'Small to mid-market companies with straightforward cash management needs',
-		    'roi_range'   => [ 15000, 75000 ],
+			'name'        => 'Cash Management Tools',
+			'description' => 'Basic cash visibility and forecasting solutions for simple treasury operations.',
+			'features'    => [
+				'Real-time cash positioning',
+				'Basic cash forecasting',
+				'Bank balance aggregation',
+				'Simple reporting',
+				'Excel-based workflows',
+			],
+			'ideal_for'   => 'Small to mid-market companies with straightforward cash management needs',
+			'roi_range'   => [ 15000, 75000 ],
 		],
 		'tms_lite'    => [
-		    'name'        => 'Treasury Management System (Lite)',
-		    'description' => 'Mid-tier treasury platform with automation and enhanced analytics.',
-		    'features'    => [
-		        'Automated bank reconciliation',
-		        'Advanced cash forecasting',
-		        'Payment processing',
-		        'Risk management basics',
-		        'Multi-entity support',
-		        'API integrations',
-		    ],
-		    'ideal_for'   => 'Mid-market to large companies with moderate complexity',
-		    'roi_range'   => [ 50000, 200000 ],
+			'name'        => 'Treasury Management System (Lite)',
+			'description' => 'Mid-tier treasury platform with automation and enhanced analytics.',
+			'features'    => [
+				'Automated bank reconciliation',
+				'Advanced cash forecasting',
+				'Payment processing',
+				'Risk management basics',
+				'Multi-entity support',
+				'API integrations',
+			],
+			'ideal_for'   => 'Mid-market to large companies with moderate complexity',
+			'roi_range'   => [ 50000, 200000 ],
 		],
 		'trms'        => [
-		    'name'        => 'Treasury & Risk Management System',
-		    'description' => 'Comprehensive enterprise treasury platform with full automation and risk management.',
-		    'features'    => [
-		        'Full treasury automation',
-		        'Sophisticated risk analytics',
-		        'Multi-currency support',
-		        'Complex derivatives handling',
-		        'Enterprise integrations',
-		        'Regulatory compliance tools',
-		        'Advanced forecasting models',
-		    ],
-		    'ideal_for'   => 'Large enterprises with complex, global treasury operations',
-		    'roi_range'   => [ 150000, 500000 ],
+			'name'        => 'Treasury & Risk Management System',
+			'description' => 'Comprehensive enterprise treasury platform with full automation and risk management.',
+			'features'    => [
+				'Full treasury automation',
+				'Sophisticated risk analytics',
+				'Multi-currency support',
+				'Complex derivatives handling',
+				'Enterprise integrations',
+				'Regulatory compliance tools',
+				'Advanced forecasting models',
+			],
+			'ideal_for'   => 'Large enterprises with complex, global treasury operations',
+			'roi_range'   => [ 150000, 500000 ],
 		],
 	];
 
@@ -69,42 +69,42 @@ class RTBCB_Category_Recommender {
 	 */
 	public static function recommend_category( $user_inputs ) {
 		$empty = [
-		    'recommended'   => '',
-		    'category_info' => [],
-		    'scores'        => [],
-		    'confidence'    => 0,
-		    'reasoning'     => '',
-		    'alternatives'  => [],
+			'recommended'   => '',
+			'category_info' => [],
+			'scores'        => [],
+			'confidence'    => 0,
+			'reasoning'     => '',
+			'alternatives'  => [],
 		];
 
 		if ( ! is_array( $user_inputs ) ) {
-		    rtbcb_log_error( 'Category recommendation inputs must be an array.' );
-		    return $empty;
+			rtbcb_log_error( 'Category recommendation inputs must be an array.' );
+			return $empty;
 		}
 
 		try {
-		    $scores = [];
+			$scores = [];
 
-		    foreach ( array_keys( self::CATEGORIES ) as $category ) {
-		        $scores[ $category ] = self::calculate_category_score( $category, $user_inputs );
-		    }
+			foreach ( array_keys( self::CATEGORIES ) as $category ) {
+				$scores[ $category ] = self::calculate_category_score( $category, $user_inputs );
+			}
 
-		    arsort( $scores );
-		    $recommended = array_key_first( $scores );
+			arsort( $scores );
+			$recommended = array_key_first( $scores );
 
-		    $category_info = self::translate_category_info( self::CATEGORIES[ $recommended ] );
+			$category_info = self::translate_category_info( self::CATEGORIES[ $recommended ] );
 
-		    return [
-		        'recommended'   => $recommended,
-		        'category_info' => $category_info,
-		        'scores'        => $scores,
-		        'confidence'    => self::calculate_confidence( $scores ),
-		        'reasoning'     => self::generate_reasoning( $recommended, $user_inputs ),
-		        'alternatives'  => self::get_alternatives( $scores, $recommended ),
-		    ];
+			return [
+				'recommended'   => $recommended,
+				'category_info' => $category_info,
+				'scores'        => $scores,
+				'confidence'    => self::calculate_confidence( $scores ),
+				'reasoning'     => self::generate_reasoning( $recommended, $user_inputs ),
+				'alternatives'  => self::get_alternatives( $scores, $recommended ),
+			];
 		} catch ( Exception $e ) {
-		    rtbcb_log_error( 'Category recommendation failed: ' . $e->getMessage() );
-		    return $empty;
+			rtbcb_log_error( 'Category recommendation failed: ' . $e->getMessage() );
+			return $empty;
 		}
 	}
 
@@ -118,10 +118,10 @@ class RTBCB_Category_Recommender {
 		$category['name']        = __( $category['name'], 'rtbcb' );
 		$category['description'] = __( $category['description'], 'rtbcb' );
 		$category['features']    = array_map(
-		    function( $feature ) {
-		        return __( $feature, 'rtbcb' );
-		    },
-		    $category['features']
+			function( $feature ) {
+				return __( $feature, 'rtbcb' );
+			},
+			$category['features']
 		);
 		$category['ideal_for']   = __( $category['ideal_for'], 'rtbcb' );
 
@@ -167,24 +167,24 @@ class RTBCB_Category_Recommender {
 	 */
 	private static function score_company_size( $category, $company_size ) {
 		$size_scores = [
-		    'cash_tools' => [
-		        '<$50M'      => 100,
-		        '$50M-$500M' => 80,
-		        '$500M-$2B'  => 40,
-		        '>$2B'       => 20,
-		    ],
-		    'tms_lite'   => [
-		        '<$50M'      => 60,
-		        '$50M-$500M' => 100,
-		        '$500M-$2B'  => 90,
-		        '>$2B'       => 70,
-		    ],
-		    'trms'       => [
-		        '<$50M'      => 20,
-		        '$50M-$500M' => 50,
-		        '$500M-$2B'  => 90,
-		        '>$2B'       => 100,
-		    ],
+			'cash_tools' => [
+				'<$50M'      => 100,
+				'$50M-$500M' => 80,
+				'$500M-$2B'  => 40,
+				'>$2B'       => 20,
+			],
+			'tms_lite'   => [
+				'<$50M'      => 60,
+				'$50M-$500M' => 100,
+				'$500M-$2B'  => 90,
+				'>$2B'       => 70,
+			],
+			'trms'       => [
+				'<$50M'      => 20,
+				'$50M-$500M' => 50,
+				'$500M-$2B'  => 90,
+				'>$2B'       => 100,
+			],
 		];
 
 		return $size_scores[ $category ][ $company_size ] ?? 50;
@@ -205,33 +205,33 @@ class RTBCB_Category_Recommender {
 		$complexity_index = 0;
 
 		if ( $num_banks <= 3 ) {
-		    $complexity_index += 1;
+			$complexity_index += 1;
 		} elseif ( $num_banks <= 8 ) {
-		    $complexity_index += 2;
+			$complexity_index += 2;
 		} else {
-		    $complexity_index += 3;
+			$complexity_index += 3;
 		}
 
 		if ( $ftes <= 2 ) {
-		    $complexity_index += 1;
+			$complexity_index += 1;
 		} elseif ( $ftes <= 5 ) {
-		    $complexity_index += 2;
+			$complexity_index += 2;
 		} else {
-		    $complexity_index += 3;
+			$complexity_index += 3;
 		}
 
 		if ( $total_hours <= 10 ) {
-		    $complexity_index += 1;
+			$complexity_index += 1;
 		} elseif ( $total_hours <= 25 ) {
-		    $complexity_index += 2;
+			$complexity_index += 2;
 		} else {
-		    $complexity_index += 3;
+			$complexity_index += 3;
 		}
 
 		$complexity_scores = [
-		    'cash_tools' => [ 1 => 100, 2 => 90, 3 => 80, 4 => 70, 5 => 60, 6 => 50, 7 => 40, 8 => 30, 9 => 20 ],
-		    'tms_lite'   => [ 1 => 60, 2 => 70, 3 => 80, 4 => 90, 5 => 100, 6 => 90, 7 => 80, 8 => 70, 9 => 60 ],
-		    'trms'       => [ 1 => 20, 2 => 30, 3 => 40, 4 => 50, 5 => 60, 6 => 70, 7 => 80, 8 => 90, 9 => 100 ],
+			'cash_tools' => [ 1 => 100, 2 => 90, 3 => 80, 4 => 70, 5 => 60, 6 => 50, 7 => 40, 8 => 30, 9 => 20 ],
+			'tms_lite'   => [ 1 => 60, 2 => 70, 3 => 80, 4 => 90, 5 => 100, 6 => 90, 7 => 80, 8 => 70, 9 => 60 ],
+			'trms'       => [ 1 => 20, 2 => 30, 3 => 40, 4 => 50, 5 => 60, 6 => 70, 7 => 80, 8 => 90, 9 => 100 ],
 		];
 
 		return $complexity_scores[ $category ][ $complexity_index ] ?? 50;
@@ -246,44 +246,44 @@ class RTBCB_Category_Recommender {
 	 */
 	private static function score_pain_points( $category, $pain_points ) {
 		if ( empty( $pain_points ) ) {
-		    return 50;
+			return 50;
 		}
 
 		$pain_point_mapping = [
-		    'cash_tools' => [
-		        'poor_visibility'    => 100,
-		        'manual_processes'   => 90,
-		        'forecast_accuracy'  => 80,
-		        'integration_issues' => 40,
-		        'compliance_risk'    => 50,
-		        'bank_fees'          => 60,
-		    ],
-		    'tms_lite'   => [
-		        'manual_processes'   => 100,
-		        'forecast_accuracy'  => 90,
-		        'poor_visibility'    => 85,
-		        'integration_issues' => 80,
-		        'bank_fees'          => 75,
-		        'compliance_risk'    => 70,
-		    ],
-		    'trms'       => [
-		        'compliance_risk'    => 100,
-		        'integration_issues' => 95,
-		        'forecast_accuracy'  => 90,
-		        'manual_processes'   => 85,
-		        'bank_fees'          => 80,
-		        'poor_visibility'    => 75,
-		    ],
+			'cash_tools' => [
+				'poor_visibility'    => 100,
+				'manual_processes'   => 90,
+				'forecast_accuracy'  => 80,
+				'integration_issues' => 40,
+				'compliance_risk'    => 50,
+				'bank_fees'          => 60,
+			],
+			'tms_lite'   => [
+				'manual_processes'   => 100,
+				'forecast_accuracy'  => 90,
+				'poor_visibility'    => 85,
+				'integration_issues' => 80,
+				'bank_fees'          => 75,
+				'compliance_risk'    => 70,
+			],
+			'trms'       => [
+				'compliance_risk'    => 100,
+				'integration_issues' => 95,
+				'forecast_accuracy'  => 90,
+				'manual_processes'   => 85,
+				'bank_fees'          => 80,
+				'poor_visibility'    => 75,
+			],
 		];
 
 		$total_score = 0;
 		$count       = 0;
 
 		foreach ( $pain_points as $pain_point ) {
-		    if ( isset( $pain_point_mapping[ $category ][ $pain_point ] ) ) {
-		        $total_score += $pain_point_mapping[ $category ][ $pain_point ];
-		        $count++;
-		    }
+			if ( isset( $pain_point_mapping[ $category ][ $pain_point ] ) ) {
+				$total_score += $pain_point_mapping[ $category ][ $pain_point ];
+				$count++;
+			}
 		}
 
 		return $count > 0 ? ( $total_score / $count ) : 50;
@@ -303,16 +303,16 @@ class RTBCB_Category_Recommender {
 		$volume_indicator = ( $num_banks * 10 ) + ( $ftes * 20 );
 
 		$volume_scores = [
-		    'cash_tools' => [ 0 => 100, 50 => 90, 100 => 70, 150 => 50, 200 => 30 ],
-		    'tms_lite'   => [ 0 => 50, 50 => 80, 100 => 100, 150 => 90, 200 => 70 ],
-		    'trms'       => [ 0 => 20, 50 => 40, 100 => 60, 150 => 80, 200 => 100 ],
+			'cash_tools' => [ 0 => 100, 50 => 90, 100 => 70, 150 => 50, 200 => 30 ],
+			'tms_lite'   => [ 0 => 50, 50 => 80, 100 => 100, 150 => 90, 200 => 70 ],
+			'trms'       => [ 0 => 20, 50 => 40, 100 => 60, 150 => 80, 200 => 100 ],
 		];
 
 		$closest_volume = 0;
 		foreach ( array_keys( $volume_scores[ $category ] ) as $volume ) {
-		    if ( abs( $volume - $volume_indicator ) < abs( $closest_volume - $volume_indicator ) ) {
-		        $closest_volume = $volume;
-		    }
+			if ( abs( $volume - $volume_indicator ) < abs( $closest_volume - $volume_indicator ) ) {
+				$closest_volume = $volume;
+			}
 		}
 
 		return $volume_scores[ $category ][ $closest_volume ];
@@ -351,68 +351,68 @@ class RTBCB_Category_Recommender {
 		$reasoning_parts = [];
 
 		$size_reasoning = [
-		    'cash_tools' => [
-		        '<$50M'      => __( 'your company size aligns perfectly with cash management tools', 'rtbcb' ),
-		        '$50M-$500M' => __( 'cash tools can effectively serve mid-market companies like yours', 'rtbcb' ),
-		        '$500M-$2B'  => __( 'while larger, your company could benefit from focused cash tools', 'rtbcb' ),
-		        '>$2B'       => __( 'cash tools may be sufficient for specific business units', 'rtbcb' ),
-		    ],
-		    'tms_lite'   => [
-		        '<$50M'      => __( 'TMS-Lite provides room for growth as your company scales', 'rtbcb' ),
-		        '$50M-$500M' => __( 'your company size is ideal for a mid-tier TMS solution', 'rtbcb' ),
-		        '$500M-$2B'  => __( 'TMS-Lite offers the right balance of features for your scale', 'rtbcb' ),
-		        '>$2B'       => __( 'TMS-Lite can serve specific regions or business units effectively', 'rtbcb' ),
-		    ],
-		    'trms'       => [
-		        '<$50M'      => __( 'TRMS provides enterprise capabilities for future growth', 'rtbcb' ),
-		        '$50M-$500M' => __( 'TRMS offers comprehensive features as you scale operations', 'rtbcb' ),
-		        '$500M-$2B'  => __( 'your company scale requires enterprise-grade treasury management', 'rtbcb' ),
-		        '>$2B'       => __( 'enterprise-scale operations demand comprehensive TRMS capabilities', 'rtbcb' ),
-		    ],
+			'cash_tools' => [
+				'<$50M'      => __( 'your company size aligns perfectly with cash management tools', 'rtbcb' ),
+				'$50M-$500M' => __( 'cash tools can effectively serve mid-market companies like yours', 'rtbcb' ),
+				'$500M-$2B'  => __( 'while larger, your company could benefit from focused cash tools', 'rtbcb' ),
+				'>$2B'       => __( 'cash tools may be sufficient for specific business units', 'rtbcb' ),
+			],
+			'tms_lite'   => [
+				'<$50M'      => __( 'TMS-Lite provides room for growth as your company scales', 'rtbcb' ),
+				'$50M-$500M' => __( 'your company size is ideal for a mid-tier TMS solution', 'rtbcb' ),
+				'$500M-$2B'  => __( 'TMS-Lite offers the right balance of features for your scale', 'rtbcb' ),
+				'>$2B'       => __( 'TMS-Lite can serve specific regions or business units effectively', 'rtbcb' ),
+			],
+			'trms'       => [
+				'<$50M'      => __( 'TRMS provides enterprise capabilities for future growth', 'rtbcb' ),
+				'$50M-$500M' => __( 'TRMS offers comprehensive features as you scale operations', 'rtbcb' ),
+				'$500M-$2B'  => __( 'your company scale requires enterprise-grade treasury management', 'rtbcb' ),
+				'>$2B'       => __( 'enterprise-scale operations demand comprehensive TRMS capabilities', 'rtbcb' ),
+			],
 		];
 
 		if ( isset( $size_reasoning[ $recommended ][ $company_size ] ) ) {
-		    $reasoning_parts[] = $size_reasoning[ $recommended ][ $company_size ];
+			$reasoning_parts[] = $size_reasoning[ $recommended ][ $company_size ];
 		}
 
 		if ( $num_banks > 5 || $ftes > 3 ) {
-		    $complexity_reasons = [
-		        'cash_tools' => __( 'streamlined cash tools can simplify your multi-bank operations', 'rtbcb' ),
-		        'tms_lite'   => __( 'automation features will significantly reduce your operational complexity', 'rtbcb' ),
-		        'trms'       => __( 'comprehensive automation is essential for your complex operations', 'rtbcb' ),
-		    ];
-		    $reasoning_parts[] = $complexity_reasons[ $recommended ];
+			$complexity_reasons = [
+				'cash_tools' => __( 'streamlined cash tools can simplify your multi-bank operations', 'rtbcb' ),
+				'tms_lite'   => __( 'automation features will significantly reduce your operational complexity', 'rtbcb' ),
+				'trms'       => __( 'comprehensive automation is essential for your complex operations', 'rtbcb' ),
+			];
+			$reasoning_parts[] = $complexity_reasons[ $recommended ];
 		}
 
 		if ( ! empty( $pain_points ) ) {
-		    $pain_reasons = [
-		        'cash_tools' => [
-		            'poor_visibility'  => __( 'cash tools excel at providing real-time visibility', 'rtbcb' ),
-		            'manual_processes' => __( 'basic automation will address your manual workflow challenges', 'rtbcb' ),
-		        ],
-		        'tms_lite'   => [
-		            'manual_processes'   => __( 'mid-tier TMS automation will eliminate most manual processes', 'rtbcb' ),
-		            'forecast_accuracy'  => __( 'advanced forecasting capabilities will improve accuracy', 'rtbcb' ),
-		            'integration_issues' => __( 'API integrations will solve your system connectivity needs', 'rtbcb' ),
-		        ],
-		        'trms'       => [
-		            'compliance_risk'   => __( 'enterprise compliance tools are crucial for your risk management', 'rtbcb' ),
-		            'integration_issues'=> __( 'comprehensive integration capabilities will unify your systems', 'rtbcb' ),
-		        ],
-		    ];
+			$pain_reasons = [
+				'cash_tools' => [
+					'poor_visibility'  => __( 'cash tools excel at providing real-time visibility', 'rtbcb' ),
+					'manual_processes' => __( 'basic automation will address your manual workflow challenges', 'rtbcb' ),
+				],
+				'tms_lite'   => [
+					'manual_processes'   => __( 'mid-tier TMS automation will eliminate most manual processes', 'rtbcb' ),
+					'forecast_accuracy'  => __( 'advanced forecasting capabilities will improve accuracy', 'rtbcb' ),
+					'integration_issues' => __( 'API integrations will solve your system connectivity needs', 'rtbcb' ),
+				],
+				'trms'       => [
+					'compliance_risk'   => __( 'enterprise compliance tools are crucial for your risk management', 'rtbcb' ),
+					'integration_issues'=> __( 'comprehensive integration capabilities will unify your systems', 'rtbcb' ),
+				],
+			];
 
-		    foreach ( $pain_points as $pain ) {
-		        if ( isset( $pain_reasons[ $recommended ][ $pain ] ) ) {
-		            $reasoning_parts[] = $pain_reasons[ $recommended ][ $pain ];
-		            break;
-		        }
-		    }
+			foreach ( $pain_points as $pain ) {
+				if ( isset( $pain_reasons[ $recommended ][ $pain ] ) ) {
+					$reasoning_parts[] = $pain_reasons[ $recommended ][ $pain ];
+					break;
+				}
+			}
 		}
 
 		return sprintf(
-		    /* translators: %s: reasoning text */
-		    __( 'Based on your profile, %s.', 'rtbcb' ),
-		    implode( ', and ', $reasoning_parts )
+			/* translators: %s: reasoning text */
+			__( 'Based on your profile, %s.', 'rtbcb' ),
+			implode( ', and ', $reasoning_parts )
 		);
 	}
 
@@ -427,13 +427,13 @@ class RTBCB_Category_Recommender {
 		$alternatives = [];
 
 		foreach ( $scores as $category => $score ) {
-		    if ( $category !== $recommended && $score > 60 ) {
-		        $alternatives[] = [
-		            'category' => $category,
-		            'info'     => self::translate_category_info( self::CATEGORIES[ $category ] ),
-		            'score'    => $score,
-		        ];
-		    }
+			if ( $category !== $recommended && $score > 60 ) {
+				$alternatives[] = [
+					'category' => $category,
+					'info'     => self::translate_category_info( self::CATEGORIES[ $category ] ),
+					'score'    => $score,
+				];
+			}
 		}
 
 		return array_slice( $alternatives, 0, 2 );
@@ -447,7 +447,7 @@ class RTBCB_Category_Recommender {
 	 */
 	public static function get_category_info( $category_key ) {
 		if ( ! isset( self::CATEGORIES[ $category_key ] ) ) {
-		    return null;
+			return null;
 		}
 		return self::translate_category_info( self::CATEGORIES[ $category_key ] );
 	}
@@ -460,7 +460,7 @@ class RTBCB_Category_Recommender {
 	public static function get_all_categories() {
 		$translated = [];
 		foreach ( self::CATEGORIES as $key => $category ) {
-		    $translated[ $key ] = self::translate_category_info( $category );
+			$translated[ $key ] = self::translate_category_info( $category );
 		}
 		return $translated;
 	}

--- a/inc/class-rtbcb-db.php
+++ b/inc/class-rtbcb-db.php
@@ -2,111 +2,111 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Database management and migration handling.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Database management and migration handling.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 /**
- * Handles database versioning and upgrades.
- */
+	* Handles database versioning and upgrades.
+	*/
 class RTBCB_DB {
-    /**
-     * Current database version.
-     */
-    const DB_VERSION = '2.0.3';
+	/**
+	 * Current database version.
+	 */
+	const DB_VERSION = '2.0.3';
 
-    /**
-     * Initialize database and handle upgrades.
-     *
-     * @return void
-     */
-    public static function init() {
-        $current = get_option( 'rtbcb_db_version', '1.0.0' );
+	/**
+	 * Initialize database and handle upgrades.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		$current = get_option( 'rtbcb_db_version', '1.0.0' );
 
-        if ( version_compare( $current, self::DB_VERSION, '<' ) ) {
-            self::upgrade( $current );
-            update_option( 'rtbcb_db_version', self::DB_VERSION );
-        }
+		if ( version_compare( $current, self::DB_VERSION, '<' ) ) {
+			self::upgrade( $current );
+			update_option( 'rtbcb_db_version', self::DB_VERSION );
+		}
 
-        // Ensure required tables exist.
-        RTBCB_Leads::init();
-        if ( class_exists( 'RTBCB_API_Log' ) ) {
-            RTBCB_API_Log::init();
-        }
-        self::create_rag_table();
-        self::seed_rag_sample_data();
-    }
+		// Ensure required tables exist.
+		RTBCB_Leads::init();
+		if ( class_exists( 'RTBCB_API_Log' ) ) {
+			RTBCB_API_Log::init();
+		}
+		self::create_rag_table();
+		self::seed_rag_sample_data();
+	}
 
-    /**
-     * Perform database upgrades.
-     *
-     * @param string $from_version Previous database version.
-     * @return void
-     */
-    private static function upgrade( $from_version ) {
-        // Run table creation/migration for leads.
-        RTBCB_Leads::init();
-        if ( class_exists( 'RTBCB_API_Log' ) ) {
-            RTBCB_API_Log::init();
-        }
+	/**
+	 * Perform database upgrades.
+	 *
+	 * @param string $from_version Previous database version.
+	 * @return void
+	 */
+	private static function upgrade( $from_version ) {
+		// Run table creation/migration for leads.
+		RTBCB_Leads::init();
+		if ( class_exists( 'RTBCB_API_Log' ) ) {
+			RTBCB_API_Log::init();
+		}
 
 	// Ensure RAG index table is present during upgrades.
 	self::create_rag_table();
 
-        if ( version_compare( $from_version, '2.0.1', '<' ) ) {
-                self::add_embedding_norm_index();
-        }
+		if ( version_compare( $from_version, '2.0.1', '<' ) ) {
+				self::add_embedding_norm_index();
+		}
 
-                if ( version_compare( $from_version, '2.0.2', '<' ) ) {
-                        RTBCB_Leads::add_missing_indexes();
-                }
+				if ( version_compare( $from_version, '2.0.2', '<' ) ) {
+						RTBCB_Leads::add_missing_indexes();
+				}
 
-                if ( version_compare( $from_version, '2.0.3', '<' ) ) {
-                        RTBCB_Leads::compress_existing_report_html();
-                }
+				if ( version_compare( $from_version, '2.0.3', '<' ) ) {
+						RTBCB_Leads::compress_existing_report_html();
+				}
 
 	// Future migrations can be handled here.
 
-        // Log the upgrade.
-        error_log( 'RTBCB: Database upgraded from version ' . $from_version . ' to ' . self::DB_VERSION );
-    }
+		// Log the upgrade.
+		error_log( 'RTBCB: Database upgraded from version ' . $from_version . ' to ' . self::DB_VERSION );
+	}
 
-    /**
-     * Create the RAG index table if it does not exist.
-     *
-     * @return void
-     */
-    private static function create_rag_table() {
-        global $wpdb;
+	/**
+	 * Create the RAG index table if it does not exist.
+	 *
+	 * @return void
+	 */
+	private static function create_rag_table() {
+		global $wpdb;
 
-        $table_name      = $wpdb->prefix . 'rtbcb_rag_index';
-        $charset_collate = $wpdb->get_charset_collate();
+		$table_name      = $wpdb->prefix . 'rtbcb_rag_index';
+		$charset_collate = $wpdb->get_charset_collate();
 
-        $sql = "CREATE TABLE {$table_name} (
-            id mediumint(9) NOT NULL AUTO_INCREMENT,
-            type varchar(20) NOT NULL,
-            ref_id varchar(100) NOT NULL,
-            text_hash varchar(64) NOT NULL,
-            embedding longtext NOT NULL,
-            metadata longtext NOT NULL,
-            embedding_norm float NOT NULL,
-            updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-            PRIMARY KEY  (id),
-            UNIQUE KEY hash_key (text_hash),
-            KEY type_ref (type, ref_id),
-            KEY embedding_norm_idx (embedding_norm)
-        ) {$charset_collate};";
+		$sql = "CREATE TABLE {$table_name} (
+			id mediumint(9) NOT NULL AUTO_INCREMENT,
+			type varchar(20) NOT NULL,
+			ref_id varchar(100) NOT NULL,
+			text_hash varchar(64) NOT NULL,
+			embedding longtext NOT NULL,
+			metadata longtext NOT NULL,
+			embedding_norm float NOT NULL,
+			updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY  (id),
+			UNIQUE KEY hash_key (text_hash),
+			KEY type_ref (type, ref_id),
+			KEY embedding_norm_idx (embedding_norm)
+		) {$charset_collate};";
 
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        dbDelta( $sql );
-    }
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
 
-    /**
-     * Add embedding_norm index to the RAG table if missing.
-     *
-     * @return void
-     */
+	/**
+	 * Add embedding_norm index to the RAG table if missing.
+	 *
+	 * @return void
+	 */
 	private static function add_embedding_norm_index() {
 		global $wpdb;
 
@@ -117,39 +117,39 @@ class RTBCB_DB {
 		}
 	}
 
-    /**
-     * Seed sample data into the RAG index when empty.
-     *
-     * @return void
-     */
-    private static function seed_rag_sample_data() {
-        global $wpdb;
+	/**
+	 * Seed sample data into the RAG index when empty.
+	 *
+	 * @return void
+	 */
+	private static function seed_rag_sample_data() {
+		global $wpdb;
 
-        $table_name = $wpdb->prefix . 'rtbcb_rag_index';
+		$table_name = $wpdb->prefix . 'rtbcb_rag_index';
 
-        // Bail if table does not exist.
-        $table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
-        if ( $table_exists !== $table_name ) {
-            return;
-        }
+		// Bail if table does not exist.
+		$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
+		if ( $table_exists !== $table_name ) {
+			return;
+		}
 
-        $count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table_name}" );
-        if ( $count > 0 ) {
-            return;
-        }
+		$count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table_name}" );
+		if ( $count > 0 ) {
+			return;
+		}
 
-        $text = 'Sample RAG content';
-        $wpdb->insert(
-            $table_name,
-            [
-                'type'          => 'sample',
-                'ref_id'        => 'sample',
-                'text_hash'     => hash( 'sha256', $text ),
-                'embedding'     => maybe_serialize( [ 0.0 ] ),
-                'metadata'      => maybe_serialize( [ 'content' => $text ] ),
-                'embedding_norm' => 0.0,
-            ],
-            [ '%s', '%s', '%s', '%s', '%s', '%f' ]
-        );
-    }
+		$text = 'Sample RAG content';
+		$wpdb->insert(
+			$table_name,
+			[
+				'type'          => 'sample',
+				'ref_id'        => 'sample',
+				'text_hash'     => hash( 'sha256', $text ),
+				'embedding'     => maybe_serialize( [ 0.0 ] ),
+				'metadata'      => maybe_serialize( [ 'content' => $text ] ),
+				'embedding_norm' => 0.0,
+			],
+			[ '%s', '%s', '%s', '%s', '%s', '%f' ]
+		);
+	}
 }

--- a/inc/class-rtbcb-enhanced-calculator.php
+++ b/inc/class-rtbcb-enhanced-calculator.php
@@ -2,18 +2,18 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Enhanced Calculator that uses AI-enriched company data for improved accuracy.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Enhanced Calculator that uses AI-enriched company data for improved accuracy.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 class RTBCB_Enhanced_Calculator extends RTBCB_Calculator {
 /**
- * Calculate enhanced ROI using AI-enriched company intelligence.
- *
- * @param array $user_inputs      Original user inputs.
- * @param array $enriched_profile AI-enriched company profile.
- * @return array Enhanced ROI scenarios with sensitivity analysis.
- */
+	* Calculate enhanced ROI using AI-enriched company intelligence.
+	*
+	* @param array $user_inputs      Original user inputs.
+	* @param array $enriched_profile AI-enriched company profile.
+	* @return array Enhanced ROI scenarios with sensitivity analysis.
+	*/
 public function calculate_enhanced_roi( $user_inputs, $enriched_profile ) {
 $base_scenarios = parent::calculate_roi( $user_inputs );
 
@@ -37,11 +37,11 @@ return $enhanced_scenarios;
 }
 
 /**
- * Calculate enhancement factors based on AI insights.
- *
- * @param array $enriched_profile Enriched profile data.
- * @return array Enhancement factor data.
- */
+	* Calculate enhancement factors based on AI insights.
+	*
+	* @param array $enriched_profile Enriched profile data.
+	* @return array Enhancement factor data.
+	*/
 private function calculate_enhancement_factors( $enriched_profile ) {
 $company_profile   = $enriched_profile['company_profile'] ?? [];
 $industry_context  = $enriched_profile['industry_context'] ?? [];
@@ -75,12 +75,12 @@ return [
 }
 
 /**
- * Apply enhancement factors to base scenarios.
- *
- * @param array $scenarios Base ROI scenarios.
- * @param array $factors   Enhancement factors.
- * @return array Enhanced scenarios.
- */
+	* Apply enhancement factors to base scenarios.
+	*
+	* @param array $scenarios Base ROI scenarios.
+	* @param array $factors   Enhancement factors.
+	* @return array Enhanced scenarios.
+	*/
 private function apply_enhancement_factors( $scenarios, $factors ) {
 foreach ( $scenarios as $key => &$scenario ) {
 if ( isset( $scenario['total_annual_benefit'] ) ) {
@@ -95,10 +95,10 @@ return $scenarios;
 
 /**
 \t * Get maturity level multiplier for ROI calculations.
- *
- * @param string $maturity_level Maturity level key.
- * @return float Multiplier.
- */
+	*
+	* @param string $maturity_level Maturity level key.
+	* @return float Multiplier.
+	*/
 private function get_maturity_multiplier( $maturity_level ) {
 $multipliers = [
 'basic'      => 1.2,
@@ -111,11 +111,11 @@ return $multipliers[ $maturity_level ] ?? 1.0;
 }
 
 /**
- * Get industry-specific multiplier.
- *
- * @param array $industry_context Industry context data.
- * @return float Multiplier.
- */
+	* Get industry-specific multiplier.
+	*
+	* @param array $industry_context Industry context data.
+	* @return float Multiplier.
+	*/
 private function get_industry_multiplier( $industry_context ) {
 $sector_analysis    = $industry_context['sector_analysis'] ?? [];
 $technology_adopt   = $sector_analysis['technology_adoption'] ?? 'mainstream';
@@ -130,11 +130,11 @@ return $adoption_multipliers[ $technology_adopt ] ?? 1.0;
 }
 
 /**
- * Get readiness multiplier based on automation readiness.
- *
- * @param string $readiness Automation readiness level.
- * @return float Multiplier.
- */
+	* Get readiness multiplier based on automation readiness.
+	*
+	* @param string $readiness Automation readiness level.
+	* @return float Multiplier.
+	*/
 private function get_readiness_multiplier( $readiness ) {
 $map = [
 'low'    => 0.8,
@@ -146,11 +146,11 @@ return $map[ $readiness ] ?? 1.0;
 }
 
 /**
- * Get financial health multiplier.
- *
- * @param string $health Financial health indicator.
- * @return float Multiplier.
- */
+	* Get financial health multiplier.
+	*
+	* @param string $health Financial health indicator.
+	* @return float Multiplier.
+	*/
 private function get_financial_health_multiplier( $health ) {
 $map = [
 'weak'   => 0.9,
@@ -162,11 +162,11 @@ return $map[ $health ] ?? 1.0;
 }
 
 /**
- * Calculate implementation complexity factor.
- *
- * @param array $strategic_insight Strategic insight data.
- * @return float Multiplier.
- */
+	* Calculate implementation complexity factor.
+	*
+	* @param array $strategic_insight Strategic insight data.
+	* @return float Multiplier.
+	*/
 private function calculate_implementation_complexity_factor( $strategic_insight ) {
 $complexity = $strategic_insight['implementation_complexity'] ?? 'medium';
 $map        = [
@@ -180,11 +180,11 @@ return $map[ $complexity ] ?? 1.0;
 }
 
 /**
- * Calculate timeline factor.
- *
- * @param array $enriched_profile Enriched profile data.
- * @return float Multiplier.
- */
+	* Calculate timeline factor.
+	*
+	* @param array $enriched_profile Enriched profile data.
+	* @return float Multiplier.
+	*/
 private function calculate_timeline_factor( $enriched_profile ) {
 $timeline = $enriched_profile['strategic_insights']['implementation_timeline'] ?? 'standard';
 $map      = [
@@ -197,12 +197,12 @@ return $map[ $timeline ] ?? 1.0;
 }
 
 /**
- * Perform sensitivity analysis on ROI calculations.
- *
- * @param array $scenarios        Enhanced scenarios.
- * @param array $enriched_profile Enriched profile data.
- * @return array Sensitivity analysis results.
- */
+	* Perform sensitivity analysis on ROI calculations.
+	*
+	* @param array $scenarios        Enhanced scenarios.
+	* @param array $enriched_profile Enriched profile data.
+	* @return array Sensitivity analysis results.
+	*/
 private function perform_sensitivity_analysis( $scenarios, $enriched_profile ) {
 $base_case    = $scenarios['base'];
 $base_benefit = $base_case['total_annual_benefit'];
@@ -236,12 +236,12 @@ return [
 }
 
 /**
- * Calculate confidence metrics for ROI projections.
- *
- * @param array $enriched_profile Enriched profile data.
- * @param array $user_inputs      Original user inputs.
- * @return array Confidence metrics.
- */
+	* Calculate confidence metrics for ROI projections.
+	*
+	* @param array $enriched_profile Enriched profile data.
+	* @param array $user_inputs      Original user inputs.
+	* @return array Confidence metrics.
+	*/
 private function calculate_confidence_metrics( $enriched_profile, $user_inputs ) {
 $data_quality                  = $this->assess_data_quality( $user_inputs );
 $ai_confidence                 = $enriched_profile['enrichment_metadata']['confidence_level'] ?? 0.8;
@@ -262,11 +262,11 @@ return [
 }
 
 /**
- * Assess data quality score.
- *
- * @param array $user_inputs User supplied inputs.
- * @return float Score between 0 and 1.
- */
+	* Assess data quality score.
+	*
+	* @param array $user_inputs User supplied inputs.
+	* @return float Score between 0 and 1.
+	*/
 private function assess_data_quality( $user_inputs ) {
 $required = [ 'ftes', 'hours_reconciliation', 'hours_cash_positioning' ];
 $filled   = 0;
@@ -281,20 +281,20 @@ return $filled / count( $required );
 
 /**
 \t * Assess industry benchmark availability.
- *
- * @param array $enriched_profile Enriched profile data.
- * @return float Score between 0 and 1.
- */
+	*
+	* @param array $enriched_profile Enriched profile data.
+	* @return float Score between 0 and 1.
+	*/
 private function assess_benchmark_availability( $enriched_profile ) {
 return ! empty( $enriched_profile['industry_context']['benchmarks'] ) ? 1.0 : 0.5;
 }
 
 /**
- * Calculate probability of implementation delay.
- *
- * @param array $enriched_profile Enriched profile data.
- * @return float Probability value.
- */
+	* Calculate probability of implementation delay.
+	*
+	* @param array $enriched_profile Enriched profile data.
+	* @return float Probability value.
+	*/
 private function calculate_delay_probability( $enriched_profile ) {
 $complexity = $enriched_profile['strategic_insights']['implementation_complexity'] ?? 'medium';
 $readiness  = $enriched_profile['company_profile']['treasury_maturity']['automation_readiness'] ?? 'medium';
@@ -315,11 +315,11 @@ return min( 0.8, $complexity_risk + $readiness_risk );
 }
 
 /**
- * Calculate probability of adoption resistance.
- *
- * @param array $enriched_profile Enriched profile data.
- * @return float Probability value.
- */
+	* Calculate probability of adoption resistance.
+	*
+	* @param array $enriched_profile Enriched profile data.
+	* @return float Probability value.
+	*/
 private function calculate_resistance_probability( $enriched_profile ) {
 $culture = $enriched_profile['company_profile']['culture'] ?? 'neutral';
 $map     = [
@@ -332,11 +332,11 @@ return $map[ $culture ] ?? 0.2;
 }
 
 /**
- * Calculate probability of competitive pressure.
- *
- * @param array $enriched_profile Enriched profile data.
- * @return float Probability value.
- */
+	* Calculate probability of competitive pressure.
+	*
+	* @param array $enriched_profile Enriched profile data.
+	* @return float Probability value.
+	*/
 private function calculate_competitive_pressure_probability( $enriched_profile ) {
 $competition = $enriched_profile['industry_context']['competition_intensity'] ?? 'medium';
 $map         = [

--- a/inc/class-rtbcb-intelligent-recommender.php
+++ b/inc/class-rtbcb-intelligent-recommender.php
@@ -2,18 +2,18 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Intelligent Recommender that uses AI insights for category recommendations.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Intelligent Recommender that uses AI insights for category recommendations.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 class RTBCB_Intelligent_Recommender extends RTBCB_Category_Recommender {
 /**
- * Generate recommendations using AI insights and rule-based scoring.
- *
- * @param array $user_inputs      Original user inputs.
- * @param array $enriched_profile AI-enriched company profile.
- * @return array Enhanced recommendation with confidence and alternatives.
- */
+	* Generate recommendations using AI insights and rule-based scoring.
+	*
+	* @param array $user_inputs      Original user inputs.
+	* @param array $enriched_profile AI-enriched company profile.
+	* @return array Enhanced recommendation with confidence and alternatives.
+	*/
 public function recommend_with_ai_insights( $user_inputs, $enriched_profile ) {
 // Get baseline recommendation from parent class.
 $base_recommendation = parent::recommend_category( $user_inputs );
@@ -47,11 +47,11 @@ return [
 }
 
 /**
- * Extract AI-based recommendation factors.
- *
- * @param array $enriched_profile Enriched profile data.
- * @return array AI factors for scoring.
- */
+	* Extract AI-based recommendation factors.
+	*
+	* @param array $enriched_profile Enriched profile data.
+	* @return array AI factors for scoring.
+	*/
 private function extract_ai_recommendation_factors( $enriched_profile ) {
 $company_profile   = $enriched_profile['company_profile'] ?? [];
 $strategic_insight = $enriched_profile['strategic_insights'] ?? [];
@@ -81,12 +81,12 @@ $company_profile['financial_indicators'] ?? []
 }
 
 /**
- * Apply AI insights to modify category scores.
- *
- * @param array $base_scores Base scores from recommender.
- * @param array $ai_factors  AI factor adjustments.
- * @return array Adjusted scores.
- */
+	* Apply AI insights to modify category scores.
+	*
+	* @param array $base_scores Base scores from recommender.
+	* @param array $ai_factors  AI factor adjustments.
+	* @return array Adjusted scores.
+	*/
 private function apply_ai_insights_to_scoring( $base_scores, $ai_factors ) {
 $enhanced_scores = $base_scores;
 
@@ -117,12 +117,12 @@ return $enhanced_scores;
 }
 
 /**
- * Assess how well each category aligns with company maturity.
- *
- * @param string $maturity_level Company maturity level.
- * @param array  $treasury_maturity Treasury maturity details.
- * @return array Category alignment adjustments.
- */
+	* Assess how well each category aligns with company maturity.
+	*
+	* @param string $maturity_level Company maturity level.
+	* @param array  $treasury_maturity Treasury maturity details.
+	* @return array Category alignment adjustments.
+	*/
 private function assess_maturity_category_alignment( $maturity_level, $treasury_maturity ) {
 $sophistication = $treasury_maturity['sophistication_level'] ?? 'manual';
 unset( $sophistication ); // Currently unused, reserved for future logic.
@@ -154,13 +154,13 @@ return $alignments[ $maturity_level ] ?? $alignments['basic'];
 }
 
 /**
- * Generate AI-enhanced reasoning for recommendation.
- *
- * @param string $recommended     Recommended category key.
- * @param array  $enriched_profile Enriched profile data.
- * @param array  $ai_factors       AI factors used.
- * @return string Reasoning text.
- */
+	* Generate AI-enhanced reasoning for recommendation.
+	*
+	* @param string $recommended     Recommended category key.
+	* @param array  $enriched_profile Enriched profile data.
+	* @param array  $ai_factors       AI factors used.
+	* @return string Reasoning text.
+	*/
 private function generate_ai_enhanced_reasoning( $recommended, $enriched_profile, $ai_factors ) {
 $company_profile   = $enriched_profile['company_profile'] ?? [];
 $strategic_insight = $enriched_profile['strategic_insights'] ?? [];
@@ -202,12 +202,12 @@ implode( ', and ', $reasoning_parts )
 }
 
 /**
- * Get intelligent alternatives based on AI insights.
- *
- * @param array $enhanced_scores  Score map of categories.
- * @param array $enriched_profile Enriched profile data.
- * @return array Alternative recommendations.
- */
+	* Get intelligent alternatives based on AI insights.
+	*
+	* @param array $enhanced_scores  Score map of categories.
+	* @param array $enriched_profile Enriched profile data.
+	* @return array Alternative recommendations.
+	*/
 private function get_intelligent_alternatives( $enhanced_scores, $enriched_profile ) {
 $alternatives  = [];
 $sorted_scores = $enhanced_scores;

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -2,163 +2,163 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Enhanced leads management for tracking form submissions.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Enhanced leads management for tracking form submissions.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 /**
- * Class RTBCB_Leads - Enhanced version with full tracking capabilities.
- */
+	* Class RTBCB_Leads - Enhanced version with full tracking capabilities.
+	*/
 class RTBCB_Leads {
-    /**
-     * Database table name.
-     *
-     * @var string
-     */
-    private static $table_name;
+	/**
+	 * Database table name.
+	 *
+	 * @var string
+	 */
+	private static $table_name;
 
-    /**
-     * Option name for cached statistics.
-     *
-     * @var string
-     */
-    private static $cache_option = 'rtbcb_lead_stats';
+	/**
+	 * Option name for cached statistics.
+	 *
+	 * @var string
+	 */
+	private static $cache_option = 'rtbcb_lead_stats';
 
-    /**
-     * Create the leads table with improved error handling.
-     *
-     * @return bool True on success, false on failure.
-     */
-    private static function create_table() {
-        global $wpdb;
+	/**
+	 * Create the leads table with improved error handling.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	private static function create_table() {
+		global $wpdb;
 
-        $charset_collate = $wpdb->get_charset_collate();
-        self::$table_name = $wpdb->prefix . 'rtbcb_leads';
+		$charset_collate = $wpdb->get_charset_collate();
+		self::$table_name = $wpdb->prefix . 'rtbcb_leads';
 
-        $sql = "CREATE TABLE " . self::$table_name . " (
-            id mediumint(9) NOT NULL AUTO_INCREMENT,
-            email varchar(255) NOT NULL,
-            company_name varchar(255) DEFAULT '',
-            company_size varchar(50) DEFAULT '',
-            industry varchar(50) DEFAULT '',
-            hours_reconciliation decimal(5,2) DEFAULT 0,
-            hours_cash_positioning decimal(5,2) DEFAULT 0,
-            num_banks int(3) DEFAULT 0,
-            ftes decimal(4,1) DEFAULT 0,
-            pain_points longtext DEFAULT '',
-            recommended_category varchar(50) DEFAULT '',
-            roi_low decimal(12,2) DEFAULT 0,
-            roi_base decimal(12,2) DEFAULT 0,
-            roi_high decimal(12,2) DEFAULT 0,
-            report_html longtext DEFAULT '',
-            ip_address varchar(45) DEFAULT '',
-            user_agent text DEFAULT '',
-            utm_source varchar(100) DEFAULT '',
-            utm_medium varchar(100) DEFAULT '',
-            utm_campaign varchar(100) DEFAULT '',
-            created_at datetime DEFAULT CURRENT_TIMESTAMP,
-            updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-            PRIMARY KEY (id),
-            UNIQUE KEY email_unique (email),
-            KEY created_at_index (created_at),
-            KEY company_size_index (company_size),
-            KEY recommended_category_index (recommended_category),
-            KEY email_created (email, created_at),
-            KEY roi_base_index (roi_base)
-        ) $charset_collate;";
+		$sql = "CREATE TABLE " . self::$table_name . " (
+			id mediumint(9) NOT NULL AUTO_INCREMENT,
+			email varchar(255) NOT NULL,
+			company_name varchar(255) DEFAULT '',
+			company_size varchar(50) DEFAULT '',
+			industry varchar(50) DEFAULT '',
+			hours_reconciliation decimal(5,2) DEFAULT 0,
+			hours_cash_positioning decimal(5,2) DEFAULT 0,
+			num_banks int(3) DEFAULT 0,
+			ftes decimal(4,1) DEFAULT 0,
+			pain_points longtext DEFAULT '',
+			recommended_category varchar(50) DEFAULT '',
+			roi_low decimal(12,2) DEFAULT 0,
+			roi_base decimal(12,2) DEFAULT 0,
+			roi_high decimal(12,2) DEFAULT 0,
+			report_html longtext DEFAULT '',
+			ip_address varchar(45) DEFAULT '',
+			user_agent text DEFAULT '',
+			utm_source varchar(100) DEFAULT '',
+			utm_medium varchar(100) DEFAULT '',
+			utm_campaign varchar(100) DEFAULT '',
+			created_at datetime DEFAULT CURRENT_TIMESTAMP,
+			updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY (id),
+			UNIQUE KEY email_unique (email),
+			KEY created_at_index (created_at),
+			KEY company_size_index (company_size),
+			KEY recommended_category_index (recommended_category),
+			KEY email_created (email, created_at),
+			KEY roi_base_index (roi_base)
+		) $charset_collate;";
 
-        try {
-            require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		try {
+			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-            $result = dbDelta( $sql );
+			$result = dbDelta( $sql );
 
-            // Check if table was actually created
-            $table_exists = $wpdb->get_var( $wpdb->prepare(
-                "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = %s AND table_name = %s",
-                DB_NAME,
-                self::$table_name
-            ) );
+			// Check if table was actually created
+			$table_exists = $wpdb->get_var( $wpdb->prepare(
+				"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = %s AND table_name = %s",
+				DB_NAME,
+				self::$table_name
+			) );
 
-            if ( ! $table_exists ) {
-                error_log( 'RTBCB: Failed to create table ' . self::$table_name );
+			if ( ! $table_exists ) {
+				error_log( 'RTBCB: Failed to create table ' . self::$table_name );
 
-                // Try to create table with simpler structure as fallback
-                $simple_sql = "CREATE TABLE IF NOT EXISTS " . self::$table_name . " (
-                    id mediumint(9) NOT NULL AUTO_INCREMENT,
-                    email varchar(255) NOT NULL,
-                    company_name varchar(255) DEFAULT '',
-                    company_size varchar(50) DEFAULT '',
-                    industry varchar(50) DEFAULT '',
-                    hours_reconciliation decimal(5,2) DEFAULT 0,
-                    hours_cash_positioning decimal(5,2) DEFAULT 0,
-                    num_banks int(3) DEFAULT 0,
-                    ftes decimal(4,1) DEFAULT 0,
-                    pain_points text DEFAULT '',
-                    recommended_category varchar(50) DEFAULT '',
-                    roi_low decimal(12,2) DEFAULT 0,
-                    roi_base decimal(12,2) DEFAULT 0,
-                    roi_high decimal(12,2) DEFAULT 0,
-                    report_html text DEFAULT '',
-                    ip_address varchar(45) DEFAULT '',
-                    user_agent text DEFAULT '',
-                    utm_source varchar(100) DEFAULT '',
-                    utm_medium varchar(100) DEFAULT '',
-                    utm_campaign varchar(100) DEFAULT '',
-                    created_at datetime DEFAULT CURRENT_TIMESTAMP,
-                    updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-                    PRIMARY KEY (id),
-                    UNIQUE KEY email_unique (email)
-                ) $charset_collate;";
+				// Try to create table with simpler structure as fallback
+				$simple_sql = "CREATE TABLE IF NOT EXISTS " . self::$table_name . " (
+					id mediumint(9) NOT NULL AUTO_INCREMENT,
+					email varchar(255) NOT NULL,
+					company_name varchar(255) DEFAULT '',
+					company_size varchar(50) DEFAULT '',
+					industry varchar(50) DEFAULT '',
+					hours_reconciliation decimal(5,2) DEFAULT 0,
+					hours_cash_positioning decimal(5,2) DEFAULT 0,
+					num_banks int(3) DEFAULT 0,
+					ftes decimal(4,1) DEFAULT 0,
+					pain_points text DEFAULT '',
+					recommended_category varchar(50) DEFAULT '',
+					roi_low decimal(12,2) DEFAULT 0,
+					roi_base decimal(12,2) DEFAULT 0,
+					roi_high decimal(12,2) DEFAULT 0,
+					report_html text DEFAULT '',
+					ip_address varchar(45) DEFAULT '',
+					user_agent text DEFAULT '',
+					utm_source varchar(100) DEFAULT '',
+					utm_medium varchar(100) DEFAULT '',
+					utm_campaign varchar(100) DEFAULT '',
+					created_at datetime DEFAULT CURRENT_TIMESTAMP,
+					updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+					PRIMARY KEY (id),
+					UNIQUE KEY email_unique (email)
+				) $charset_collate;";
 
-                $wpdb->query( $simple_sql );
+				$wpdb->query( $simple_sql );
 
-                // Check again
-                $table_exists = $wpdb->get_var( $wpdb->prepare(
-                    "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = %s AND table_name = %s",
-                    DB_NAME,
-                    self::$table_name
-                ) );
+				// Check again
+				$table_exists = $wpdb->get_var( $wpdb->prepare(
+					"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = %s AND table_name = %s",
+					DB_NAME,
+					self::$table_name
+				) );
 
-                if ( ! $table_exists ) {
-                    error_log( 'RTBCB: Failed to create table even with simple structure' );
-                    return false;
-                }
-            }
+				if ( ! $table_exists ) {
+					error_log( 'RTBCB: Failed to create table even with simple structure' );
+					return false;
+				}
+			}
 
-            error_log( 'RTBCB: Successfully created/updated table ' . self::$table_name );
-            return true;
+			error_log( 'RTBCB: Successfully created/updated table ' . self::$table_name );
+			return true;
 
-        } catch ( Exception $e ) {
-            error_log( 'RTBCB: Exception creating table: ' . $e->getMessage() );
-            return false;
-        } catch ( Error $e ) {
-            error_log( 'RTBCB: Fatal error creating table: ' . $e->getMessage() );
-            return false;
-        }
-    }
+		} catch ( Exception $e ) {
+			error_log( 'RTBCB: Exception creating table: ' . $e->getMessage() );
+			return false;
+		} catch ( Error $e ) {
+			error_log( 'RTBCB: Fatal error creating table: ' . $e->getMessage() );
+			return false;
+		}
+	}
 
-    /**
-     * Initialize the class with better error handling.
-     */
-    public static function init() {
-        global $wpdb;
-        self::$table_name = $wpdb->prefix . 'rtbcb_leads';
+	/**
+	 * Initialize the class with better error handling.
+	 */
+	public static function init() {
+		global $wpdb;
+		self::$table_name = $wpdb->prefix . 'rtbcb_leads';
 
-        // Try to create table and log results
-        $table_created = self::create_table();
+		// Try to create table and log results
+		$table_created = self::create_table();
 
-        if ( ! $table_created ) {
-            error_log( 'RTBCB: Warning - leads table creation failed, plugin may not function correctly' );
+		if ( ! $table_created ) {
+			error_log( 'RTBCB: Warning - leads table creation failed, plugin may not function correctly' );
 
-            // Add admin notice for database issues
-            add_action( 'admin_notices', function() {
-                echo '<div class="notice notice-error"><p>';
-                echo esc_html__( 'Real Treasury Business Case Builder: Database table creation failed. Please check your database permissions.', 'rtbcb' );
-                echo '</p></div>';
-            } );
-        }
-    }
+			// Add admin notice for database issues
+			add_action( 'admin_notices', function() {
+				echo '<div class="notice notice-error"><p>';
+				echo esc_html__( 'Real Treasury Business Case Builder: Database table creation failed. Please check your database permissions.', 'rtbcb' );
+				echo '</p></div>';
+			} );
+		}
+	}
 	/**
 	 * Add missing indexes to the leads table.
 	 *
@@ -166,8 +166,8 @@ class RTBCB_Leads {
 	 *
 	 * @return void
 	 */
-        public static function add_missing_indexes() {
-                global $wpdb;
+		public static function add_missing_indexes() {
+				global $wpdb;
 
 		self::$table_name = $wpdb->prefix . 'rtbcb_leads';
 
@@ -182,233 +182,233 @@ class RTBCB_Leads {
 			$wpdb->query( 'ALTER TABLE ' . self::$table_name . ' ADD KEY created_at_index (created_at)' );
 		}
 
-                if ( ! in_array( 'recommended_category_index', $index_names, true ) ) {
-                        $wpdb->query( 'ALTER TABLE ' . self::$table_name . ' ADD KEY recommended_category_index (recommended_category)' );
-                }
-        }
+				if ( ! in_array( 'recommended_category_index', $index_names, true ) ) {
+						$wpdb->query( 'ALTER TABLE ' . self::$table_name . ' ADD KEY recommended_category_index (recommended_category)' );
+				}
+		}
 
-    /**
-     * Compress existing report_html entries.
-     *
-     * @return void
-     */
-    public static function compress_existing_report_html() {
-        global $wpdb;
+	/**
+	 * Compress existing report_html entries.
+	 *
+	 * @return void
+	 */
+	public static function compress_existing_report_html() {
+		global $wpdb;
 
-        self::$table_name = $wpdb->prefix . 'rtbcb_leads';
+		self::$table_name = $wpdb->prefix . 'rtbcb_leads';
 
-        $leads = $wpdb->get_results(
-            "SELECT id, report_html FROM " . self::$table_name . " WHERE report_html != ''",
-            ARRAY_A
-        );
+		$leads = $wpdb->get_results(
+			"SELECT id, report_html FROM " . self::$table_name . " WHERE report_html != ''",
+			ARRAY_A
+		);
 
-        foreach ( $leads as $lead ) {
-            if ( false !== @gzuncompress( $lead['report_html'] ) ) {
-                continue;
-            }
+		foreach ( $leads as $lead ) {
+			if ( false !== @gzuncompress( $lead['report_html'] ) ) {
+				continue;
+			}
 
-            $compressed = gzcompress( $lead['report_html'] );
-            $wpdb->update(
-                self::$table_name,
-                [ 'report_html' => $compressed ],
-                [ 'id' => $lead['id'] ],
-                [ '%s' ],
-                [ '%d' ]
-            );
-        }
-    }
+			$compressed = gzcompress( $lead['report_html'] );
+			$wpdb->update(
+				self::$table_name,
+				[ 'report_html' => $compressed ],
+				[ 'id' => $lead['id'] ],
+				[ '%s' ],
+				[ '%d' ]
+			);
+		}
+	}
 
 
-    /**
-     * Save a lead to the database.
-     *
-     * @param array $lead_data Lead information.
-     * @return int|false Lead ID or false on failure.
-     */
-    public static function save_lead( $lead_data ) {
-        global $wpdb;
+	/**
+	 * Save a lead to the database.
+	 *
+	 * @param array $lead_data Lead information.
+	 * @return int|false Lead ID or false on failure.
+	 */
+	public static function save_lead( $lead_data ) {
+		global $wpdb;
 
-        // Validate required fields
-        if ( empty( $lead_data['email'] ) || ! is_email( $lead_data['email'] ) ) {
-            error_log( 'RTBCB: Invalid email provided to save_lead' );
-            return false;
-        }
+		// Validate required fields
+		if ( empty( $lead_data['email'] ) || ! is_email( $lead_data['email'] ) ) {
+			error_log( 'RTBCB: Invalid email provided to save_lead' );
+			return false;
+		}
 
-        // Sanitize data with proper validation
-        $sanitized_data = [
-            'email'                   => sanitize_email( $lead_data['email'] ),
-            'company_name'            => sanitize_text_field( $lead_data['company_name'] ?? '' ),
-            'company_size'            => sanitize_text_field( $lead_data['company_size'] ?? '' ),
-            'industry'                => sanitize_text_field( $lead_data['industry'] ?? '' ),
-            'hours_reconciliation'    => floatval( $lead_data['hours_reconciliation'] ?? 0 ),
-            'hours_cash_positioning'  => floatval( $lead_data['hours_cash_positioning'] ?? 0 ),
-            'num_banks'               => intval( $lead_data['num_banks'] ?? 0 ),
-            'ftes'                    => floatval( $lead_data['ftes'] ?? 0 ),
-            'pain_points'             => maybe_serialize( $lead_data['pain_points'] ?? [] ),
-            'recommended_category'    => sanitize_text_field( $lead_data['recommended_category'] ?? '' ),
-            'roi_low'                 => floatval( $lead_data['roi_low'] ?? 0 ),
-            'roi_base'                => floatval( $lead_data['roi_base'] ?? 0 ),
-            'roi_high'                => floatval( $lead_data['roi_high'] ?? 0 ),
-            'report_html'             => wp_kses_post( $lead_data['report_html'] ?? '' ),
-            'ip_address'              => self::get_client_ip(),
-            'user_agent'              => sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ?? '' ),
-            'utm_source'              => sanitize_text_field( $_GET['utm_source'] ?? '' ),
-            'utm_medium'              => sanitize_text_field( $_GET['utm_medium'] ?? '' ),
-            'utm_campaign'            => sanitize_text_field( $_GET['utm_campaign'] ?? '' ),
-        ];
+		// Sanitize data with proper validation
+		$sanitized_data = [
+			'email'                   => sanitize_email( $lead_data['email'] ),
+			'company_name'            => sanitize_text_field( $lead_data['company_name'] ?? '' ),
+			'company_size'            => sanitize_text_field( $lead_data['company_size'] ?? '' ),
+			'industry'                => sanitize_text_field( $lead_data['industry'] ?? '' ),
+			'hours_reconciliation'    => floatval( $lead_data['hours_reconciliation'] ?? 0 ),
+			'hours_cash_positioning'  => floatval( $lead_data['hours_cash_positioning'] ?? 0 ),
+			'num_banks'               => intval( $lead_data['num_banks'] ?? 0 ),
+			'ftes'                    => floatval( $lead_data['ftes'] ?? 0 ),
+			'pain_points'             => maybe_serialize( $lead_data['pain_points'] ?? [] ),
+			'recommended_category'    => sanitize_text_field( $lead_data['recommended_category'] ?? '' ),
+			'roi_low'                 => floatval( $lead_data['roi_low'] ?? 0 ),
+			'roi_base'                => floatval( $lead_data['roi_base'] ?? 0 ),
+			'roi_high'                => floatval( $lead_data['roi_high'] ?? 0 ),
+			'report_html'             => wp_kses_post( $lead_data['report_html'] ?? '' ),
+			'ip_address'              => self::get_client_ip(),
+			'user_agent'              => sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ?? '' ),
+			'utm_source'              => sanitize_text_field( $_GET['utm_source'] ?? '' ),
+			'utm_medium'              => sanitize_text_field( $_GET['utm_medium'] ?? '' ),
+			'utm_campaign'            => sanitize_text_field( $_GET['utm_campaign'] ?? '' ),
+		];
 
-        if ( ! empty( $sanitized_data['report_html'] ) ) {
-            $sanitized_data['report_html'] = gzcompress( $sanitized_data['report_html'] );
-        }
+		if ( ! empty( $sanitized_data['report_html'] ) ) {
+			$sanitized_data['report_html'] = gzcompress( $sanitized_data['report_html'] );
+		}
 
-        // Prepare format array to match the sanitized data
-        $formats = [
-            '%s', // email
-            '%s', // company_name
-            '%s', // company_size
-            '%s', // industry
-            '%f', // hours_reconciliation
-            '%f', // hours_cash_positioning
-            '%d', // num_banks
-            '%f', // ftes
-            '%s', // pain_points (serialized)
-            '%s', // recommended_category
-            '%f', // roi_low
-            '%f', // roi_base
-            '%f', // roi_high
-            '%s', // report_html
-            '%s', // ip_address
-            '%s', // user_agent
-            '%s', // utm_source
-            '%s', // utm_medium
-            '%s', // utm_campaign
-        ];
+		// Prepare format array to match the sanitized data
+		$formats = [
+			'%s', // email
+			'%s', // company_name
+			'%s', // company_size
+			'%s', // industry
+			'%f', // hours_reconciliation
+			'%f', // hours_cash_positioning
+			'%d', // num_banks
+			'%f', // ftes
+			'%s', // pain_points (serialized)
+			'%s', // recommended_category
+			'%f', // roi_low
+			'%f', // roi_base
+			'%f', // roi_high
+			'%s', // report_html
+			'%s', // ip_address
+			'%s', // user_agent
+			'%s', // utm_source
+			'%s', // utm_medium
+			'%s', // utm_campaign
+		];
 
-        // Check if lead exists
-        try {
-            $existing_lead = self::get_lead_by_email( $sanitized_data['email'] );
+		// Check if lead exists
+		try {
+			$existing_lead = self::get_lead_by_email( $sanitized_data['email'] );
 
-            if ( $existing_lead ) {
-                // Update existing lead
-                $result = $wpdb->update(
-                    self::$table_name,
-                    $sanitized_data,
-                    [ 'email' => $sanitized_data['email'] ],
-                    $formats,
-                    [ '%s' ]
-                );
+			if ( $existing_lead ) {
+				// Update existing lead
+				$result = $wpdb->update(
+					self::$table_name,
+					$sanitized_data,
+					[ 'email' => $sanitized_data['email'] ],
+					$formats,
+					[ '%s' ]
+				);
 
-                if ( false === $result ) {
-                    error_log( 'RTBCB: Database update failed: ' . $wpdb->last_error );
-                    return false;
-                }
+				if ( false === $result ) {
+					error_log( 'RTBCB: Database update failed: ' . $wpdb->last_error );
+					return false;
+				}
 
-                self::update_cached_statistics();
-                rtbcb_clear_report_cache();
-                return intval( $existing_lead['id'] );
-            } else {
-                // Insert new lead
-                $result = $wpdb->insert(
-                    self::$table_name,
-                    $sanitized_data,
-                    $formats
-                );
+				self::update_cached_statistics();
+				rtbcb_clear_report_cache();
+				return intval( $existing_lead['id'] );
+			} else {
+				// Insert new lead
+				$result = $wpdb->insert(
+					self::$table_name,
+					$sanitized_data,
+					$formats
+				);
 
-                if ( false === $result ) {
-                    error_log( 'RTBCB: Database insert failed: ' . $wpdb->last_error );
-                    return false;
-                }
+				if ( false === $result ) {
+					error_log( 'RTBCB: Database insert failed: ' . $wpdb->last_error );
+					return false;
+				}
 
-                $lead_id = $wpdb->insert_id;
-                self::update_cached_statistics();
-                rtbcb_clear_report_cache();
-                return $lead_id;
-            }
-        } catch ( Exception $e ) {
-            error_log( 'RTBCB: Exception in save_lead: ' . $e->getMessage() );
-            return false;
-        } catch ( Error $e ) {
-            error_log( 'RTBCB: Fatal error in save_lead: ' . $e->getMessage() );
-            return false;
-        }
-    }
+				$lead_id = $wpdb->insert_id;
+				self::update_cached_statistics();
+				rtbcb_clear_report_cache();
+				return $lead_id;
+			}
+		} catch ( Exception $e ) {
+			error_log( 'RTBCB: Exception in save_lead: ' . $e->getMessage() );
+			return false;
+		} catch ( Error $e ) {
+			error_log( 'RTBCB: Fatal error in save_lead: ' . $e->getMessage() );
+			return false;
+		}
+	}
 
-    /**
-     * Get a lead by email address.
-     *
-     * @param string $email Email address.
-     * @return array|null Lead data or null if not found.
-     */
-    public static function get_lead_by_email( $email ) {
-        global $wpdb;
+	/**
+	 * Get a lead by email address.
+	 *
+	 * @param string $email Email address.
+	 * @return array|null Lead data or null if not found.
+	 */
+	public static function get_lead_by_email( $email ) {
+		global $wpdb;
 
-        $result = $wpdb->get_row(
-            $wpdb->prepare(
-                "SELECT * FROM " . self::$table_name . " WHERE email = %s",
-                sanitize_email( $email )
-            ),
-            ARRAY_A
-        );
+		$result = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM " . self::$table_name . " WHERE email = %s",
+				sanitize_email( $email )
+			),
+			ARRAY_A
+		);
 
-        if ( $result ) {
-            $result['pain_points'] = maybe_unserialize( $result['pain_points'] );
+		if ( $result ) {
+			$result['pain_points'] = maybe_unserialize( $result['pain_points'] );
 
-            if ( ! empty( $result['report_html'] ) ) {
-                $uncompressed = @gzuncompress( $result['report_html'] );
-                if ( false !== $uncompressed ) {
-                    $result['report_html'] = $uncompressed;
-                }
-            }
-        }
+			if ( ! empty( $result['report_html'] ) ) {
+				$uncompressed = @gzuncompress( $result['report_html'] );
+				if ( false !== $uncompressed ) {
+					$result['report_html'] = $uncompressed;
+				}
+			}
+		}
 
-        return $result;
-    }
+		return $result;
+	}
 
-    /**
-     * Get all leads with pagination and filtering.
-     *
-     * @param array $args Query arguments.
-     * @return array Leads data with pagination info.
-     */
-    public static function get_all_leads( $args = [] ) {
-        global $wpdb;
+	/**
+	 * Get all leads with pagination and filtering.
+	 *
+	 * @param array $args Query arguments.
+	 * @return array Leads data with pagination info.
+	 */
+	public static function get_all_leads( $args = [] ) {
+		global $wpdb;
 
-        $defaults = [
-            'per_page'    => 20,
-            'page'        => 1,
-            'orderby'     => 'created_at',
-            'order'       => 'DESC',
-            'search'      => '',
-            'category'    => '',
-            'date_from'   => '',
-            'date_to'     => '',
-        ];
+		$defaults = [
+			'per_page'    => 20,
+			'page'        => 1,
+			'orderby'     => 'created_at',
+			'order'       => 'DESC',
+			'search'      => '',
+			'category'    => '',
+			'date_from'   => '',
+			'date_to'     => '',
+		];
 
-        $args = wp_parse_args( $args, $defaults );
+		$args = wp_parse_args( $args, $defaults );
 
-        // Build WHERE clause
-        $where_conditions = [ '1=1' ];
-        $prepare_values = [];
+		// Build WHERE clause
+		$where_conditions = [ '1=1' ];
+		$prepare_values = [];
 
-        if ( ! empty( $args['search'] ) ) {
-            $where_conditions[] = 'email LIKE %s';
-            $prepare_values[] = '%' . $wpdb->esc_like( $args['search'] ) . '%';
-        }
+		if ( ! empty( $args['search'] ) ) {
+			$where_conditions[] = 'email LIKE %s';
+			$prepare_values[] = '%' . $wpdb->esc_like( $args['search'] ) . '%';
+		}
 
-        if ( ! empty( $args['category'] ) ) {
-            $where_conditions[] = 'recommended_category = %s';
-            $prepare_values[] = $args['category'];
-        }
+		if ( ! empty( $args['category'] ) ) {
+			$where_conditions[] = 'recommended_category = %s';
+			$prepare_values[] = $args['category'];
+		}
 
-        if ( ! empty( $args['date_from'] ) ) {
-            $where_conditions[] = 'created_at >= %s';
-            $prepare_values[] = $args['date_from'] . ' 00:00:00';
-        }
+		if ( ! empty( $args['date_from'] ) ) {
+			$where_conditions[] = 'created_at >= %s';
+			$prepare_values[] = $args['date_from'] . ' 00:00:00';
+		}
 
-        if ( ! empty( $args['date_to'] ) ) {
-            $where_conditions[] = 'created_at <= %s';
-            $prepare_values[] = $args['date_to'] . ' 23:59:59';
-        }
+		if ( ! empty( $args['date_to'] ) ) {
+			$where_conditions[] = 'created_at <= %s';
+			$prepare_values[] = $args['date_to'] . ' 23:59:59';
+		}
 
 		$where_clause = implode( ' AND ', $where_conditions );
 
@@ -424,169 +424,169 @@ class RTBCB_Leads {
 		$leads       = $wpdb->get_results( $wpdb->prepare( $sql, $prepare_values ), ARRAY_A );
 		$total_leads = (int) $wpdb->get_var( 'SELECT FOUND_ROWS()' );
 
-        // Unserialize pain points and decompress report HTML.
-        foreach ( $leads as &$lead ) {
-            $lead['pain_points'] = maybe_unserialize( $lead['pain_points'] );
+		// Unserialize pain points and decompress report HTML.
+		foreach ( $leads as &$lead ) {
+			$lead['pain_points'] = maybe_unserialize( $lead['pain_points'] );
 
-            if ( ! empty( $lead['report_html'] ) ) {
-                $uncompressed = @gzuncompress( $lead['report_html'] );
-                if ( false !== $uncompressed ) {
-                    $lead['report_html'] = $uncompressed;
-                }
-            }
-        }
+			if ( ! empty( $lead['report_html'] ) ) {
+				$uncompressed = @gzuncompress( $lead['report_html'] );
+				if ( false !== $uncompressed ) {
+					$lead['report_html'] = $uncompressed;
+				}
+			}
+		}
 
-        return [
-            'leads'       => $leads,
-            'total'       => intval( $total_leads ),
-            'per_page'    => $args['per_page'],
-            'current_page'=> $args['page'],
-            'total_pages' => ceil( $total_leads / $args['per_page'] ),
-        ];
-    }
+		return [
+			'leads'       => $leads,
+			'total'       => intval( $total_leads ),
+			'per_page'    => $args['per_page'],
+			'current_page'=> $args['page'],
+			'total_pages' => ceil( $total_leads / $args['per_page'] ),
+		];
+	}
 
-    /**
-     * Get lead statistics.
-     *
-     * @return array Statistics data.
-     */
-    public static function get_statistics() {
-        global $wpdb;
+	/**
+	 * Get lead statistics.
+	 *
+	 * @return array Statistics data.
+	 */
+	public static function get_statistics() {
+		global $wpdb;
 
-        $stats = [];
+		$stats = [];
 
-        // Total leads
-        $stats['total_leads'] = $wpdb->get_var( "SELECT COUNT(*) FROM " . self::$table_name );
+		// Total leads
+		$stats['total_leads'] = $wpdb->get_var( "SELECT COUNT(*) FROM " . self::$table_name );
 
-        // Leads by category
-        $category_stats = $wpdb->get_results(
-            "SELECT recommended_category, COUNT(*) as count FROM " . self::$table_name . " 
-             WHERE recommended_category != '' 
-             GROUP BY recommended_category",
-            ARRAY_A
-        );
-        $stats['by_category'] = $category_stats;
+		// Leads by category
+		$category_stats = $wpdb->get_results(
+			"SELECT recommended_category, COUNT(*) as count FROM " . self::$table_name . " 
+			 WHERE recommended_category != '' 
+			 GROUP BY recommended_category",
+			ARRAY_A
+		);
+		$stats['by_category'] = $category_stats;
 
-        // Leads by company size
-        $size_stats = $wpdb->get_results(
-            "SELECT company_size, COUNT(*) as count FROM " . self::$table_name . " 
-             WHERE company_size != '' 
-             GROUP BY company_size",
-            ARRAY_A
-        );
-        $stats['by_company_size'] = $size_stats;
+		// Leads by company size
+		$size_stats = $wpdb->get_results(
+			"SELECT company_size, COUNT(*) as count FROM " . self::$table_name . " 
+			 WHERE company_size != '' 
+			 GROUP BY company_size",
+			ARRAY_A
+		);
+		$stats['by_company_size'] = $size_stats;
 
-        // Average ROI
-        $roi_stats = $wpdb->get_row(
-            "SELECT AVG(roi_low) as avg_low, AVG(roi_base) as avg_base, AVG(roi_high) as avg_high 
-             FROM " . self::$table_name . " 
-             WHERE roi_base > 0",
-            ARRAY_A
-        );
-        $stats['average_roi'] = $roi_stats;
+		// Average ROI
+		$roi_stats = $wpdb->get_row(
+			"SELECT AVG(roi_low) as avg_low, AVG(roi_base) as avg_base, AVG(roi_high) as avg_high 
+			 FROM " . self::$table_name . " 
+			 WHERE roi_base > 0",
+			ARRAY_A
+		);
+		$stats['average_roi'] = $roi_stats;
 
-        // Recent activity (last 30 days)
-        $stats['recent_leads'] = $wpdb->get_var(
-            "SELECT COUNT(*) FROM " . self::$table_name . "
-             WHERE created_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)"
-        );
+		// Recent activity (last 30 days)
+		$stats['recent_leads'] = $wpdb->get_var(
+			"SELECT COUNT(*) FROM " . self::$table_name . "
+			 WHERE created_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)"
+		);
 
-        return $stats;
-    }
+		return $stats;
+	}
 
-    /**
-     * Update cached statistics option.
-     *
-     * @return array Cached statistics.
-     */
-    public static function update_cached_statistics() {
-        $stats = self::get_statistics();
-        update_option( self::$cache_option, $stats );
-        return $stats;
-    }
+	/**
+	 * Update cached statistics option.
+	 *
+	 * @return array Cached statistics.
+	 */
+	public static function update_cached_statistics() {
+		$stats = self::get_statistics();
+		update_option( self::$cache_option, $stats );
+		return $stats;
+	}
 
-    /**
-     * Retrieve cached statistics.
-     *
-     * @return array Cached statistics.
-     */
-    public static function get_cached_statistics() {
-        $stats = get_option( self::$cache_option, [] );
-        if ( empty( $stats ) ) {
-            $stats = self::update_cached_statistics();
-        }
-        return $stats;
-    }
+	/**
+	 * Retrieve cached statistics.
+	 *
+	 * @return array Cached statistics.
+	 */
+	public static function get_cached_statistics() {
+		$stats = get_option( self::$cache_option, [] );
+		if ( empty( $stats ) ) {
+			$stats = self::update_cached_statistics();
+		}
+		return $stats;
+	}
 
-    /**
-     * Export leads to CSV.
-     *
-     * @param array $args Export arguments.
-     * @return string CSV content.
-     */
-    public static function export_to_csv( $args = [] ) {
-        $leads_data = self::get_all_leads( array_merge( $args, [ 'per_page' => -1 ] ) );
-        $leads = $leads_data['leads'];
+	/**
+	 * Export leads to CSV.
+	 *
+	 * @param array $args Export arguments.
+	 * @return string CSV content.
+	 */
+	public static function export_to_csv( $args = [] ) {
+		$leads_data = self::get_all_leads( array_merge( $args, [ 'per_page' => -1 ] ) );
+		$leads = $leads_data['leads'];
 
-        $csv_content = '';
+		$csv_content = '';
 
-        // Headers
-        $headers = [
-            'Email', 'Company Size', 'Industry', 'Hours Reconciliation',
-            'Hours Cash Positioning', 'Number of Banks', 'FTEs',
-            'Pain Points', 'Recommended Category', 'ROI Low', 'ROI Base',
-            'ROI High', 'Created At', 'UTM Source', 'UTM Medium', 'UTM Campaign'
-        ];
-        $csv_content .= implode( ',', $headers ) . "\n";
+		// Headers
+		$headers = [
+			'Email', 'Company Size', 'Industry', 'Hours Reconciliation',
+			'Hours Cash Positioning', 'Number of Banks', 'FTEs',
+			'Pain Points', 'Recommended Category', 'ROI Low', 'ROI Base',
+			'ROI High', 'Created At', 'UTM Source', 'UTM Medium', 'UTM Campaign'
+		];
+		$csv_content .= implode( ',', $headers ) . "\n";
 
-        // Data rows
-        foreach ( $leads as $lead ) {
-            $row = [
-                '"' . str_replace( '"', '""', $lead['email'] ) . '"',
-                '"' . str_replace( '"', '""', $lead['company_size'] ) . '"',
-                '"' . str_replace( '"', '""', $lead['industry'] ) . '"',
-                $lead['hours_reconciliation'],
-                $lead['hours_cash_positioning'],
-                $lead['num_banks'],
-                $lead['ftes'],
-                '"' . str_replace( '"', '""', implode( '; ', (array) $lead['pain_points'] ) ) . '"',
-                '"' . str_replace( '"', '""', $lead['recommended_category'] ) . '"',
-                $lead['roi_low'],
-                $lead['roi_base'],
-                $lead['roi_high'],
-                $lead['created_at'],
-                '"' . str_replace( '"', '""', $lead['utm_source'] ) . '"',
-                '"' . str_replace( '"', '""', $lead['utm_medium'] ) . '"',
-                '"' . str_replace( '"', '""', $lead['utm_campaign'] ) . '"',
-            ];
-            $csv_content .= implode( ',', $row ) . "\n";
-        }
+		// Data rows
+		foreach ( $leads as $lead ) {
+			$row = [
+				'"' . str_replace( '"', '""', $lead['email'] ) . '"',
+				'"' . str_replace( '"', '""', $lead['company_size'] ) . '"',
+				'"' . str_replace( '"', '""', $lead['industry'] ) . '"',
+				$lead['hours_reconciliation'],
+				$lead['hours_cash_positioning'],
+				$lead['num_banks'],
+				$lead['ftes'],
+				'"' . str_replace( '"', '""', implode( '; ', (array) $lead['pain_points'] ) ) . '"',
+				'"' . str_replace( '"', '""', $lead['recommended_category'] ) . '"',
+				$lead['roi_low'],
+				$lead['roi_base'],
+				$lead['roi_high'],
+				$lead['created_at'],
+				'"' . str_replace( '"', '""', $lead['utm_source'] ) . '"',
+				'"' . str_replace( '"', '""', $lead['utm_medium'] ) . '"',
+				'"' . str_replace( '"', '""', $lead['utm_campaign'] ) . '"',
+			];
+			$csv_content .= implode( ',', $row ) . "\n";
+		}
 
-        return $csv_content;
-    }
+		return $csv_content;
+	}
 
-    /**
-     * Get client IP address.
-     *
-     * @return string IP address.
-     */
-    private static function get_client_ip() {
-        $ip_keys = [ 'HTTP_X_FORWARDED_FOR', 'HTTP_X_REAL_IP', 'HTTP_CLIENT_IP', 'REMOTE_ADDR' ];
+	/**
+	 * Get client IP address.
+	 *
+	 * @return string IP address.
+	 */
+	private static function get_client_ip() {
+		$ip_keys = [ 'HTTP_X_FORWARDED_FOR', 'HTTP_X_REAL_IP', 'HTTP_CLIENT_IP', 'REMOTE_ADDR' ];
 
-        foreach ( $ip_keys as $key ) {
-            if ( ! empty( $_SERVER[ $key ] ) ) {
-                $ip = $_SERVER[ $key ];
-                if ( strpos( $ip, ',' ) !== false ) {
-                    $ip = trim( explode( ',', $ip )[0] );
-                }
-                if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
-                    return $ip;
-                }
-            }
-        }
+		foreach ( $ip_keys as $key ) {
+			if ( ! empty( $_SERVER[ $key ] ) ) {
+				$ip = $_SERVER[ $key ];
+				if ( strpos( $ip, ',' ) !== false ) {
+					$ip = trim( explode( ',', $ip )[0] );
+				}
+				if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+					return $ip;
+				}
+			}
+		}
 
-        return $_SERVER['REMOTE_ADDR'] ?? '';
-    }
+		return $_SERVER['REMOTE_ADDR'] ?? '';
+	}
 }
 
 // Initialize the class

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2,318 +2,318 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Enhanced LLM integration with comprehensive business analysis
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Enhanced LLM integration with comprehensive business analysis
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/helpers.php';
 
 class RTBCB_LLM {
-    private $api_key;
-    private $current_inputs = [];
+	private $api_key;
+	private $current_inputs = [];
 
-    /**
-     * GPT-5 configuration settings.
-     *
-     * @var array
-     */
-    private $gpt5_config;
+	/**
+	 * GPT-5 configuration settings.
+	 *
+	 * @var array
+	 */
+	private $gpt5_config;
 
-    /**
-     * Last JSON-decoded request body sent to OpenAI.
-     *
-     * @var array|null
-     */
-    protected $last_request;
+	/**
+	 * Last JSON-decoded request body sent to OpenAI.
+	 *
+	 * @var array|null
+	 */
+	protected $last_request;
 
-    /**
-     * Last response or WP_Error returned from the OpenAI API.
-     *
-     * @var array|WP_Error|null
-     */
-    protected $last_response;
+	/**
+	 * Last response or WP_Error returned from the OpenAI API.
+	 *
+	 * @var array|WP_Error|null
+	 */
+	protected $last_response;
 
-    /**
-     * Serialized company research from the last request.
-     *
-     * @var string|null
-     */
-    protected $last_company_research;
+	/**
+	 * Serialized company research from the last request.
+	 *
+	 * @var string|null
+	 */
+	protected $last_company_research;
 
-    public function __construct() {
-        $this->api_key = rtbcb_get_openai_api_key();
+	public function __construct() {
+		$this->api_key = rtbcb_get_openai_api_key();
 
-        $timeout           = rtbcb_get_api_timeout();
-        $max_output_tokens = intval( get_option( 'rtbcb_gpt5_max_output_tokens', 8000 ) );
-        $config            = rtbcb_get_gpt5_config(
-            array_merge(
-                get_option( 'rtbcb_gpt5_config', [] ),
-                [
-                    'timeout'           => $timeout,
-                    'max_output_tokens' => $max_output_tokens,
-                ]
-            )
-        );
-        $this->gpt5_config = $config;
+		$timeout           = rtbcb_get_api_timeout();
+		$max_output_tokens = intval( get_option( 'rtbcb_gpt5_max_output_tokens', 8000 ) );
+		$config            = rtbcb_get_gpt5_config(
+			array_merge(
+				get_option( 'rtbcb_gpt5_config', [] ),
+				[
+					'timeout'           => $timeout,
+					'max_output_tokens' => $max_output_tokens,
+				]
+			)
+		);
+		$this->gpt5_config = $config;
 
-        if ( empty( $this->api_key ) ) {
-            error_log( 'RTBCB: OpenAI API key not configured' );
-        }
-    }
+		if ( empty( $this->api_key ) ) {
+			error_log( 'RTBCB: OpenAI API key not configured' );
+		}
+	}
 
-    /**
-     * Get the configured model for a given tier.
-     *
-     * Retrieves the model name from the WordPress options table and falls
-     * back to the plugin's default if the option is not set.
-     *
-     * @param string $tier Model tier identifier.
-     * @return string Sanitized model name.
-     */
-    private function get_model( $tier ) {
-        $tier    = sanitize_key( $tier );
-        $default = rtbcb_get_default_model( $tier );
-        $model   = get_option( "rtbcb_{$tier}_model", $default );
+	/**
+	 * Get the configured model for a given tier.
+	 *
+	 * Retrieves the model name from the WordPress options table and falls
+	 * back to the plugin's default if the option is not set.
+	 *
+	 * @param string $tier Model tier identifier.
+	 * @return string Sanitized model name.
+	 */
+	private function get_model( $tier ) {
+		$tier    = sanitize_key( $tier );
+		$default = rtbcb_get_default_model( $tier );
+		$model   = get_option( "rtbcb_{$tier}_model", $default );
 
-        return sanitize_text_field( $model );
-    }
+		return sanitize_text_field( $model );
+	}
 
-    /**
-     * Retrieve the last request body sent to the OpenAI API.
-     *
-     * @return array|null Last request body.
-     */
-    public function get_last_request() {
-        return $this->last_request;
-    }
+	/**
+	 * Retrieve the last request body sent to the OpenAI API.
+	 *
+	 * @return array|null Last request body.
+	 */
+	public function get_last_request() {
+		return $this->last_request;
+	}
 
-    /**
-     * Retrieve the last response returned from the OpenAI API.
-     *
-     * @return array|WP_Error|null Last response or WP_Error.
-     */
-    public function get_last_response() {
-        return $this->last_response;
-    }
+	/**
+	 * Retrieve the last response returned from the OpenAI API.
+	 *
+	 * @return array|WP_Error|null Last response or WP_Error.
+	 */
+	public function get_last_response() {
+		return $this->last_response;
+	}
 
-    /**
-     * Estimate token usage from a desired word count.
-     *
-     * @param int $words Desired word count.
-     * @return int Estimated token count capped by configuration.
-     */
-    private function estimate_tokens( $words ) {
-        $words       = max( 0, intval( $words ) );
-        $tokens      = (int) ceil( $words * 1.5 );
-        $limit       = intval( $this->gpt5_config['max_output_tokens'] ?? 8000 );
-        $min_tokens  = intval( $this->gpt5_config['min_output_tokens'] ?? 1 );
-        $limit       = min( 128000, max( $min_tokens, $limit ) );
+	/**
+	 * Estimate token usage from a desired word count.
+	 *
+	 * @param int $words Desired word count.
+	 * @return int Estimated token count capped by configuration.
+	 */
+	private function estimate_tokens( $words ) {
+		$words       = max( 0, intval( $words ) );
+		$tokens      = (int) ceil( $words * 1.5 );
+		$limit       = intval( $this->gpt5_config['max_output_tokens'] ?? 8000 );
+		$min_tokens  = intval( $this->gpt5_config['min_output_tokens'] ?? 1 );
+		$limit       = min( 128000, max( $min_tokens, $limit ) );
 
-        return max( $min_tokens, min( $tokens, $limit ) );
-    }
+		return max( $min_tokens, min( $tokens, $limit ) );
+	}
 
-    /**
-     * Determine token limit for a report type.
-     *
-     * @param string $type Report type identifier.
-     * @return int Estimated token count for the report.
-     */
-    private function tokens_for_report( $type ) {
-        $targets = [
-            'business_case'             => 600,
-            'industry_commentary'       => 60,
-            'company_overview'          => 400,
-            'industry_overview'         => 400,
-            'treasury_tech_overview'    => 400,
-            'real_treasury_overview'    => 400,
-            'category_recommendation'   => 200,
-            'benefits_estimate'         => 200,
-            'comprehensive_business_case' => 2000,
-            'competitive_context'       => 200,
-            'industry_analysis'         => 400,
-            'tech_research'             => 400,
-        ];
+	/**
+	 * Determine token limit for a report type.
+	 *
+	 * @param string $type Report type identifier.
+	 * @return int Estimated token count for the report.
+	 */
+	private function tokens_for_report( $type ) {
+		$targets = [
+			'business_case'             => 600,
+			'industry_commentary'       => 60,
+			'company_overview'          => 400,
+			'industry_overview'         => 400,
+			'treasury_tech_overview'    => 400,
+			'real_treasury_overview'    => 400,
+			'category_recommendation'   => 200,
+			'benefits_estimate'         => 200,
+			'comprehensive_business_case' => 2000,
+			'competitive_context'       => 200,
+			'industry_analysis'         => 400,
+			'tech_research'             => 400,
+		];
 
-        $words = $targets[ $type ] ?? 800;
+		$words = $targets[ $type ] ?? 800;
 
-        return $this->estimate_tokens( $words );
-    }
+		return $this->estimate_tokens( $words );
+	}
 
-    /**
-     * Generate a simplified business case analysis.
-     *
-     * Attempts to call the LLM for a brief analysis. If no API key is
-     * configured or the LLM call fails, a {@see WP_Error} is returned for the
-     * caller to handle.
-     *
-     * @param array       $user_inputs    Sanitized user inputs.
-     * @param array       $roi_data       ROI calculation data.
-     * @param array       $context_chunks Optional context strings for the prompt.
-     * @param string|null $model          LLM model to use.
-     *
-     * @return array|WP_Error Simplified analysis array or error object.
-     */
-    public function generate_business_case( $user_inputs, $roi_data, $context_chunks = [], $model = null ) {
-        $inputs = [
-            'company_name'           => sanitize_text_field( $user_inputs['company_name'] ?? '' ),
-            'company_size'           => sanitize_text_field( $user_inputs['company_size'] ?? '' ),
-            'industry'               => sanitize_text_field( $user_inputs['industry'] ?? '' ),
-            'hours_reconciliation'   => floatval( $user_inputs['hours_reconciliation'] ?? 0 ),
-            'hours_cash_positioning' => floatval( $user_inputs['hours_cash_positioning'] ?? 0 ),
-            'num_banks'              => intval( $user_inputs['num_banks'] ?? 0 ),
-            'ftes'                   => floatval( $user_inputs['ftes'] ?? 0 ),
-            'pain_points'            => array_map( 'sanitize_text_field', (array) ( $user_inputs['pain_points'] ?? [] ) ),
-        ];
+	/**
+	 * Generate a simplified business case analysis.
+	 *
+	 * Attempts to call the LLM for a brief analysis. If no API key is
+	 * configured or the LLM call fails, a {@see WP_Error} is returned for the
+	 * caller to handle.
+	 *
+	 * @param array       $user_inputs    Sanitized user inputs.
+	 * @param array       $roi_data       ROI calculation data.
+	 * @param array       $context_chunks Optional context strings for the prompt.
+	 * @param string|null $model          LLM model to use.
+	 *
+	 * @return array|WP_Error Simplified analysis array or error object.
+	 */
+	public function generate_business_case( $user_inputs, $roi_data, $context_chunks = [], $model = null ) {
+		$inputs = [
+			'company_name'           => sanitize_text_field( $user_inputs['company_name'] ?? '' ),
+			'company_size'           => sanitize_text_field( $user_inputs['company_size'] ?? '' ),
+			'industry'               => sanitize_text_field( $user_inputs['industry'] ?? '' ),
+			'hours_reconciliation'   => floatval( $user_inputs['hours_reconciliation'] ?? 0 ),
+			'hours_cash_positioning' => floatval( $user_inputs['hours_cash_positioning'] ?? 0 ),
+			'num_banks'              => intval( $user_inputs['num_banks'] ?? 0 ),
+			'ftes'                   => floatval( $user_inputs['ftes'] ?? 0 ),
+			'pain_points'            => array_map( 'sanitize_text_field', (array) ( $user_inputs['pain_points'] ?? [] ) ),
+		];
 
-        $this->current_inputs = $inputs;
+		$this->current_inputs = $inputs;
 
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
 
-        $selected_model = $model ? sanitize_text_field( $model ) : $this->get_model( 'mini' );
-        $prompt = 'Create a concise treasury technology business case in JSON with keys '
-            . 'executive_summary (strategic_positioning, business_case_strength, key_value_drivers[], '
-            . 'executive_recommendation), operational_analysis (current_state_assessment), '
-            . 'industry_insights (sector_trends, competitive_benchmarks, regulatory_considerations).'
-            . '\nCompany: ' . $inputs['company_name']
-            . '\nIndustry: ' . $inputs['industry']
-            . '\nSize: ' . $inputs['company_size']
-            . '\nPain Points: ' . implode( ', ', $inputs['pain_points'] );
+		$selected_model = $model ? sanitize_text_field( $model ) : $this->get_model( 'mini' );
+		$prompt = 'Create a concise treasury technology business case in JSON with keys '
+			. 'executive_summary (strategic_positioning, business_case_strength, key_value_drivers[], '
+			. 'executive_recommendation), operational_analysis (current_state_assessment), '
+			. 'industry_insights (sector_trends, competitive_benchmarks, regulatory_considerations).'
+			. '\nCompany: ' . $inputs['company_name']
+			. '\nIndustry: ' . $inputs['industry']
+			. '\nSize: ' . $inputs['company_size']
+			. '\nPain Points: ' . implode( ', ', $inputs['pain_points'] );
 
-        if ( ! empty( $context_chunks ) ) {
-            $prompt .= '\nContext: ' . implode( '\n', array_map( 'sanitize_text_field', $context_chunks ) );
-        }
+		if ( ! empty( $context_chunks ) ) {
+			$prompt .= '\nContext: ' . implode( '\n', array_map( 'sanitize_text_field', $context_chunks ) );
+		}
 
-        $history   = [
-            [
-                'role'    => 'user',
-                'content' => $prompt,
-            ],
-        ];
-        $context = $this->build_context_for_responses( $history );
-        $tokens  = $this->tokens_for_report( 'business_case' );
-        $response = $this->call_openai_with_retry( $selected_model, $context, $tokens );
+		$history   = [
+			[
+				'role'    => 'user',
+				'content' => $prompt,
+			],
+		];
+		$context = $this->build_context_for_responses( $history );
+		$tokens  = $this->tokens_for_report( 'business_case' );
+		$response = $this->call_openai_with_retry( $selected_model, $context, $tokens );
 
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error( 'llm_failure', __( 'Unable to generate analysis at this time.', 'rtbcb' ) );
-        }
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'llm_failure', __( 'Unable to generate analysis at this time.', 'rtbcb' ) );
+		}
 
-        $parsed = rtbcb_parse_gpt5_response( $response );
-        $json   = json_decode( $parsed['output_text'], true );
+		$parsed = rtbcb_parse_gpt5_response( $response );
+		$json   = json_decode( $parsed['output_text'], true );
 
-        if ( ! is_array( $json ) ) {
-            return new WP_Error( 'llm_parse_error', __( 'Invalid response from language model.', 'rtbcb' ) );
-        }
+		if ( ! is_array( $json ) ) {
+			return new WP_Error( 'llm_parse_error', __( 'Invalid response from language model.', 'rtbcb' ) );
+		}
 
-        $analysis = [
-            'company_name'       => $inputs['company_name'],
-            'analysis_date'      => current_time( 'Y-m-d' ),
-            'executive_summary'  => [
-                'strategic_positioning'   => sanitize_text_field( $json['executive_summary']['strategic_positioning'] ?? '' ),
-                'business_case_strength'  => sanitize_text_field( $json['executive_summary']['business_case_strength'] ?? '' ),
-                'key_value_drivers'       => array_map( 'sanitize_text_field', $json['executive_summary']['key_value_drivers'] ?? [] ),
-                'executive_recommendation'=> sanitize_text_field( $json['executive_summary']['executive_recommendation'] ?? '' ),
-            ],
-            'operational_analysis' => [
-                'current_state_assessment' => sanitize_text_field( $json['operational_analysis']['current_state_assessment'] ?? '' ),
-            ],
-            'industry_insights'   => [
-                'sector_trends'          => sanitize_text_field( $json['industry_insights']['sector_trends'] ?? '' ),
-                'competitive_benchmarks' => sanitize_text_field( $json['industry_insights']['competitive_benchmarks'] ?? '' ),
-                'regulatory_considerations' => sanitize_text_field( $json['industry_insights']['regulatory_considerations'] ?? '' ),
-            ],
-            'financial_analysis' => $this->build_financial_analysis( $roi_data, $inputs ),
-        ];
+		$analysis = [
+			'company_name'       => $inputs['company_name'],
+			'analysis_date'      => current_time( 'Y-m-d' ),
+			'executive_summary'  => [
+				'strategic_positioning'   => sanitize_text_field( $json['executive_summary']['strategic_positioning'] ?? '' ),
+				'business_case_strength'  => sanitize_text_field( $json['executive_summary']['business_case_strength'] ?? '' ),
+				'key_value_drivers'       => array_map( 'sanitize_text_field', $json['executive_summary']['key_value_drivers'] ?? [] ),
+				'executive_recommendation'=> sanitize_text_field( $json['executive_summary']['executive_recommendation'] ?? '' ),
+			],
+			'operational_analysis' => [
+				'current_state_assessment' => sanitize_text_field( $json['operational_analysis']['current_state_assessment'] ?? '' ),
+			],
+			'industry_insights'   => [
+				'sector_trends'          => sanitize_text_field( $json['industry_insights']['sector_trends'] ?? '' ),
+				'competitive_benchmarks' => sanitize_text_field( $json['industry_insights']['competitive_benchmarks'] ?? '' ),
+				'regulatory_considerations' => sanitize_text_field( $json['industry_insights']['regulatory_considerations'] ?? '' ),
+			],
+			'financial_analysis' => $this->build_financial_analysis( $roi_data, $inputs ),
+		];
 
-        return $analysis;
-    }
+		return $analysis;
+	}
 
-    /**
-     * Generate short commentary for a given industry.
-     *
-     * @param string $industry Industry slug.
-     * @return string|WP_Error Commentary text or error object.
-     */
-    public function generate_industry_commentary( $industry ) {
-        $industry = sanitize_text_field( $industry );
+	/**
+	 * Generate short commentary for a given industry.
+	 *
+	 * @param string $industry Industry slug.
+	 * @return string|WP_Error Commentary text or error object.
+	 */
+	public function generate_industry_commentary( $industry ) {
+		$industry = sanitize_text_field( $industry );
 
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
 
-        $model  = $this->get_model( 'mini' );
-        $prompt = 'Provide a brief treasury industry commentary for the ' . $industry . ' industry in two sentences.';
+		$model  = $this->get_model( 'mini' );
+		$prompt = 'Provide a brief treasury industry commentary for the ' . $industry . ' industry in two sentences.';
 
-        $history  = [
-            [
-                'role'    => 'user',
-                'content' => $prompt,
-            ],
-        ];
-        $context = $this->build_context_for_responses( $history );
-        $tokens  = $this->tokens_for_report( 'industry_commentary' );
-        $response = $this->call_openai_with_retry( $model, $context, $tokens, null, $chunk_callback );
+		$history  = [
+			[
+				'role'    => 'user',
+				'content' => $prompt,
+			],
+		];
+		$context = $this->build_context_for_responses( $history );
+		$tokens  = $this->tokens_for_report( 'industry_commentary' );
+		$response = $this->call_openai_with_retry( $model, $context, $tokens, null, $chunk_callback );
 
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error( 'llm_failure', __( 'Unable to generate commentary at this time.', 'rtbcb' ) );
-        }
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'llm_failure', __( 'Unable to generate commentary at this time.', 'rtbcb' ) );
+		}
 
-        $parsed     = rtbcb_parse_gpt5_response( $response );
-        $commentary = sanitize_textarea_field( $parsed['output_text'] );
+		$parsed     = rtbcb_parse_gpt5_response( $response );
+		$commentary = sanitize_textarea_field( $parsed['output_text'] );
 
-        if ( empty( $commentary ) ) {
-            return new WP_Error( 'llm_empty_response', __( 'No commentary returned.', 'rtbcb' ) );
-        }
+		if ( empty( $commentary ) ) {
+			return new WP_Error( 'llm_empty_response', __( 'No commentary returned.', 'rtbcb' ) );
+		}
 
-        return $commentary;
-    }
+		return $commentary;
+	}
 
-    /**
-     * Generate a comprehensive company overview with structured analysis.
-     *
-     * @param string $company_name Company name.
-     * @return array|WP_Error Structured overview array or error object.
-     */
-    public function generate_company_overview( $company_name ) {
-        $company_name = sanitize_text_field( $company_name );
+	/**
+	 * Generate a comprehensive company overview with structured analysis.
+	 *
+	 * @param string $company_name Company name.
+	 * @return array|WP_Error Structured overview array or error object.
+	 */
+	public function generate_company_overview( $company_name ) {
+		$company_name = sanitize_text_field( $company_name );
 
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
 
-        $model = $this->get_model( 'mini' );
+		$model = $this->get_model( 'mini' );
 
-        // System prompt optimized for comprehensive company analysis
-        $system_prompt = <<<'SYSTEM'
+		// System prompt optimized for comprehensive company analysis
+		$system_prompt = <<<'SYSTEM'
 You are a senior treasury technology consultant.
 Return only valid JSON matching this schema:
 {
-  "type": "object",
-  "properties": {
-    "analysis": {"type": "string", "minLength": 200},
-    "recommendations": {"type": "array", "items": {"type": "string"}, "minItems": 1},
-    "references": {"type": "array", "items": {"type": "string", "format": "uri"}},
-    "metrics": {
-      "type": "object",
-      "properties": {
-        "revenue": {"type": "number"},
-        "staff_count": {"type": "number"},
-        "baseline_efficiency": {"type": "number"}
-      },
-      "required": ["revenue", "staff_count", "baseline_efficiency"]
-    }
-  },
-  "required": ["analysis", "recommendations", "references", "metrics"]
+	"type": "object",
+	"properties": {
+	"analysis": {"type": "string", "minLength": 200},
+	"recommendations": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+	"references": {"type": "array", "items": {"type": "string", "format": "uri"}},
+	"metrics": {
+	  "type": "object",
+	  "properties": {
+		"revenue": {"type": "number"},
+		"staff_count": {"type": "number"},
+		"baseline_efficiency": {"type": "number"}
+	  },
+	  "required": ["revenue", "staff_count", "baseline_efficiency"]
+	}
+	},
+	"required": ["analysis", "recommendations", "references", "metrics"]
 }
 No explanatory text outside the JSON. If any field is unknown, use null.
 SYSTEM;
 
-        // Enhanced user prompt with comprehensive company analysis request
-        $user_prompt = sprintf(
-            <<<'USER'
+		// Enhanced user prompt with comprehensive company analysis request
+		$user_prompt = sprintf(
+			<<<'USER'
 Provide a comprehensive company overview and treasury technology analysis for %s.
 
 # Required Analysis Coverage:
@@ -356,399 +356,399 @@ If available from your knowledge, include relevant details about:
 
 Respond with valid JSON only, following the specified schema exactly.
 USER,
-            $company_name
-        );
-
-        $history = [
-            [
-                'role'    => 'user',
-                'content' => $user_prompt,
-            ],
-        ];
-
-        $context = $this->build_context_for_responses( $history, $system_prompt );
-        $tokens  = $this->tokens_for_report( 'company_overview' );
-        $response = $this->call_openai_with_retry( $model, $context, $tokens, 3 ); // Reduce retries
-
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error( 'llm_failure', $response->get_error_message() );
-        }
-
-        $parsed  = rtbcb_parse_gpt5_response( $response );
-        $content = $parsed['output_text'];
-
-        if ( empty( $content ) ) {
-            return new WP_Error( 'llm_empty_response', __( 'No overview returned.', 'rtbcb' ) );
-        }
-
-        // Parse JSON response
-        $json = json_decode( $content, true );
-
-        if ( ! is_array( $json ) ) {
-            return new WP_Error( 'llm_parse_error', __( 'Invalid JSON response from language model.', 'rtbcb' ) );
-        }
-
-        // Validate required fields
-        $required_fields = [ 'analysis', 'recommendations', 'references', 'metrics' ];
-        $missing_fields  = array_diff( $required_fields, array_keys( $json ) );
-
-        if ( ! empty( $missing_fields ) ) {
-            return new WP_Error(
-                'llm_missing_fields',
-                __( 'Missing required fields in response: ', 'rtbcb' ) . implode( ', ', $missing_fields )
-            );
-        }
-
-        // Additional validation for content quality
-        $analysis = trim( $json['analysis'] ?? '' );
-        if ( strlen( $analysis ) < 200 ) {
-            return new WP_Error( 'llm_insufficient_analysis', __( 'Analysis content is too brief.', 'rtbcb' ) );
-        }
-
-        if ( empty( $json['recommendations'] ) || ! is_array( $json['recommendations'] ) ) {
-            return new WP_Error( 'llm_missing_recommendations', __( 'No recommendations provided.', 'rtbcb' ) );
-        }
-
-        if ( empty( $json['metrics'] ) || ! is_array( $json['metrics'] ) ) {
-            return new WP_Error( 'llm_missing_metrics', __( 'No metrics provided.', 'rtbcb' ) );
-        }
-
-        // Sanitize and structure the response
-        $metrics = [
-            'revenue'            => floatval( $json['metrics']['revenue'] ?? 0 ),
-            'staff_count'        => intval( $json['metrics']['staff_count'] ?? 0 ),
-            'baseline_efficiency' => floatval( $json['metrics']['baseline_efficiency'] ?? 0 ),
-        ];
-
-        return [
-            'company_name'   => $company_name,
-            'analysis'       => sanitize_textarea_field( $json['analysis'] ),
-            'recommendations' => array_map( 'sanitize_text_field', array_filter( (array) $json['recommendations'] ) ),
-            'references'     => array_map( 'esc_url_raw', array_filter( (array) $json['references'] ) ),
-            'metrics'        => $metrics,
-            'generated_at'   => current_time( 'Y-m-d H:i:s' ),
-            'analysis_type'  => rtbcb_get_analysis_type() . '_company_overview',
-        ];
-    }
-
-    /**
-     * Generate an industry overview.
-     *
-     * @param string $industry     Industry name.
-     * @param string $company_size Company size description.
-     * @return string|WP_Error Overview text or error object.
-     */
-    public function generate_industry_overview( $industry, $company_size ) {
-        $industry     = sanitize_text_field( $industry );
-        $company_size = sanitize_text_field( $company_size );
-
-        if ( empty( $industry ) || empty( $company_size ) ) {
-            return new WP_Error( 'invalid_params', __( 'Industry and company size required.', 'rtbcb' ) );
-        }
-
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
-
-        $model  = $this->get_model( 'mini' );
-        $prompt = 'Provide an industry overview for ' . $industry . ' companies of size ' . $company_size .
-            '. Cover treasury challenges, key regulations, seasonal patterns, industry benchmarks, common pain points, and opportunities.';
-
-        $history  = [
-            [
-                'role'    => 'user',
-                'content' => $prompt,
-            ],
-        ];
-        $context = $this->build_context_for_responses( $history );
-        $tokens  = $this->tokens_for_report( 'industry_overview' );
-        $response = $this->call_openai_with_retry( $model, $context, $tokens );
-
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error( 'llm_failure', __( 'Unable to generate overview at this time.', 'rtbcb' ) );
-        }
-
-        $parsed   = rtbcb_parse_gpt5_response( $response );
-        $overview = sanitize_textarea_field( $parsed['output_text'] );
-
-        if ( empty( $overview ) ) {
-            return new WP_Error( 'llm_empty_response', __( 'No overview returned.', 'rtbcb' ) );
-        }
-
-        return $overview;
-    }
-
-    /**
-     * Generate a treasury technology overview.
-     *
-     * @param array $company_data Company data including focus areas and complexity.
-     * @return string|WP_Error Overview text or error object.
-     */
-    public function generate_treasury_tech_overview( $company_data ) {
-        $company_data = rtbcb_sanitize_form_data( (array) $company_data );
-        $focus_areas  = array_map( 'sanitize_text_field', (array) ( $company_data['focus_areas'] ?? [] ) );
-        $focus_areas  = array_filter( $focus_areas );
-        $complexity   = sanitize_text_field( $company_data['complexity'] ?? '' );
-        $name         = sanitize_text_field( $company_data['name'] ?? '' );
-        $size         = sanitize_text_field( $company_data['size'] ?? '' );
-
-        if ( empty( $focus_areas ) ) {
-            return new WP_Error( 'no_focus_areas', __( 'No focus areas provided.', 'rtbcb' ) );
-        }
-
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
-
-        $areas_list = implode( ', ', $focus_areas );
-        $model      = $this->get_model( 'mini' );
-        $prompt     = 'Provide a treasury technology overview for ' . $name . '. Company size: ' . $size . '. Complexity: ' . $complexity . '. Focus on: ' . $areas_list . '. Include current landscape, emerging trends, technology gaps, key vendor or solution comparisons, implementation considerations, and adoption trends.';
-
-        $history  = [
-            [
-                'role'    => 'user',
-                'content' => $prompt,
-            ],
-        ];
-        $context = $this->build_context_for_responses( $history );
-        $tokens  = $this->tokens_for_report( 'treasury_tech_overview' );
-        $response = $this->call_openai_with_retry( $model, $context, $tokens );
-
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error( 'llm_failure', __( 'Unable to generate overview at this time.', 'rtbcb' ) );
-        }
-
-        $parsed   = rtbcb_parse_gpt5_response( $response );
-        $overview = sanitize_textarea_field( $parsed['output_text'] );
-
-        if ( empty( $overview ) ) {
-            return new WP_Error( 'llm_empty_response', __( 'No overview returned.', 'rtbcb' ) );
-        }
-
-        return $overview;
-    }
-
-    /**
-     * Generate a Real Treasury platform overview.
-     *
-     * @param array $company_data {
-     *     Company context data.
-     *
-     *     @type bool   $include_portal Include portal integration details.
-     *     @type string $company_size   Company size description.
-     *     @type string $industry       Company industry.
-     *     @type array  $challenges     List of identified challenges.
-     *     @type array  $categories     Vendor categories to highlight.
-     * }
-     * @return string|WP_Error Overview text or error object.
-     */
-    public function generate_real_treasury_overview( $company_data ) {
-        $include_portal = ! empty( $company_data['include_portal'] );
-        $company_size   = sanitize_text_field( $company_data['company_size'] ?? '' );
-        $industry       = sanitize_text_field( $company_data['industry'] ?? '' );
-        $challenges     = array_filter( array_map( 'sanitize_text_field', (array) ( $company_data['challenges'] ?? [] ) ) );
-        $categories     = array_filter( array_map( 'sanitize_text_field', (array) ( $company_data['categories'] ?? [] ) ) );
-
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
-
-        $model  = $this->get_model( 'mini' );
-        $prompt = 'Provide an overview of Real Treasury, a treasury consulting company that helps organizations optimize treasury operations, benchmark market practices, and evaluate technology options for a ' . ( $company_size ?: __( 'company', 'rtbcb' ) ) . ' in the ' . ( $industry ?: __( 'unspecified', 'rtbcb' ) ) . ' industry.';
-
-        if ( ! empty( $challenges ) ) {
-            $prompt .= ' Address these challenges: ' . implode( ', ', $challenges ) . '.';
-        }
-
-        if ( ! empty( $categories ) ) {
-            $prompt .= ' Highlight how Real Treasury advises on vendor categories: ' . implode( ', ', $categories ) . '.';
-        }
-
-        if ( $include_portal ) {
-            $prompt .= ' Include how clients access Real Treasury research and tools through a client portal.';
-        }
-
-        $prompt .= ' Provide sections for consulting services, vendor ecosystem advisory, Real Treasury differentiators, implementation approach, and support/community aspects.';
-
-        $history  = [
-            [
-                'role'    => 'user',
-                'content' => $prompt,
-            ],
-        ];
-        $context = $this->build_context_for_responses( $history );
-        $tokens  = $this->tokens_for_report( 'real_treasury_overview' );
-        $response = $this->call_openai_with_retry( $model, $context, $tokens );
-
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error( 'llm_failure', __( 'Unable to generate overview at this time.', 'rtbcb' ) );
-        }
-
-        $parsed   = rtbcb_parse_gpt5_response( $response );
-        $overview = sanitize_textarea_field( $parsed['output_text'] );
-
-        if ( empty( $overview ) ) {
-            return new WP_Error( 'llm_empty_response', __( 'No overview returned.', 'rtbcb' ) );
-        }
-
-        return $overview;
-    }
-
-    /**
-     * Generate implementation roadmap and success factors for a category.
-     *
-     * @param string $category Category key.
-     * @return array|WP_Error Roadmap and success factor text or error object.
-     */
-    public function generate_category_recommendation( $category ) {
-        $category = sanitize_text_field( $category );
-
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
-
-        $info = RTBCB_Category_Recommender::get_category_info( $category );
-        if ( empty( $info ) ) {
-            return new WP_Error( 'invalid_category', __( 'Invalid category.', 'rtbcb' ) );
-        }
-
-        $model  = $this->get_model( 'mini' );
-        $prompt = 'Return a JSON object with keys "roadmap" and "success_factors" describing the implementation roadmap and key success factors for adopting a ' . $info['name'] . ' solution.';
-
-        $history  = [
-            [
-                'role'    => 'user',
-                'content' => $prompt,
-            ],
-        ];
-        $context = $this->build_context_for_responses( $history );
-        $tokens  = $this->tokens_for_report( 'category_recommendation' );
-        $response = $this->call_openai_with_retry( $model, $context, $tokens );
-
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error( 'llm_failure', __( 'Unable to generate recommendation details at this time.', 'rtbcb' ) );
-        }
-
-        $parsed_response = rtbcb_parse_gpt5_response( $response );
-        $parsed          = json_decode( $parsed_response['output_text'], true );
-
-        if ( empty( $parsed ) || ! is_array( $parsed ) ) {
-            return new WP_Error( 'llm_empty_response', __( 'No recommendation details returned.', 'rtbcb' ) );
-        }
-
-        return [
-            'roadmap'        => sanitize_textarea_field( $parsed['roadmap'] ?? '' ),
-            'success_factors' => sanitize_textarea_field( $parsed['success_factors'] ?? '' ),
-        ];
-    }
-
-    /**
-     * Generate benefits estimate based on company metrics and category.
-     *
-     * @param float  $revenue     Annual revenue.
-     * @param int    $staff_count Number of staff.
-     * @param float  $efficiency  Current efficiency percentage.
-     * @param string $category    Solution category.
-     * @return array|WP_Error Structured benefits estimate or error object.
-     */
-    public function generate_benefits_estimate( $revenue, $staff_count, $efficiency, $category ) {
-        $revenue     = floatval( $revenue );
-        $staff_count = intval( $staff_count );
-        $efficiency  = floatval( $efficiency );
-        $category    = sanitize_text_field( $category );
-
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
-
-        $model  = $this->get_model( 'mini' );
-        $prompt = 'Return a JSON object with keys "time_savings_hours", "cost_reduction_usd", '
-            . '"efficiency_gain_percent", "roi_percent", "roi_timeline_months", '
-            . '"risk_mitigation", "productivity_gain_percent" describing expected benefits for a '
-            . $category . ' solution. Revenue: ' . $revenue . ', Staff: ' . $staff_count . ', '
-            . 'Efficiency: ' . $efficiency . '.';
-
-        $history  = [
-            [
-                'role'    => 'user',
-                'content' => $prompt,
-            ],
-        ];
-        $context = $this->build_context_for_responses( $history );
-        $tokens  = $this->tokens_for_report( 'benefits_estimate' );
-        $response = $this->call_openai_with_retry( $model, $context, $tokens );
-
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error( 'llm_failure', __( 'Unable to generate benefits estimate at this time.', 'rtbcb' ) );
-        }
-
-        $parsed_response = rtbcb_parse_gpt5_response( $response );
-        $parsed          = json_decode( $parsed_response['output_text'], true );
-
-        if ( empty( $parsed ) || ! is_array( $parsed ) ) {
-            return new WP_Error( 'llm_empty_response', __( 'No estimate returned.', 'rtbcb' ) );
-        }
-
-        $estimate = [
-            'time_savings_hours'       => floatval( $parsed['time_savings_hours'] ?? 0 ),
-            'cost_reduction_usd'       => floatval( $parsed['cost_reduction_usd'] ?? 0 ),
-            'efficiency_gain_percent'  => floatval( $parsed['efficiency_gain_percent'] ?? 0 ),
-            'roi_percent'              => floatval( $parsed['roi_percent'] ?? 0 ),
-            'roi_timeline_months'      => floatval( $parsed['roi_timeline_months'] ?? 0 ),
-            'risk_mitigation'          => sanitize_textarea_field( $parsed['risk_mitigation'] ?? '' ),
-            'productivity_gain_percent'=> floatval( $parsed['productivity_gain_percent'] ?? 0 ),
-        ];
-
-        return $estimate;
-    }
-
-    /**
-     * Generate comprehensive business case with deep analysis.
-     *
-     * Returns a {@see WP_Error} when the API key is missing or when the LLM
-     * call or response parsing fails.
-     *
-     * @param array                     $user_inputs    Sanitized user inputs.
-     * @param array                     $roi_data       ROI calculation data.
-     * @param callable|array|Traversable $context_chunks Optional context provider or strings for the prompt.
-     * @param callable|null             $chunk_callback Optional streaming callback.
-     *
-     * @return array|WP_Error Comprehensive analysis array or error object.
-     */
-    public function generate_comprehensive_business_case( $user_inputs, $roi_data, $context_chunks = [], $chunk_callback = null ) {
-
-        if ( rtbcb_heavy_features_disabled() ) {
-            return new WP_Error( 'heavy_features_disabled', __( 'AI features are disabled.', 'rtbcb' ) );
-        }
-        $this->current_inputs = $user_inputs;
-
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
-
-        $company_name = sanitize_text_field( $user_inputs['company_name'] ?? '' );
-        $industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
-        $company_size = sanitize_text_field( $user_inputs['company_size'] ?? '' );
-
-        $company_research  = rtbcb_get_research_cache( $company_name, $industry, 'company' );
-        $industry_analysis  = rtbcb_get_research_cache( $company_name, $industry, 'industry' );
-        $tech_landscape     = rtbcb_get_research_cache( $company_name, $industry, 'treasury' );
-
-        $batch_prompts = [];
-
-        if ( false === $company_research ) {
-            $batch_prompts['company'] = [
-                'instructions' => 'Return JSON with company_profile {business_stage,key_characteristics,treasury_priorities,common_challenges} and treasury_maturity {level,rationale}.',
-                'input'        => 'Company: ' . $company_name . "\nIndustry: " . $industry . "\nSize: " . $company_size,
-            ];
-        }
-
-        if ( false === $industry_analysis ) {
-            $batch_prompts['industry'] = [
-                'instructions' => 'Return JSON with analysis, recommendations, references, errors.',
-                'input'        => 'Provide sector trends, competitive benchmarks, and regulatory considerations for the ' . $industry . ' industry.',
-            ];
-        }
+			$company_name
+		);
+
+		$history = [
+			[
+				'role'    => 'user',
+				'content' => $user_prompt,
+			],
+		];
+
+		$context = $this->build_context_for_responses( $history, $system_prompt );
+		$tokens  = $this->tokens_for_report( 'company_overview' );
+		$response = $this->call_openai_with_retry( $model, $context, $tokens, 3 ); // Reduce retries
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'llm_failure', $response->get_error_message() );
+		}
+
+		$parsed  = rtbcb_parse_gpt5_response( $response );
+		$content = $parsed['output_text'];
+
+		if ( empty( $content ) ) {
+			return new WP_Error( 'llm_empty_response', __( 'No overview returned.', 'rtbcb' ) );
+		}
+
+		// Parse JSON response
+		$json = json_decode( $content, true );
+
+		if ( ! is_array( $json ) ) {
+			return new WP_Error( 'llm_parse_error', __( 'Invalid JSON response from language model.', 'rtbcb' ) );
+		}
+
+		// Validate required fields
+		$required_fields = [ 'analysis', 'recommendations', 'references', 'metrics' ];
+		$missing_fields  = array_diff( $required_fields, array_keys( $json ) );
+
+		if ( ! empty( $missing_fields ) ) {
+			return new WP_Error(
+				'llm_missing_fields',
+				__( 'Missing required fields in response: ', 'rtbcb' ) . implode( ', ', $missing_fields )
+			);
+		}
+
+		// Additional validation for content quality
+		$analysis = trim( $json['analysis'] ?? '' );
+		if ( strlen( $analysis ) < 200 ) {
+			return new WP_Error( 'llm_insufficient_analysis', __( 'Analysis content is too brief.', 'rtbcb' ) );
+		}
+
+		if ( empty( $json['recommendations'] ) || ! is_array( $json['recommendations'] ) ) {
+			return new WP_Error( 'llm_missing_recommendations', __( 'No recommendations provided.', 'rtbcb' ) );
+		}
+
+		if ( empty( $json['metrics'] ) || ! is_array( $json['metrics'] ) ) {
+			return new WP_Error( 'llm_missing_metrics', __( 'No metrics provided.', 'rtbcb' ) );
+		}
+
+		// Sanitize and structure the response
+		$metrics = [
+			'revenue'            => floatval( $json['metrics']['revenue'] ?? 0 ),
+			'staff_count'        => intval( $json['metrics']['staff_count'] ?? 0 ),
+			'baseline_efficiency' => floatval( $json['metrics']['baseline_efficiency'] ?? 0 ),
+		];
+
+		return [
+			'company_name'   => $company_name,
+			'analysis'       => sanitize_textarea_field( $json['analysis'] ),
+			'recommendations' => array_map( 'sanitize_text_field', array_filter( (array) $json['recommendations'] ) ),
+			'references'     => array_map( 'esc_url_raw', array_filter( (array) $json['references'] ) ),
+			'metrics'        => $metrics,
+			'generated_at'   => current_time( 'Y-m-d H:i:s' ),
+			'analysis_type'  => rtbcb_get_analysis_type() . '_company_overview',
+		];
+	}
+
+	/**
+	 * Generate an industry overview.
+	 *
+	 * @param string $industry     Industry name.
+	 * @param string $company_size Company size description.
+	 * @return string|WP_Error Overview text or error object.
+	 */
+	public function generate_industry_overview( $industry, $company_size ) {
+		$industry     = sanitize_text_field( $industry );
+		$company_size = sanitize_text_field( $company_size );
+
+		if ( empty( $industry ) || empty( $company_size ) ) {
+			return new WP_Error( 'invalid_params', __( 'Industry and company size required.', 'rtbcb' ) );
+		}
+
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
+
+		$model  = $this->get_model( 'mini' );
+		$prompt = 'Provide an industry overview for ' . $industry . ' companies of size ' . $company_size .
+			'. Cover treasury challenges, key regulations, seasonal patterns, industry benchmarks, common pain points, and opportunities.';
+
+		$history  = [
+			[
+				'role'    => 'user',
+				'content' => $prompt,
+			],
+		];
+		$context = $this->build_context_for_responses( $history );
+		$tokens  = $this->tokens_for_report( 'industry_overview' );
+		$response = $this->call_openai_with_retry( $model, $context, $tokens );
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'llm_failure', __( 'Unable to generate overview at this time.', 'rtbcb' ) );
+		}
+
+		$parsed   = rtbcb_parse_gpt5_response( $response );
+		$overview = sanitize_textarea_field( $parsed['output_text'] );
+
+		if ( empty( $overview ) ) {
+			return new WP_Error( 'llm_empty_response', __( 'No overview returned.', 'rtbcb' ) );
+		}
+
+		return $overview;
+	}
+
+	/**
+	 * Generate a treasury technology overview.
+	 *
+	 * @param array $company_data Company data including focus areas and complexity.
+	 * @return string|WP_Error Overview text or error object.
+	 */
+	public function generate_treasury_tech_overview( $company_data ) {
+		$company_data = rtbcb_sanitize_form_data( (array) $company_data );
+		$focus_areas  = array_map( 'sanitize_text_field', (array) ( $company_data['focus_areas'] ?? [] ) );
+		$focus_areas  = array_filter( $focus_areas );
+		$complexity   = sanitize_text_field( $company_data['complexity'] ?? '' );
+		$name         = sanitize_text_field( $company_data['name'] ?? '' );
+		$size         = sanitize_text_field( $company_data['size'] ?? '' );
+
+		if ( empty( $focus_areas ) ) {
+			return new WP_Error( 'no_focus_areas', __( 'No focus areas provided.', 'rtbcb' ) );
+		}
+
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
+
+		$areas_list = implode( ', ', $focus_areas );
+		$model      = $this->get_model( 'mini' );
+		$prompt     = 'Provide a treasury technology overview for ' . $name . '. Company size: ' . $size . '. Complexity: ' . $complexity . '. Focus on: ' . $areas_list . '. Include current landscape, emerging trends, technology gaps, key vendor or solution comparisons, implementation considerations, and adoption trends.';
+
+		$history  = [
+			[
+				'role'    => 'user',
+				'content' => $prompt,
+			],
+		];
+		$context = $this->build_context_for_responses( $history );
+		$tokens  = $this->tokens_for_report( 'treasury_tech_overview' );
+		$response = $this->call_openai_with_retry( $model, $context, $tokens );
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'llm_failure', __( 'Unable to generate overview at this time.', 'rtbcb' ) );
+		}
+
+		$parsed   = rtbcb_parse_gpt5_response( $response );
+		$overview = sanitize_textarea_field( $parsed['output_text'] );
+
+		if ( empty( $overview ) ) {
+			return new WP_Error( 'llm_empty_response', __( 'No overview returned.', 'rtbcb' ) );
+		}
+
+		return $overview;
+	}
+
+	/**
+	 * Generate a Real Treasury platform overview.
+	 *
+	 * @param array $company_data {
+	 *     Company context data.
+	 *
+	 *     @type bool   $include_portal Include portal integration details.
+	 *     @type string $company_size   Company size description.
+	 *     @type string $industry       Company industry.
+	 *     @type array  $challenges     List of identified challenges.
+	 *     @type array  $categories     Vendor categories to highlight.
+	 * }
+	 * @return string|WP_Error Overview text or error object.
+	 */
+	public function generate_real_treasury_overview( $company_data ) {
+		$include_portal = ! empty( $company_data['include_portal'] );
+		$company_size   = sanitize_text_field( $company_data['company_size'] ?? '' );
+		$industry       = sanitize_text_field( $company_data['industry'] ?? '' );
+		$challenges     = array_filter( array_map( 'sanitize_text_field', (array) ( $company_data['challenges'] ?? [] ) ) );
+		$categories     = array_filter( array_map( 'sanitize_text_field', (array) ( $company_data['categories'] ?? [] ) ) );
+
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
+
+		$model  = $this->get_model( 'mini' );
+		$prompt = 'Provide an overview of Real Treasury, a treasury consulting company that helps organizations optimize treasury operations, benchmark market practices, and evaluate technology options for a ' . ( $company_size ?: __( 'company', 'rtbcb' ) ) . ' in the ' . ( $industry ?: __( 'unspecified', 'rtbcb' ) ) . ' industry.';
+
+		if ( ! empty( $challenges ) ) {
+			$prompt .= ' Address these challenges: ' . implode( ', ', $challenges ) . '.';
+		}
+
+		if ( ! empty( $categories ) ) {
+			$prompt .= ' Highlight how Real Treasury advises on vendor categories: ' . implode( ', ', $categories ) . '.';
+		}
+
+		if ( $include_portal ) {
+			$prompt .= ' Include how clients access Real Treasury research and tools through a client portal.';
+		}
+
+		$prompt .= ' Provide sections for consulting services, vendor ecosystem advisory, Real Treasury differentiators, implementation approach, and support/community aspects.';
+
+		$history  = [
+			[
+				'role'    => 'user',
+				'content' => $prompt,
+			],
+		];
+		$context = $this->build_context_for_responses( $history );
+		$tokens  = $this->tokens_for_report( 'real_treasury_overview' );
+		$response = $this->call_openai_with_retry( $model, $context, $tokens );
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'llm_failure', __( 'Unable to generate overview at this time.', 'rtbcb' ) );
+		}
+
+		$parsed   = rtbcb_parse_gpt5_response( $response );
+		$overview = sanitize_textarea_field( $parsed['output_text'] );
+
+		if ( empty( $overview ) ) {
+			return new WP_Error( 'llm_empty_response', __( 'No overview returned.', 'rtbcb' ) );
+		}
+
+		return $overview;
+	}
+
+	/**
+	 * Generate implementation roadmap and success factors for a category.
+	 *
+	 * @param string $category Category key.
+	 * @return array|WP_Error Roadmap and success factor text or error object.
+	 */
+	public function generate_category_recommendation( $category ) {
+		$category = sanitize_text_field( $category );
+
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
+
+		$info = RTBCB_Category_Recommender::get_category_info( $category );
+		if ( empty( $info ) ) {
+			return new WP_Error( 'invalid_category', __( 'Invalid category.', 'rtbcb' ) );
+		}
+
+		$model  = $this->get_model( 'mini' );
+		$prompt = 'Return a JSON object with keys "roadmap" and "success_factors" describing the implementation roadmap and key success factors for adopting a ' . $info['name'] . ' solution.';
+
+		$history  = [
+			[
+				'role'    => 'user',
+				'content' => $prompt,
+			],
+		];
+		$context = $this->build_context_for_responses( $history );
+		$tokens  = $this->tokens_for_report( 'category_recommendation' );
+		$response = $this->call_openai_with_retry( $model, $context, $tokens );
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'llm_failure', __( 'Unable to generate recommendation details at this time.', 'rtbcb' ) );
+		}
+
+		$parsed_response = rtbcb_parse_gpt5_response( $response );
+		$parsed          = json_decode( $parsed_response['output_text'], true );
+
+		if ( empty( $parsed ) || ! is_array( $parsed ) ) {
+			return new WP_Error( 'llm_empty_response', __( 'No recommendation details returned.', 'rtbcb' ) );
+		}
+
+		return [
+			'roadmap'        => sanitize_textarea_field( $parsed['roadmap'] ?? '' ),
+			'success_factors' => sanitize_textarea_field( $parsed['success_factors'] ?? '' ),
+		];
+	}
+
+	/**
+	 * Generate benefits estimate based on company metrics and category.
+	 *
+	 * @param float  $revenue     Annual revenue.
+	 * @param int    $staff_count Number of staff.
+	 * @param float  $efficiency  Current efficiency percentage.
+	 * @param string $category    Solution category.
+	 * @return array|WP_Error Structured benefits estimate or error object.
+	 */
+	public function generate_benefits_estimate( $revenue, $staff_count, $efficiency, $category ) {
+		$revenue     = floatval( $revenue );
+		$staff_count = intval( $staff_count );
+		$efficiency  = floatval( $efficiency );
+		$category    = sanitize_text_field( $category );
+
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
+
+		$model  = $this->get_model( 'mini' );
+		$prompt = 'Return a JSON object with keys "time_savings_hours", "cost_reduction_usd", '
+			. '"efficiency_gain_percent", "roi_percent", "roi_timeline_months", '
+			. '"risk_mitigation", "productivity_gain_percent" describing expected benefits for a '
+			. $category . ' solution. Revenue: ' . $revenue . ', Staff: ' . $staff_count . ', '
+			. 'Efficiency: ' . $efficiency . '.';
+
+		$history  = [
+			[
+				'role'    => 'user',
+				'content' => $prompt,
+			],
+		];
+		$context = $this->build_context_for_responses( $history );
+		$tokens  = $this->tokens_for_report( 'benefits_estimate' );
+		$response = $this->call_openai_with_retry( $model, $context, $tokens );
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'llm_failure', __( 'Unable to generate benefits estimate at this time.', 'rtbcb' ) );
+		}
+
+		$parsed_response = rtbcb_parse_gpt5_response( $response );
+		$parsed          = json_decode( $parsed_response['output_text'], true );
+
+		if ( empty( $parsed ) || ! is_array( $parsed ) ) {
+			return new WP_Error( 'llm_empty_response', __( 'No estimate returned.', 'rtbcb' ) );
+		}
+
+		$estimate = [
+			'time_savings_hours'       => floatval( $parsed['time_savings_hours'] ?? 0 ),
+			'cost_reduction_usd'       => floatval( $parsed['cost_reduction_usd'] ?? 0 ),
+			'efficiency_gain_percent'  => floatval( $parsed['efficiency_gain_percent'] ?? 0 ),
+			'roi_percent'              => floatval( $parsed['roi_percent'] ?? 0 ),
+			'roi_timeline_months'      => floatval( $parsed['roi_timeline_months'] ?? 0 ),
+			'risk_mitigation'          => sanitize_textarea_field( $parsed['risk_mitigation'] ?? '' ),
+			'productivity_gain_percent'=> floatval( $parsed['productivity_gain_percent'] ?? 0 ),
+		];
+
+		return $estimate;
+	}
+
+	/**
+	 * Generate comprehensive business case with deep analysis.
+	 *
+	 * Returns a {@see WP_Error} when the API key is missing or when the LLM
+	 * call or response parsing fails.
+	 *
+	 * @param array                     $user_inputs    Sanitized user inputs.
+	 * @param array                     $roi_data       ROI calculation data.
+	 * @param callable|array|Traversable $context_chunks Optional context provider or strings for the prompt.
+	 * @param callable|null             $chunk_callback Optional streaming callback.
+	 *
+	 * @return array|WP_Error Comprehensive analysis array or error object.
+	 */
+	public function generate_comprehensive_business_case( $user_inputs, $roi_data, $context_chunks = [], $chunk_callback = null ) {
+
+		if ( rtbcb_heavy_features_disabled() ) {
+			return new WP_Error( 'heavy_features_disabled', __( 'AI features are disabled.', 'rtbcb' ) );
+		}
+		$this->current_inputs = $user_inputs;
+
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
+
+		$company_name = sanitize_text_field( $user_inputs['company_name'] ?? '' );
+		$industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
+		$company_size = sanitize_text_field( $user_inputs['company_size'] ?? '' );
+
+		$company_research  = rtbcb_get_research_cache( $company_name, $industry, 'company' );
+		$industry_analysis  = rtbcb_get_research_cache( $company_name, $industry, 'industry' );
+		$tech_landscape     = rtbcb_get_research_cache( $company_name, $industry, 'treasury' );
+
+		$batch_prompts = [];
+
+		if ( false === $company_research ) {
+			$batch_prompts['company'] = [
+				'instructions' => 'Return JSON with company_profile {business_stage,key_characteristics,treasury_priorities,common_challenges} and treasury_maturity {level,rationale}.',
+				'input'        => 'Company: ' . $company_name . "\nIndustry: " . $industry . "\nSize: " . $company_size,
+			];
+		}
+
+		if ( false === $industry_analysis ) {
+			$batch_prompts['industry'] = [
+				'instructions' => 'Return JSON with analysis, recommendations, references, errors.',
+				'input'        => 'Provide sector trends, competitive benchmarks, and regulatory considerations for the ' . $industry . ' industry.',
+			];
+		}
 
 if ( false === $tech_landscape ) {
 $tech_prompt = 'Briefly summarize treasury technology solutions relevant to a ' . $company_size . ' company in the ' . $industry . ' industry.';
@@ -771,262 +771,262 @@ $batch_prompts['tech'] = [
 ];
 }
 
-        $batch_results = [];
-        if ( ! empty( $batch_prompts ) ) {
-            $batch_results = $this->generate_research_batch( $batch_prompts );
-            if ( is_wp_error( $batch_results ) ) {
-                $batch_results = [];
-            }
-        }
+		$batch_results = [];
+		if ( ! empty( $batch_prompts ) ) {
+			$batch_results = $this->generate_research_batch( $batch_prompts );
+			if ( is_wp_error( $batch_results ) ) {
+				$batch_results = [];
+			}
+		}
 
-        if ( false === $company_research ) {
-            if ( isset( $batch_results['company'] ) && ! is_wp_error( $batch_results['company'] ) ) {
-                $json = json_decode( $batch_results['company'], true );
-                if ( is_array( $json ) ) {
-                    $company_research = [
-                        'company_profile'  => [
-                            'business_stage'      => sanitize_text_field( $json['company_profile']['business_stage'] ?? '' ),
-                            'key_characteristics' => sanitize_text_field( $json['company_profile']['key_characteristics'] ?? '' ),
-                            'treasury_priorities' => sanitize_text_field( $json['company_profile']['treasury_priorities'] ?? '' ),
-                            'common_challenges'   => sanitize_text_field( $json['company_profile']['common_challenges'] ?? '' ),
-                        ],
-                        'treasury_maturity' => [
-                            'level'     => sanitize_text_field( $json['treasury_maturity']['level'] ?? '' ),
-                            'rationale' => sanitize_text_field( $json['treasury_maturity']['rationale'] ?? '' ),
-                        ],
-                    ];
-                }
-            }
+		if ( false === $company_research ) {
+			if ( isset( $batch_results['company'] ) && ! is_wp_error( $batch_results['company'] ) ) {
+				$json = json_decode( $batch_results['company'], true );
+				if ( is_array( $json ) ) {
+					$company_research = [
+						'company_profile'  => [
+							'business_stage'      => sanitize_text_field( $json['company_profile']['business_stage'] ?? '' ),
+							'key_characteristics' => sanitize_text_field( $json['company_profile']['key_characteristics'] ?? '' ),
+							'treasury_priorities' => sanitize_text_field( $json['company_profile']['treasury_priorities'] ?? '' ),
+							'common_challenges'   => sanitize_text_field( $json['company_profile']['common_challenges'] ?? '' ),
+						],
+						'treasury_maturity' => [
+							'level'     => sanitize_text_field( $json['treasury_maturity']['level'] ?? '' ),
+							'rationale' => sanitize_text_field( $json['treasury_maturity']['rationale'] ?? '' ),
+						],
+					];
+				}
+			}
 
-            if ( false === $company_research ) {
-                $company_research = $this->conduct_company_research( $user_inputs );
-            }
+			if ( false === $company_research ) {
+				$company_research = $this->conduct_company_research( $user_inputs );
+			}
 
-            if ( ! is_wp_error( $company_research ) ) {
-                rtbcb_set_research_cache( $company_name, $industry, 'company', $company_research );
-            } else {
-                return $company_research;
-            }
-        }
+			if ( ! is_wp_error( $company_research ) ) {
+				rtbcb_set_research_cache( $company_name, $industry, 'company', $company_research );
+			} else {
+				return $company_research;
+			}
+		}
 
-        if ( false === $industry_analysis ) {
-            if ( isset( $batch_results['industry'] ) && ! is_wp_error( $batch_results['industry'] ) ) {
-                $json = json_decode( $batch_results['industry'], true );
-                if ( is_array( $json ) ) {
-                    $industry_analysis = [
-                        'analysis'        => sanitize_text_field( $json['analysis'] ?? '' ),
-                        'recommendations' => array_map( 'sanitize_text_field', $json['recommendations'] ?? [] ),
-                        'references'      => array_map( 'sanitize_text_field', $json['references'] ?? [] ),
-                        'errors'          => array_map( 'sanitize_text_field', $json['errors'] ?? [] ),
-                    ];
-                }
-            }
+		if ( false === $industry_analysis ) {
+			if ( isset( $batch_results['industry'] ) && ! is_wp_error( $batch_results['industry'] ) ) {
+				$json = json_decode( $batch_results['industry'], true );
+				if ( is_array( $json ) ) {
+					$industry_analysis = [
+						'analysis'        => sanitize_text_field( $json['analysis'] ?? '' ),
+						'recommendations' => array_map( 'sanitize_text_field', $json['recommendations'] ?? [] ),
+						'references'      => array_map( 'sanitize_text_field', $json['references'] ?? [] ),
+						'errors'          => array_map( 'sanitize_text_field', $json['errors'] ?? [] ),
+					];
+				}
+			}
 
-            if ( false === $industry_analysis ) {
-                $industry_analysis = $this->analyze_industry_context( $user_inputs );
-            }
+			if ( false === $industry_analysis ) {
+				$industry_analysis = $this->analyze_industry_context( $user_inputs );
+			}
 
-            if ( ! is_wp_error( $industry_analysis ) ) {
-                rtbcb_set_research_cache( $company_name, $industry, 'industry', $industry_analysis );
-            } else {
-                return $industry_analysis;
-            }
-        }
+			if ( ! is_wp_error( $industry_analysis ) ) {
+				rtbcb_set_research_cache( $company_name, $industry, 'industry', $industry_analysis );
+			} else {
+				return $industry_analysis;
+			}
+		}
 
-        if ( false === $tech_landscape ) {
-            if ( isset( $batch_results['tech'] ) && ! is_wp_error( $batch_results['tech'] ) ) {
-                $tech_landscape = sanitize_textarea_field( $batch_results['tech'] );
-            }
+		if ( false === $tech_landscape ) {
+			if ( isset( $batch_results['tech'] ) && ! is_wp_error( $batch_results['tech'] ) ) {
+				$tech_landscape = sanitize_textarea_field( $batch_results['tech'] );
+			}
 
-            if ( false === $tech_landscape ) {
-                $tech_landscape = $this->research_treasury_solutions( $user_inputs, $context_chunks );
-            }
+			if ( false === $tech_landscape ) {
+				$tech_landscape = $this->research_treasury_solutions( $user_inputs, $context_chunks );
+			}
 
-            if ( ! is_wp_error( $tech_landscape ) ) {
-                rtbcb_set_research_cache( $company_name, $industry, 'treasury', $tech_landscape );
-            } else {
-                return $tech_landscape;
-            }
-        }
-        
-        // Generate comprehensive report
-        $model = $this->select_optimal_model( $user_inputs, $context_chunks );
-        $prompt = $this->build_comprehensive_prompt( 
-            $user_inputs, 
-            $roi_data, 
-            $company_research,
-            $industry_analysis,
-            $tech_landscape
-        );
-        
-        $history  = [
-            [
-                'role'    => 'user',
-                'content' => $prompt,
-            ],
-        ];
+			if ( ! is_wp_error( $tech_landscape ) ) {
+				rtbcb_set_research_cache( $company_name, $industry, 'treasury', $tech_landscape );
+			} else {
+				return $tech_landscape;
+			}
+		}
+		
+		// Generate comprehensive report
+		$model = $this->select_optimal_model( $user_inputs, $context_chunks );
+		$prompt = $this->build_comprehensive_prompt( 
+			$user_inputs, 
+			$roi_data, 
+			$company_research,
+			$industry_analysis,
+			$tech_landscape
+		);
+		
+		$history  = [
+			[
+				'role'    => 'user',
+				'content' => $prompt,
+			],
+		];
 		$context = $this->build_context_for_responses( $history );
 		$tokens  = $this->tokens_for_report( 'comprehensive_business_case' );
 		$response = $this->call_openai_with_retry( $model, $context, $tokens, null, $chunk_callback );
 
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
-        $parsed = $this->parse_comprehensive_response( $response );
+		$parsed = $this->parse_comprehensive_response( $response );
 
-        if ( is_wp_error( $parsed ) ) {
-            return $parsed;
-        }
+		if ( is_wp_error( $parsed ) ) {
+			return $parsed;
+		}
 
-        if ( isset( $parsed['error'] ) ) {
-            return new WP_Error( 'llm_parse_error', $parsed['error'] );
-        }
+		if ( isset( $parsed['error'] ) ) {
+			return new WP_Error( 'llm_parse_error', $parsed['error'] );
+		}
 
-        $analysis = $this->enhance_with_research( $parsed, $company_research, $industry_analysis, $tech_landscape );
+		$analysis = $this->enhance_with_research( $parsed, $company_research, $industry_analysis, $tech_landscape );
 
-        return [
-            'executive_summary'      => $analysis['executive_summary'] ?? [],
-            'company_overview'       => $analysis['research']['company']['company_profile'] ?? [],
-            'industry_analysis'      => $analysis['industry_insights'] ?? [],
-            'treasury_maturity'      => $analysis['research']['company']['treasury_maturity'] ?? '',
-            'technology_landscape'   => $analysis['research']['technology'] ?? '',
-            'financial_analysis'     => $analysis['financial_analysis'] ?? [],
-            'implementation_roadmap' => $analysis['technology_recommendations'] ?? [],
-            'risk_mitigation'        => $analysis['risk_mitigation'] ?? [],
-            'next_steps'             => $analysis['next_steps'] ?? [],
-            'raw'                    => $analysis,
-        ];
-    }
+		return [
+			'executive_summary'      => $analysis['executive_summary'] ?? [],
+			'company_overview'       => $analysis['research']['company']['company_profile'] ?? [],
+			'industry_analysis'      => $analysis['industry_insights'] ?? [],
+			'treasury_maturity'      => $analysis['research']['company']['treasury_maturity'] ?? '',
+			'technology_landscape'   => $analysis['research']['technology'] ?? '',
+			'financial_analysis'     => $analysis['financial_analysis'] ?? [],
+			'implementation_roadmap' => $analysis['technology_recommendations'] ?? [],
+			'risk_mitigation'        => $analysis['risk_mitigation'] ?? [],
+			'next_steps'             => $analysis['next_steps'] ?? [],
+			'raw'                    => $analysis,
+		];
+	}
 
-    /**
-     * Parse and validate comprehensive OpenAI response.
-     *
-     * @param array $response Raw response from wp_remote_post.
-     *
-     * @return array|WP_Error Structured analysis array or error object.
-     */
-    private function parse_comprehensive_response( $response ) {
-        $parsed_response = rtbcb_parse_gpt5_response( $response, true );
-        $content         = $parsed_response['output_text'];
-        $decoded         = $parsed_response['raw'];
+	/**
+	 * Parse and validate comprehensive OpenAI response.
+	 *
+	 * @param array $response Raw response from wp_remote_post.
+	 *
+	 * @return array|WP_Error Structured analysis array or error object.
+	 */
+	private function parse_comprehensive_response( $response ) {
+		$parsed_response = rtbcb_parse_gpt5_response( $response, true );
+		$content         = $parsed_response['output_text'];
+		$decoded         = $parsed_response['raw'];
 
-        if ( empty( $decoded ) ) {
-            return new WP_Error( 'llm_response_decode_error', __( 'Failed to decode response body.', 'rtbcb' ) );
-        }
+		if ( empty( $decoded ) ) {
+			return new WP_Error( 'llm_response_decode_error', __( 'Failed to decode response body.', 'rtbcb' ) );
+		}
 
-        if ( is_string( $content ) ) {
-            $json = json_decode( $content, true );
-        } else {
-            $json = is_array( $content ) ? $content : [];
-        }
+		if ( is_string( $content ) ) {
+			$json = json_decode( $content, true );
+		} else {
+			$json = is_array( $content ) ? $content : [];
+		}
 
-        if ( ! is_array( $json ) ) {
-            return new WP_Error( 'llm_response_parse_error', __( 'Invalid JSON from language model.', 'rtbcb' ) );
-        }
+		if ( ! is_array( $json ) ) {
+			return new WP_Error( 'llm_response_parse_error', __( 'Invalid JSON from language model.', 'rtbcb' ) );
+		}
 
-        $required = [
-            'executive_summary',
-            'operational_analysis',
-            'industry_insights',
-            'technology_recommendations',
-            'financial_analysis',
-            'risk_mitigation',
-            'next_steps',
-        ];
+		$required = [
+			'executive_summary',
+			'operational_analysis',
+			'industry_insights',
+			'technology_recommendations',
+			'financial_analysis',
+			'risk_mitigation',
+			'next_steps',
+		];
 
-        $missing = array_diff( $required, array_keys( $json ) );
+		$missing = array_diff( $required, array_keys( $json ) );
 
-        if ( ! empty( $missing ) ) {
-            return new WP_Error(
-                'llm_missing_fields',
-                __( 'Missing required fields: ', 'rtbcb' ) . implode( ', ', $missing )
-            );
-        }
+		if ( ! empty( $missing ) ) {
+			return new WP_Error(
+				'llm_missing_fields',
+				__( 'Missing required fields: ', 'rtbcb' ) . implode( ', ', $missing )
+			);
+		}
 
-        return [
-            'executive_summary'      => [
-                'strategic_positioning'   => sanitize_text_field( $json['executive_summary']['strategic_positioning'] ?? '' ),
-                'business_case_strength'  => sanitize_text_field( $json['executive_summary']['business_case_strength'] ?? '' ),
-                'key_value_drivers'       => array_map( 'sanitize_text_field', $json['executive_summary']['key_value_drivers'] ?? [] ),
-                'executive_recommendation'=> sanitize_text_field( $json['executive_summary']['executive_recommendation'] ?? '' ),
-                'confidence_level'        => floatval( $json['executive_summary']['confidence_level'] ?? 0 ),
-            ],
-            'operational_analysis'   => [
-                'current_state_assessment' => [
-                    'efficiency_rating'   => sanitize_text_field( $json['operational_analysis']['current_state_assessment']['efficiency_rating'] ?? '' ),
-                    'benchmark_comparison'=> sanitize_text_field( $json['operational_analysis']['current_state_assessment']['benchmark_comparison'] ?? '' ),
-                    'capacity_utilization'=> sanitize_text_field( $json['operational_analysis']['current_state_assessment']['capacity_utilization'] ?? '' ),
-                ],
-                'process_inefficiencies'  => array_map(
-                    function ( $item ) {
-                        return [
-                            'process'     => sanitize_text_field( $item['process'] ?? '' ),
-                            'impact'      => sanitize_text_field( $item['impact'] ?? '' ),
-                            'description' => sanitize_textarea_field( $item['description'] ?? '' ),
-                        ];
-                    },
-                    is_array( $json['operational_analysis']['process_inefficiencies'] ?? null )
-                        ? $json['operational_analysis']['process_inefficiencies']
-                        : []
-                ),
-                'automation_opportunities' => array_map(
-                    function ( $item ) {
-                        return [
-                            'area'                 => sanitize_text_field( $item['area'] ?? '' ),
-                            'complexity'           => sanitize_text_field( $item['complexity'] ?? '' ),
-                            'potential_hours_saved'=> floatval( $item['potential_hours_saved'] ?? 0 ),
-                        ];
-                    },
-                    $json['operational_analysis']['automation_opportunities'] ?? []
-                ),
-            ],
-            'industry_insights'      => [
-                'sector_trends'          => sanitize_text_field( $json['industry_insights']['sector_trends'] ?? '' ),
-                'competitive_benchmarks' => sanitize_text_field( $json['industry_insights']['competitive_benchmarks'] ?? '' ),
-                'regulatory_considerations' => sanitize_text_field( $json['industry_insights']['regulatory_considerations'] ?? '' ),
-            ],
-            'technology_recommendations' => [
-                'primary_solution' => [
-                    'category'     => sanitize_text_field( $json['technology_recommendations']['primary_solution']['category'] ?? '' ),
-                    'rationale'    => sanitize_text_field( $json['technology_recommendations']['primary_solution']['rationale'] ?? '' ),
-                    'key_features' => array_map( 'sanitize_text_field', $json['technology_recommendations']['primary_solution']['key_features'] ?? [] ),
-                ],
-                'implementation_approach' => [
-                    'phase_1'        => sanitize_text_field( $json['technology_recommendations']['implementation_approach']['phase_1'] ?? '' ),
-                    'phase_2'        => sanitize_text_field( $json['technology_recommendations']['implementation_approach']['phase_2'] ?? '' ),
-                    'success_metrics'=> array_map( 'sanitize_text_field', $json['technology_recommendations']['implementation_approach']['success_metrics'] ?? [] ),
-                ],
-            ],
-            'financial_analysis'     => [
-                'investment_breakdown' => [
-                    'software_licensing'      => sanitize_text_field( $json['financial_analysis']['investment_breakdown']['software_licensing'] ?? '' ),
-                    'implementation_services' => sanitize_text_field( $json['financial_analysis']['investment_breakdown']['implementation_services'] ?? '' ),
-                    'training_change_management' => sanitize_text_field( $json['financial_analysis']['investment_breakdown']['training_change_management'] ?? '' ),
-                ],
-                'payback_analysis'    => [
-                    'payback_months' => floatval( $json['financial_analysis']['payback_analysis']['payback_months'] ?? 0 ),
-                    'roi_3_year'     => floatval( $json['financial_analysis']['payback_analysis']['roi_3_year'] ?? 0 ),
-                    'npv_analysis'   => sanitize_text_field( $json['financial_analysis']['payback_analysis']['npv_analysis'] ?? '' ),
-                ],
-            ],
-            'risk_mitigation'        => [
-                'implementation_risks' => array_map( 'sanitize_text_field', $json['risk_mitigation']['implementation_risks'] ?? [] ),
-                'mitigation_strategies' => [
-                    'risk_1_mitigation' => sanitize_text_field( $json['risk_mitigation']['mitigation_strategies']['risk_1_mitigation'] ?? '' ),
-                    'risk_2_mitigation' => sanitize_text_field( $json['risk_mitigation']['mitigation_strategies']['risk_2_mitigation'] ?? '' ),
-                ],
-            ],
-            'next_steps'             => array_map( 'sanitize_text_field', $json['next_steps'] ?? [] ),
-        ];
-    }
+		return [
+			'executive_summary'      => [
+				'strategic_positioning'   => sanitize_text_field( $json['executive_summary']['strategic_positioning'] ?? '' ),
+				'business_case_strength'  => sanitize_text_field( $json['executive_summary']['business_case_strength'] ?? '' ),
+				'key_value_drivers'       => array_map( 'sanitize_text_field', $json['executive_summary']['key_value_drivers'] ?? [] ),
+				'executive_recommendation'=> sanitize_text_field( $json['executive_summary']['executive_recommendation'] ?? '' ),
+				'confidence_level'        => floatval( $json['executive_summary']['confidence_level'] ?? 0 ),
+			],
+			'operational_analysis'   => [
+				'current_state_assessment' => [
+					'efficiency_rating'   => sanitize_text_field( $json['operational_analysis']['current_state_assessment']['efficiency_rating'] ?? '' ),
+					'benchmark_comparison'=> sanitize_text_field( $json['operational_analysis']['current_state_assessment']['benchmark_comparison'] ?? '' ),
+					'capacity_utilization'=> sanitize_text_field( $json['operational_analysis']['current_state_assessment']['capacity_utilization'] ?? '' ),
+				],
+				'process_inefficiencies'  => array_map(
+					function ( $item ) {
+						return [
+							'process'     => sanitize_text_field( $item['process'] ?? '' ),
+							'impact'      => sanitize_text_field( $item['impact'] ?? '' ),
+							'description' => sanitize_textarea_field( $item['description'] ?? '' ),
+						];
+					},
+					is_array( $json['operational_analysis']['process_inefficiencies'] ?? null )
+						? $json['operational_analysis']['process_inefficiencies']
+						: []
+				),
+				'automation_opportunities' => array_map(
+					function ( $item ) {
+						return [
+							'area'                 => sanitize_text_field( $item['area'] ?? '' ),
+							'complexity'           => sanitize_text_field( $item['complexity'] ?? '' ),
+							'potential_hours_saved'=> floatval( $item['potential_hours_saved'] ?? 0 ),
+						];
+					},
+					$json['operational_analysis']['automation_opportunities'] ?? []
+				),
+			],
+			'industry_insights'      => [
+				'sector_trends'          => sanitize_text_field( $json['industry_insights']['sector_trends'] ?? '' ),
+				'competitive_benchmarks' => sanitize_text_field( $json['industry_insights']['competitive_benchmarks'] ?? '' ),
+				'regulatory_considerations' => sanitize_text_field( $json['industry_insights']['regulatory_considerations'] ?? '' ),
+			],
+			'technology_recommendations' => [
+				'primary_solution' => [
+					'category'     => sanitize_text_field( $json['technology_recommendations']['primary_solution']['category'] ?? '' ),
+					'rationale'    => sanitize_text_field( $json['technology_recommendations']['primary_solution']['rationale'] ?? '' ),
+					'key_features' => array_map( 'sanitize_text_field', $json['technology_recommendations']['primary_solution']['key_features'] ?? [] ),
+				],
+				'implementation_approach' => [
+					'phase_1'        => sanitize_text_field( $json['technology_recommendations']['implementation_approach']['phase_1'] ?? '' ),
+					'phase_2'        => sanitize_text_field( $json['technology_recommendations']['implementation_approach']['phase_2'] ?? '' ),
+					'success_metrics'=> array_map( 'sanitize_text_field', $json['technology_recommendations']['implementation_approach']['success_metrics'] ?? [] ),
+				],
+			],
+			'financial_analysis'     => [
+				'investment_breakdown' => [
+					'software_licensing'      => sanitize_text_field( $json['financial_analysis']['investment_breakdown']['software_licensing'] ?? '' ),
+					'implementation_services' => sanitize_text_field( $json['financial_analysis']['investment_breakdown']['implementation_services'] ?? '' ),
+					'training_change_management' => sanitize_text_field( $json['financial_analysis']['investment_breakdown']['training_change_management'] ?? '' ),
+				],
+				'payback_analysis'    => [
+					'payback_months' => floatval( $json['financial_analysis']['payback_analysis']['payback_months'] ?? 0 ),
+					'roi_3_year'     => floatval( $json['financial_analysis']['payback_analysis']['roi_3_year'] ?? 0 ),
+					'npv_analysis'   => sanitize_text_field( $json['financial_analysis']['payback_analysis']['npv_analysis'] ?? '' ),
+				],
+			],
+			'risk_mitigation'        => [
+				'implementation_risks' => array_map( 'sanitize_text_field', $json['risk_mitigation']['implementation_risks'] ?? [] ),
+				'mitigation_strategies' => [
+					'risk_1_mitigation' => sanitize_text_field( $json['risk_mitigation']['mitigation_strategies']['risk_1_mitigation'] ?? '' ),
+					'risk_2_mitigation' => sanitize_text_field( $json['risk_mitigation']['mitigation_strategies']['risk_2_mitigation'] ?? '' ),
+				],
+			],
+			'next_steps'             => array_map( 'sanitize_text_field', $json['next_steps'] ?? [] ),
+		];
+	}
 
-    /**
-     * Conduct company-specific research.
-     *
-     * @param array $user_inputs User-provided company details.
-     * @return array Structured research data.
-     */
+	/**
+	 * Conduct company-specific research.
+	 *
+	 * @param array $user_inputs User-provided company details.
+	 * @return array Structured research data.
+	 */
 	private function conduct_company_research( $user_inputs ) {
 	$company_name = sanitize_text_field( $user_inputs['company_name'] ?? '' );
 	$industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
@@ -1048,547 +1048,547 @@ $batch_prompts['tech'] = [
 
 	$this->last_company_research = wp_json_encode( $research );
 
-        return $research;
-    }
+		return $research;
+	}
 
-    /**
-     * Build detailed company profile
-     */
-    private function build_company_profile( $company_name, $industry, $company_size ) {
-        $size_profiles = [
-            '<$50M' => [
-                'stage' => 'emerging growth',
-                'characteristics' => 'agile decision-making, resource constraints, high growth potential',
-                'treasury_focus' => 'cash flow optimization, banking relationship efficiency',
-                'typical_challenges' => 'manual processes, limited treasury expertise, cash flow volatility'
-            ],
-            '$50M-$500M' => [
-                'stage' => 'scaling business',
-                'characteristics' => 'expanding operations, increasing complexity, professionalization',
-                'treasury_focus' => 'process automation, risk management, strategic cash management',
-                'typical_challenges' => 'growing complexity, system integration, resource allocation'
-            ],
-            '$500M-$2B' => [
-                'stage' => 'established enterprise',
-                'characteristics' => 'mature operations, multiple business units, geographic diversity',
-                'treasury_focus' => 'enterprise integration, advanced analytics, risk optimization',
-                'typical_challenges' => 'legacy systems, coordination complexity, regulatory compliance'
-            ],
-            '>$2B' => [
-                'stage' => 'large enterprise',
-                'characteristics' => 'global operations, sophisticated structure, regulatory oversight',
-                'treasury_focus' => 'enterprise-wide optimization, regulatory compliance, strategic finance',
-                'typical_challenges' => 'system complexity, governance requirements, scale management'
-            ]
-        ];
-        
-        $profile = $size_profiles[$company_size] ?? $size_profiles['$50M-$500M'];
-        
-        return [
-            'company_name' => $company_name,
-            'revenue_segment' => $company_size,
-            'business_stage' => $profile['stage'],
-            'key_characteristics' => $profile['characteristics'],
-            'treasury_priorities' => $profile['treasury_focus'],
-            'common_challenges' => $profile['typical_challenges'],
-            'industry_context' => $this->get_industry_context( $industry ),
-        ];
-    }
+	/**
+	 * Build detailed company profile
+	 */
+	private function build_company_profile( $company_name, $industry, $company_size ) {
+		$size_profiles = [
+			'<$50M' => [
+				'stage' => 'emerging growth',
+				'characteristics' => 'agile decision-making, resource constraints, high growth potential',
+				'treasury_focus' => 'cash flow optimization, banking relationship efficiency',
+				'typical_challenges' => 'manual processes, limited treasury expertise, cash flow volatility'
+			],
+			'$50M-$500M' => [
+				'stage' => 'scaling business',
+				'characteristics' => 'expanding operations, increasing complexity, professionalization',
+				'treasury_focus' => 'process automation, risk management, strategic cash management',
+				'typical_challenges' => 'growing complexity, system integration, resource allocation'
+			],
+			'$500M-$2B' => [
+				'stage' => 'established enterprise',
+				'characteristics' => 'mature operations, multiple business units, geographic diversity',
+				'treasury_focus' => 'enterprise integration, advanced analytics, risk optimization',
+				'typical_challenges' => 'legacy systems, coordination complexity, regulatory compliance'
+			],
+			'>$2B' => [
+				'stage' => 'large enterprise',
+				'characteristics' => 'global operations, sophisticated structure, regulatory oversight',
+				'treasury_focus' => 'enterprise-wide optimization, regulatory compliance, strategic finance',
+				'typical_challenges' => 'system complexity, governance requirements, scale management'
+			]
+		];
+		
+		$profile = $size_profiles[$company_size] ?? $size_profiles['$50M-$500M'];
+		
+		return [
+			'company_name' => $company_name,
+			'revenue_segment' => $company_size,
+			'business_stage' => $profile['stage'],
+			'key_characteristics' => $profile['characteristics'],
+			'treasury_priorities' => $profile['treasury_focus'],
+			'common_challenges' => $profile['typical_challenges'],
+			'industry_context' => $this->get_industry_context( $industry ),
+		];
+	}
 
-    /**
-     * Get industry-specific context
-     */
-    private function get_industry_context( $industry ) {
-        $contexts = [
-            'manufacturing' => [
-                'cash_flow_pattern' => 'cyclical with seasonal variations',
-                'working_capital_intensity' => 'high inventory and receivables',
-                'regulatory_environment' => 'environmental and safety regulations',
-                'treasury_priorities' => 'supply chain financing, FX risk management'
-            ],
-            'technology' => [
-                'cash_flow_pattern' => 'rapid growth with high volatility',
-                'working_capital_intensity' => 'low physical assets, high cash burn',
-                'regulatory_environment' => 'data privacy and cybersecurity',
-                'treasury_priorities' => 'liquidity management, investment optimization'
-            ],
-            'retail' => [
-                'cash_flow_pattern' => 'highly seasonal and promotional',
-                'working_capital_intensity' => 'inventory-heavy with payment timing',
-                'regulatory_environment' => 'consumer protection and payment regulations',
-                'treasury_priorities' => 'cash forecasting, payment processing optimization'
-            ],
-            // Add more industries as needed
-        ];
-        
-        return $contexts[$industry] ?? [
-            'cash_flow_pattern' => 'varies by business model',
-            'working_capital_intensity' => 'moderate',
-            'regulatory_environment' => 'standard compliance requirements',
-            'treasury_priorities' => 'operational efficiency and risk management'
-        ];
-    }
+	/**
+	 * Get industry-specific context
+	 */
+	private function get_industry_context( $industry ) {
+		$contexts = [
+			'manufacturing' => [
+				'cash_flow_pattern' => 'cyclical with seasonal variations',
+				'working_capital_intensity' => 'high inventory and receivables',
+				'regulatory_environment' => 'environmental and safety regulations',
+				'treasury_priorities' => 'supply chain financing, FX risk management'
+			],
+			'technology' => [
+				'cash_flow_pattern' => 'rapid growth with high volatility',
+				'working_capital_intensity' => 'low physical assets, high cash burn',
+				'regulatory_environment' => 'data privacy and cybersecurity',
+				'treasury_priorities' => 'liquidity management, investment optimization'
+			],
+			'retail' => [
+				'cash_flow_pattern' => 'highly seasonal and promotional',
+				'working_capital_intensity' => 'inventory-heavy with payment timing',
+				'regulatory_environment' => 'consumer protection and payment regulations',
+				'treasury_priorities' => 'cash forecasting, payment processing optimization'
+			],
+			// Add more industries as needed
+		];
+		
+		return $contexts[$industry] ?? [
+			'cash_flow_pattern' => 'varies by business model',
+			'working_capital_intensity' => 'moderate',
+			'regulatory_environment' => 'standard compliance requirements',
+			'treasury_priorities' => 'operational efficiency and risk management'
+		];
+	}
 
-    /**
-     * Analyze the competitive landscape for a given industry.
-     *
-     * Provides a list of competitors and brief notes on their strengths. If an
-     * OpenAI API key is configured, the method will query the language model for
-     * up-to-date insights; otherwise a basic set of placeholder competitors is
-     * returned.
-     *
-     * @param string $industry Industry name or slug.
-     * @return array {
-     *     @type array $competitors List of competitors, each having `name` and
-     *                              `strength` keys.
-     * }
-     */
-    private function analyze_competitive_context( $industry ) {
-        $industry = sanitize_text_field( $industry );
+	/**
+	 * Analyze the competitive landscape for a given industry.
+	 *
+	 * Provides a list of competitors and brief notes on their strengths. If an
+	 * OpenAI API key is configured, the method will query the language model for
+	 * up-to-date insights; otherwise a basic set of placeholder competitors is
+	 * returned.
+	 *
+	 * @param string $industry Industry name or slug.
+	 * @return array {
+	 *     @type array $competitors List of competitors, each having `name` and
+	 *                              `strength` keys.
+	 * }
+	 */
+	private function analyze_competitive_context( $industry ) {
+		$industry = sanitize_text_field( $industry );
 
-        $default = [
-            'competitors' => [
-                [
-                    'name'     => 'General Competitor A',
-                    'strength' => __( 'broad market reach', 'rtbcb' ),
-                ],
-                [
-                    'name'     => 'General Competitor B',
-                    'strength' => __( 'cost leadership', 'rtbcb' ),
-                ],
-            ],
-        ];
+		$default = [
+			'competitors' => [
+				[
+					'name'     => 'General Competitor A',
+					'strength' => __( 'broad market reach', 'rtbcb' ),
+				],
+				[
+					'name'     => 'General Competitor B',
+					'strength' => __( 'cost leadership', 'rtbcb' ),
+				],
+			],
+		];
 
-        if ( empty( $this->api_key ) ) {
-            return $default;
-        }
+		if ( empty( $this->api_key ) ) {
+			return $default;
+		}
 
-        $model        = $this->get_model( 'mini' );
-        $system_prompt = 'You are a market analyst. Return only JSON with an array "competitors" of objects each having "name" and "strength".';
-        $user_prompt   = sprintf( 'Identify three major competitors in the %s industry and note one key strength for each.', $industry );
+		$model        = $this->get_model( 'mini' );
+		$system_prompt = 'You are a market analyst. Return only JSON with an array "competitors" of objects each having "name" and "strength".';
+		$user_prompt   = sprintf( 'Identify three major competitors in the %s industry and note one key strength for each.', $industry );
 
-        $history = [
-            [
-                'role'    => 'system',
-                'content' => $system_prompt,
-            ],
-            [
-                'role'    => 'user',
-                'content' => $user_prompt,
-            ],
-        ];
+		$history = [
+			[
+				'role'    => 'system',
+				'content' => $system_prompt,
+			],
+			[
+				'role'    => 'user',
+				'content' => $user_prompt,
+			],
+		];
 
-        $context = $this->build_context_for_responses( $history );
-        $tokens  = $this->tokens_for_report( 'competitive_context' );
-        $response = $this->call_openai_with_retry( $model, $context, $tokens );
+		$context = $this->build_context_for_responses( $history );
+		$tokens  = $this->tokens_for_report( 'competitive_context' );
+		$response = $this->call_openai_with_retry( $model, $context, $tokens );
 
-        if ( is_wp_error( $response ) ) {
-            return $default;
-        }
+		if ( is_wp_error( $response ) ) {
+			return $default;
+		}
 
-        $parsed = rtbcb_parse_gpt5_response( $response );
-        $json   = json_decode( $parsed['output_text'], true );
+		$parsed = rtbcb_parse_gpt5_response( $response );
+		$json   = json_decode( $parsed['output_text'], true );
 
-        if ( ! is_array( $json ) || empty( $json['competitors'] ) || ! is_array( $json['competitors'] ) ) {
-            return $default;
-        }
+		if ( ! is_array( $json ) || empty( $json['competitors'] ) || ! is_array( $json['competitors'] ) ) {
+			return $default;
+		}
 
-        $competitors = [];
+		$competitors = [];
 
-        foreach ( $json['competitors'] as $comp ) {
-            if ( ! is_array( $comp ) ) {
-                continue;
-            }
+		foreach ( $json['competitors'] as $comp ) {
+			if ( ! is_array( $comp ) ) {
+				continue;
+			}
 
-            $name     = sanitize_text_field( $comp['name'] ?? '' );
-            $strength = sanitize_text_field( $comp['strength'] ?? '' );
+			$name     = sanitize_text_field( $comp['name'] ?? '' );
+			$strength = sanitize_text_field( $comp['strength'] ?? '' );
 
-            if ( ! empty( $name ) ) {
-                $competitors[] = [
-                    'name'     => $name,
-                    'strength' => $strength,
-                ];
-            }
-        }
+			if ( ! empty( $name ) ) {
+				$competitors[] = [
+					'name'     => $name,
+					'strength' => $strength,
+				];
+			}
+		}
 
-        if ( empty( $competitors ) ) {
-            return $default;
-        }
+		if ( empty( $competitors ) ) {
+			return $default;
+		}
 
-        return [
-            'competitors' => $competitors,
-        ];
-    }
+		return [
+			'competitors' => $competitors,
+		];
+	}
 
-    /**
-     * Analyze a company's market position within its industry.
-     *
-     * @param string $industry     Industry name.
-     * @param string $company_size Company size descriptor.
-     * @return array Structured data including market share, peers, and growth outlook.
-     */
-    private function analyze_market_position( $industry, $company_size ) {
-        $industry     = sanitize_text_field( $industry );
-        $company_size = sanitize_text_field( $company_size );
+	/**
+	 * Analyze a company's market position within its industry.
+	 *
+	 * @param string $industry     Industry name.
+	 * @param string $company_size Company size descriptor.
+	 * @return array Structured data including market share, peers, and growth outlook.
+	 */
+	private function analyze_market_position( $industry, $company_size ) {
+		$industry     = sanitize_text_field( $industry );
+		$company_size = sanitize_text_field( $company_size );
 
-        $market_shares = [
-            '<$50M'      => 'emerging niche player',
-            '$50M-$500M' => 'growing regional player',
-            '$500M-$2B'  => 'established contender',
-            '>$2B'       => 'market leader',
-        ];
+		$market_shares = [
+			'<$50M'      => 'emerging niche player',
+			'$50M-$500M' => 'growing regional player',
+			'$500M-$2B'  => 'established contender',
+			'>$2B'       => 'market leader',
+		];
 
-        $industry_peers = [
-            'manufacturing' => [
-                'peers'  => [ 'Acme Manufacturing', 'Global Fabricators' ],
-                'growth' => 'stable',
-            ],
-            'technology'    => [
-                'peers'  => [ 'Innovatech', 'NextGen Software' ],
-                'growth' => 'rapid',
-            ],
-            'retail'        => [
-                'peers'  => [ 'RetailCo', 'ShopSmart' ],
-                'growth' => 'moderate',
-            ],
-        ];
+		$industry_peers = [
+			'manufacturing' => [
+				'peers'  => [ 'Acme Manufacturing', 'Global Fabricators' ],
+				'growth' => 'stable',
+			],
+			'technology'    => [
+				'peers'  => [ 'Innovatech', 'NextGen Software' ],
+				'growth' => 'rapid',
+			],
+			'retail'        => [
+				'peers'  => [ 'RetailCo', 'ShopSmart' ],
+				'growth' => 'moderate',
+			],
+		];
 
-        $selected = $industry_peers[ $industry ] ?? [
-            'peers'  => [ 'General Competitor A', 'General Competitor B' ],
-            'growth' => 'moderate',
-        ];
+		$selected = $industry_peers[ $industry ] ?? [
+			'peers'  => [ 'General Competitor A', 'General Competitor B' ],
+			'growth' => 'moderate',
+		];
 
-        return [
-            'market_share'   => sanitize_text_field( $market_shares[ $company_size ] ?? 'unknown' ),
-            'peers'          => array_map( 'sanitize_text_field', $selected['peers'] ),
-            'growth_outlook' => sanitize_text_field( $selected['growth'] ),
-        ];
-    }
+		return [
+			'market_share'   => sanitize_text_field( $market_shares[ $company_size ] ?? 'unknown' ),
+			'peers'          => array_map( 'sanitize_text_field', $selected['peers'] ),
+			'growth_outlook' => sanitize_text_field( $selected['growth'] ),
+		];
+	}
 
-    /**
-     * Assess treasury maturity based on user inputs.
-     *
-     * @param array $user_inputs Sanitized user inputs.
-     * @return array {
-     *     @type string $level     Assessed maturity level.
-     *     @type string $rationale Rationale for the assessment.
-     * }
-     */
-    private function assess_treasury_maturity( $user_inputs ) {
-        $company_data = [
-            'ftes' => isset( $user_inputs['ftes'] ) ? floatval( $user_inputs['ftes'] ) : 0,
-        ];
+	/**
+	 * Assess treasury maturity based on user inputs.
+	 *
+	 * @param array $user_inputs Sanitized user inputs.
+	 * @return array {
+	 *     @type string $level     Assessed maturity level.
+	 *     @type string $rationale Rationale for the assessment.
+	 * }
+	 */
+	private function assess_treasury_maturity( $user_inputs ) {
+		$company_data = [
+			'ftes' => isset( $user_inputs['ftes'] ) ? floatval( $user_inputs['ftes'] ) : 0,
+		];
 
-        if ( class_exists( 'RTBCB_Maturity_Model' ) ) {
-            $model      = new RTBCB_Maturity_Model();
-            $assessment = $model->assess( $company_data );
+		if ( class_exists( 'RTBCB_Maturity_Model' ) ) {
+			$model      = new RTBCB_Maturity_Model();
+			$assessment = $model->assess( $company_data );
 
-            return [
-                'level'     => sanitize_text_field( $assessment['level'] ?? '' ),
-                'rationale' => sanitize_text_field( $assessment['assessment'] ?? '' ),
-            ];
-        }
+			return [
+				'level'     => sanitize_text_field( $assessment['level'] ?? '' ),
+				'rationale' => sanitize_text_field( $assessment['assessment'] ?? '' ),
+			];
+		}
 
-        $ftes  = $company_data['ftes'];
-        $level = __( 'Basic', 'rtbcb' );
+		$ftes  = $company_data['ftes'];
+		$level = __( 'Basic', 'rtbcb' );
 
-        if ( $ftes > 5 ) {
-            $level = __( 'Advanced', 'rtbcb' );
-        } elseif ( $ftes > 2 ) {
-            $level = __( 'Intermediate', 'rtbcb' );
-        }
+		if ( $ftes > 5 ) {
+			$level = __( 'Advanced', 'rtbcb' );
+		} elseif ( $ftes > 2 ) {
+			$level = __( 'Intermediate', 'rtbcb' );
+		}
 
-        $rationale = sprintf(
-            /* translators: %d: number of treasury FTEs */
-            __( 'Assessment based on %d treasury FTEs.', 'rtbcb' ),
-            $ftes
-        );
+		$rationale = sprintf(
+			/* translators: %d: number of treasury FTEs */
+			__( 'Assessment based on %d treasury FTEs.', 'rtbcb' ),
+			$ftes
+		);
 
-        return [
-            'level'     => sanitize_text_field( $level ),
-            'rationale' => sanitize_text_field( $rationale ),
-        ];
-    }
+		return [
+			'level'     => sanitize_text_field( $level ),
+			'rationale' => sanitize_text_field( $rationale ),
+		];
+	}
 
-    /**
-     * Project growth trajectory based on company size and industry.
-     *
-     * @param string $company_size Company size descriptor.
-     * @param string $industry     Industry name or slug.
-     * @return array {
-     *     @type string $size_tier        Tier label derived from company size.
-     *     @type string $size_outlook     Growth outlook based on company size.
-     *     @type string $industry_tier    Tier label derived from industry.
-     *     @type string $industry_outlook Growth outlook based on industry.
-     *     @type string $summary          Combined sanitized summary.
-     * }
-     */
-    private function project_growth_path( $company_size, $industry ) {
-        $company_size = sanitize_text_field( $company_size );
-        $industry     = sanitize_key( $industry );
+	/**
+	 * Project growth trajectory based on company size and industry.
+	 *
+	 * @param string $company_size Company size descriptor.
+	 * @param string $industry     Industry name or slug.
+	 * @return array {
+	 *     @type string $size_tier        Tier label derived from company size.
+	 *     @type string $size_outlook     Growth outlook based on company size.
+	 *     @type string $industry_tier    Tier label derived from industry.
+	 *     @type string $industry_outlook Growth outlook based on industry.
+	 *     @type string $summary          Combined sanitized summary.
+	 * }
+	 */
+	private function project_growth_path( $company_size, $industry ) {
+		$company_size = sanitize_text_field( $company_size );
+		$industry     = sanitize_key( $industry );
 
-        $size_outlooks = [
-            '<$50M'      => [ 'tier' => 'startup',    'description' => __( 'high growth potential', 'rtbcb' ) ],
-            '$50M-$500M' => [ 'tier' => 'scaleup',    'description' => __( 'scaling trajectory', 'rtbcb' ) ],
-            '$500M-$2B'  => [ 'tier' => 'growth',     'description' => __( 'steady expansion', 'rtbcb' ) ],
-            '>$2B'       => [ 'tier' => 'enterprise', 'description' => __( 'mature growth', 'rtbcb' ) ],
-        ];
+		$size_outlooks = [
+			'<$50M'      => [ 'tier' => 'startup',    'description' => __( 'high growth potential', 'rtbcb' ) ],
+			'$50M-$500M' => [ 'tier' => 'scaleup',    'description' => __( 'scaling trajectory', 'rtbcb' ) ],
+			'$500M-$2B'  => [ 'tier' => 'growth',     'description' => __( 'steady expansion', 'rtbcb' ) ],
+			'>$2B'       => [ 'tier' => 'enterprise', 'description' => __( 'mature growth', 'rtbcb' ) ],
+		];
 
-        $industry_outlooks = [
-            'technology'    => [ 'tier' => 'hyper-growth', 'description' => __( 'rapid expansion', 'rtbcb' ) ],
-            'manufacturing' => [ 'tier' => 'stable',       'description' => __( 'stable outlook', 'rtbcb' ) ],
-            'retail'        => [ 'tier' => 'competitive',  'description' => __( 'moderate growth', 'rtbcb' ) ],
-            'finance'       => [ 'tier' => 'regulated',    'description' => __( 'regulated stability', 'rtbcb' ) ],
-        ];
+		$industry_outlooks = [
+			'technology'    => [ 'tier' => 'hyper-growth', 'description' => __( 'rapid expansion', 'rtbcb' ) ],
+			'manufacturing' => [ 'tier' => 'stable',       'description' => __( 'stable outlook', 'rtbcb' ) ],
+			'retail'        => [ 'tier' => 'competitive',  'description' => __( 'moderate growth', 'rtbcb' ) ],
+			'finance'       => [ 'tier' => 'regulated',    'description' => __( 'regulated stability', 'rtbcb' ) ],
+		];
 
-        $size_data     = $size_outlooks[ $company_size ] ?? [ 'tier' => 'baseline', 'description' => __( 'stable', 'rtbcb' ) ];
-        $industry_data = $industry_outlooks[ $industry ] ?? [ 'tier' => 'neutral',  'description' => __( 'neutral', 'rtbcb' ) ];
+		$size_data     = $size_outlooks[ $company_size ] ?? [ 'tier' => 'baseline', 'description' => __( 'stable', 'rtbcb' ) ];
+		$industry_data = $industry_outlooks[ $industry ] ?? [ 'tier' => 'neutral',  'description' => __( 'neutral', 'rtbcb' ) ];
 
-        return [
-            'size_tier'        => sanitize_text_field( $size_data['tier'] ),
-            'size_outlook'     => sanitize_text_field( $size_data['description'] ),
-            'industry_tier'    => sanitize_text_field( $industry_data['tier'] ),
-            'industry_outlook' => sanitize_text_field( $industry_data['description'] ),
-            'summary'          => sanitize_text_field( $size_data['description'] . '; ' . $industry_data['description'] ),
-        ];
-    }
+		return [
+			'size_tier'        => sanitize_text_field( $size_data['tier'] ),
+			'size_outlook'     => sanitize_text_field( $size_data['description'] ),
+			'industry_tier'    => sanitize_text_field( $industry_data['tier'] ),
+			'industry_outlook' => sanitize_text_field( $industry_data['description'] ),
+			'summary'          => sanitize_text_field( $size_data['description'] . '; ' . $industry_data['description'] ),
+		];
+	}
 
-    /**
-     * Execute company, industry, and technology research in a single LLM call.
-     *
-     * @param array                     $user_inputs    Sanitized user inputs.
-     * @param callable|array|Traversable $context_chunks Optional context strings.
-     * @return array|WP_Error {
-     *     @type array  $company_research  Company research data.
-     *     @type array  $industry_analysis Industry analysis data.
-     *     @type string $tech_landscape    Technology landscape summary.
-     * }
-     */
-    private function run_batched_research( $user_inputs, $context_chunks ) {
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
+	/**
+	 * Execute company, industry, and technology research in a single LLM call.
+	 *
+	 * @param array                     $user_inputs    Sanitized user inputs.
+	 * @param callable|array|Traversable $context_chunks Optional context strings.
+	 * @return array|WP_Error {
+	 *     @type array  $company_research  Company research data.
+	 *     @type array  $industry_analysis Industry analysis data.
+	 *     @type string $tech_landscape    Technology landscape summary.
+	 * }
+	 */
+	private function run_batched_research( $user_inputs, $context_chunks ) {
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
 
-        $company_name = sanitize_text_field( $user_inputs['company_name'] ?? '' );
-        $industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
-        $company_size = sanitize_text_field( $user_inputs['company_size'] ?? '' );
+		$company_name = sanitize_text_field( $user_inputs['company_name'] ?? '' );
+		$industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
+		$company_size = sanitize_text_field( $user_inputs['company_size'] ?? '' );
 
-        $model = $this->get_model( 'mini' );
+		$model = $this->get_model( 'mini' );
 
-        $system_prompt = <<<'SYSTEM'
+		$system_prompt = <<<'SYSTEM'
 You are a senior treasury technology consultant. Return a single JSON object with the following structure and no additional text:
 {
-  "company_research": {
-    "company_profile": {
-      "business_stage": string,
-      "key_characteristics": string,
-      "treasury_priorities": string,
-      "common_challenges": string
-    },
-    "treasury_maturity": {
-      "level": string,
-      "rationale": string
-    }
-  },
-  "industry_analysis": {
-    "analysis": string,
-    "recommendations": [string],
-    "references": [string],
-    "errors": [string]
-  },
-  "technology_landscape": string
+	"company_research": {
+	"company_profile": {
+	  "business_stage": string,
+	  "key_characteristics": string,
+	  "treasury_priorities": string,
+	  "common_challenges": string
+	},
+	"treasury_maturity": {
+	  "level": string,
+	  "rationale": string
+	}
+	},
+	"industry_analysis": {
+	"analysis": string,
+	"recommendations": [string],
+	"references": [string],
+	"errors": [string]
+	},
+	"technology_landscape": string
 }
 SYSTEM;
 
-        $user_prompt = 'Company: ' . $company_name . "\n";
-        $user_prompt .= 'Industry: ' . $industry . "\n";
-        $user_prompt .= 'Size: ' . $company_size . "\n";
-        if ( ! empty( $context_chunks ) ) {
-            $user_prompt .= 'Context: ' . implode( '\n', array_map( 'sanitize_text_field', $context_chunks ) );
-        }
+		$user_prompt = 'Company: ' . $company_name . "\n";
+		$user_prompt .= 'Industry: ' . $industry . "\n";
+		$user_prompt .= 'Size: ' . $company_size . "\n";
+		if ( ! empty( $context_chunks ) ) {
+			$user_prompt .= 'Context: ' . implode( '\n', array_map( 'sanitize_text_field', $context_chunks ) );
+		}
 
-        $history = [
-            [
-                'role'    => 'user',
-                'content' => $user_prompt,
-            ],
-        ];
-        $context  = $this->build_context_for_responses( $history, $system_prompt );
-        $response = $this->call_openai_with_retry( $model, $context );
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
+		$history = [
+			[
+				'role'    => 'user',
+				'content' => $user_prompt,
+			],
+		];
+		$context  = $this->build_context_for_responses( $history, $system_prompt );
+		$response = $this->call_openai_with_retry( $model, $context );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
-        $parsed = rtbcb_parse_gpt5_response( $response );
-        $json   = json_decode( $parsed['output_text'], true );
+		$parsed = rtbcb_parse_gpt5_response( $response );
+		$json   = json_decode( $parsed['output_text'], true );
 
-        if ( ! is_array( $json ) ) {
-            return new WP_Error( 'llm_parse_error', __( 'Invalid response from language model.', 'rtbcb' ) );
-        }
+		if ( ! is_array( $json ) ) {
+			return new WP_Error( 'llm_parse_error', __( 'Invalid response from language model.', 'rtbcb' ) );
+		}
 
-        $company_profile = [
-            'business_stage'      => sanitize_text_field( $json['company_research']['company_profile']['business_stage'] ?? '' ),
-            'key_characteristics' => sanitize_text_field( $json['company_research']['company_profile']['key_characteristics'] ?? '' ),
-            'treasury_priorities' => sanitize_text_field( $json['company_research']['company_profile']['treasury_priorities'] ?? '' ),
-            'common_challenges'   => sanitize_text_field( $json['company_research']['company_profile']['common_challenges'] ?? '' ),
-        ];
+		$company_profile = [
+			'business_stage'      => sanitize_text_field( $json['company_research']['company_profile']['business_stage'] ?? '' ),
+			'key_characteristics' => sanitize_text_field( $json['company_research']['company_profile']['key_characteristics'] ?? '' ),
+			'treasury_priorities' => sanitize_text_field( $json['company_research']['company_profile']['treasury_priorities'] ?? '' ),
+			'common_challenges'   => sanitize_text_field( $json['company_research']['company_profile']['common_challenges'] ?? '' ),
+		];
 
-        $treasury_maturity = [
-            'level'     => sanitize_text_field( $json['company_research']['treasury_maturity']['level'] ?? '' ),
-            'rationale' => sanitize_text_field( $json['company_research']['treasury_maturity']['rationale'] ?? '' ),
-        ];
+		$treasury_maturity = [
+			'level'     => sanitize_text_field( $json['company_research']['treasury_maturity']['level'] ?? '' ),
+			'rationale' => sanitize_text_field( $json['company_research']['treasury_maturity']['rationale'] ?? '' ),
+		];
 
-        $company_research = [
-            'company_profile'  => $company_profile,
-            'treasury_maturity'=> $treasury_maturity,
-        ];
+		$company_research = [
+			'company_profile'  => $company_profile,
+			'treasury_maturity'=> $treasury_maturity,
+		];
 
-        $industry_analysis = [
-            'analysis'        => sanitize_text_field( $json['industry_analysis']['analysis'] ?? '' ),
-            'recommendations' => array_map( 'sanitize_text_field', $json['industry_analysis']['recommendations'] ?? [] ),
-            'references'      => array_map( 'sanitize_text_field', $json['industry_analysis']['references'] ?? [] ),
-            'errors'          => array_map( 'sanitize_text_field', $json['industry_analysis']['errors'] ?? [] ),
-        ];
+		$industry_analysis = [
+			'analysis'        => sanitize_text_field( $json['industry_analysis']['analysis'] ?? '' ),
+			'recommendations' => array_map( 'sanitize_text_field', $json['industry_analysis']['recommendations'] ?? [] ),
+			'references'      => array_map( 'sanitize_text_field', $json['industry_analysis']['references'] ?? [] ),
+			'errors'          => array_map( 'sanitize_text_field', $json['industry_analysis']['errors'] ?? [] ),
+		];
 
-        $tech_landscape = sanitize_textarea_field( $json['technology_landscape'] ?? '' );
+		$tech_landscape = sanitize_textarea_field( $json['technology_landscape'] ?? '' );
 
-        $this->last_company_research = wp_json_encode( $company_research );
+		$this->last_company_research = wp_json_encode( $company_research );
 
-        return [
-            'company_research' => $company_research,
-            'industry_analysis' => $industry_analysis,
-            'tech_landscape'    => $tech_landscape,
-        ];
-    }
+		return [
+			'company_research' => $company_research,
+			'industry_analysis' => $industry_analysis,
+			'tech_landscape'    => $tech_landscape,
+		];
+	}
 
-    /**
-     * Generate multiple research responses in a single OpenAI request.
-     *
-     * Each prompt should include `instructions` and `input` keys. The returned
-     * array preserves the original prompt keys.
-     *
-     * @param array $prompts Associative array of prompt data.
-     * @return array|WP_Error Array of responses or error object.
-     */
-    private function generate_research_batch( $prompts ) {
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
+	/**
+	 * Generate multiple research responses in a single OpenAI request.
+	 *
+	 * Each prompt should include `instructions` and `input` keys. The returned
+	 * array preserves the original prompt keys.
+	 *
+	 * @param array $prompts Associative array of prompt data.
+	 * @return array|WP_Error Array of responses or error object.
+	 */
+	private function generate_research_batch( $prompts ) {
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
 
-        if ( empty( $prompts ) || ! is_array( $prompts ) ) {
-            return new WP_Error( 'empty_prompt', __( 'Prompts array cannot be empty.', 'rtbcb' ) );
-        }
+		if ( empty( $prompts ) || ! is_array( $prompts ) ) {
+			return new WP_Error( 'empty_prompt', __( 'Prompts array cannot be empty.', 'rtbcb' ) );
+		}
 
-        $model  = $this->get_model( 'mini' );
-        $inputs = [];
-        foreach ( $prompts as $prompt ) {
-            $instructions = sanitize_textarea_field( $prompt['instructions'] ?? '' );
-            $input        = sanitize_textarea_field( $prompt['input'] ?? '' );
-            $inputs[]     = $instructions ? $instructions . "\n" . $input : $input;
-        }
+		$model  = $this->get_model( 'mini' );
+		$inputs = [];
+		foreach ( $prompts as $prompt ) {
+			$instructions = sanitize_textarea_field( $prompt['instructions'] ?? '' );
+			$input        = sanitize_textarea_field( $prompt['input'] ?? '' );
+			$inputs[]     = $instructions ? $instructions . "\n" . $input : $input;
+		}
 
-        $body = [
-            'model'            => $model,
-            'input'            => $inputs,
-            'max_output_tokens'=> intval( $this->gpt5_config['max_output_tokens'] ?? 8000 ),
-            'stream'           => false,
-        ];
+		$body = [
+			'model'            => $model,
+			'input'            => $inputs,
+			'max_output_tokens'=> intval( $this->gpt5_config['max_output_tokens'] ?? 8000 ),
+			'stream'           => false,
+		];
 
-        if ( rtbcb_model_supports_temperature( $model ) ) {
-            $body['temperature'] = floatval( $this->gpt5_config['temperature'] ?? 0.7 );
-        }
+		if ( rtbcb_model_supports_temperature( $model ) ) {
+			$body['temperature'] = floatval( $this->gpt5_config['temperature'] ?? 0.7 );
+		}
 
 	$timeout  = intval( $this->gpt5_config['timeout'] ?? 300 );
-        $response = wp_remote_post(
-            'https://api.openai.com/v1/responses',
-            [
-                'headers' => [
-                    'Authorization' => 'Bearer ' . $this->api_key,
-                    'Content-Type'  => 'application/json',
-                ],
-                'body'    => wp_json_encode( $body ),
-                'timeout' => $timeout,
-            ]
-        );
+		$response = wp_remote_post(
+			'https://api.openai.com/v1/responses',
+			[
+				'headers' => [
+					'Authorization' => 'Bearer ' . $this->api_key,
+					'Content-Type'  => 'application/json',
+				],
+				'body'    => wp_json_encode( $body ),
+				'timeout' => $timeout,
+			]
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
-        $status = wp_remote_retrieve_response_code( $response );
-        if ( $status < 200 || $status >= 300 ) {
-            return new WP_Error(
-                'llm_http_status',
-                __( 'Language model request failed.', 'rtbcb' ),
-                [ 'status' => $status ]
-            );
-        }
+		$status = wp_remote_retrieve_response_code( $response );
+		if ( $status < 200 || $status >= 300 ) {
+			return new WP_Error(
+				'llm_http_status',
+				__( 'Language model request failed.', 'rtbcb' ),
+				[ 'status' => $status ]
+			);
+		}
 
-        $decoded = json_decode( wp_remote_retrieve_body( $response ), true );
-        if ( ! is_array( $decoded ) ) {
-            return new WP_Error( 'llm_response_decode_error', __( 'Failed to decode response body.', 'rtbcb' ) );
-        }
+		$decoded = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $decoded ) ) {
+			return new WP_Error( 'llm_response_decode_error', __( 'Failed to decode response body.', 'rtbcb' ) );
+		}
 
-        $outputs = $decoded['output'] ?? [];
-        $keys    = array_keys( $prompts );
-        $results = [];
+		$outputs = $decoded['output'] ?? [];
+		$keys    = array_keys( $prompts );
+		$results = [];
 
-        foreach ( $keys as $index => $key ) {
-            $text = '';
-            if ( isset( $outputs[ $index ]['content'] ) && is_array( $outputs[ $index ]['content'] ) ) {
-                foreach ( $outputs[ $index ]['content'] as $piece ) {
-                    if ( isset( $piece['text'] ) ) {
-                        $text .= $piece['text'];
-                    }
-                }
-            } elseif ( isset( $outputs[ $index ]['output_text'] ) ) {
-                $text = $outputs[ $index ]['output_text'];
-            }
+		foreach ( $keys as $index => $key ) {
+			$text = '';
+			if ( isset( $outputs[ $index ]['content'] ) && is_array( $outputs[ $index ]['content'] ) ) {
+				foreach ( $outputs[ $index ]['content'] as $piece ) {
+					if ( isset( $piece['text'] ) ) {
+						$text .= $piece['text'];
+					}
+				}
+			} elseif ( isset( $outputs[ $index ]['output_text'] ) ) {
+				$text = $outputs[ $index ]['output_text'];
+			}
 
-            $text = trim( $text );
-            if ( '' === $text ) {
-                $results[ $key ] = new WP_Error( 'llm_empty_response', __( 'Empty response from language model.', 'rtbcb' ) );
-            } else {
-                $results[ $key ] = $text;
-            }
-        }
+			$text = trim( $text );
+			if ( '' === $text ) {
+				$results[ $key ] = new WP_Error( 'llm_empty_response', __( 'Empty response from language model.', 'rtbcb' ) );
+			} else {
+				$results[ $key ] = $text;
+			}
+		}
 
-        return $results;
-    }
+		return $results;
+	}
 
-    /**
-     * Analyze industry context using the LLM.
-     *
-     * @param array $user_inputs Sanitized user inputs.
-     * @return array|WP_Error Industry analysis or error object.
-     */
-    private function analyze_industry_context( $user_inputs ) {
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
+	/**
+	 * Analyze industry context using the LLM.
+	 *
+	 * @param array $user_inputs Sanitized user inputs.
+	 * @return array|WP_Error Industry analysis or error object.
+	 */
+	private function analyze_industry_context( $user_inputs ) {
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
 
-        $industry = sanitize_text_field( $user_inputs['industry'] ?? '' );
-        if ( empty( $industry ) ) {
-            return [
-                'analysis'        => '',
-                'recommendations' => [],
-                'references'      => [],
-                'errors'          => [],
-            ];
-        }
+		$industry = sanitize_text_field( $user_inputs['industry'] ?? '' );
+		if ( empty( $industry ) ) {
+			return [
+				'analysis'        => '',
+				'recommendations' => [],
+				'references'      => [],
+				'errors'          => [],
+			];
+		}
 
-        $model = $this->get_model( 'mini' );
+		$model = $this->get_model( 'mini' );
 
-        $system_prompt = <<<'SYSTEM'
+		$system_prompt = <<<'SYSTEM'
 You are a senior treasury technology consultant tasked with delivering comprehensive, research-based analysis. Begin by reviewing the request and identifying the main aspects to address. Your responses must be formatted strictly as a single JSON object according to the specified schema, and no text should appear outside this JSON.
 
 # Output Format
 Return a single JSON object with these fields, in the exact order shown:
 {
-  "analysis": string,
-  "recommendations": [string],
-  "references": [string],
-  "errors": [string]
+	"analysis": string,
+	"recommendations": [string],
+	"references": [string],
+	"errors": [string]
 }
 
 ## Formatting Rules
@@ -1601,280 +1601,280 @@ Return a single JSON object with these fields, in the exact order shown:
 Before generating your response, create a concise checklist (3-7 bullets) of what you will do to ensure your approach is methodical and covers all aspects of the request. After constructing the JSON, validate that your output strictly follows the schema and formatting requirements before returning it.
 SYSTEM;
 
-        $user_prompt = 'Provide sector_trends, competitive_benchmarks, and regulatory_considerations for the ' . $industry . ' industry in JSON.';
+		$user_prompt = 'Provide sector_trends, competitive_benchmarks, and regulatory_considerations for the ' . $industry . ' industry in JSON.';
 
-        $history = [
-            [
-                'role'    => 'user',
-                'content' => $user_prompt,
-            ],
-        ];
-        $context = $this->build_context_for_responses( $history, $system_prompt );
-        $tokens  = $this->tokens_for_report( 'industry_analysis' );
-        $response = $this->call_openai_with_retry( $model, $context, $tokens );
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
+		$history = [
+			[
+				'role'    => 'user',
+				'content' => $user_prompt,
+			],
+		];
+		$context = $this->build_context_for_responses( $history, $system_prompt );
+		$tokens  = $this->tokens_for_report( 'industry_analysis' );
+		$response = $this->call_openai_with_retry( $model, $context, $tokens );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
-        $parsed_response = rtbcb_parse_gpt5_response( $response );
-        $json            = json_decode( $parsed_response['output_text'], true );
+		$parsed_response = rtbcb_parse_gpt5_response( $response );
+		$json            = json_decode( $parsed_response['output_text'], true );
 
-        if ( ! is_array( $json ) ) {
-            return new WP_Error( 'llm_parse_error', __( 'Invalid response from language model.', 'rtbcb' ) );
-        }
+		if ( ! is_array( $json ) ) {
+			return new WP_Error( 'llm_parse_error', __( 'Invalid response from language model.', 'rtbcb' ) );
+		}
 
-        return [
-            'analysis'        => sanitize_text_field( $json['analysis'] ?? '' ),
-            'recommendations' => array_map( 'sanitize_text_field', $json['recommendations'] ?? [] ),
-            'references'      => array_map( 'sanitize_text_field', $json['references'] ?? [] ),
-            'errors'          => array_map( 'sanitize_text_field', $json['errors'] ?? [] ),
-        ];
-    }
+		return [
+			'analysis'        => sanitize_text_field( $json['analysis'] ?? '' ),
+			'recommendations' => array_map( 'sanitize_text_field', $json['recommendations'] ?? [] ),
+			'references'      => array_map( 'sanitize_text_field', $json['references'] ?? [] ),
+			'errors'          => array_map( 'sanitize_text_field', $json['errors'] ?? [] ),
+		];
+	}
 
-    /**
-     * Research treasury technology solutions using the LLM.
-     *
-     * @param array $user_inputs    Sanitized user inputs.
-     * @param array $context_chunks Optional context strings.
-     * @return string|WP_Error Research summary or error object.
-     */
-    private function research_treasury_solutions( $user_inputs, $context_chunks ) {
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
+	/**
+	 * Research treasury technology solutions using the LLM.
+	 *
+	 * @param array $user_inputs    Sanitized user inputs.
+	 * @param array $context_chunks Optional context strings.
+	 * @return string|WP_Error Research summary or error object.
+	 */
+	private function research_treasury_solutions( $user_inputs, $context_chunks ) {
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
 
-        $industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
-        $company_size = sanitize_text_field( $user_inputs['company_size'] ?? '' );
+		$industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
+		$company_size = sanitize_text_field( $user_inputs['company_size'] ?? '' );
 
-        $model  = $this->get_model( 'mini' );
-        $prompt = 'Briefly summarize treasury technology solutions relevant to a ' . $company_size . ' company in the ' . $industry . ' industry.';
+		$model  = $this->get_model( 'mini' );
+		$prompt = 'Briefly summarize treasury technology solutions relevant to a ' . $company_size . ' company in the ' . $industry . ' industry.';
 
-        if ( ! empty( $context_chunks ) ) {
-            $prompt .= '\nContext: ' . implode( '\n', array_map( 'sanitize_text_field', $context_chunks ) );
-        }
+		if ( ! empty( $context_chunks ) ) {
+			$prompt .= '\nContext: ' . implode( '\n', array_map( 'sanitize_text_field', $context_chunks ) );
+		}
 
-        $history  = [
-            [
-                'role'    => 'user',
-                'content' => $prompt,
-            ],
-        ];
-        $context = $this->build_context_for_responses( $history );
-        $tokens  = $this->tokens_for_report( 'tech_research' );
-        $response = $this->call_openai_with_retry( $model, $context, $tokens );
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
+		$history  = [
+			[
+				'role'    => 'user',
+				'content' => $prompt,
+			],
+		];
+		$context = $this->build_context_for_responses( $history );
+		$tokens  = $this->tokens_for_report( 'tech_research' );
+		$response = $this->call_openai_with_retry( $model, $context, $tokens );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
-        $parsed  = rtbcb_parse_gpt5_response( $response );
-        $summary = sanitize_textarea_field( $parsed['output_text'] );
+		$parsed  = rtbcb_parse_gpt5_response( $response );
+		$summary = sanitize_textarea_field( $parsed['output_text'] );
 
-        if ( empty( $summary ) ) {
-            return new WP_Error( 'llm_empty_response', __( 'No technology research returned.', 'rtbcb' ) );
-        }
+		if ( empty( $summary ) ) {
+			return new WP_Error( 'llm_empty_response', __( 'No technology research returned.', 'rtbcb' ) );
+		}
 
-        return $summary;
-    }
+		return $summary;
+	}
 
-    /**
-     * Select the optimal model for comprehensive analysis.
-     *
-      * @param array                     $user_inputs    Sanitized user inputs.
-      * @param callable|array|Traversable $context_chunks Optional context strings.
-     * @return string Model identifier.
-     */
-    private function select_optimal_model( $user_inputs, $context_chunks ) {
-        $model         = $this->get_model( 'advanced' );
-        $context_count = 0;
+	/**
+	 * Select the optimal model for comprehensive analysis.
+	 *
+	  * @param array                     $user_inputs    Sanitized user inputs.
+	  * @param callable|array|Traversable $context_chunks Optional context strings.
+	 * @return string Model identifier.
+	 */
+	private function select_optimal_model( $user_inputs, $context_chunks ) {
+		$model         = $this->get_model( 'advanced' );
+		$context_count = 0;
 
-        if ( is_callable( $context_chunks ) || $context_chunks instanceof Traversable ) {
-            // Lazily provided context; treat as empty without invoking.
-        } elseif ( is_array( $context_chunks ) || $context_chunks instanceof Countable ) {
-            $context_count = count( $context_chunks );
-        }
+		if ( is_callable( $context_chunks ) || $context_chunks instanceof Traversable ) {
+			// Lazily provided context; treat as empty without invoking.
+		} elseif ( is_array( $context_chunks ) || $context_chunks instanceof Countable ) {
+			$context_count = count( $context_chunks );
+		}
 
-        if ( $context_count < 3 ) {
-            $model = $this->get_model( 'premium' );
-        }
+		if ( $context_count < 3 ) {
+			$model = $this->get_model( 'premium' );
+		}
 
-        return sanitize_text_field( $model );
-    }
+		return sanitize_text_field( $model );
+	}
 
-    /**
-     * Build comprehensive prompt with research context
-     */
-    private function build_comprehensive_prompt( $user_inputs, $roi_data, $company_research, $industry_analysis, $tech_landscape ) {
-        $company_name    = $user_inputs['company_name'] ?? 'the company';
-        $company_profile = $company_research['company_profile'];
+	/**
+	 * Build comprehensive prompt with research context
+	 */
+	private function build_comprehensive_prompt( $user_inputs, $roi_data, $company_research, $industry_analysis, $tech_landscape ) {
+		$company_name    = $user_inputs['company_name'] ?? 'the company';
+		$company_profile = $company_research['company_profile'];
 
-        $prompt  = "As a senior treasury technology consultant with 15+ years of experience, create a comprehensive business case for {$company_name}.\n\n";
+		$prompt  = "As a senior treasury technology consultant with 15+ years of experience, create a comprehensive business case for {$company_name}.\n\n";
 
-        // Add detailed context sections...
-        $prompt .= "EXECUTIVE BRIEF:\n";
-        $prompt .= "Create a strategic business case that justifies treasury technology investment with:\n";
-        $prompt .= "- Clear ROI projections with risk-adjusted scenarios\n";
-        $prompt .= "- Industry-specific operational improvements\n";
-        $prompt .= "- Implementation roadmap with success metrics\n";
-        $prompt .= "- Risk mitigation strategies\n\n";
+		// Add detailed context sections...
+		$prompt .= "EXECUTIVE BRIEF:\n";
+		$prompt .= "Create a strategic business case that justifies treasury technology investment with:\n";
+		$prompt .= "- Clear ROI projections with risk-adjusted scenarios\n";
+		$prompt .= "- Industry-specific operational improvements\n";
+		$prompt .= "- Implementation roadmap with success metrics\n";
+		$prompt .= "- Risk mitigation strategies\n\n";
 
-        // Company Context
-        $prompt .= "COMPANY PROFILE:\n";
-        $prompt .= "Company: {$company_name}\n";
-        $prompt .= "Industry: " . ($user_inputs['industry'] ?? 'Not specified') . "\n";
-        $prompt .= "Revenue Size: " . ($user_inputs['company_size'] ?? 'Not specified') . "\n";
-        $prompt .= "Business Stage: {$company_profile['business_stage']}\n";
-        $prompt .= "Key Characteristics: {$company_profile['key_characteristics']}\n";
-        $prompt .= "Treasury Priorities: {$company_profile['treasury_priorities']}\n";
-        $prompt .= "Common Challenges: {$company_profile['common_challenges']}\n\n";
-        
-        // Current State Analysis
-        $prompt .= "CURRENT TREASURY OPERATIONS:\n";
-        $prompt .= "Weekly Reconciliation Hours: " . ($user_inputs['hours_reconciliation'] ?? 0) . "\n";
-        $prompt .= "Weekly Cash Positioning Hours: " . ($user_inputs['hours_cash_positioning'] ?? 0) . "\n";
-        $prompt .= "Banking Relationships: " . ($user_inputs['num_banks'] ?? 0) . "\n";
-        $prompt .= "Treasury Team Size: " . ($user_inputs['ftes'] ?? 0) . " FTEs\n";
-        $prompt .= "Key Pain Points: " . implode(', ', $user_inputs['pain_points'] ?? []) . "\n\n";
+		// Company Context
+		$prompt .= "COMPANY PROFILE:\n";
+		$prompt .= "Company: {$company_name}\n";
+		$prompt .= "Industry: " . ($user_inputs['industry'] ?? 'Not specified') . "\n";
+		$prompt .= "Revenue Size: " . ($user_inputs['company_size'] ?? 'Not specified') . "\n";
+		$prompt .= "Business Stage: {$company_profile['business_stage']}\n";
+		$prompt .= "Key Characteristics: {$company_profile['key_characteristics']}\n";
+		$prompt .= "Treasury Priorities: {$company_profile['treasury_priorities']}\n";
+		$prompt .= "Common Challenges: {$company_profile['common_challenges']}\n\n";
+		
+		// Current State Analysis
+		$prompt .= "CURRENT TREASURY OPERATIONS:\n";
+		$prompt .= "Weekly Reconciliation Hours: " . ($user_inputs['hours_reconciliation'] ?? 0) . "\n";
+		$prompt .= "Weekly Cash Positioning Hours: " . ($user_inputs['hours_cash_positioning'] ?? 0) . "\n";
+		$prompt .= "Banking Relationships: " . ($user_inputs['num_banks'] ?? 0) . "\n";
+		$prompt .= "Treasury Team Size: " . ($user_inputs['ftes'] ?? 0) . " FTEs\n";
+		$prompt .= "Key Pain Points: " . implode(', ', $user_inputs['pain_points'] ?? []) . "\n\n";
 
-        // Industry Context
-        if ( ! empty( $industry_analysis ) ) {
-            if ( ! empty( $industry_analysis['analysis'] ) ) {
-                $prompt .= "INDUSTRY CONTEXT:\n" . $industry_analysis['analysis'] . "\n\n";
-            }
-            if ( ! empty( $industry_analysis['recommendations'] ) ) {
-                $prompt .= "INDUSTRY RECOMMENDATIONS:\n- " . implode( "\n- ", $industry_analysis['recommendations'] ) . "\n\n";
-            }
-            if ( ! empty( $industry_analysis['references'] ) ) {
-                $prompt .= "INDUSTRY REFERENCES:\n- " . implode( "\n- ", $industry_analysis['references'] ) . "\n\n";
-            }
-        }
+		// Industry Context
+		if ( ! empty( $industry_analysis ) ) {
+			if ( ! empty( $industry_analysis['analysis'] ) ) {
+				$prompt .= "INDUSTRY CONTEXT:\n" . $industry_analysis['analysis'] . "\n\n";
+			}
+			if ( ! empty( $industry_analysis['recommendations'] ) ) {
+				$prompt .= "INDUSTRY RECOMMENDATIONS:\n- " . implode( "\n- ", $industry_analysis['recommendations'] ) . "\n\n";
+			}
+			if ( ! empty( $industry_analysis['references'] ) ) {
+				$prompt .= "INDUSTRY REFERENCES:\n- " . implode( "\n- ", $industry_analysis['references'] ) . "\n\n";
+			}
+		}
 
-        // Treasury technology landscape
-        if ( ! empty( $tech_landscape ) ) {
-            $prompt .= "TECHNOLOGY LANDSCAPE:\n{$tech_landscape}\n\n";
-        }
+		// Treasury technology landscape
+		if ( ! empty( $tech_landscape ) ) {
+			$prompt .= "TECHNOLOGY LANDSCAPE:\n{$tech_landscape}\n\n";
+		}
 
-        // ROI Analysis
-        $prompt .= "PROJECTED ROI ANALYSIS:\n";
-        $prompt .= "Conservative Scenario: $" . number_format($roi_data['conservative']['total_annual_benefit'] ?? 0) . "\n";
-        $prompt .= "Base Case Scenario: $" . number_format($roi_data['base']['total_annual_benefit'] ?? 0) . "\n";
-        $prompt .= "Optimistic Scenario: $" . number_format($roi_data['optimistic']['total_annual_benefit'] ?? 0) . "\n\n";
-        
-        // Strategic Context
-        if ( ! empty( $user_inputs['business_objective'] ) ) {
-            $prompt .= "Primary Business Objective: " . $user_inputs['business_objective'] . "\n";
-        }
-        if ( ! empty( $user_inputs['implementation_timeline'] ) ) {
-            $prompt .= "Implementation Timeline: " . $user_inputs['implementation_timeline'] . "\n";
-        }
-        if ( ! empty( $user_inputs['budget_range'] ) ) {
-            $prompt .= "Budget Range: " . $user_inputs['budget_range'] . "\n";
-        }
+		// ROI Analysis
+		$prompt .= "PROJECTED ROI ANALYSIS:\n";
+		$prompt .= "Conservative Scenario: $" . number_format($roi_data['conservative']['total_annual_benefit'] ?? 0) . "\n";
+		$prompt .= "Base Case Scenario: $" . number_format($roi_data['base']['total_annual_benefit'] ?? 0) . "\n";
+		$prompt .= "Optimistic Scenario: $" . number_format($roi_data['optimistic']['total_annual_benefit'] ?? 0) . "\n\n";
+		
+		// Strategic Context
+		if ( ! empty( $user_inputs['business_objective'] ) ) {
+			$prompt .= "Primary Business Objective: " . $user_inputs['business_objective'] . "\n";
+		}
+		if ( ! empty( $user_inputs['implementation_timeline'] ) ) {
+			$prompt .= "Implementation Timeline: " . $user_inputs['implementation_timeline'] . "\n";
+		}
+		if ( ! empty( $user_inputs['budget_range'] ) ) {
+			$prompt .= "Budget Range: " . $user_inputs['budget_range'] . "\n";
+		}
 
-        $prompt .= "\nDELIVER A PROFESSIONAL BUSINESS CASE:\n";
-        $prompt .= "Respond with a comprehensive JSON structure containing all required sections.\n";
-        $prompt .= "Ensure each section provides actionable insights specific to {$company_name}'s situation.\n";
-        $prompt .= "Use professional consulting language appropriate for C-level executives.\n\n";
+		$prompt .= "\nDELIVER A PROFESSIONAL BUSINESS CASE:\n";
+		$prompt .= "Respond with a comprehensive JSON structure containing all required sections.\n";
+		$prompt .= "Ensure each section provides actionable insights specific to {$company_name}'s situation.\n";
+		$prompt .= "Use professional consulting language appropriate for C-level executives.\n\n";
 
-        $prompt .= "REQUIRED JSON STRUCTURE (respond with ONLY this JSON, no other text):\n";
-        $prompt .= json_encode([
-            'executive_summary' => [
-                'strategic_positioning' => "2-3 sentences about {$company_name}'s strategic position and readiness for treasury technology",
-                'business_case_strength' => 'Strong|Moderate|Compelling',
-                'key_value_drivers' => [
-                    "Primary value driver specific to {$company_name}",
-                    "Secondary value driver for their industry/size",
-                    "Third strategic benefit for their situation"
-                ],
-                'executive_recommendation' => "Clear recommendation with specific next steps for {$company_name}",
-                'confidence_level' => 'decimal between 0.7-0.95'
-            ],
-            'operational_analysis' => [
-                'current_state_assessment' => [
-                    'efficiency_rating' => 'Excellent|Good|Fair|Poor',
-                    'benchmark_comparison' => "How {$company_name} compares to industry peers",
-                    'capacity_utilization' => "Analysis of current team capacity and bottlenecks"
-                ],
-                'process_inefficiencies' => [
-                    [
-                        'process' => 'specific process name',
-                        'impact' => 'High|Medium|Low',
-                        'description' => 'detailed description of inefficiency'
-                    ]
-                ],
-                'automation_opportunities' => [
-                    [
-                        'area' => 'process area',
-                        'complexity' => 'High|Medium|Low',
-                        'potential_hours_saved' => 'number'
-                    ]
-                ]
-            ],
-            'industry_insights' => [
-                'sector_trends' => "Key trends affecting {$company_name}'s industry",
-                'competitive_benchmarks' => "How competitors are leveraging treasury technology",
-                'regulatory_considerations' => "Relevant compliance and regulatory factors"
-            ],
-            'technology_recommendations' => [
-                'primary_solution' => [
-                    'category' => 'recommended category',
-                    'rationale' => "Why this fits {$company_name} specifically",
-                    'key_features' => ['feature1', 'feature2', 'feature3']
-                ],
-                'implementation_approach' => [
-                    'phase_1' => 'initial implementation focus',
-                    'phase_2' => 'expansion phase',
-                    'success_metrics' => ['metric1', 'metric2', 'metric3']
-                ]
-            ],
-            'financial_analysis' => [
-                'investment_breakdown' => [
-                    'software_licensing' => 'estimated cost range',
-                    'implementation_services' => 'estimated cost range',
-                    'training_change_management' => 'estimated cost range'
-                ],
-                'payback_analysis' => [
-                    'payback_months' => 'number',
-                    'roi_3_year' => 'percentage',
-                    'npv_analysis' => 'positive value justification'
-                ]
-            ],
-            'risk_mitigation' => [
-                'implementation_risks' => [
-                    "Risk specific to {$company_name}'s situation",
-                    "Industry-specific risk consideration",
-                    "Technology adoption risk"
-                ],
-                'mitigation_strategies' => [
-                    'risk_1_mitigation' => 'specific mitigation approach',
-                    'risk_2_mitigation' => 'specific mitigation approach'
-                ]
-            ],
-            'next_steps' => [
-                "Immediate action for {$company_name} leadership",
-                "Vendor evaluation and selection process",
-                "Implementation planning and timeline",
-                "Change management and training program"
-            ]
-        ], JSON_PRETTY_PRINT);
-        
-        return $prompt;
-    }
+		$prompt .= "REQUIRED JSON STRUCTURE (respond with ONLY this JSON, no other text):\n";
+		$prompt .= json_encode([
+			'executive_summary' => [
+				'strategic_positioning' => "2-3 sentences about {$company_name}'s strategic position and readiness for treasury technology",
+				'business_case_strength' => 'Strong|Moderate|Compelling',
+				'key_value_drivers' => [
+					"Primary value driver specific to {$company_name}",
+					"Secondary value driver for their industry/size",
+					"Third strategic benefit for their situation"
+				],
+				'executive_recommendation' => "Clear recommendation with specific next steps for {$company_name}",
+				'confidence_level' => 'decimal between 0.7-0.95'
+			],
+			'operational_analysis' => [
+				'current_state_assessment' => [
+					'efficiency_rating' => 'Excellent|Good|Fair|Poor',
+					'benchmark_comparison' => "How {$company_name} compares to industry peers",
+					'capacity_utilization' => "Analysis of current team capacity and bottlenecks"
+				],
+				'process_inefficiencies' => [
+					[
+						'process' => 'specific process name',
+						'impact' => 'High|Medium|Low',
+						'description' => 'detailed description of inefficiency'
+					]
+				],
+				'automation_opportunities' => [
+					[
+						'area' => 'process area',
+						'complexity' => 'High|Medium|Low',
+						'potential_hours_saved' => 'number'
+					]
+				]
+			],
+			'industry_insights' => [
+				'sector_trends' => "Key trends affecting {$company_name}'s industry",
+				'competitive_benchmarks' => "How competitors are leveraging treasury technology",
+				'regulatory_considerations' => "Relevant compliance and regulatory factors"
+			],
+			'technology_recommendations' => [
+				'primary_solution' => [
+					'category' => 'recommended category',
+					'rationale' => "Why this fits {$company_name} specifically",
+					'key_features' => ['feature1', 'feature2', 'feature3']
+				],
+				'implementation_approach' => [
+					'phase_1' => 'initial implementation focus',
+					'phase_2' => 'expansion phase',
+					'success_metrics' => ['metric1', 'metric2', 'metric3']
+				]
+			],
+			'financial_analysis' => [
+				'investment_breakdown' => [
+					'software_licensing' => 'estimated cost range',
+					'implementation_services' => 'estimated cost range',
+					'training_change_management' => 'estimated cost range'
+				],
+				'payback_analysis' => [
+					'payback_months' => 'number',
+					'roi_3_year' => 'percentage',
+					'npv_analysis' => 'positive value justification'
+				]
+			],
+			'risk_mitigation' => [
+				'implementation_risks' => [
+					"Risk specific to {$company_name}'s situation",
+					"Industry-specific risk consideration",
+					"Technology adoption risk"
+				],
+				'mitigation_strategies' => [
+					'risk_1_mitigation' => 'specific mitigation approach',
+					'risk_2_mitigation' => 'specific mitigation approach'
+				]
+			],
+			'next_steps' => [
+				"Immediate action for {$company_name} leadership",
+				"Vendor evaluation and selection process",
+				"Implementation planning and timeline",
+				"Change management and training program"
+			]
+		], JSON_PRETTY_PRINT);
+		
+		return $prompt;
+	}
 
-    /**
-     * Enhance parsed analysis with research context.
-     *
-     * @param array $analysis          Parsed analysis from LLM.
-     * @param array  $company_research  Company research data.
-     * @param array  $industry_analysis Industry analysis data.
-     * @param string $tech_landscape    Technology landscape summary.
-     * @return array Enhanced analysis.
-     */
-    private function enhance_with_research( $analysis, $company_research, $industry_analysis, $tech_landscape ) {
-        $analysis['research'] = [
-            'company'   => $company_research,
-            'industry'  => $industry_analysis,
-            'technology' => $tech_landscape,
-        ];
+	/**
+	 * Enhance parsed analysis with research context.
+	 *
+	 * @param array $analysis          Parsed analysis from LLM.
+	 * @param array  $company_research  Company research data.
+	 * @param array  $industry_analysis Industry analysis data.
+	 * @param string $tech_landscape    Technology landscape summary.
+	 * @return array Enhanced analysis.
+	 */
+	private function enhance_with_research( $analysis, $company_research, $industry_analysis, $tech_landscape ) {
+		$analysis['research'] = [
+			'company'   => $company_research,
+			'industry'  => $industry_analysis,
+			'technology' => $tech_landscape,
+		];
 
 return $analysis;
 }
@@ -1887,9 +1887,9 @@ return $analysis;
 	 */
 	public function enrich_company_profile( $user_inputs ) {
 
-        if ( rtbcb_heavy_features_disabled() ) {
-            return new WP_Error( 'heavy_features_disabled', __( 'AI features are disabled.', 'rtbcb' ) );
-        }
+		if ( rtbcb_heavy_features_disabled() ) {
+			return new WP_Error( 'heavy_features_disabled', __( 'AI features are disabled.', 'rtbcb' ) );
+		}
 	if ( empty( $this->api_key ) ) {
 	return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
 	}
@@ -1935,65 +1935,65 @@ return $analysis;
 	```json
 	{
 	  "company_profile": {
-	    "enhanced_description": "string - comprehensive company description",
-	    "business_model": "string - primary business model and revenue streams",
-	    "market_position": "string - competitive position and market standing",
-	    "maturity_level": "basic|developing|strategic|optimized",
-	    "financial_indicators": {
-	      "estimated_revenue": "number - best estimate in USD",
-	      "growth_stage": "startup|growth|mature|decline",
-	      "financial_health": "strong|stable|concerning|unknown"
-	    },
-	    "treasury_maturity": {
-	      "current_state": "string - assessment of current treasury operations",
-	      "sophistication_level": "manual|semi_automated|automated|strategic",
-	      "key_gaps": ["array of identified gaps"],
-	      "automation_readiness": "low|medium|high"
-	    },
-	    "strategic_context": {
-	      "primary_challenges": ["array of business challenges"],
-	      "growth_objectives": ["array of growth objectives"],
-	      "competitive_pressures": ["array of competitive factors"],
-	      "regulatory_environment": "string - regulatory considerations"
-	    }
+		"enhanced_description": "string - comprehensive company description",
+		"business_model": "string - primary business model and revenue streams",
+		"market_position": "string - competitive position and market standing",
+		"maturity_level": "basic|developing|strategic|optimized",
+		"financial_indicators": {
+		  "estimated_revenue": "number - best estimate in USD",
+		  "growth_stage": "startup|growth|mature|decline",
+		  "financial_health": "strong|stable|concerning|unknown"
+		},
+		"treasury_maturity": {
+		  "current_state": "string - assessment of current treasury operations",
+		  "sophistication_level": "manual|semi_automated|automated|strategic",
+		  "key_gaps": ["array of identified gaps"],
+		  "automation_readiness": "low|medium|high"
+		},
+		"strategic_context": {
+		  "primary_challenges": ["array of business challenges"],
+		  "growth_objectives": ["array of growth objectives"],
+		  "competitive_pressures": ["array of competitive factors"],
+		  "regulatory_environment": "string - regulatory considerations"
+		}
 	  },
 	  "industry_context": {
-	    "sector_analysis": {
-	      "market_dynamics": "string - current market conditions",
-	      "growth_trends": "string - industry growth patterns",
-	      "disruption_factors": ["array of disruptive forces"],
-	      "technology_adoption": "laggard|follower|mainstream|leader"
-	    },
-	    "benchmarking": {
-	      "typical_treasury_setup": "string - industry norm for treasury operations",
-	      "common_pain_points": ["array of industry-wide challenges"],
-	      "technology_penetration": "low|medium|high",
-	      "investment_patterns": "string - typical technology investment patterns"
-	    },
-	    "regulatory_landscape": {
-	      "key_regulations": ["array of relevant regulations"],
-	      "compliance_complexity": "low|medium|high|very_high",
-	      "upcoming_changes": ["array of anticipated regulatory changes"]
-	    }
+		"sector_analysis": {
+		  "market_dynamics": "string - current market conditions",
+		  "growth_trends": "string - industry growth patterns",
+		  "disruption_factors": ["array of disruptive forces"],
+		  "technology_adoption": "laggard|follower|mainstream|leader"
+		},
+		"benchmarking": {
+		  "typical_treasury_setup": "string - industry norm for treasury operations",
+		  "common_pain_points": ["array of industry-wide challenges"],
+		  "technology_penetration": "low|medium|high",
+		  "investment_patterns": "string - typical technology investment patterns"
+		},
+		"regulatory_landscape": {
+		  "key_regulations": ["array of relevant regulations"],
+		  "compliance_complexity": "low|medium|high|very_high",
+		  "upcoming_changes": ["array of anticipated regulatory changes"]
+		}
 	  },
 	  "strategic_insights": {
-	    "technology_readiness": "not_ready|ready|urgent_need",
-	    "investment_justification": "weak|moderate|strong|compelling",
-	    "implementation_complexity": "low|medium|high|very_high",
-	    "expected_benefits": {
-	      "efficiency_gains": "string - expected efficiency improvements",
-	      "risk_reduction": "string - risk mitigation benefits",
-	      "strategic_value": "string - strategic business value",
-	      "competitive_advantage": "string - competitive positioning benefits"
-	    },
-	    "critical_success_factors": ["array of key success factors"],
-	    "potential_obstacles": ["array of implementation challenges"]
+		"technology_readiness": "not_ready|ready|urgent_need",
+		"investment_justification": "weak|moderate|strong|compelling",
+		"implementation_complexity": "low|medium|high|very_high",
+		"expected_benefits": {
+		  "efficiency_gains": "string - expected efficiency improvements",
+		  "risk_reduction": "string - risk mitigation benefits",
+		  "strategic_value": "string - strategic business value",
+		  "competitive_advantage": "string - competitive positioning benefits"
+		},
+		"critical_success_factors": ["array of key success factors"],
+		"potential_obstacles": ["array of implementation challenges"]
 	  },
 	  "enrichment_metadata": {
-	    "confidence_level": "number - 0.0 to 1.0",
-	    "data_sources": ["array of information sources considered"],
-	    "analysis_depth": "surface|moderate|comprehensive",
-	    "recommendations_priority": "low|medium|high|urgent"
+		"confidence_level": "number - 0.0 to 1.0",
+		"data_sources": ["array of information sources considered"],
+		"analysis_depth": "surface|moderate|comprehensive",
+		"recommendations_priority": "low|medium|high|urgent"
 	  }
 	}
 	```
@@ -2069,9 +2069,9 @@ return $analysis;
 	 */
 	public function generate_strategic_analysis( $enriched_profile, $roi_scenarios, $recommendation, $rag_baseline ) {
 
-        if ( rtbcb_heavy_features_disabled() ) {
-            return new WP_Error( 'heavy_features_disabled', __( 'AI features are disabled.', 'rtbcb' ) );
-        }
+		if ( rtbcb_heavy_features_disabled() ) {
+			return new WP_Error( 'heavy_features_disabled', __( 'AI features are disabled.', 'rtbcb' ) );
+		}
 	if ( empty( $this->api_key ) ) {
 	return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
 	}
@@ -2128,77 +2128,77 @@ return $analysis;
 	```json
 	{
 	  "executive_summary": {
-	    "strategic_positioning": "string - 2-3 sentences on strategic position",
-	    "business_case_strength": "weak|moderate|strong|compelling",
-	    "key_value_drivers": ["array of 3-4 primary value drivers"],
-	    "executive_recommendation": "string - clear recommendation with next steps",
-	    "confidence_level": "number - 0.7 to 0.95"
+		"strategic_positioning": "string - 2-3 sentences on strategic position",
+		"business_case_strength": "weak|moderate|strong|compelling",
+		"key_value_drivers": ["array of 3-4 primary value drivers"],
+		"executive_recommendation": "string - clear recommendation with next steps",
+		"confidence_level": "number - 0.7 to 0.95"
 	  },
 	  "operational_analysis": {
-	    "current_state_assessment": {
-	      "efficiency_rating": "poor|fair|good|excellent",
-	      "benchmark_comparison": "string - vs industry peers",
-	      "capacity_utilization": "string - team capacity analysis"
-	    },
-	    "process_improvements": [
-	      {
-	        "process_area": "string - specific process",
-	        "current_state": "string - current approach",
-	        "improved_state": "string - post-implementation state",
-	        "impact_level": "low|medium|high|transformational"
-	      }
-	    ],
-	    "automation_opportunities": [
-	      {
-	        "opportunity": "string - automation opportunity",
-	        "complexity": "low|medium|high",
-	        "time_savings": "number - hours per week",
-	        "implementation_effort": "low|medium|high"
-	      }
-	    ]
+		"current_state_assessment": {
+		  "efficiency_rating": "poor|fair|good|excellent",
+		  "benchmark_comparison": "string - vs industry peers",
+		  "capacity_utilization": "string - team capacity analysis"
+		},
+		"process_improvements": [
+		  {
+			"process_area": "string - specific process",
+			"current_state": "string - current approach",
+			"improved_state": "string - post-implementation state",
+			"impact_level": "low|medium|high|transformational"
+		  }
+		],
+		"automation_opportunities": [
+		  {
+			"opportunity": "string - automation opportunity",
+			"complexity": "low|medium|high",
+			"time_savings": "number - hours per week",
+			"implementation_effort": "low|medium|high"
+		  }
+		]
 	  },
 	  "financial_analysis": {
-	    "investment_breakdown": {
-	      "software_licensing": "string - cost range and considerations",
-	      "implementation_services": "string - cost range and scope",
-	      "training_change_management": "string - cost range and requirements",
-	      "ongoing_support": "string - annual costs"
-	    },
-	    "payback_analysis": {
-	      "payback_months": "number - expected payback period",
-	      "roi_3_year": "number - 3 year ROI percentage",
-	      "npv_analysis": "string - net present value assessment",
-	      "sensitivity_factors": ["array of factors affecting ROI"]
-	    }
+		"investment_breakdown": {
+		  "software_licensing": "string - cost range and considerations",
+		  "implementation_services": "string - cost range and scope",
+		  "training_change_management": "string - cost range and requirements",
+		  "ongoing_support": "string - annual costs"
+		},
+		"payback_analysis": {
+		  "payback_months": "number - expected payback period",
+		  "roi_3_year": "number - 3 year ROI percentage",
+		  "npv_analysis": "string - net present value assessment",
+		  "sensitivity_factors": ["array of factors affecting ROI"]
+		}
 	  },
 	  "implementation_roadmap": [
-	    {
-	      "phase": "string - phase name",
-	      "duration": "string - time estimate",
-	      "key_activities": ["array of activities"],
-	      "success_criteria": ["array of success metrics"],
-	      "risks": ["array of phase-specific risks"]
-	    }
+		{
+		  "phase": "string - phase name",
+		  "duration": "string - time estimate",
+		  "key_activities": ["array of activities"],
+		  "success_criteria": ["array of success metrics"],
+		  "risks": ["array of phase-specific risks"]
+		}
 	  ],
 	  "risk_mitigation": {
-	    "implementation_risks": ["array of key risks"],
-	    "mitigation_strategies": {
-	      "change_management": "string - change management approach",
-	      "technical_integration": "string - integration risk mitigation",
-	      "vendor_selection": "string - vendor risk mitigation",
-	      "timeline_management": "string - timeline risk mitigation"
-	    },
-	    "success_factors": ["array of critical success factors"]
+		"implementation_risks": ["array of key risks"],
+		"mitigation_strategies": {
+		  "change_management": "string - change management approach",
+		  "technical_integration": "string - integration risk mitigation",
+		  "vendor_selection": "string - vendor risk mitigation",
+		  "timeline_management": "string - timeline risk mitigation"
+		},
+		"success_factors": ["array of critical success factors"]
 	  },
 	  "next_steps": {
-	    "immediate": ["array of immediate actions (next 30 days)"],
-	    "short_term": ["array of short-term milestones (3-6 months)"],
-	    "long_term": ["array of long-term objectives (6+ months)"]
+		"immediate": ["array of immediate actions (next 30 days)"],
+		"short_term": ["array of short-term milestones (3-6 months)"],
+		"long_term": ["array of long-term objectives (6+ months)"]
 	  },
 	  "vendor_considerations": {
-	    "evaluation_criteria": ["array of key selection criteria"],
-	    "due_diligence_areas": ["array of due diligence focus areas"],
-	    "negotiation_priorities": ["array of contract negotiation priorities"]
+		"evaluation_criteria": ["array of key selection criteria"],
+		"due_diligence_areas": ["array of due diligence focus areas"],
+		"negotiation_priorities": ["array of contract negotiation priorities"]
 	  }
 	}
 	```
@@ -2295,9 +2295,9 @@ return $analysis;
 	private function validate_company_profile( $profile, $user_inputs ) {
 	return [
 	'name'                => $user_inputs['company_name'],
-       'enhanced_description' => wp_kses_post( $profile['enhanced_description'] ?? '' ),
-       'business_model'      => wp_kses_post( $profile['business_model'] ?? '' ),
-       'market_position'     => wp_kses_post( $profile['market_position'] ?? '' ),
+	   'enhanced_description' => wp_kses_post( $profile['enhanced_description'] ?? '' ),
+	   'business_model'      => wp_kses_post( $profile['business_model'] ?? '' ),
+	   'market_position'     => wp_kses_post( $profile['market_position'] ?? '' ),
 	'maturity_level'      => in_array( $profile['maturity_level'] ?? '', [ 'basic', 'developing', 'strategic', 'optimized' ], true )
 	? $profile['maturity_level']
 	: 'basic',
@@ -2307,7 +2307,7 @@ return $analysis;
 	'financial_health'  => sanitize_text_field( $profile['financial_indicators']['financial_health'] ?? 'unknown' ),
 	],
 	'treasury_maturity'   => [
-       'current_state'        => wp_kses_post( $profile['treasury_maturity']['current_state'] ?? '' ),
+	   'current_state'        => wp_kses_post( $profile['treasury_maturity']['current_state'] ?? '' ),
 	'sophistication_level' => sanitize_text_field( $profile['treasury_maturity']['sophistication_level'] ?? 'manual' ),
 	'key_gaps'            => array_map( 'sanitize_text_field', $profile['treasury_maturity']['key_gaps'] ?? [] ),
 	'automation_readiness' => sanitize_text_field( $profile['treasury_maturity']['automation_readiness'] ?? 'medium' ),
@@ -2316,7 +2316,7 @@ return $analysis;
 	'primary_challenges'   => array_map( 'sanitize_text_field', $profile['strategic_context']['primary_challenges'] ?? [] ),
 	'growth_objectives'    => array_map( 'sanitize_text_field', $profile['strategic_context']['growth_objectives'] ?? [] ),
 	'competitive_pressures' => array_map( 'sanitize_text_field', $profile['strategic_context']['competitive_pressures'] ?? [] ),
-       'regulatory_environment' => wp_kses_post( $profile['strategic_context']['regulatory_environment'] ?? '' ),
+	   'regulatory_environment' => wp_kses_post( $profile['strategic_context']['regulatory_environment'] ?? '' ),
 	],
 	];
 	}
@@ -2347,16 +2347,16 @@ return $analysis;
 	private function validate_industry_context( $context ) {
 	return [
 	'sector_analysis'    => [
-       'market_dynamics'   => wp_kses_post( $context['sector_analysis']['market_dynamics'] ?? '' ),
-       'growth_trends'     => wp_kses_post( $context['sector_analysis']['growth_trends'] ?? '' ),
+	   'market_dynamics'   => wp_kses_post( $context['sector_analysis']['market_dynamics'] ?? '' ),
+	   'growth_trends'     => wp_kses_post( $context['sector_analysis']['growth_trends'] ?? '' ),
 	'disruption_factors' => array_map( 'sanitize_text_field', $context['sector_analysis']['disruption_factors'] ?? [] ),
 	'technology_adoption' => sanitize_text_field( $context['sector_analysis']['technology_adoption'] ?? 'follower' ),
 	],
 	'benchmarking'       => [
-       'typical_treasury_setup' => wp_kses_post( $context['benchmarking']['typical_treasury_setup'] ?? '' ),
+	   'typical_treasury_setup' => wp_kses_post( $context['benchmarking']['typical_treasury_setup'] ?? '' ),
 	'common_pain_points'     => array_map( 'sanitize_text_field', $context['benchmarking']['common_pain_points'] ?? [] ),
 	'technology_penetration' => sanitize_text_field( $context['benchmarking']['technology_penetration'] ?? 'medium' ),
-       'investment_patterns'    => wp_kses_post( $context['benchmarking']['investment_patterns'] ?? '' ),
+	   'investment_patterns'    => wp_kses_post( $context['benchmarking']['investment_patterns'] ?? '' ),
 	],
 	'regulatory_landscape' => [
 	'key_regulations'      => array_map( 'sanitize_text_field', $context['regulatory_landscape']['key_regulations'] ?? [] ),
@@ -2378,10 +2378,10 @@ return $analysis;
 	'investment_justification' => sanitize_text_field( $insights['investment_justification'] ?? 'weak' ),
 	'implementation_complexity' => sanitize_text_field( $insights['implementation_complexity'] ?? 'medium' ),
 	'expected_benefits'        => [
-       'efficiency_gains'     => wp_kses_post( $insights['expected_benefits']['efficiency_gains'] ?? '' ),
-       'risk_reduction'       => wp_kses_post( $insights['expected_benefits']['risk_reduction'] ?? '' ),
-       'strategic_value'      => wp_kses_post( $insights['expected_benefits']['strategic_value'] ?? '' ),
-       'competitive_advantage' => wp_kses_post( $insights['expected_benefits']['competitive_advantage'] ?? '' ),
+	   'efficiency_gains'     => wp_kses_post( $insights['expected_benefits']['efficiency_gains'] ?? '' ),
+	   'risk_reduction'       => wp_kses_post( $insights['expected_benefits']['risk_reduction'] ?? '' ),
+	   'strategic_value'      => wp_kses_post( $insights['expected_benefits']['strategic_value'] ?? '' ),
+	   'competitive_advantage' => wp_kses_post( $insights['expected_benefits']['competitive_advantage'] ?? '' ),
 	],
 	'critical_success_factors' => array_map( 'sanitize_text_field', $insights['critical_success_factors'] ?? [] ),
 	'potential_obstacles'      => array_map( 'sanitize_text_field', $insights['potential_obstacles'] ?? [] ),
@@ -2544,16 +2544,16 @@ return $analysis;
 		$max_retry_time  = max( $base_timeout, intval( $this->gpt5_config['max_retry_time'] ?? $base_timeout ) );
 		$start_time      = microtime( true );
 		
-		        for ( $attempt = 1; $attempt <= $max_retries; $attempt++ ) {
-		            $elapsed = microtime( true ) - $start_time;
-		            if ( $elapsed >= $max_retry_time ) {
-		                break;
-		            }
+				for ( $attempt = 1; $attempt <= $max_retries; $attempt++ ) {
+					$elapsed = microtime( true ) - $start_time;
+					if ( $elapsed >= $max_retry_time ) {
+						break;
+					}
 		
-		            $remaining                    = $max_retry_time - $elapsed;
-		            $this->gpt5_config['timeout'] = min( $current_timeout, $remaining );
+					$remaining                    = $max_retry_time - $elapsed;
+					$this->gpt5_config['timeout'] = min( $current_timeout, $remaining );
 		
-		            $response = $this->call_openai( $model, $prompt, $current_tokens, $chunk_handler );
+					$response = $this->call_openai( $model, $prompt, $current_tokens, $chunk_handler );
 		
 		if ( ! is_wp_error( $response ) ) {
 		$this->gpt5_config['timeout'] = $base_timeout;
@@ -2568,635 +2568,635 @@ return $analysis;
 		return $response;
 		}
 		
-		            $error_code = $response->get_error_code();
-		            if ( in_array( $error_code, [ 'no_api_key', 'empty_prompt' ], true ) ) {
-		                $this->gpt5_config['timeout'] = $base_timeout;
-		                return $response;
-		            }
+					$error_code = $response->get_error_code();
+					if ( in_array( $error_code, [ 'no_api_key', 'empty_prompt' ], true ) ) {
+						$this->gpt5_config['timeout'] = $base_timeout;
+						return $response;
+					}
 		
-		            if ( 'llm_http_status' === $error_code ) {
-		                $data   = $response->get_error_data();
-		                $status = isset( $data['status'] ) ? intval( $data['status'] ) : 0;
-		                if ( $status >= 400 && $status < 500 && 429 !== $status ) {
-		                    $this->gpt5_config['timeout'] = $base_timeout;
-		                    return $response;
-		                }
-		            }
+					if ( 'llm_http_status' === $error_code ) {
+						$data   = $response->get_error_data();
+						$status = isset( $data['status'] ) ? intval( $data['status'] ) : 0;
+						if ( $status >= 400 && $status < 500 && 429 !== $status ) {
+							$this->gpt5_config['timeout'] = $base_timeout;
+							return $response;
+						}
+					}
 		
-		            error_log( "RTBCB: OpenAI attempt {$attempt} failed: " . $response->get_error_message() );
+					error_log( "RTBCB: OpenAI attempt {$attempt} failed: " . $response->get_error_message() );
 		
-		            if ( $attempt < $max_retries ) {
-		                if ( null !== $current_tokens ) {
-		                    $min_tokens    = intval( $this->gpt5_config['min_output_tokens'] ?? 1 );
-		                    $current_tokens = max( $min_tokens, (int) ( $current_tokens * 0.9 ) );
-		                }
+					if ( $attempt < $max_retries ) {
+						if ( null !== $current_tokens ) {
+							$min_tokens    = intval( $this->gpt5_config['min_output_tokens'] ?? 1 );
+							$current_tokens = max( $min_tokens, (int) ( $current_tokens * 0.9 ) );
+						}
 		
-		                $current_timeout = min( $current_timeout + 5, $max_retry_time );
+						$current_timeout = min( $current_timeout + 5, $max_retry_time );
 		
-		                $elapsed = microtime( true ) - $start_time;
-		                $delay   = min( pow( 2, $attempt - 1 ), $max_retry_time - $elapsed );
-		                if ( $delay > 0 ) {
-		                    $jitter = wp_rand( 0, 1000 ) / 1000;
-		                    usleep( (int) ( ( $delay + $jitter ) * 1000000 ) );
-		                }
-		            }
-		        }
+						$elapsed = microtime( true ) - $start_time;
+						$delay   = min( pow( 2, $attempt - 1 ), $max_retry_time - $elapsed );
+						if ( $delay > 0 ) {
+							$jitter = wp_rand( 0, 1000 ) / 1000;
+							usleep( (int) ( ( $delay + $jitter ) * 1000000 ) );
+						}
+					}
+				}
 		
-		        $this->gpt5_config['timeout'] = $base_timeout;
+				$this->gpt5_config['timeout'] = $base_timeout;
 
-        return $response; // Return last error
-    }
+		return $response; // Return last error
+	}
 
-    /**
-     * Build instructions and input for the Responses API.
-     *
-     * @param array       $history       Array of conversation items.
-     * @param string|null $system_prompt Optional system prompt.
-     *
-     * @return array {
-     *     @type string $instructions System prompt for the model.
-     *     @type string $input        User prompt for the model.
-     * }
-     */
-    private function build_context_for_responses( $history, $system_prompt = null ) {
-        $default_system = 'You are a senior treasury technology consultant. Provide detailed, research-driven analysis in the exact JSON format requested. Do not include any text outside the JSON structure.';
+	/**
+	 * Build instructions and input for the Responses API.
+	 *
+	 * @param array       $history       Array of conversation items.
+	 * @param string|null $system_prompt Optional system prompt.
+	 *
+	 * @return array {
+	 *     @type string $instructions System prompt for the model.
+	 *     @type string $input        User prompt for the model.
+	 * }
+	 */
+	private function build_context_for_responses( $history, $system_prompt = null ) {
+		$default_system = 'You are a senior treasury technology consultant. Provide detailed, research-driven analysis in the exact JSON format requested. Do not include any text outside the JSON structure.';
 
-        $system_prompt = $system_prompt ? $system_prompt : $default_system;
+		$system_prompt = $system_prompt ? $system_prompt : $default_system;
 
-        $input_parts = [];
+		$input_parts = [];
 
-        foreach ( (array) $history as $item ) {
-            if ( ! is_array( $item ) || 'user' !== ( $item['role'] ?? '' ) || ! isset( $item['content'] ) ) {
-                continue;
-            }
+		foreach ( (array) $history as $item ) {
+			if ( ! is_array( $item ) || 'user' !== ( $item['role'] ?? '' ) || ! isset( $item['content'] ) ) {
+				continue;
+			}
 
-            $input_parts[] = function_exists( 'sanitize_textarea_field' ) ? sanitize_textarea_field( $item['content'] ) : $item['content'];
-        }
+			$input_parts[] = function_exists( 'sanitize_textarea_field' ) ? sanitize_textarea_field( $item['content'] ) : $item['content'];
+		}
 
-        $instructions = function_exists( 'sanitize_textarea_field' ) ? sanitize_textarea_field( $system_prompt ) : $system_prompt;
+		$instructions = function_exists( 'sanitize_textarea_field' ) ? sanitize_textarea_field( $system_prompt ) : $system_prompt;
 
-        return [
-            'instructions' => $instructions,
-            'input'        => implode( "\n", $input_parts ),
-        ];
-    }
+		return [
+			'instructions' => $instructions,
+			'input'        => implode( "\n", $input_parts ),
+		];
+	}
 
-    /**
-     * Call the OpenAI Responses API.
-     *
-     * @param string       $model             Model name.
-     * @param array|string $prompt            Prompt array or string.
-     * @param int|null     $max_output_tokens Maximum output tokens.
-     * @param callable|null $chunk_handler    Optional streaming handler.
-     * @return array|WP_Error HTTP response array or WP_Error on failure.
-     */
-    private function call_openai( $model, $prompt, $max_output_tokens = null, $chunk_handler = null ) {
-        if ( empty( $this->api_key ) ) {
-            return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-        }
+	/**
+	 * Call the OpenAI Responses API.
+	 *
+	 * @param string       $model             Model name.
+	 * @param array|string $prompt            Prompt array or string.
+	 * @param int|null     $max_output_tokens Maximum output tokens.
+	 * @param callable|null $chunk_handler    Optional streaming handler.
+	 * @return array|WP_Error HTTP response array or WP_Error on failure.
+	 */
+	private function call_openai( $model, $prompt, $max_output_tokens = null, $chunk_handler = null ) {
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
 
-        $endpoint         = 'https://api.openai.com/v1/responses'; // Correct endpoint.
-        $model_name       = sanitize_text_field( $model ?: 'gpt-5-mini' );
-        $model_name       = rtbcb_normalize_model_name( $model_name );
-        $default_tokens    = intval( $this->gpt5_config['max_output_tokens'] ?? 8000 );
-        $max_output_tokens = intval( $max_output_tokens ?? $default_tokens );
-        $min_tokens        = intval( $this->gpt5_config['min_output_tokens'] ?? 1 );
-        $max_output_tokens = min( 128000, max( $min_tokens, $max_output_tokens ) );
+		$endpoint         = 'https://api.openai.com/v1/responses'; // Correct endpoint.
+		$model_name       = sanitize_text_field( $model ?: 'gpt-5-mini' );
+		$model_name       = rtbcb_normalize_model_name( $model_name );
+		$default_tokens    = intval( $this->gpt5_config['max_output_tokens'] ?? 8000 );
+		$max_output_tokens = intval( $max_output_tokens ?? $default_tokens );
+		$min_tokens        = intval( $this->gpt5_config['min_output_tokens'] ?? 1 );
+		$max_output_tokens = min( 128000, max( $min_tokens, $max_output_tokens ) );
 
-        if ( is_array( $prompt ) && isset( $prompt['input'] ) ) {
-            $instructions = sanitize_textarea_field( $prompt['instructions'] ?? '' );
-            $input        = sanitize_textarea_field( $prompt['input'] );
-        } else {
-            $instructions = '';
-            $input        = sanitize_textarea_field( (string) $prompt );
-        }
+		if ( is_array( $prompt ) && isset( $prompt['input'] ) ) {
+			$instructions = sanitize_textarea_field( $prompt['instructions'] ?? '' );
+			$input        = sanitize_textarea_field( $prompt['input'] );
+		} else {
+			$instructions = '';
+			$input        = sanitize_textarea_field( (string) $prompt );
+		}
 
-        if ( '' === trim( $input ) ) {
-            return new WP_Error( 'empty_prompt', __( 'Prompt cannot be empty.', 'rtbcb' ) );
-        }
+		if ( '' === trim( $input ) ) {
+			return new WP_Error( 'empty_prompt', __( 'Prompt cannot be empty.', 'rtbcb' ) );
+		}
 
-        $body = [
-            'model' => $model_name,
-            'input' => $input,
-            'max_output_tokens' => $max_output_tokens,
-        ];
+		$body = [
+			'model' => $model_name,
+			'input' => $input,
+			'max_output_tokens' => $max_output_tokens,
+		];
 
-        if ( ! empty( $instructions ) ) {
-            $body['instructions'] = $instructions;
-        }
+		if ( ! empty( $instructions ) ) {
+			$body['instructions'] = $instructions;
+		}
 
-        if ( strpos( $model_name, 'gpt-5' ) === 0 ) {
-            $body['reasoning'] = [
-                'effort' => $this->get_reasoning_effort_for_task( $prompt ),
-            ];
-            $body['text'] = [
-                'verbosity' => $this->get_verbosity_for_task( $prompt ),
-            ];
-        }
+		if ( strpos( $model_name, 'gpt-5' ) === 0 ) {
+			$body['reasoning'] = [
+				'effort' => $this->get_reasoning_effort_for_task( $prompt ),
+			];
+			$body['text'] = [
+				'verbosity' => $this->get_verbosity_for_task( $prompt ),
+			];
+		}
 
-        if ( rtbcb_model_supports_temperature( $model_name ) ) {
-            $body['temperature'] = floatval( $this->gpt5_config['temperature'] ?? 0.7 );
-        }
+		if ( rtbcb_model_supports_temperature( $model_name ) ) {
+			$body['temperature'] = floatval( $this->gpt5_config['temperature'] ?? 0.7 );
+		}
 
-        if ( isset( $this->gpt5_config['store'] ) ) {
-            $body['store'] = (bool) $this->gpt5_config['store'];
-        }
+		if ( isset( $this->gpt5_config['store'] ) ) {
+			$body['store'] = (bool) $this->gpt5_config['store'];
+		}
 
-        // Enable streaming so partial chunks are returned progressively.
-        $body['stream'] = true;
+		// Enable streaming so partial chunks are returned progressively.
+		$body['stream'] = true;
 
-        do_action( 'rtbcb_llm_prompt_sent', $body );
+		do_action( 'rtbcb_llm_prompt_sent', $body );
 
 	$timeout   = intval( $this->gpt5_config['timeout'] ?? 300 );
-        $payload   = wp_json_encode( $body );
-        $buffer    = '';
-        $last_event = '';
-        $last_chunk = '';
-        $ch        = curl_init( $endpoint );
-        curl_setopt( $ch, CURLOPT_HTTPHEADER, [
-            'Authorization: Bearer ' . $this->api_key,
-            'Content-Type: application/json',
-        ] );
-        curl_setopt( $ch, CURLOPT_POST, true );
-        curl_setopt( $ch, CURLOPT_POSTFIELDS, $payload );
-        curl_setopt( $ch, CURLOPT_TIMEOUT, $timeout );
-        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function ( $curl, $data ) use ( &$buffer, &$last_event, &$last_chunk, $chunk_handler ) {
-            $last_chunk = $data;
-            if ( is_callable( $chunk_handler ) ) {
-                call_user_func( $chunk_handler, $data );
-            }
+		$payload   = wp_json_encode( $body );
+		$buffer    = '';
+		$last_event = '';
+		$last_chunk = '';
+		$ch        = curl_init( $endpoint );
+		curl_setopt( $ch, CURLOPT_HTTPHEADER, [
+			'Authorization: Bearer ' . $this->api_key,
+			'Content-Type: application/json',
+		] );
+		curl_setopt( $ch, CURLOPT_POST, true );
+		curl_setopt( $ch, CURLOPT_POSTFIELDS, $payload );
+		curl_setopt( $ch, CURLOPT_TIMEOUT, $timeout );
+		curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function ( $curl, $data ) use ( &$buffer, &$last_event, &$last_chunk, $chunk_handler ) {
+			$last_chunk = $data;
+			if ( is_callable( $chunk_handler ) ) {
+				call_user_func( $chunk_handler, $data );
+			}
 
-            $buffer .= $data;
-            while ( false !== ( $pos = strpos( $buffer, "\n" ) ) ) {
-                $line   = trim( substr( $buffer, 0, $pos ) );
-                $buffer = substr( $buffer, $pos + 1 );
-                if ( '' === $line ) {
-                    continue;
-                }
-                if ( 0 === strpos( $line, 'data:' ) ) {
-                    $payload_line = trim( substr( $line, strpos( $line, ':' ) + 1 ) );
-                    if ( '[DONE]' === $payload_line ) {
-                        continue;
-                    }
-                    $last_event = $payload_line;
-                }
-            }
+			$buffer .= $data;
+			while ( false !== ( $pos = strpos( $buffer, "\n" ) ) ) {
+				$line   = trim( substr( $buffer, 0, $pos ) );
+				$buffer = substr( $buffer, $pos + 1 );
+				if ( '' === $line ) {
+					continue;
+				}
+				if ( 0 === strpos( $line, 'data:' ) ) {
+					$payload_line = trim( substr( $line, strpos( $line, ':' ) + 1 ) );
+					if ( '[DONE]' === $payload_line ) {
+						continue;
+					}
+					$last_event = $payload_line;
+				}
+			}
 
-            return strlen( $data );
-        } );
+			return strlen( $data );
+		} );
 
-        $this->last_request = $body;
-        $ok                 = curl_exec( $ch );
-        $error              = curl_error( $ch );
-        $http_code          = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
-        curl_close( $ch );
+		$this->last_request = $body;
+		$ok                 = curl_exec( $ch );
+		$error              = curl_error( $ch );
+		$http_code          = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+		curl_close( $ch );
 
-        if ( false === $ok ) {
-            if ( false !== strpos( strtolower( $error ), 'timed out' ) ) {
-                return new WP_Error(
-                    'llm_timeout',
-                    __( 'The request took longer than our 5-minute limit. Try Fast Mode or request email delivery.', 'rtbcb' )
-                );
-            }
+		if ( false === $ok ) {
+			if ( false !== strpos( strtolower( $error ), 'timed out' ) ) {
+				return new WP_Error(
+					'llm_timeout',
+					__( 'The request took longer than our 5-minute limit. Try Fast Mode or request email delivery.', 'rtbcb' )
+				);
+			}
 
-            return new WP_Error(
-                'llm_http_error',
-                sprintf( __( 'Language model request failed: %s', 'rtbcb' ), $error )
-            );
-        }
+			return new WP_Error(
+				'llm_http_error',
+				sprintf( __( 'Language model request failed: %s', 'rtbcb' ), $error )
+			);
+		}
 
-        if ( '' !== trim( $buffer ) ) {
-            $line = trim( $buffer );
-            if ( 0 === strpos( $line, 'data:' ) ) {
-                $payload_line = trim( substr( $line, strpos( $line, ':' ) + 1 ) );
-                if ( '[DONE]' !== $payload_line ) {
-                    $last_event = $payload_line;
-                }
-            }
-        }
+		if ( '' !== trim( $buffer ) ) {
+			$line = trim( $buffer );
+			if ( 0 === strpos( $line, 'data:' ) ) {
+				$payload_line = trim( substr( $line, strpos( $line, ':' ) + 1 ) );
+				if ( '[DONE]' !== $payload_line ) {
+					$last_event = $payload_line;
+				}
+			}
+		}
 
-        $response_body = $last_event ? $last_event : $last_chunk;
+		$response_body = $last_event ? $last_event : $last_chunk;
 
-        $decoded = json_decode( $response_body, true );
+		$decoded = json_decode( $response_body, true );
 
-        if ( null === $decoded || JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
-            error_log( 'RTBCB: Malformed LLM response: ' . $response_body );
+		if ( null === $decoded || JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
+			error_log( 'RTBCB: Malformed LLM response: ' . $response_body );
 
-            if ( class_exists( 'RTBCB_API_Log' ) ) {
-                $company      = rtbcb_get_current_company();
-                $user_email   = $this->current_inputs['email'] ?? ( $company['email'] ?? '' );
-                $company_name = $this->current_inputs['company_name'] ?? ( $company['name'] ?? '' );
-                RTBCB_API_Log::save_log( $body, [ 'raw_body' => $response_body ], get_current_user_id(), $user_email, $company_name );
-            }
+			if ( class_exists( 'RTBCB_API_Log' ) ) {
+				$company      = rtbcb_get_current_company();
+				$user_email   = $this->current_inputs['email'] ?? ( $company['email'] ?? '' );
+				$company_name = $this->current_inputs['company_name'] ?? ( $company['name'] ?? '' );
+				RTBCB_API_Log::save_log( $body, [ 'raw_body' => $response_body ], get_current_user_id(), $user_email, $company_name );
+			}
 
-            $error                 = new WP_Error( 'llm_response_format', __( 'Malformed response received from language model.', 'rtbcb' ) );
-            $this->last_response   = $error;
-            return $error;
-        }
+			$error                 = new WP_Error( 'llm_response_format', __( 'Malformed response received from language model.', 'rtbcb' ) );
+			$this->last_response   = $error;
+			return $error;
+		}
 
-        $response = [
-            'body'     => $response_body,
-            'response' => [ 'code' => $http_code, 'message' => '' ],
-            'headers'  => [],
-        ];
+		$response = [
+			'body'     => $response_body,
+			'response' => [ 'code' => $http_code, 'message' => '' ],
+			'headers'  => [],
+		];
 
-        $this->last_response = $response;
+		$this->last_response = $response;
 
-        if ( class_exists( 'RTBCB_API_Log' ) ) {
-            $company      = rtbcb_get_current_company();
-            $user_email   = $this->current_inputs['email'] ?? ( $company['email'] ?? '' );
-            $company_name = $this->current_inputs['company_name'] ?? ( $company['name'] ?? '' );
-            RTBCB_API_Log::save_log( $body, $decoded, get_current_user_id(), $user_email, $company_name );
-        }
+		if ( class_exists( 'RTBCB_API_Log' ) ) {
+			$company      = rtbcb_get_current_company();
+			$user_email   = $this->current_inputs['email'] ?? ( $company['email'] ?? '' );
+			$company_name = $this->current_inputs['company_name'] ?? ( $company['name'] ?? '' );
+			RTBCB_API_Log::save_log( $body, $decoded, get_current_user_id(), $user_email, $company_name );
+		}
 
-        if ( $http_code >= 400 ) {
-            if ( isset( $decoded['error']['message'] ) ) {
-                $message = $decoded['error']['message'];
-            } elseif ( isset( $decoded['message'] ) ) {
-                $message = $decoded['message'];
-            } else {
-                $message = wp_json_encode( $decoded );
-            }
+		if ( $http_code >= 400 ) {
+			if ( isset( $decoded['error']['message'] ) ) {
+				$message = $decoded['error']['message'];
+			} elseif ( isset( $decoded['message'] ) ) {
+				$message = $decoded['message'];
+			} else {
+				$message = wp_json_encode( $decoded );
+			}
 
-            $message = sanitize_text_field( $message );
+			$message = sanitize_text_field( $message );
 
-            return new WP_Error( 'llm_http_status', $message, [ 'status' => $http_code ] );
-        }
+			return new WP_Error( 'llm_http_status', $message, [ 'status' => $http_code ] );
+		}
 
-        return $response;
-    }
+		return $response;
+	}
 
-    /**
-     * Determine appropriate reasoning effort based on task complexity.
-     *
-     * @param array|string $prompt Prompt data or text.
-     * @return string Reasoning effort level.
-     */
-    private function get_reasoning_effort_for_task( $prompt ) {
-        $prompt_text = is_array( $prompt )
-            ? ( $prompt['input'] ?? '' ) . ' ' . ( $prompt['instructions'] ?? '' )
-            : (string) $prompt;
+	/**
+	 * Determine appropriate reasoning effort based on task complexity.
+	 *
+	 * @param array|string $prompt Prompt data or text.
+	 * @return string Reasoning effort level.
+	 */
+	private function get_reasoning_effort_for_task( $prompt ) {
+		$prompt_text = is_array( $prompt )
+			? ( $prompt['input'] ?? '' ) . ' ' . ( $prompt['instructions'] ?? '' )
+			: (string) $prompt;
 
-        $prompt_lower = strtolower( $prompt_text );
+		$prompt_lower = strtolower( $prompt_text );
 
-        // High effort for complex business analysis
-        if ( strpos( $prompt_lower, 'comprehensive' ) !== false ||
-            strpos( $prompt_lower, 'business case' ) !== false ||
-            strpos( $prompt_lower, 'analysis' ) !== false ||
-            strpos( $prompt_lower, 'financial' ) !== false ) {
-            return 'high';
-        }
+		// High effort for complex business analysis
+		if ( strpos( $prompt_lower, 'comprehensive' ) !== false ||
+			strpos( $prompt_lower, 'business case' ) !== false ||
+			strpos( $prompt_lower, 'analysis' ) !== false ||
+			strpos( $prompt_lower, 'financial' ) !== false ) {
+			return 'high';
+		}
 
-        // Medium effort for standard tasks
-        if ( strpos( $prompt_lower, 'generate' ) !== false ||
-            strpos( $prompt_lower, 'create' ) !== false ) {
-            return 'medium';
-        }
+		// Medium effort for standard tasks
+		if ( strpos( $prompt_lower, 'generate' ) !== false ||
+			strpos( $prompt_lower, 'create' ) !== false ) {
+			return 'medium';
+		}
 
-        // Low effort for simple requests
-        return 'low';
-    }
+		// Low effort for simple requests
+		return 'low';
+	}
 
-    /**
-     * Determine appropriate verbosity based on output requirements.
-     *
-     * @param array|string $prompt Prompt data or text.
-     * @return string Verbosity level.
-     */
-    private function get_verbosity_for_task( $prompt ) {
-        $prompt_text = is_array( $prompt )
-            ? ( $prompt['input'] ?? '' ) . ' ' . ( $prompt['instructions'] ?? '' )
-            : (string) $prompt;
+	/**
+	 * Determine appropriate verbosity based on output requirements.
+	 *
+	 * @param array|string $prompt Prompt data or text.
+	 * @return string Verbosity level.
+	 */
+	private function get_verbosity_for_task( $prompt ) {
+		$prompt_text = is_array( $prompt )
+			? ( $prompt['input'] ?? '' ) . ' ' . ( $prompt['instructions'] ?? '' )
+			: (string) $prompt;
 
-        $prompt_lower = strtolower( $prompt_text );
+		$prompt_lower = strtolower( $prompt_text );
 
-        // High verbosity for detailed business cases
-        if ( strpos( $prompt_lower, 'comprehensive' ) !== false ||
-            strpos( $prompt_lower, 'detailed' ) !== false ||
-            strpos( $prompt_lower, 'analysis' ) !== false ) {
-            return 'high';
-        }
+		// High verbosity for detailed business cases
+		if ( strpos( $prompt_lower, 'comprehensive' ) !== false ||
+			strpos( $prompt_lower, 'detailed' ) !== false ||
+			strpos( $prompt_lower, 'analysis' ) !== false ) {
+			return 'high';
+		}
 
-        // Medium verbosity for standard generation
-        return 'medium';
-    }
+		// Medium verbosity for standard generation
+		return 'medium';
+	}
 
-    /**
-     * Log details about a GPT-5 API call.
-     *
-     * @param array|string $context  Context or instructions sent to the model.
-     * @param array        $response Decoded response array or HTTP response array.
-     * @param string|null  $error    Optional error message.
-     */
-    private function log_gpt5_call( $context, $response, $error = null ) {
-        $context_serialized = is_array( $context ) ? wp_json_encode( $context ) : (string) $context;
-        $context_size       = strlen( $context_serialized );
+	/**
+	 * Log details about a GPT-5 API call.
+	 *
+	 * @param array|string $context  Context or instructions sent to the model.
+	 * @param array        $response Decoded response array or HTTP response array.
+	 * @param string|null  $error    Optional error message.
+	 */
+	private function log_gpt5_call( $context, $response, $error = null ) {
+		$context_serialized = is_array( $context ) ? wp_json_encode( $context ) : (string) $context;
+		$context_size       = strlen( $context_serialized );
 
-        $response_for_parser = ( is_array( $response ) && isset( $response['body'] ) )
-            ? $response
-            : [ 'body' => wp_json_encode( is_array( $response ) ? $response : [] ) ];
+		$response_for_parser = ( is_array( $response ) && isset( $response['body'] ) )
+			? $response
+			: [ 'body' => wp_json_encode( is_array( $response ) ? $response : [] ) ];
 
-        $parsed = rtbcb_parse_gpt5_response( $response_for_parser, true );
-        $content = $parsed['output_text'];
-        $usage   = $parsed['raw']['usage'] ?? [];
+		$parsed = rtbcb_parse_gpt5_response( $response_for_parser, true );
+		$content = $parsed['output_text'];
+		$usage   = $parsed['raw']['usage'] ?? [];
 
-        $completion_tokens = intval( $usage['completion_tokens'] ?? 0 );
-        $reasoning_tokens  = intval( $usage['reasoning_tokens'] ?? 0 );
-        $total_tokens      = intval( $usage['total_tokens'] ?? 0 );
-        $response_length   = strlen( $content );
-        $memory            = rtbcb_get_memory_status();
+		$completion_tokens = intval( $usage['completion_tokens'] ?? 0 );
+		$reasoning_tokens  = intval( $usage['reasoning_tokens'] ?? 0 );
+		$total_tokens      = intval( $usage['total_tokens'] ?? 0 );
+		$response_length   = strlen( $content );
+		$memory            = rtbcb_get_memory_status();
 
-        $log_message = sprintf(
-            'RTBCB GPT5 Call: context_size=%d, completion_tokens=%d, reasoning_tokens=%d, total_tokens=%d, response_length=%d, peak_memory=%d',
-            $context_size,
-            $completion_tokens,
-            $reasoning_tokens,
-            $total_tokens,
-            $response_length,
-            intval( $memory['peak'] ?? 0 )
-        );
+		$log_message = sprintf(
+			'RTBCB GPT5 Call: context_size=%d, completion_tokens=%d, reasoning_tokens=%d, total_tokens=%d, response_length=%d, peak_memory=%d',
+			$context_size,
+			$completion_tokens,
+			$reasoning_tokens,
+			$total_tokens,
+			$response_length,
+			intval( $memory['peak'] ?? 0 )
+		);
 
-        if ( ! empty( $error ) ) {
-            $log_message .= ', error=' . $error;
-        }
+		if ( ! empty( $error ) ) {
+			$log_message .= ', error=' . $error;
+		}
 
-        error_log( $log_message );
-    }
+		error_log( $log_message );
+	}
 
-    /**
-     * Extract content and decoded data from an OpenAI response.
-     *
-     * @param array $response HTTP response array.
-     * @return array {string, array} Content string and decoded array.
-     */
-    private function extract_openai_output( $response ) {
-        $body    = wp_remote_retrieve_body( $response );
-        $decoded = json_decode( $body, true );
+	/**
+	 * Extract content and decoded data from an OpenAI response.
+	 *
+	 * @param array $response HTTP response array.
+	 * @return array {string, array} Content string and decoded array.
+	 */
+	private function extract_openai_output( $response ) {
+		$body    = wp_remote_retrieve_body( $response );
+		$decoded = json_decode( $body, true );
 
-        if ( ! is_array( $decoded ) ) {
-            return [ '', [] ];
-        }
+		if ( ! is_array( $decoded ) ) {
+			return [ '', [] ];
+		}
 
-        $content = '';
+		$content = '';
 
-        if ( isset( $decoded['output'] ) && is_array( $decoded['output'] ) ) {
-            foreach ( $decoded['output'] as $chunk ) {
-                if ( ! is_array( $chunk ) ) {
-                    continue;
-                }
+		if ( isset( $decoded['output'] ) && is_array( $decoded['output'] ) ) {
+			foreach ( $decoded['output'] as $chunk ) {
+				if ( ! is_array( $chunk ) ) {
+					continue;
+				}
 
-                $text = '';
-                if ( isset( $chunk['content'] ) && is_array( $chunk['content'] ) ) {
-                    foreach ( $chunk['content'] as $piece ) {
-                        if ( isset( $piece['text'] ) && '' !== $piece['text'] ) {
-                            $text = $piece['text'];
-                            break;
-                        }
-                    }
-                }
+				$text = '';
+				if ( isset( $chunk['content'] ) && is_array( $chunk['content'] ) ) {
+					foreach ( $chunk['content'] as $piece ) {
+						if ( isset( $piece['text'] ) && '' !== $piece['text'] ) {
+							$text = $piece['text'];
+							break;
+						}
+					}
+				}
 
-                if ( 'message' === ( $chunk['type'] ?? '' ) || '' !== $text ) {
-                    $content = $text;
-                    break;
-                }
-            }
-        }
+				if ( 'message' === ( $chunk['type'] ?? '' ) || '' !== $text ) {
+					$content = $text;
+					break;
+				}
+			}
+		}
 
-        if ( '' === $content && isset( $decoded['output_text'] ) ) {
-            $content = is_array( $decoded['output_text'] ) ? implode( ' ', (array) $decoded['output_text'] ) : $decoded['output_text'];
-        }
+		if ( '' === $content && isset( $decoded['output_text'] ) ) {
+			$content = is_array( $decoded['output_text'] ) ? implode( ' ', (array) $decoded['output_text'] ) : $decoded['output_text'];
+		}
 
-        return [ $content, $decoded ];
-    }
+		return [ $content, $decoded ];
+	}
 
-    // Helper methods for enhanced analysis
-    private function calculate_efficiency_rating( $user_inputs ) {
-        $total_hours = ($user_inputs['hours_reconciliation'] ?? 0) + ($user_inputs['hours_cash_positioning'] ?? 0);
-        $team_size = $user_inputs['ftes'] ?? 1;
-        $hours_per_fte = $team_size > 0 ? $total_hours / $team_size : $total_hours;
-        
-        if ( $hours_per_fte < 5 ) return 'Good';
-        if ( $hours_per_fte < 15 ) return 'Fair'; 
-        return 'Poor';
-    }
+	// Helper methods for enhanced analysis
+	private function calculate_efficiency_rating( $user_inputs ) {
+		$total_hours = ($user_inputs['hours_reconciliation'] ?? 0) + ($user_inputs['hours_cash_positioning'] ?? 0);
+		$team_size = $user_inputs['ftes'] ?? 1;
+		$hours_per_fte = $team_size > 0 ? $total_hours / $team_size : $total_hours;
+		
+		if ( $hours_per_fte < 5 ) return 'Good';
+		if ( $hours_per_fte < 15 ) return 'Fair'; 
+		return 'Poor';
+	}
 
-    private function get_automation_level( $user_inputs ) {
-        $pain_points = $user_inputs['pain_points'] ?? [];
-        if ( in_array( 'manual_processes', $pain_points ) ) return 'low';
-        if ( in_array( 'integration_issues', $pain_points ) ) return 'moderate';
-        return 'moderate';
-    }
+	private function get_automation_level( $user_inputs ) {
+		$pain_points = $user_inputs['pain_points'] ?? [];
+		if ( in_array( 'manual_processes', $pain_points ) ) return 'low';
+		if ( in_array( 'integration_issues', $pain_points ) ) return 'moderate';
+		return 'moderate';
+	}
 
-    private function analyze_process_inefficiencies( $user_inputs ) {
-        $inefficiencies = [];
-        $pain_points = $user_inputs['pain_points'] ?? [];
-        
-        foreach ( $pain_points as $pain_point ) {
-            switch ( $pain_point ) {
-                case 'manual_processes':
-                    $inefficiencies[] = [
-                        'process' => 'Bank Reconciliation',
-                        'impact' => 'High',
-                        'description' => 'Manual data entry and reconciliation processes consume significant time and introduce error risk'
-                    ];
-                    break;
-                case 'poor_visibility':
-                    $inefficiencies[] = [
-                        'process' => 'Cash Position Reporting',
-                        'impact' => 'High', 
-                        'description' => 'Lack of real-time visibility delays decision-making and impacts working capital optimization'
-                    ];
-                    break;
-                case 'forecast_accuracy':
-                    $inefficiencies[] = [
-                        'process' => 'Cash Forecasting',
-                        'impact' => 'Medium',
-                        'description' => 'Inaccurate forecasting leads to suboptimal cash positioning and increased financing costs'
-                    ];
-                    break;
-            }
-        }
-        
-        return $inefficiencies;
-    }
+	private function analyze_process_inefficiencies( $user_inputs ) {
+		$inefficiencies = [];
+		$pain_points = $user_inputs['pain_points'] ?? [];
+		
+		foreach ( $pain_points as $pain_point ) {
+			switch ( $pain_point ) {
+				case 'manual_processes':
+					$inefficiencies[] = [
+						'process' => 'Bank Reconciliation',
+						'impact' => 'High',
+						'description' => 'Manual data entry and reconciliation processes consume significant time and introduce error risk'
+					];
+					break;
+				case 'poor_visibility':
+					$inefficiencies[] = [
+						'process' => 'Cash Position Reporting',
+						'impact' => 'High', 
+						'description' => 'Lack of real-time visibility delays decision-making and impacts working capital optimization'
+					];
+					break;
+				case 'forecast_accuracy':
+					$inefficiencies[] = [
+						'process' => 'Cash Forecasting',
+						'impact' => 'Medium',
+						'description' => 'Inaccurate forecasting leads to suboptimal cash positioning and increased financing costs'
+					];
+					break;
+			}
+		}
+		
+		return $inefficiencies;
+	}
 
-    private function identify_automation_opportunities( $user_inputs ) {
-        $opportunities = [];
-        
-        if ( ($user_inputs['hours_reconciliation'] ?? 0) > 0 ) {
-            $opportunities[] = [
-                'area' => 'Bank Reconciliation',
-                'complexity' => 'Medium',
-                'potential_hours_saved' => round( ($user_inputs['hours_reconciliation'] ?? 0) * 0.7, 1 )
-            ];
-        }
-        
-        if ( ($user_inputs['hours_cash_positioning'] ?? 0) > 0 ) {
-            $opportunities[] = [
-                'area' => 'Cash Position Management',
-                'complexity' => 'Low',
-                'potential_hours_saved' => round( ($user_inputs['hours_cash_positioning'] ?? 0) * 0.5, 1 )
-            ];
-        }
-        
-        return $opportunities;
-    }
+	private function identify_automation_opportunities( $user_inputs ) {
+		$opportunities = [];
+		
+		if ( ($user_inputs['hours_reconciliation'] ?? 0) > 0 ) {
+			$opportunities[] = [
+				'area' => 'Bank Reconciliation',
+				'complexity' => 'Medium',
+				'potential_hours_saved' => round( ($user_inputs['hours_reconciliation'] ?? 0) * 0.7, 1 )
+			];
+		}
+		
+		if ( ($user_inputs['hours_cash_positioning'] ?? 0) > 0 ) {
+			$opportunities[] = [
+				'area' => 'Cash Position Management',
+				'complexity' => 'Low',
+				'potential_hours_saved' => round( ($user_inputs['hours_cash_positioning'] ?? 0) * 0.5, 1 )
+			];
+		}
+		
+		return $opportunities;
+	}
 
-    private function get_industry_trends( $industry ) {
-        $trends = [
-            'manufacturing' => 'Digital transformation initiatives are driving treasury automation adoption, with focus on supply chain finance integration and sustainability reporting',
-            'technology' => 'Rapid growth companies are prioritizing real-time cash management and automated forecasting to support scaling operations',
-            'retail' => 'Omnichannel payment processing and seasonal cash flow management are key drivers for treasury technology investment'
-        ];
-        
-        return $trends[$industry] ?? 'Companies across industries are modernizing treasury operations to improve efficiency and risk management';
-    }
+	private function get_industry_trends( $industry ) {
+		$trends = [
+			'manufacturing' => 'Digital transformation initiatives are driving treasury automation adoption, with focus on supply chain finance integration and sustainability reporting',
+			'technology' => 'Rapid growth companies are prioritizing real-time cash management and automated forecasting to support scaling operations',
+			'retail' => 'Omnichannel payment processing and seasonal cash flow management are key drivers for treasury technology investment'
+		];
+		
+		return $trends[$industry] ?? 'Companies across industries are modernizing treasury operations to improve efficiency and risk management';
+	}
 
-    private function build_financial_analysis( $roi_data, $user_inputs ) {
-        $base_benefit = $roi_data['base']['total_annual_benefit'] ?? 0;
-        $estimated_cost = $base_benefit * 0.4; // Rough estimate
-        
-        return [
-            'investment_breakdown' => [
-                'software_licensing' => '$' . number_format( $estimated_cost * 0.6 ) . ' - $' . number_format( $estimated_cost * 0.8 ),
-                'implementation_services' => '$' . number_format( $estimated_cost * 0.15 ) . ' - $' . number_format( $estimated_cost * 0.25 ),
-                'training_change_management' => '$' . number_format( $estimated_cost * 0.05 ) . ' - $' . number_format( $estimated_cost * 0.15 )
-            ],
-            'payback_analysis' => [
-                'payback_months' => $base_benefit > 0 ? round( 12 * $estimated_cost / $base_benefit ) : 24,
-                'roi_3_year' => round( ( $base_benefit * 3 - $estimated_cost ) / $estimated_cost * 100 ),
-                'npv_analysis' => 'Positive NPV of $' . number_format( $base_benefit * 2.5 - $estimated_cost ) . ' over 3 years at 10% discount rate'
-            ]
-        ];
-    }
+	private function build_financial_analysis( $roi_data, $user_inputs ) {
+		$base_benefit = $roi_data['base']['total_annual_benefit'] ?? 0;
+		$estimated_cost = $base_benefit * 0.4; // Rough estimate
+		
+		return [
+			'investment_breakdown' => [
+				'software_licensing' => '$' . number_format( $estimated_cost * 0.6 ) . ' - $' . number_format( $estimated_cost * 0.8 ),
+				'implementation_services' => '$' . number_format( $estimated_cost * 0.15 ) . ' - $' . number_format( $estimated_cost * 0.25 ),
+				'training_change_management' => '$' . number_format( $estimated_cost * 0.05 ) . ' - $' . number_format( $estimated_cost * 0.15 )
+			],
+			'payback_analysis' => [
+				'payback_months' => $base_benefit > 0 ? round( 12 * $estimated_cost / $base_benefit ) : 24,
+				'roi_3_year' => round( ( $base_benefit * 3 - $estimated_cost ) / $estimated_cost * 100 ),
+				'npv_analysis' => 'Positive NPV of $' . number_format( $base_benefit * 2.5 - $estimated_cost ) . ' over 3 years at 10% discount rate'
+			]
+		];
+	}
 }
 
 /**
- * Parse a GPT-5 response into output text, reasoning, and function calls.
- *
- * The parser first looks for a convenience `output_text` field. If a valid
- * string is not found, it manually walks the `output` chunks, prioritizing
- * message content before reasoning.
- *
- * @param array $response  HTTP response array from wp_remote_post().
- * @param bool  $store_raw Optional. Include full raw payload. Default false.
- * @return array {
- *     @type string $output_text    Combined output text from the response.
- *     @type array  $reasoning      Reasoning segments provided by the model.
- *     @type array  $function_calls Function call items returned by the model.
- *     @type array  $raw            Raw decoded response body.
- *     @type bool   $truncated      Whether the response hit the token limit.
- * }
- */
+	* Parse a GPT-5 response into output text, reasoning, and function calls.
+	*
+	* The parser first looks for a convenience `output_text` field. If a valid
+	* string is not found, it manually walks the `output` chunks, prioritizing
+	* message content before reasoning.
+	*
+	* @param array $response  HTTP response array from wp_remote_post().
+	* @param bool  $store_raw Optional. Include full raw payload. Default false.
+	* @return array {
+	*     @type string $output_text    Combined output text from the response.
+	*     @type array  $reasoning      Reasoning segments provided by the model.
+	*     @type array  $function_calls Function call items returned by the model.
+	*     @type array  $raw            Raw decoded response body.
+	*     @type bool   $truncated      Whether the response hit the token limit.
+	* }
+	*/
 function rtbcb_parse_gpt5_response( $response, $store_raw = false ) {
-    $body    = wp_remote_retrieve_body( $response );
-    $decoded = json_decode( $body, true );
+	$body    = wp_remote_retrieve_body( $response );
+	$decoded = json_decode( $body, true );
 
-    if ( ! is_array( $decoded ) ) {
-        return [
-            'output_text'    => '',
-            'reasoning'      => [],
-            'function_calls' => [],
-            'raw'            => [],
-        ];
-    }
+	if ( ! is_array( $decoded ) ) {
+		return [
+			'output_text'    => '',
+			'reasoning'      => [],
+			'function_calls' => [],
+			'raw'            => [],
+		];
+	}
 
-    $output_text    = '';
-    $reasoning      = [];
-    $function_calls = [];
-    $truncated      = false;
+	$output_text    = '';
+	$reasoning      = [];
+	$function_calls = [];
+	$truncated      = false;
 
-    // PRIORITY 1: Convenience field.
-    if ( isset( $decoded['output_text'] ) && ! empty( trim( $decoded['output_text'] ) ) ) {
-        $output_text = trim( $decoded['output_text'] );
+	// PRIORITY 1: Convenience field.
+	if ( isset( $decoded['output_text'] ) && ! empty( trim( $decoded['output_text'] ) ) ) {
+		$output_text = trim( $decoded['output_text'] );
 
-        // Reject trivial responses.
-        if ( strlen( $output_text ) < 20 ||
-            false !== stripos( $output_text, 'pong' ) ||
-            false !== stripos( $output_text, 'how can I help' ) ) {
-            error_log( 'RTBCB: Detected trivial response: ' . $output_text );
-            $output_text = '';
-        }
-    }
+		// Reject trivial responses.
+		if ( strlen( $output_text ) < 20 ||
+			false !== stripos( $output_text, 'pong' ) ||
+			false !== stripos( $output_text, 'how can I help' ) ) {
+			error_log( 'RTBCB: Detected trivial response: ' . $output_text );
+			$output_text = '';
+		}
+	}
 
-    // PRIORITY 2: Manual parsing when no good output text was found.
-    if ( empty( $output_text ) && isset( $decoded['output'] ) && is_array( $decoded['output'] ) ) {
+	// PRIORITY 2: Manual parsing when no good output text was found.
+	if ( empty( $output_text ) && isset( $decoded['output'] ) && is_array( $decoded['output'] ) ) {
 
-        // First pass: Look for message content only.
-        foreach ( $decoded['output'] as $chunk ) {
-            if ( ! is_array( $chunk ) || 'message' !== ( $chunk['type'] ?? '' ) ) {
-                continue;
-            }
+		// First pass: Look for message content only.
+		foreach ( $decoded['output'] as $chunk ) {
+			if ( ! is_array( $chunk ) || 'message' !== ( $chunk['type'] ?? '' ) ) {
+				continue;
+			}
 
-            if ( isset( $chunk['content'] ) && is_array( $chunk['content'] ) ) {
-                foreach ( $chunk['content'] as $content_piece ) {
-                    if ( isset( $content_piece['text'] ) && ! empty( trim( $content_piece['text'] ) ) ) {
-                        $candidate = trim( $content_piece['text'] );
+			if ( isset( $chunk['content'] ) && is_array( $chunk['content'] ) ) {
+				foreach ( $chunk['content'] as $content_piece ) {
+					if ( isset( $content_piece['text'] ) && ! empty( trim( $content_piece['text'] ) ) ) {
+						$candidate = trim( $content_piece['text'] );
 
-                        if ( strlen( $candidate ) >= 20 &&
-                            false === stripos( $candidate, 'pong' ) ) {
-                            $output_text = $candidate;
-                            break 2;
-                        }
-                    }
-                }
-            }
-        }
+						if ( strlen( $candidate ) >= 20 &&
+							false === stripos( $candidate, 'pong' ) ) {
+							$output_text = $candidate;
+							break 2;
+						}
+					}
+				}
+			}
+		}
 
-        // Second pass: Collect reasoning and function calls.
-        foreach ( $decoded['output'] as $chunk ) {
-            $chunk_type = $chunk['type'] ?? '';
+		// Second pass: Collect reasoning and function calls.
+		foreach ( $decoded['output'] as $chunk ) {
+			$chunk_type = $chunk['type'] ?? '';
 
-            if ( 'reasoning' === $chunk_type ) {
-                if ( isset( $chunk['content'] ) && is_array( $chunk['content'] ) ) {
-                    foreach ( $chunk['content'] as $piece ) {
-                        if ( isset( $piece['text'] ) && ! empty( $piece['text'] ) ) {
-                            $reasoning[] = $piece['text'];
-                        }
-                    }
-                }
-            }
+			if ( 'reasoning' === $chunk_type ) {
+				if ( isset( $chunk['content'] ) && is_array( $chunk['content'] ) ) {
+					foreach ( $chunk['content'] as $piece ) {
+						if ( isset( $piece['text'] ) && ! empty( $piece['text'] ) ) {
+							$reasoning[] = $piece['text'];
+						}
+					}
+				}
+			}
 
-            if ( 'function_call' === $chunk_type ) {
-                $function_calls[] = $chunk;
-            }
-        }
-    }
+			if ( 'function_call' === $chunk_type ) {
+				$function_calls[] = $chunk;
+			}
+		}
+	}
 
-    // Log quality metrics.
-    $text_length   = strlen( $output_text );
-    $usage         = $decoded['usage'] ?? [];
-    $output_tokens = $usage['output_tokens'] ?? 0;
-    $config        = rtbcb_get_gpt5_config();
-    if ( 'incomplete' === ( $decoded['status'] ?? '' ) ) {
-        $truncated = true;
-    }
-    if ( ! $truncated && $output_tokens >= $config['max_output_tokens'] ) {
-        $truncated = true;
-    }
-    if ( $truncated ) {
-        error_log( 'RTBCB: OpenAI response truncated at ' . $output_tokens . ' tokens' );
-    }
+	// Log quality metrics.
+	$text_length   = strlen( $output_text );
+	$usage         = $decoded['usage'] ?? [];
+	$output_tokens = $usage['output_tokens'] ?? 0;
+	$config        = rtbcb_get_gpt5_config();
+	if ( 'incomplete' === ( $decoded['status'] ?? '' ) ) {
+		$truncated = true;
+	}
+	if ( ! $truncated && $output_tokens >= $config['max_output_tokens'] ) {
+		$truncated = true;
+	}
+	if ( $truncated ) {
+		error_log( 'RTBCB: OpenAI response truncated at ' . $output_tokens . ' tokens' );
+	}
 
-    error_log(
-        sprintf(
-            'RTBCB: Parsed response - text_length=%d, output_tokens=%d, reasoning_chunks=%d',
-            $text_length,
-            $output_tokens,
-            count( $reasoning )
-        )
-    );
+	error_log(
+		sprintf(
+			'RTBCB: Parsed response - text_length=%d, output_tokens=%d, reasoning_chunks=%d',
+			$text_length,
+			$output_tokens,
+			count( $reasoning )
+		)
+	);
 
-    if ( $output_tokens > 50 && $text_length < 100 ) {
-        error_log( 'RTBCB: WARNING - High token count but short text output' );
-    }
+	if ( $output_tokens > 50 && $text_length < 100 ) {
+		error_log( 'RTBCB: WARNING - High token count but short text output' );
+	}
 
-    return [
-        'output_text'    => $output_text,
-        'reasoning'      => $reasoning,
-        'function_calls' => $function_calls,
-        'raw'            => $store_raw ? $decoded : [],
-        'truncated'      => $truncated,
-    ];
+	return [
+		'output_text'    => $output_text,
+		'reasoning'      => $reasoning,
+		'function_calls' => $function_calls,
+		'raw'            => $store_raw ? $decoded : [],
+		'truncated'      => $truncated,
+	];
 }
 

--- a/inc/class-rtbcb-logger.php
+++ b/inc/class-rtbcb-logger.php
@@ -2,103 +2,103 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Structured logging utilities.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Structured logging utilities.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 /**
-         * Structured logging for API interactions.
-         */
-        class RTBCB_Logger {
-            /**
-             * Send a structured log record.
-             *
-             * @param string $event   Event name.
-             * @param array  $context Context data.
-             * @return void
-             */
-    public static function log( $event, $context = [] ) {
-        $record = [
-            'timestamp' => gmdate( 'c' ),
-            'event'     => $event,
-            'context'   => $context,
-        ];
+		 * Structured logging for API interactions.
+		 */
+		class RTBCB_Logger {
+			/**
+			 * Send a structured log record.
+			 *
+			 * @param string $event   Event name.
+			 * @param array  $context Context data.
+			 * @return void
+			 */
+	public static function log( $event, $context = [] ) {
+		$record = [
+			'timestamp' => gmdate( 'c' ),
+			'event'     => $event,
+			'context'   => $context,
+		];
 
-        error_log( 'RTBCB_LOG: ' . wp_json_encode( $record ) );
+		error_log( 'RTBCB_LOG: ' . wp_json_encode( $record ) );
 
-        $endpoint = sanitize_text_field( get_option( 'rtbcb_log_endpoint', '' ) );
-                if ( $endpoint ) {
-                        rtbcb_wp_remote_post_with_retry(
-                        $endpoint,
-                        [
-                        'headers' => [ 'Content-Type' => 'application/json' ],
-                        'body'    => wp_json_encode( $record ),
-                        'timeout' => 2,
-                        ]
-                        );
-        }
-    }
+		$endpoint = sanitize_text_field( get_option( 'rtbcb_log_endpoint', '' ) );
+				if ( $endpoint ) {
+						rtbcb_wp_remote_post_with_retry(
+						$endpoint,
+						[
+						'headers' => [ 'Content-Type' => 'application/json' ],
+						'body'    => wp_json_encode( $record ),
+						'timeout' => 2,
+						]
+						);
+		}
+	}
 
-    /**
-     * Log request details on shutdown.
-     *
-     * @param float $start_time Request start time.
-     * @param array $payload    Sanitized request payload.
-     * @return void
-     */
-    public static function log_shutdown( $start_time, $payload ) {
-        $duration = ( microtime( true ) - $start_time ) * 1000;
-        $code     = http_response_code();
+	/**
+	 * Log request details on shutdown.
+	 *
+	 * @param float $start_time Request start time.
+	 * @param array $payload    Sanitized request payload.
+	 * @return void
+	 */
+	public static function log_shutdown( $start_time, $payload ) {
+		$duration = ( microtime( true ) - $start_time ) * 1000;
+		$code     = http_response_code();
 
-        $log = [
-            'payload'          => $payload,
-            'response_time_ms' => round( $duration ),
-            'status_code'      => $code,
-        ];
+		$log = [
+			'payload'          => $payload,
+			'response_time_ms' => round( $duration ),
+			'status_code'      => $code,
+		];
 
-        $error = error_get_last();
-        if ( $error ) {
-            $log['error'] = $error['message'];
-        }
+		$error = error_get_last();
+		if ( $error ) {
+			$log['error'] = $error['message'];
+		}
 
-        if ( 504 === $code || ( isset( $log['error'] ) && false !== stripos( $log['error'], 'timeout' ) ) ) {
-            self::record_timeout();
-        }
+		if ( 504 === $code || ( isset( $log['error'] ) && false !== stripos( $log['error'], 'timeout' ) ) ) {
+			self::record_timeout();
+		}
 
-        self::log( 'generate_case', $log );
-    }
+		self::log( 'generate_case', $log );
+	}
 
-    /**
-     * Increment timeout counter and trigger alert if threshold exceeded.
-     *
-     * @return void
-     */
-    public static function record_timeout() {
-        $count = (int) get_transient( 'rtbcb_timeout_count' );
-        $count++;
-        set_transient( 'rtbcb_timeout_count', $count, 300 );
+	/**
+	 * Increment timeout counter and trigger alert if threshold exceeded.
+	 *
+	 * @return void
+	 */
+	public static function record_timeout() {
+		$count = (int) get_transient( 'rtbcb_timeout_count' );
+		$count++;
+		set_transient( 'rtbcb_timeout_count', $count, 300 );
 
-        if ( $count >= 3 ) {
-            self::send_timeout_alert( $count );
-            delete_transient( 'rtbcb_timeout_count' );
-        }
-    }
+		if ( $count >= 3 ) {
+			self::send_timeout_alert( $count );
+			delete_transient( 'rtbcb_timeout_count' );
+		}
+	}
 
-    /**
-     * Send timeout alert email.
-     *
-     * @param int $count Timeout count.
-     * @return void
-     */
-    private static function send_timeout_alert( $count ) {
-        $admin_email = get_option( 'admin_email' );
-        $subject     = __( 'Business Case Builder timeout alert', 'rtbcb' );
-        $message     = sprintf(
-            __( 'The Business Case Builder API timed out %d times in the last five minutes.', 'rtbcb' ),
-            $count
-        );
-        wp_mail( $admin_email, $subject, $message );
-    }
+	/**
+	 * Send timeout alert email.
+	 *
+	 * @param int $count Timeout count.
+	 * @return void
+	 */
+	private static function send_timeout_alert( $count ) {
+		$admin_email = get_option( 'admin_email' );
+		$subject     = __( 'Business Case Builder timeout alert', 'rtbcb' );
+		$message     = sprintf(
+			__( 'The Business Case Builder API timed out %d times in the last five minutes.', 'rtbcb' ),
+			$count
+		);
+		wp_mail( $admin_email, $subject, $message );
+	}
 }
 

--- a/inc/class-rtbcb-maturity-model.php
+++ b/inc/class-rtbcb-maturity-model.php
@@ -2,77 +2,77 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Simple treasury maturity model.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Simple treasury maturity model.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 /**
- * Provides a basic maturity assessment.
- */
+	* Provides a basic maturity assessment.
+	*/
 class RTBCB_Maturity_Model {
-    /**
-     * Assess maturity level using full-time equivalents.
-     *
-     * @param array $company_data Company data inputs.
-     * @return array Assessment results.
-     */
-    public function assess( $company_data ) {
-        $level = __( 'Basic', 'rtbcb' );
-        $ftes  = isset( $company_data['ftes'] ) ? floatval( $company_data['ftes'] ) : 1.0;
+	/**
+	 * Assess maturity level using full-time equivalents.
+	 *
+	 * @param array $company_data Company data inputs.
+	 * @return array Assessment results.
+	 */
+	public function assess( $company_data ) {
+		$level = __( 'Basic', 'rtbcb' );
+		$ftes  = isset( $company_data['ftes'] ) ? floatval( $company_data['ftes'] ) : 1.0;
 
-        if ( $ftes > 5 ) {
-            $level = __( 'Advanced', 'rtbcb' );
-        } elseif ( $ftes > 2 ) {
-            $level = __( 'Intermediate', 'rtbcb' );
-        }
+		if ( $ftes > 5 ) {
+			$level = __( 'Advanced', 'rtbcb' );
+		} elseif ( $ftes > 2 ) {
+			$level = __( 'Intermediate', 'rtbcb' );
+		}
 
-        return [
-            'level'      => $level,
-            'assessment' => sprintf(
-                /* translators: %s: maturity level */
-                __( 'Treasury maturity level: %s', 'rtbcb' ),
-                $level
-            ),
-            'score'      => rand( 60, 90 ),
-        ];
-    }
+		return [
+			'level'      => $level,
+			'assessment' => sprintf(
+				/* translators: %s: maturity level */
+				__( 'Treasury maturity level: %s', 'rtbcb' ),
+				$level
+			),
+			'score'      => rand( 60, 90 ),
+		];
+	}
 
-    /**
-     * Assess treasury maturity from user inputs.
-     *
-     * Sanitizes provided data and derives a maturity level
-     * with explanatory rationale.
-     *
-     * @param array $user_inputs User-provided data.
-     * @return array {
-     *     @type string $level     Maturity level.
-     *     @type string $rationale Explanation for the level.
-     * }
-     */
-    private function assess_treasury_maturity( $user_inputs ) {
-        $sanitized = [];
+	/**
+	 * Assess treasury maturity from user inputs.
+	 *
+	 * Sanitizes provided data and derives a maturity level
+	 * with explanatory rationale.
+	 *
+	 * @param array $user_inputs User-provided data.
+	 * @return array {
+	 *     @type string $level     Maturity level.
+	 *     @type string $rationale Explanation for the level.
+	 * }
+	 */
+	private function assess_treasury_maturity( $user_inputs ) {
+		$sanitized = [];
 
-        foreach ( $user_inputs as $key => $value ) {
-            $sanitized[ $key ] = sanitize_text_field( $value );
-        }
+		foreach ( $user_inputs as $key => $value ) {
+			$sanitized[ $key ] = sanitize_text_field( $value );
+		}
 
-        $ftes = isset( $sanitized['ftes'] ) ? floatval( $sanitized['ftes'] ) : 0.0;
+		$ftes = isset( $sanitized['ftes'] ) ? floatval( $sanitized['ftes'] ) : 0.0;
 
-        if ( $ftes > 5 ) {
-            $level     = __( 'Advanced', 'rtbcb' );
-            $rationale = __( 'More than five dedicated treasury FTEs suggests advanced maturity.', 'rtbcb' );
-        } elseif ( $ftes > 2 ) {
-            $level     = __( 'Intermediate', 'rtbcb' );
-            $rationale = __( 'Between two and five FTEs indicates intermediate maturity.', 'rtbcb' );
-        } else {
-            $level     = __( 'Basic', 'rtbcb' );
-            $rationale = __( 'Limited FTEs dedicated to treasury keep maturity at a basic level.', 'rtbcb' );
-        }
+		if ( $ftes > 5 ) {
+			$level     = __( 'Advanced', 'rtbcb' );
+			$rationale = __( 'More than five dedicated treasury FTEs suggests advanced maturity.', 'rtbcb' );
+		} elseif ( $ftes > 2 ) {
+			$level     = __( 'Intermediate', 'rtbcb' );
+			$rationale = __( 'Between two and five FTEs indicates intermediate maturity.', 'rtbcb' );
+		} else {
+			$level     = __( 'Basic', 'rtbcb' );
+			$rationale = __( 'Limited FTEs dedicated to treasury keep maturity at a basic level.', 'rtbcb' );
+		}
 
-        return [
-            'level'     => $level,
-            'rationale' => $rationale,
-        ];
-    }
+		return [
+			'level'     => $level,
+			'rationale' => $rationale,
+		];
+	}
 }

--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -2,263 +2,263 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Implements Retrieval-Augmented Generation logic for the plugin.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Implements Retrieval-Augmented Generation logic for the plugin.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 /**
- * Class RTBCB_RAG.
- */
+	* Class RTBCB_RAG.
+	*/
 class RTBCB_RAG {
-    /**
-     * Constructor.
-     */
-    public function __construct() {
-        RTBCB_DB::init();
-    }
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		RTBCB_DB::init();
+	}
 
-    /**
-     * Rebuild the RAG index from portal data.
-     *
-     * Optionally invalidates cached search results.
-     *
-     * @return void
-     */
-    public function rebuild_index() {
-        // Ensure the index table exists.
-        RTBCB_DB::init();
+	/**
+	 * Rebuild the RAG index from portal data.
+	 *
+	 * Optionally invalidates cached search results.
+	 *
+	 * @return void
+	 */
+	public function rebuild_index() {
+		// Ensure the index table exists.
+		RTBCB_DB::init();
 
-        // Get vendor data from Portal.
-        $vendors = apply_filters( 'rt_portal_get_vendors', [] );
-        $notes   = apply_filters( 'rt_portal_get_vendor_notes', [] );
+		// Get vendor data from Portal.
+		$vendors = apply_filters( 'rt_portal_get_vendors', [] );
+		$notes   = apply_filters( 'rt_portal_get_vendor_notes', [] );
 
-        foreach ( $vendors as $vendor ) {
-            $this->index_vendor( $vendor );
-        }
+		foreach ( $vendors as $vendor ) {
+			$this->index_vendor( $vendor );
+		}
 
-        foreach ( $notes as $note ) {
-            $this->index_note( $note );
-        }
+		foreach ( $notes as $note ) {
+			$this->index_note( $note );
+		}
 
-        // Seed sample data when no real data is available.
-        if ( empty( $vendors ) && empty( $notes ) ) {
-            $this->index_note(
-                [
-                    'id'      => 'sample',
-                    'content' => 'Sample RAG data. Use the rebuild button after configuring the portal to refresh.',
-                ]
-            );
-        }
+		// Seed sample data when no real data is available.
+		if ( empty( $vendors ) && empty( $notes ) ) {
+			$this->index_note(
+				[
+					'id'      => 'sample',
+					'content' => 'Sample RAG data. Use the rebuild button after configuring the portal to refresh.',
+				]
+			);
+		}
 
-        if ( function_exists( 'update_option' ) ) {
-            update_option( 'rtbcb_last_indexed', current_time( 'mysql' ) );
-        }
+		if ( function_exists( 'update_option' ) ) {
+			update_option( 'rtbcb_last_indexed', current_time( 'mysql' ) );
+		}
 
-        if ( function_exists( 'rtbcb_invalidate_rag_cache' ) ) {
-            $flush = true;
-            if ( function_exists( 'apply_filters' ) ) {
-                $flush = apply_filters( 'rtbcb_flush_search_cache_on_rebuild', $flush );
-            }
-            if ( $flush ) {
-                rtbcb_invalidate_rag_cache();
-            }
-        }
-    }
+		if ( function_exists( 'rtbcb_invalidate_rag_cache' ) ) {
+			$flush = true;
+			if ( function_exists( 'apply_filters' ) ) {
+				$flush = apply_filters( 'rtbcb_flush_search_cache_on_rebuild', $flush );
+			}
+			if ( $flush ) {
+				rtbcb_invalidate_rag_cache();
+			}
+		}
+	}
 
-    /**
-     * Search the index for similar content.
-     *
-     * Caches results using the WordPress object cache.
-     *
-     * @param string $query Query string.
-     * @param int    $top_k Number of results.
-     *
-     * @return array Matching rows.
-     */
-    public function search_similar( $query, $top_k = 3 ) {
+	/**
+	 * Search the index for similar content.
+	 *
+	 * Caches results using the WordPress object cache.
+	 *
+	 * @param string $query Query string.
+	 * @param int    $top_k Number of results.
+	 *
+	 * @return array Matching rows.
+	 */
+	public function search_similar( $query, $top_k = 3 ) {
 
-        if ( rtbcb_heavy_features_disabled() ) {
-            return [];
-        }
-        $normalized = strtolower( trim( function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $query ) : strip_tags( $query ) ) );
-        $version    = function_exists( 'get_option' ) ? (int) get_option( 'rtbcb_rag_cache_version', 1 ) : 1;
-        $cache_key  = 'rtbcb_rag_' . md5( $normalized . '|' . $top_k . '|' . $version );
+		if ( rtbcb_heavy_features_disabled() ) {
+			return [];
+		}
+		$normalized = strtolower( trim( function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $query ) : strip_tags( $query ) ) );
+		$version    = function_exists( 'get_option' ) ? (int) get_option( 'rtbcb_rag_cache_version', 1 ) : 1;
+		$cache_key  = 'rtbcb_rag_' . md5( $normalized . '|' . $top_k . '|' . $version );
 
-        $cached = function_exists( 'wp_cache_get' ) ? wp_cache_get( $cache_key, 'rtbcb_rag_search' ) : false;
-        if ( false !== $cached ) {
-            return $cached;
-        }
+		$cached = function_exists( 'wp_cache_get' ) ? wp_cache_get( $cache_key, 'rtbcb_rag_search' ) : false;
+		if ( false !== $cached ) {
+			return $cached;
+		}
 
-        $query_embedding = $this->get_embedding( $query );
-        $results         = $this->cosine_similarity_search( $query_embedding, $top_k );
+		$query_embedding = $this->get_embedding( $query );
+		$results         = $this->cosine_similarity_search( $query_embedding, $top_k );
 
-        $ttl = defined( 'MINUTE_IN_SECONDS' ) ? 15 * MINUTE_IN_SECONDS : 900;
-        if ( function_exists( 'wp_cache_set' ) ) {
-            wp_cache_set( $cache_key, $results, 'rtbcb_rag_search', $ttl );
-        }
+		$ttl = defined( 'MINUTE_IN_SECONDS' ) ? 15 * MINUTE_IN_SECONDS : 900;
+		if ( function_exists( 'wp_cache_set' ) ) {
+			wp_cache_set( $cache_key, $results, 'rtbcb_rag_search', $ttl );
+		}
 
-        return $results;
-    }
+		return $results;
+	}
 
-    /**
-     * Retrieve context metadata for a query.
-     *
-     * Calls {@see search_similar()} and returns only the metadata portion of
-     * the results. If embeddings cannot be generated, an empty array is
-     * returned.
-     *
-     * @param string $query Query string.
-     * @param int    $top_k Number of results to retrieve.
-     *
-     * @return array List of metadata arrays.
-     */
-    public function get_context( $query, $top_k = 3 ) {
+	/**
+	 * Retrieve context metadata for a query.
+	 *
+	 * Calls {@see search_similar()} and returns only the metadata portion of
+	 * the results. If embeddings cannot be generated, an empty array is
+	 * returned.
+	 *
+	 * @param string $query Query string.
+	 * @param int    $top_k Number of results to retrieve.
+	 *
+	 * @return array List of metadata arrays.
+	 */
+	public function get_context( $query, $top_k = 3 ) {
 
-        if ( rtbcb_heavy_features_disabled() ) {
-            return [];
-        }
-        $embedding = $this->get_embedding( $query );
-        if ( empty( $embedding ) ) {
-            return [];
-        }
+		if ( rtbcb_heavy_features_disabled() ) {
+			return [];
+		}
+		$embedding = $this->get_embedding( $query );
+		if ( empty( $embedding ) ) {
+			return [];
+		}
 
-        $results = $this->search_similar( $query, $top_k );
-        $context = [];
+		$results = $this->search_similar( $query, $top_k );
+		$context = [];
 
-        foreach ( $results as $row ) {
-            if ( isset( $row['metadata'] ) ) {
-                $context[] = $row['metadata'];
-            }
-        }
+		foreach ( $results as $row ) {
+			if ( isset( $row['metadata'] ) ) {
+				$context[] = $row['metadata'];
+			}
+		}
 
-        return $context;
-    }
+		return $context;
+	}
 
-    /**
-     * Index a vendor record.
-     *
-     * @param array $vendor Vendor data.
-     *
-     * @return void
-     */
-    private function index_vendor( $vendor ) {
-        global $wpdb;
-        $table_name = $wpdb->prefix . 'rtbcb_rag_index';
+	/**
+	 * Index a vendor record.
+	 *
+	 * @param array $vendor Vendor data.
+	 *
+	 * @return void
+	 */
+	private function index_vendor( $vendor ) {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'rtbcb_rag_index';
 
-        $text = '';
-        if ( is_array( $vendor ) ) {
-            $text = ( $vendor['description'] ?? '' ) . ' ' . ( $vendor['name'] ?? '' );
-        } else {
-            $text = (string) $vendor;
-        }
+		$text = '';
+		if ( is_array( $vendor ) ) {
+			$text = ( $vendor['description'] ?? '' ) . ' ' . ( $vendor['name'] ?? '' );
+		} else {
+			$text = (string) $vendor;
+		}
 
-        $text_hash = hash( 'sha256', $text );
-        $embedding = $this->get_embedding( $text );
+		$text_hash = hash( 'sha256', $text );
+		$embedding = $this->get_embedding( $text );
 
-        $wpdb->replace(
-            $table_name,
-            [
-                'type'          => 'vendor',
-                'ref_id'        => isset( $vendor['id'] ) ? sanitize_text_field( $vendor['id'] ) : '',
-                'text_hash'     => $text_hash,
-                'embedding'     => maybe_serialize( $embedding ),
-                'metadata'      => maybe_serialize( $vendor ),
-                'embedding_norm' => $this->calculate_embedding_norm( $embedding ),
-            ],
-            [ '%s', '%s', '%s', '%s', '%s', '%f' ]
-        );
-    }
+		$wpdb->replace(
+			$table_name,
+			[
+				'type'          => 'vendor',
+				'ref_id'        => isset( $vendor['id'] ) ? sanitize_text_field( $vendor['id'] ) : '',
+				'text_hash'     => $text_hash,
+				'embedding'     => maybe_serialize( $embedding ),
+				'metadata'      => maybe_serialize( $vendor ),
+				'embedding_norm' => $this->calculate_embedding_norm( $embedding ),
+			],
+			[ '%s', '%s', '%s', '%s', '%s', '%f' ]
+		);
+	}
 
-    /**
-     * Index a note record.
-     *
-     * @param array $note Note data.
-     *
-     * @return void
-     */
-    private function index_note( $note ) {
-        global $wpdb;
-        $table_name = $wpdb->prefix . 'rtbcb_rag_index';
+	/**
+	 * Index a note record.
+	 *
+	 * @param array $note Note data.
+	 *
+	 * @return void
+	 */
+	private function index_note( $note ) {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'rtbcb_rag_index';
 
-        $text = is_array( $note ) ? ( $note['content'] ?? '' ) : (string) $note;
-        $text_hash = hash( 'sha256', $text );
-        $embedding = $this->get_embedding( $text );
+		$text = is_array( $note ) ? ( $note['content'] ?? '' ) : (string) $note;
+		$text_hash = hash( 'sha256', $text );
+		$embedding = $this->get_embedding( $text );
 
-        $wpdb->replace(
-            $table_name,
-            [
-                'type'          => 'note',
-                'ref_id'        => isset( $note['id'] ) ? sanitize_text_field( $note['id'] ) : '',
-                'text_hash'     => $text_hash,
-                'embedding'     => maybe_serialize( $embedding ),
-                'metadata'      => maybe_serialize( $note ),
-                'embedding_norm' => $this->calculate_embedding_norm( $embedding ),
-            ],
-            [ '%s', '%s', '%s', '%s', '%s', '%f' ]
-        );
-    }
+		$wpdb->replace(
+			$table_name,
+			[
+				'type'          => 'note',
+				'ref_id'        => isset( $note['id'] ) ? sanitize_text_field( $note['id'] ) : '',
+				'text_hash'     => $text_hash,
+				'embedding'     => maybe_serialize( $embedding ),
+				'metadata'      => maybe_serialize( $note ),
+				'embedding_norm' => $this->calculate_embedding_norm( $embedding ),
+			],
+			[ '%s', '%s', '%s', '%s', '%s', '%f' ]
+		);
+	}
 
-    /**
-     * Retrieve embedding vector for text.
-     *
-     * @param string $text Text to embed.
-     *
-     * @return array Embedding vector.
-     */
-    private function get_embedding( $text ) {
-        $api_key = get_option( 'rtbcb_openai_api_key' );
-        $model   = get_option( 'rtbcb_embedding_model', 'text-embedding-3-small' );
+	/**
+	 * Retrieve embedding vector for text.
+	 *
+	 * @param string $text Text to embed.
+	 *
+	 * @return array Embedding vector.
+	 */
+	private function get_embedding( $text ) {
+		$api_key = get_option( 'rtbcb_openai_api_key' );
+		$model   = get_option( 'rtbcb_embedding_model', 'text-embedding-3-small' );
 
-        if ( empty( $api_key ) ) {
-            return [];
-        }
+		if ( empty( $api_key ) ) {
+			return [];
+		}
 
-        $endpoint = 'https://api.openai.com/v1/embeddings';
-        $args     = [
-            'headers' => [
-                'Authorization' => 'Bearer ' . $api_key,
-                'Content-Type'  => 'application/json',
-            ],
-            'body'    => wp_json_encode(
-                [
-                    'model' => $model,
-                    'input' => $text,
-                ]
-            ),
-            'timeout' => rtbcb_get_api_timeout(),
-        ];
+		$endpoint = 'https://api.openai.com/v1/embeddings';
+		$args     = [
+			'headers' => [
+				'Authorization' => 'Bearer ' . $api_key,
+				'Content-Type'  => 'application/json',
+			],
+			'body'    => wp_json_encode(
+				[
+					'model' => $model,
+					'input' => $text,
+				]
+			),
+			'timeout' => rtbcb_get_api_timeout(),
+		];
 
 $response = rtbcb_wp_remote_post_with_retry( $endpoint, $args );
-        if ( is_wp_error( $response ) ) {
-            return [];
-        }
+		if ( is_wp_error( $response ) ) {
+			return [];
+		}
 
-        $body = wp_remote_retrieve_body( $response );
-        $data = json_decode( $body, true );
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
 
-        return $data['data'][0]['embedding'] ?? [];
-    }
+		return $data['data'][0]['embedding'] ?? [];
+	}
 
-    /**
-     * Search embeddings using cosine similarity.
-     *
-     * @param array $query_embedding Query embedding.
-     * @param int   $top_k           Number of results.
-     *
-     * @return array
-     */
-    private function cosine_similarity_search( $query_embedding, $top_k ) {
-        global $wpdb;
-        $table_name = $wpdb->prefix . 'rtbcb_rag_index';
+	/**
+	 * Search embeddings using cosine similarity.
+	 *
+	 * @param array $query_embedding Query embedding.
+	 * @param int   $top_k           Number of results.
+	 *
+	 * @return array
+	 */
+	private function cosine_similarity_search( $query_embedding, $top_k ) {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'rtbcb_rag_index';
 
-        $table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
-        if ( $table_exists !== $table_name ) {
-            return [];
-        }
+		$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
+		if ( $table_exists !== $table_name ) {
+			return [];
+		}
 
-        $query_norm = $this->calculate_embedding_norm( $query_embedding );
-        $limit      = max( $top_k * 10, $top_k );
+		$query_norm = $this->calculate_embedding_norm( $query_embedding );
+		$limit      = max( $top_k * 10, $top_k );
 
 		$range = 1;
 		$rows  = $wpdb->get_results(
@@ -272,71 +272,71 @@ $response = rtbcb_wp_remote_post_with_retry( $endpoint, $args );
 			ARRAY_A
 		);
 
-        $scores = [];
-        foreach ( $rows as $row ) {
-            $embedding = maybe_unserialize( $row['embedding'] );
-            if ( ! is_array( $embedding ) ) {
-                continue;
-            }
-            $score    = $this->cosine_similarity( $query_embedding, $embedding );
-            $scores[] = [
-                'score'    => $score,
-                'type'     => $row['type'],
-                'ref_id'   => $row['ref_id'],
-                'metadata' => maybe_unserialize( $row['metadata'] ),
-            ];
-        }
+		$scores = [];
+		foreach ( $rows as $row ) {
+			$embedding = maybe_unserialize( $row['embedding'] );
+			if ( ! is_array( $embedding ) ) {
+				continue;
+			}
+			$score    = $this->cosine_similarity( $query_embedding, $embedding );
+			$scores[] = [
+				'score'    => $score,
+				'type'     => $row['type'],
+				'ref_id'   => $row['ref_id'],
+				'metadata' => maybe_unserialize( $row['metadata'] ),
+			];
+		}
 
-        usort(
-            $scores,
-            static function ( $a, $b ) {
-                if ( $a['score'] === $b['score'] ) {
-                    return 0;
-                }
-                return ( $a['score'] > $b['score'] ) ? -1 : 1;
-            }
-        );
+		usort(
+			$scores,
+			static function ( $a, $b ) {
+				if ( $a['score'] === $b['score'] ) {
+					return 0;
+				}
+				return ( $a['score'] > $b['score'] ) ? -1 : 1;
+			}
+		);
 
-        return array_slice( $scores, 0, $top_k );
-    }
+		return array_slice( $scores, 0, $top_k );
+	}
 
-    /**
-     * Calculate the Euclidean norm of an embedding vector.
-     *
-     * @param array $embedding Embedding vector.
-     *
-     * @return float Vector norm.
-     */
-    private function calculate_embedding_norm( $embedding ) {
-        $norm = 0;
-        foreach ( $embedding as $value ) {
-            $norm += $value * $value;
-        }
-        return sqrt( $norm );
-    }
+	/**
+	 * Calculate the Euclidean norm of an embedding vector.
+	 *
+	 * @param array $embedding Embedding vector.
+	 *
+	 * @return float Vector norm.
+	 */
+	private function calculate_embedding_norm( $embedding ) {
+		$norm = 0;
+		foreach ( $embedding as $value ) {
+			$norm += $value * $value;
+		}
+		return sqrt( $norm );
+	}
 
-    /**
-     * Calculate cosine similarity between two vectors.
-     *
-     * @param array $a Vector A.
-     * @param array $b Vector B.
-     *
-     * @return float Similarity score.
-     */
-    private function cosine_similarity( $a, $b ) {
-        $dot = 0;
-        $norm_a = 0;
-        $norm_b = 0;
-        $length  = min( count( $a ), count( $b ) );
-        for ( $i = 0; $i < $length; $i++ ) {
-            $dot    += $a[ $i ] * $b[ $i ];
-            $norm_a += $a[ $i ] * $a[ $i ];
-            $norm_b += $b[ $i ] * $b[ $i ];
-        }
-        if ( 0 === $norm_a || 0 === $norm_b ) {
-            return 0;
-        }
-        return $dot / ( sqrt( $norm_a ) * sqrt( $norm_b ) );
-    }
+	/**
+	 * Calculate cosine similarity between two vectors.
+	 *
+	 * @param array $a Vector A.
+	 * @param array $b Vector B.
+	 *
+	 * @return float Similarity score.
+	 */
+	private function cosine_similarity( $a, $b ) {
+		$dot = 0;
+		$norm_a = 0;
+		$norm_b = 0;
+		$length  = min( count( $a ), count( $b ) );
+		for ( $i = 0; $i < $length; $i++ ) {
+			$dot    += $a[ $i ] * $b[ $i ];
+			$norm_a += $a[ $i ] * $a[ $i ];
+			$norm_b += $b[ $i ] * $b[ $i ];
+		}
+		if ( 0 === $norm_a || 0 === $norm_b ) {
+			return 0;
+		}
+		return $dot / ( sqrt( $norm_a ) * sqrt( $norm_b ) );
+	}
 }
 

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -2,277 +2,277 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Routes model selection based on request complexity.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Routes model selection based on request complexity.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 require_once __DIR__ . '/helpers.php';
 
 /**
- * Class RTBCB_Router.
- */
+	* Class RTBCB_Router.
+	*/
 class RTBCB_Router {
-    /**
-     * Handle form submission and generate the business case.
-     *
-     * @param string $report_type Optional report type (fast, basic or comprehensive).
-     *
-     * @return void
-     */
-    public function handle_form_submission( $report_type = 'basic' ) {
-        // Nonce verification.
-        if (
-            ! isset( $_POST['rtbcb_nonce'] )
-            || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ), 'rtbcb_generate' )
-        ) {
-            wp_send_json_error( [ 'message' => __( 'Nonce verification failed.', 'rtbcb' ) ], 403 );
-            return;
-        }
+	/**
+	 * Handle form submission and generate the business case.
+	 *
+	 * @param string $report_type Optional report type (fast, basic or comprehensive).
+	 *
+	 * @return void
+	 */
+	public function handle_form_submission( $report_type = 'basic' ) {
+		// Nonce verification.
+		if (
+			! isset( $_POST['rtbcb_nonce'] )
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ), 'rtbcb_generate' )
+		) {
+			wp_send_json_error( [ 'message' => __( 'Nonce verification failed.', 'rtbcb' ) ], 403 );
+			return;
+		}
 
-        try {
-            // Sanitize and validate input.
-            $validator      = new RTBCB_Validator();
-            $validated_data = $validator->validate( $_POST );
+		try {
+			// Sanitize and validate input.
+			$validator      = new RTBCB_Validator();
+			$validated_data = $validator->validate( $_POST );
 
-            if ( isset( $validated_data['error'] ) ) {
-                wp_send_json_error( [ 'message' => $validated_data['error'] ], 400 );
-                return;
-            }
+			if ( isset( $validated_data['error'] ) ) {
+				wp_send_json_error( [ 'message' => $validated_data['error'] ], 400 );
+				return;
+			}
 
-            $form_data = $validated_data;
+			$form_data = $validated_data;
 
-            // Determine report type from request if provided.
-            if ( isset( $_POST['report_type'] ) ) {
-                $report_type = sanitize_text_field( wp_unslash( $_POST['report_type'] ) );
-            }
+			// Determine report type from request if provided.
+			if ( isset( $_POST['report_type'] ) ) {
+				$report_type = sanitize_text_field( wp_unslash( $_POST['report_type'] ) );
+			}
 
-                        // Perform ROI calculations.
-                        $calculations    = RTBCB_Calculator::calculate_roi( $form_data );
-                        $recommendation  = RTBCB_Category_Recommender::recommend_category( $form_data );
-                        $calculations    = RTBCB_Calculator::calculate_category_refined_roi(
-                            $form_data,
-                            $recommendation['category_info']
-                        );
+						// Perform ROI calculations.
+						$calculations    = RTBCB_Calculator::calculate_roi( $form_data );
+						$recommendation  = RTBCB_Category_Recommender::recommend_category( $form_data );
+						$calculations    = RTBCB_Calculator::calculate_category_refined_roi(
+							$form_data,
+							$recommendation['category_info']
+						);
 
-            $fast_mode = 'fast' === $report_type || ! empty( $_POST['fast_mode'] ) || rtbcb_heavy_features_disabled();
-            if ( $fast_mode ) {
-                $report_html = $this->get_fast_report_html( $form_data, $calculations );
+			$fast_mode = 'fast' === $report_type || ! empty( $_POST['fast_mode'] ) || rtbcb_heavy_features_disabled();
+			if ( $fast_mode ) {
+				$report_html = $this->get_fast_report_html( $form_data, $calculations );
 
-                $lead_data = array_merge(
-                    $form_data,
-                    [
-                        'roi_low'    => $calculations['conservative']['roi_percentage'] ?? 0,
-                        'roi_base'   => $calculations['base']['roi_percentage'] ?? 0,
-                        'roi_high'   => $calculations['optimistic']['roi_percentage'] ?? 0,
-                        'report_html' => $report_html,
-                    ]
-                );
+				$lead_data = array_merge(
+					$form_data,
+					[
+						'roi_low'    => $calculations['conservative']['roi_percentage'] ?? 0,
+						'roi_base'   => $calculations['base']['roi_percentage'] ?? 0,
+						'roi_high'   => $calculations['optimistic']['roi_percentage'] ?? 0,
+						'report_html' => $report_html,
+					]
+				);
 
-                $lead_id = RTBCB_Leads::save_lead( $lead_data );
+				$lead_id = RTBCB_Leads::save_lead( $lead_data );
 
-                $upload_dir  = wp_upload_dir();
-                $reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
-                if ( ! file_exists( $reports_dir ) ) {
-                    wp_mkdir_p( $reports_dir );
-                }
+				$upload_dir  = wp_upload_dir();
+				$reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
+				if ( ! file_exists( $reports_dir ) ) {
+					wp_mkdir_p( $reports_dir );
+				}
 
-                $filepath = trailingslashit( $reports_dir ) . 'report-' . $lead_id . '.html';
-                file_put_contents( $filepath, $report_html );
+				$filepath = trailingslashit( $reports_dir ) . 'report-' . $lead_id . '.html';
+				file_put_contents( $filepath, $report_html );
 
-                $to      = sanitize_email( $form_data['email'] );
-                $subject = sprintf( __( 'Your Business Case from %s', 'rtbcb' ), get_bloginfo( 'name' ) );
-                $message = __( 'Thank you for using the Business Case Builder. Your report is attached.', 'rtbcb' );
-                wp_mail( $to, $subject, $message, [], [ $filepath ] );
+				$to      = sanitize_email( $form_data['email'] );
+				$subject = sprintf( __( 'Your Business Case from %s', 'rtbcb' ), get_bloginfo( 'name' ) );
+				$message = __( 'Thank you for using the Business Case Builder. Your report is attached.', 'rtbcb' );
+				wp_mail( $to, $subject, $message, [], [ $filepath ] );
 
-                if ( file_exists( $filepath ) ) {
-                    unlink( $filepath );
-                }
+				if ( file_exists( $filepath ) ) {
+					unlink( $filepath );
+				}
 
-                wp_send_json_success(
-                    [
-                        'message'     => __( 'Business case generated successfully.', 'rtbcb' ),
-                        'report_id'   => $lead_id,
-                        'report_html' => $report_html,
-                    ]
-                );
-                return;
-            }
+				wp_send_json_success(
+					[
+						'message'     => __( 'Business case generated successfully.', 'rtbcb' ),
+						'report_id'   => $lead_id,
+						'report_html' => $report_html,
+					]
+				);
+				return;
+			}
 
-            // Instantiate necessary classes.
-            $llm = new RTBCB_LLM();
-            $rag = new RTBCB_RAG();
+			// Instantiate necessary classes.
+			$llm = new RTBCB_LLM();
+			$rag = new RTBCB_RAG();
 
-            // Generate context from RAG.
-            $rag_context = $rag->get_context( $form_data['company_description'] );
+			// Generate context from RAG.
+			$rag_context = $rag->get_context( $form_data['company_description'] );
 
-            if ( 'comprehensive' === $report_type ) {
-                // Generate comprehensive business case with LLM.
-                $business_case_data = $llm->generate_comprehensive_business_case( $form_data, $calculations, $rag_context );
-            } else {
-                // Route to the appropriate model.
-                $model = $this->route_model( $form_data, $rag_context );
-                if ( is_wp_error( $model ) ) {
-                    throw new Exception( $model->get_error_message() );
-                }
+			if ( 'comprehensive' === $report_type ) {
+				// Generate comprehensive business case with LLM.
+				$business_case_data = $llm->generate_comprehensive_business_case( $form_data, $calculations, $rag_context );
+			} else {
+				// Route to the appropriate model.
+				$model = $this->route_model( $form_data, $rag_context );
+				if ( is_wp_error( $model ) ) {
+					throw new Exception( $model->get_error_message() );
+				}
 
-                // Generate basic business case with LLM.
-                $business_case_data = $llm->generate_business_case( $form_data, $calculations, $rag_context, $model );
-            }
+				// Generate basic business case with LLM.
+				$business_case_data = $llm->generate_business_case( $form_data, $calculations, $rag_context, $model );
+			}
 
-            // Check for LLM generation errors before proceeding.
-            if ( is_wp_error( $business_case_data ) ) {
-                $error_message = $business_case_data->get_error_message();
-                $error_data    = $business_case_data->get_error_data();
-                $status        = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
+			// Check for LLM generation errors before proceeding.
+			if ( is_wp_error( $business_case_data ) ) {
+				$error_message = $business_case_data->get_error_message();
+				$error_data    = $business_case_data->get_error_data();
+				$status        = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
 
-                wp_send_json_error(
-                    [
-                        'message'    => $error_message,
-                        'error_code' => $business_case_data->get_error_code(),
-                    ],
-                    $status
-                );
-                return;
-            }
+				wp_send_json_error(
+					[
+						'message'    => $error_message,
+						'error_code' => $business_case_data->get_error_code(),
+					],
+					$status
+				);
+				return;
+			}
 
-            // Generate report HTML based on type.
-            $report_html = 'comprehensive' === $report_type ?
-                $this->get_comprehensive_report_html( $business_case_data ) :
-                $this->get_report_html( $business_case_data );
+			// Generate report HTML based on type.
+			$report_html = 'comprehensive' === $report_type ?
+				$this->get_comprehensive_report_html( $business_case_data ) :
+				$this->get_report_html( $business_case_data );
 
-            // Save the lead.
-            $leads   = new RTBCB_Leads();
-            $lead_id = $leads->save_lead( $form_data, $business_case_data );
+			// Save the lead.
+			$leads   = new RTBCB_Leads();
+			$lead_id = $leads->save_lead( $form_data, $business_case_data );
 
-            // Write report HTML to temporary file in uploads directory.
-            $upload_dir  = wp_upload_dir();
-            $reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
-            if ( ! file_exists( $reports_dir ) ) {
-                wp_mkdir_p( $reports_dir );
-            }
+			// Write report HTML to temporary file in uploads directory.
+			$upload_dir  = wp_upload_dir();
+			$reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
+			if ( ! file_exists( $reports_dir ) ) {
+				wp_mkdir_p( $reports_dir );
+			}
 
-            $filepath = trailingslashit( $reports_dir ) . 'report-' . $lead_id . '.html';
-            file_put_contents( $filepath, $report_html );
+			$filepath = trailingslashit( $reports_dir ) . 'report-' . $lead_id . '.html';
+			file_put_contents( $filepath, $report_html );
 
-            // Prepare and send the report email.
-            $to      = sanitize_email( $form_data['email'] );
-            $subject = sprintf(
-                __( 'Your Business Case from %s', 'rtbcb' ),
-                get_bloginfo( 'name' )
-            );
-            $message = __( 'Thank you for using the Business Case Builder. Your report is attached.', 'rtbcb' );
-            wp_mail( $to, $subject, $message, [], [ $filepath ] );
+			// Prepare and send the report email.
+			$to      = sanitize_email( $form_data['email'] );
+			$subject = sprintf(
+				__( 'Your Business Case from %s', 'rtbcb' ),
+				get_bloginfo( 'name' )
+			);
+			$message = __( 'Thank you for using the Business Case Builder. Your report is attached.', 'rtbcb' );
+			wp_mail( $to, $subject, $message, [], [ $filepath ] );
 
-            // Clean up temporary file.
-            if ( file_exists( $filepath ) ) {
-                unlink( $filepath );
-            }
+			// Clean up temporary file.
+			if ( file_exists( $filepath ) ) {
+				unlink( $filepath );
+			}
 
-            // Send success response.
-            wp_send_json_success(
-                [
-                    'message'     => __( 'Business case generated successfully.', 'rtbcb' ),
-                    'report_id'   => $lead_id,
-                    'report_html' => $report_html,
-                ]
-            );
-        } catch ( Exception $e ) {
-            // Log the detailed error to debug.log.
-            error_log( 'RTBCB Form Submission Error: ' . $e->getMessage() );
+			// Send success response.
+			wp_send_json_success(
+				[
+					'message'     => __( 'Business case generated successfully.', 'rtbcb' ),
+					'report_id'   => $lead_id,
+					'report_html' => $report_html,
+				]
+			);
+		} catch ( Exception $e ) {
+			// Log the detailed error to debug.log.
+			error_log( 'RTBCB Form Submission Error: ' . $e->getMessage() );
 
-            // Send a generic error response to the client.
-            wp_send_json_error(
-                [
-                    'message' => sprintf(
-                        __( 'An unexpected error occurred while generating your report. Please check the server logs for more details. Error: %s', 'rtbcb' ),
-                        $e->getMessage()
-                    ),
-                ],
-                500
-            );
-        }
-    }
-    /**
-     * Route to the appropriate LLM model.
-     *
-     * @param array $inputs User inputs.
-     * @param array $chunks Context chunks.
-     *
-     * @return string|WP_Error Model name or error if no model configured.
-     */
-    public function route_model( $inputs, $chunks ) {
-        $complexity = $this->calculate_complexity( $inputs, $chunks );
-        $category   = RTBCB_Category_Recommender::recommend_category( $inputs )['recommended'];
+			// Send a generic error response to the client.
+			wp_send_json_error(
+				[
+					'message' => sprintf(
+						__( 'An unexpected error occurred while generating your report. Please check the server logs for more details. Error: %s', 'rtbcb' ),
+						$e->getMessage()
+					),
+				],
+				500
+			);
+		}
+	}
+	/**
+	 * Route to the appropriate LLM model.
+	 *
+	 * @param array $inputs User inputs.
+	 * @param array $chunks Context chunks.
+	 *
+	 * @return string|WP_Error Model name or error if no model configured.
+	 */
+	public function route_model( $inputs, $chunks ) {
+		$complexity = $this->calculate_complexity( $inputs, $chunks );
+		$category   = RTBCB_Category_Recommender::recommend_category( $inputs )['recommended'];
 
-        // Get available models
-        $mini_model    = get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) );
-        $premium_model = get_option( 'rtbcb_premium_model', rtbcb_get_default_model( 'premium' ) );
+		// Get available models
+		$mini_model    = get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) );
+		$premium_model = get_option( 'rtbcb_premium_model', rtbcb_get_default_model( 'premium' ) );
 
-        // Start with mini model as default
-        $model     = $mini_model;
-        $reasoning = 'Default mini model for basic requests';
+		// Start with mini model as default
+		$model     = $mini_model;
+		$reasoning = 'Default mini model for basic requests';
 
-        if ( $complexity > 0.6 || 'trms' === $category ) {
-            $model     = $premium_model;
-            $reasoning = 'Premium model for high complexity or TRMS category';
-        } elseif ( 'tms_lite' === $category && $complexity > 0.4 ) {
-            $model     = $premium_model;
-            $reasoning = 'Premium model for TMS-Lite with moderate complexity';
-        }
+		if ( $complexity > 0.6 || 'trms' === $category ) {
+			$model     = $premium_model;
+			$reasoning = 'Premium model for high complexity or TRMS category';
+		} elseif ( 'tms_lite' === $category && $complexity > 0.4 ) {
+			$model     = $premium_model;
+			$reasoning = 'Premium model for TMS-Lite with moderate complexity';
+		}
 
-        // Validate selected model
-        if ( empty( $model ) ) {
-            $error = new WP_Error(
-                'rtbcb_missing_model',
-                __( 'No language model configured. Please review the plugin settings.', 'rtbcb' )
-            );
-            error_log( 'RTBCB: ' . $error->get_error_message() );
-            return $error;
-        }
+		// Validate selected model
+		if ( empty( $model ) ) {
+			$error = new WP_Error(
+				'rtbcb_missing_model',
+				__( 'No language model configured. Please review the plugin settings.', 'rtbcb' )
+			);
+			error_log( 'RTBCB: ' . $error->get_error_message() );
+			return $error;
+		}
 
-        error_log( "RTBCB: Model selected: {$model} (Complexity: {$complexity}, Category: {$category}, Reason: {$reasoning})" );
+		error_log( "RTBCB: Model selected: {$model} (Complexity: {$complexity}, Category: {$category}, Reason: {$reasoning})" );
 
-        return $model;
-    }
+		return $model;
+	}
 
-    /**
-     * Calculate complexity score for model routing.
-     *
-     * @param array $inputs User inputs.
-     * @param array $chunks Context chunks.
-     *
-     * @return float Complexity score between 0 and 1.
-     */
-    private function calculate_complexity( $inputs, $chunks ) {
-        $score = 0;
+	/**
+	 * Calculate complexity score for model routing.
+	 *
+	 * @param array $inputs User inputs.
+	 * @param array $chunks Context chunks.
+	 *
+	 * @return float Complexity score between 0 and 1.
+	 */
+	private function calculate_complexity( $inputs, $chunks ) {
+		$score = 0;
 
-        $pain_points = isset( $inputs['pain_points'] ) ? (array) $inputs['pain_points'] : [];
-        $score      += count( $pain_points ) * 0.1;
-        $score      += count( $chunks ) * 0.2;
+		$pain_points = isset( $inputs['pain_points'] ) ? (array) $inputs['pain_points'] : [];
+		$score      += count( $pain_points ) * 0.1;
+		$score      += count( $chunks ) * 0.2;
 
-        if ( isset( $inputs['company_size'] ) && '>$2B' === $inputs['company_size'] ) {
-            $score += 0.3;
-        }
+		if ( isset( $inputs['company_size'] ) && '>$2B' === $inputs['company_size'] ) {
+			$score += 0.3;
+		}
 
-        return min( 1.0, $score );
-    }
+		return min( 1.0, $score );
+	}
 
-    /**
-     * Generate report HTML.
-     *
-     * @param array $business_case_data Business case data.
-     *
-     * @return string Report HTML.
-     */
-    public function get_report_html( $business_case_data ) {
-        $template_path = RTBCB_DIR . 'templates/report-template.php';
+	/**
+	 * Generate report HTML.
+	 *
+	 * @param array $business_case_data Business case data.
+	 *
+	 * @return string Report HTML.
+	 */
+	public function get_report_html( $business_case_data ) {
+		$template_path = RTBCB_DIR . 'templates/report-template.php';
 
-        if ( ! file_exists( $template_path ) ) {
-            return '';
-        }
+		if ( ! file_exists( $template_path ) ) {
+			return '';
+		}
 
-        $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
+		$business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
 	$report_data        = $business_case_data['report_data'] ?? null;
 	$hash_source        = $report_data ?: $business_case_data;
 	$data_hash          = md5( wp_json_encode( $hash_source ) );
@@ -280,19 +280,19 @@ class RTBCB_Router {
 	$cache_key          = md5( $template_path . ':' . $data_hash . ':' . $version );
 
 	$cached_html = wp_cache_get( $cache_key, 'rtbcb_reports' );
-        if ( false !== $cached_html ) {
-            return $cached_html;
-        }
+		if ( false !== $cached_html ) {
+			return $cached_html;
+		}
 
-        ob_start();
-        include $template_path;
-        $html = ob_get_clean();
-        $html = wp_kses( $html, rtbcb_get_report_allowed_html() );
+		ob_start();
+		include $template_path;
+		$html = ob_get_clean();
+		$html = wp_kses( $html, rtbcb_get_report_allowed_html() );
 
-        wp_cache_set( $cache_key, $html, 'rtbcb_reports', HOUR_IN_SECONDS );
+		wp_cache_set( $cache_key, $html, 'rtbcb_reports', HOUR_IN_SECONDS );
 
-        return $html;
-    }
+		return $html;
+	}
 
 	/**
 	 * Generate fast mode report HTML.
@@ -319,24 +319,24 @@ class RTBCB_Router {
 		return wp_kses( $html, rtbcb_get_report_allowed_html() );
 	}
 
-   /**
-    * Generate comprehensive report HTML from template with proper data transformation.
-    *
-    * @param array $business_case_data Business case data.
-    *
-    * @return string
-    */
-    private function get_comprehensive_report_html( $business_case_data ) {
-        $template_path = RTBCB_DIR . 'templates/comprehensive-report-template.php';
+	/**
+	* Generate comprehensive report HTML from template with proper data transformation.
+	*
+	* @param array $business_case_data Business case data.
+	*
+	* @return string
+	*/
+	private function get_comprehensive_report_html( $business_case_data ) {
+		$template_path = RTBCB_DIR . 'templates/comprehensive-report-template.php';
 
-        if ( file_exists( $template_path ) ) {
-            rtbcb_log_api_debug( 'Router: using comprehensive template', [ 'template_path' => $template_path ] );
-        } else {
-            rtbcb_log_api_debug( 'Router: comprehensive template missing, using basic template', [ 'template_path' => $template_path ] );
-            return $this->get_report_html( $business_case_data );
-        }
+		if ( file_exists( $template_path ) ) {
+			rtbcb_log_api_debug( 'Router: using comprehensive template', [ 'template_path' => $template_path ] );
+		} else {
+			rtbcb_log_api_debug( 'Router: comprehensive template missing, using basic template', [ 'template_path' => $template_path ] );
+			return $this->get_report_html( $business_case_data );
+		}
 
-       $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
+	   $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
 
 	$report_data = $business_case_data['report_data'] ?? null;
 	$hash_source = $report_data ?: $business_case_data;
@@ -345,277 +345,277 @@ class RTBCB_Router {
 	$cache_key  = md5( $template_path . ':' . $data_hash . ':' . $version );
 
 	$cached_html = wp_cache_get( $cache_key, 'rtbcb_reports' );
-       if ( false !== $cached_html ) {
-           return $cached_html;
-       }
+	   if ( false !== $cached_html ) {
+		   return $cached_html;
+	   }
 
-       if ( null === $report_data ) {
-           // Transform data structure for comprehensive template.
-           $report_data = $this->transform_data_for_template( $business_case_data );
-       }
+	   if ( null === $report_data ) {
+		   // Transform data structure for comprehensive template.
+		   $report_data = $this->transform_data_for_template( $business_case_data );
+	   }
 
-       ob_start();
-       include $template_path;
-       $html = ob_get_clean();
-       $html = wp_kses( $html, rtbcb_get_report_allowed_html() );
+	   ob_start();
+	   include $template_path;
+	   $html = ob_get_clean();
+	   $html = wp_kses( $html, rtbcb_get_report_allowed_html() );
 
-       wp_cache_set( $cache_key, $html, 'rtbcb_reports', HOUR_IN_SECONDS );
+	   wp_cache_set( $cache_key, $html, 'rtbcb_reports', HOUR_IN_SECONDS );
 
-       return $html;
-   }
+	   return $html;
+	}
 
-   /**
-    * Transform LLM response data into the structure expected by comprehensive template.
-    *
-    * @param array $business_case_data Business case data.
-    *
-    * @return array
-    */
-   private function transform_data_for_template( $business_case_data ) {
-       $defaults = [
-           'company_name'           => '',
-           'base_roi'               => 0,
-           'roi_base'               => 0,
-           'recommended_category'   => '',
-           'category_info'          => [],
-           'executive_summary'      => '',
-           'narrative'              => '',
-           'executive_recommendation' => '',
-           'recommendation'         => '',
-           'payback_months'         => 'N/A',
-           'sensitivity_analysis'   => [],
-           'company_analysis'       => '',
-           'maturity_level'         => 'intermediate',
-           'current_state_analysis' => '',
-           'market_analysis'        => '',
-           'tech_adoption_level'    => 'medium',
-           'operational_analysis'   => [],
-           'risks'                  => [],
-           'confidence'             => 0.85,
-           'processing_time'        => 0,
-       ];
-       $business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
+	/**
+	* Transform LLM response data into the structure expected by comprehensive template.
+	*
+	* @param array $business_case_data Business case data.
+	*
+	* @return array
+	*/
+	private function transform_data_for_template( $business_case_data ) {
+	   $defaults = [
+		   'company_name'           => '',
+		   'base_roi'               => 0,
+		   'roi_base'               => 0,
+		   'recommended_category'   => '',
+		   'category_info'          => [],
+		   'executive_summary'      => '',
+		   'narrative'              => '',
+		   'executive_recommendation' => '',
+		   'recommendation'         => '',
+		   'payback_months'         => 'N/A',
+		   'sensitivity_analysis'   => [],
+		   'company_analysis'       => '',
+		   'maturity_level'         => 'intermediate',
+		   'current_state_analysis' => '',
+		   'market_analysis'        => '',
+		   'tech_adoption_level'    => 'medium',
+		   'operational_analysis'   => [],
+		   'risks'                  => [],
+		   'confidence'             => 0.85,
+		   'processing_time'        => 0,
+	   ];
+	   $business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
 
-       // Get current company data.
-       $company      = rtbcb_get_current_company();
-       $company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
+	   // Get current company data.
+	   $company      = rtbcb_get_current_company();
+	   $company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
 
-       // Derive recommended category and details from recommendation if not provided.
-       $recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
-       $category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
+	   // Derive recommended category and details from recommendation if not provided.
+	   $recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
+	   $category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
 
-       // Prepare operational and risk data with fallbacks.
-       $operational_analysis = array_map( 'sanitize_text_field', (array) $business_case_data['operational_analysis'] );
-       if ( empty( $operational_analysis ) ) {
-           $operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
-       }
+	   // Prepare operational and risk data with fallbacks.
+	   $operational_analysis = array_map( 'sanitize_text_field', (array) $business_case_data['operational_analysis'] );
+	   if ( empty( $operational_analysis ) ) {
+		   $operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
+	   }
 
-       $implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
-       if ( empty( $implementation_risks ) ) {
-           $implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
-       }
+	   $implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
+	   if ( empty( $implementation_risks ) ) {
+		   $implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
+	   }
 
-       // Create structured data format expected by template.
-       $report_data = [
-           'metadata'           => [
-               'company_name'     => $company_name,
-               'analysis_date'    => current_time( 'Y-m-d' ),
-               'analysis_type'    => rtbcb_get_analysis_type(),
-               'confidence_level' => floatval( $business_case_data['confidence'] ),
-               'processing_time'  => intval( $business_case_data['processing_time'] ),
-           ],
-           'executive_summary'  => [
-               'strategic_positioning'    => wp_kses_post( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
-               'key_value_drivers'       => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation' => wp_kses_post( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
-               'business_case_strength'  => $this->determine_business_case_strength( $business_case_data ),
-           ],
-           'financial_analysis' => [
-               'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
-               'payback_analysis'   => [
-                   'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
-               ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
-           ],
-           'company_intelligence' => [
-               'enriched_profile' => [
-                   'enhanced_description' => wp_kses_post( $business_case_data['company_analysis'] ),
-                   'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
-                   'treasury_maturity'    => [
-                       'current_state' => wp_kses_post( $business_case_data['current_state_analysis'] ),
-                   ],
-               ],
-               'industry_context' => [
-                   'sector_analysis' => [
-                       'market_dynamics' => wp_kses_post( $business_case_data['market_analysis'] ),
-                   ],
-                   'benchmarking'   => [
-                       'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
-                   ],
-               ],
-           ],
-           'technology_strategy' => [
-               'recommended_category' => $recommended_category,
-               'category_details'     => $category_details,
-           ],
-           'operational_insights' => $operational_analysis,
-           'risk_analysis'        => [
-               'implementation_risks' => $implementation_risks,
-           ],
-           'action_plan'          => [
-               'immediate_steps'      => $this->extract_immediate_steps( $business_case_data ),
-               'short_term_milestones'=> $this->extract_short_term_steps( $business_case_data ),
-               'long_term_objectives' => $this->extract_long_term_steps( $business_case_data ),
-           ],
-       ];
+	   // Create structured data format expected by template.
+	   $report_data = [
+		   'metadata'           => [
+			   'company_name'     => $company_name,
+			   'analysis_date'    => current_time( 'Y-m-d' ),
+			   'analysis_type'    => rtbcb_get_analysis_type(),
+			   'confidence_level' => floatval( $business_case_data['confidence'] ),
+			   'processing_time'  => intval( $business_case_data['processing_time'] ),
+		   ],
+		   'executive_summary'  => [
+			   'strategic_positioning'    => wp_kses_post( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
+			   'key_value_drivers'       => $this->extract_value_drivers( $business_case_data ),
+			   'executive_recommendation' => wp_kses_post( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
+			   'business_case_strength'  => $this->determine_business_case_strength( $business_case_data ),
+		   ],
+		   'financial_analysis' => [
+			   'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
+			   'payback_analysis'   => [
+				   'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
+			   ],
+			   'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
+		   ],
+		   'company_intelligence' => [
+			   'enriched_profile' => [
+				   'enhanced_description' => wp_kses_post( $business_case_data['company_analysis'] ),
+				   'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
+				   'treasury_maturity'    => [
+					   'current_state' => wp_kses_post( $business_case_data['current_state_analysis'] ),
+				   ],
+			   ],
+			   'industry_context' => [
+				   'sector_analysis' => [
+					   'market_dynamics' => wp_kses_post( $business_case_data['market_analysis'] ),
+				   ],
+				   'benchmarking'   => [
+					   'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
+				   ],
+			   ],
+		   ],
+		   'technology_strategy' => [
+			   'recommended_category' => $recommended_category,
+			   'category_details'     => $category_details,
+		   ],
+		   'operational_insights' => $operational_analysis,
+		   'risk_analysis'        => [
+			   'implementation_risks' => $implementation_risks,
+		   ],
+		   'action_plan'          => [
+			   'immediate_steps'      => $this->extract_immediate_steps( $business_case_data ),
+			   'short_term_milestones'=> $this->extract_short_term_steps( $business_case_data ),
+			   'long_term_objectives' => $this->extract_long_term_steps( $business_case_data ),
+		   ],
+	   ];
 
-       return $report_data;
-   }
+	   return $report_data;
+	}
 
-   /**
-    * Extract value drivers from business case data.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
-   private function extract_value_drivers( $data ) {
-       $drivers = [];
+	/**
+	* Extract value drivers from business case data.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
+	private function extract_value_drivers( $data ) {
+	   $drivers = [];
 
-       // Extract from various possible sources.
-       if ( ! empty( $data['value_drivers'] ) ) {
-           $drivers = (array) $data['value_drivers'];
-       } elseif ( ! empty( $data['key_benefits'] ) ) {
-           $drivers = (array) $data['key_benefits'];
-       } else {
-           // Default value drivers.
-           $drivers = [
-               __( 'Automated cash management processes', 'rtbcb' ),
-               __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
-               __( 'Reduced operational risk and errors', 'rtbcb' ),
-               __( 'Improved regulatory compliance', 'rtbcb' ),
-           ];
-       }
+	   // Extract from various possible sources.
+	   if ( ! empty( $data['value_drivers'] ) ) {
+		   $drivers = (array) $data['value_drivers'];
+	   } elseif ( ! empty( $data['key_benefits'] ) ) {
+		   $drivers = (array) $data['key_benefits'];
+	   } else {
+		   // Default value drivers.
+		   $drivers = [
+			   __( 'Automated cash management processes', 'rtbcb' ),
+			   __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
+			   __( 'Reduced operational risk and errors', 'rtbcb' ),
+			   __( 'Improved regulatory compliance', 'rtbcb' ),
+		   ];
+	   }
 
-       return array_slice( $drivers, 0, 4 );
-   }
+	   return array_slice( $drivers, 0, 4 );
+	}
 
-   /**
-    * Format ROI scenarios for template.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
-   private function format_roi_scenarios( $data ) {
-       // Try to get ROI data from various possible locations.
-       if ( ! empty( $data['scenarios'] ) ) {
-           return $data['scenarios'];
-       }
+	/**
+	* Format ROI scenarios for template.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
+	private function format_roi_scenarios( $data ) {
+	   // Try to get ROI data from various possible locations.
+	   if ( ! empty( $data['scenarios'] ) ) {
+		   return $data['scenarios'];
+	   }
 
-       if ( ! empty( $data['roi_scenarios'] ) ) {
-           return $data['roi_scenarios'];
-       }
+	   if ( ! empty( $data['roi_scenarios'] ) ) {
+		   return $data['roi_scenarios'];
+	   }
 
-       // Fallback to default structure.
-       return [
-           'conservative' => [
-               'total_annual_benefit' => $data['roi_low'] ?? 0,
-               'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
-           ],
-           'base' => [
-               'total_annual_benefit' => $data['roi_base'] ?? 0,
-               'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
-           ],
-           'optimistic' => [
-               'total_annual_benefit' => $data['roi_high'] ?? 0,
-               'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
-           ],
-       ];
-   }
+	   // Fallback to default structure.
+	   return [
+		   'conservative' => [
+			   'total_annual_benefit' => $data['roi_low'] ?? 0,
+			   'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
+			   'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
+			   'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
+		   ],
+		   'base' => [
+			   'total_annual_benefit' => $data['roi_base'] ?? 0,
+			   'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
+			   'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
+			   'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
+		   ],
+		   'optimistic' => [
+			   'total_annual_benefit' => $data['roi_high'] ?? 0,
+			   'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
+			   'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
+			   'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
+		   ],
+	   ];
+	}
 
-   /**
-    * Determine business case strength based on ROI.
-    *
-    * @param array $data Business case data.
-    *
-    * @return string
-    */
-   private function determine_business_case_strength( $data ) {
-       $base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
+	/**
+	* Determine business case strength based on ROI.
+	*
+	* @param array $data Business case data.
+	*
+	* @return string
+	*/
+	private function determine_business_case_strength( $data ) {
+	   $base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
 
-       if ( $base_roi > 500000 ) {
-           return 'Compelling';
-       } elseif ( $base_roi > 200000 ) {
-           return 'Strong';
-       } elseif ( $base_roi > 50000 ) {
-           return 'Moderate';
-       } else {
-           return 'Developing';
-       }
-   }
+	   if ( $base_roi > 500000 ) {
+		   return 'Compelling';
+	   } elseif ( $base_roi > 200000 ) {
+		   return 'Strong';
+	   } elseif ( $base_roi > 50000 ) {
+		   return 'Moderate';
+	   } else {
+		   return 'Developing';
+	   }
+	}
 
-   /**
-    * Extract action steps from business case data.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
-   private function extract_immediate_steps( $data ) {
-       if ( ! empty( $data['next_actions'] ) ) {
-           $all_actions = (array) $data['next_actions'];
-           return array_slice( $all_actions, 0, 3 );
-       }
+	/**
+	* Extract action steps from business case data.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
+	private function extract_immediate_steps( $data ) {
+	   if ( ! empty( $data['next_actions'] ) ) {
+		   $all_actions = (array) $data['next_actions'];
+		   return array_slice( $all_actions, 0, 3 );
+	   }
 
-       return [
-           __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
-           __( 'Form project steering committee', 'rtbcb' ),
-           __( 'Conduct detailed requirements gathering', 'rtbcb' ),
-       ];
-   }
+	   return [
+		   __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
+		   __( 'Form project steering committee', 'rtbcb' ),
+		   __( 'Conduct detailed requirements gathering', 'rtbcb' ),
+	   ];
+	}
 
-   /**
-    * Extract short term action steps.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
-   private function extract_short_term_steps( $data ) {
-       if ( ! empty( $data['implementation_steps'] ) ) {
-           $steps = (array) $data['implementation_steps'];
-           return array_slice( $steps, 0, 4 );
-       }
+	/**
+	* Extract short term action steps.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
+	private function extract_short_term_steps( $data ) {
+	   if ( ! empty( $data['implementation_steps'] ) ) {
+		   $steps = (array) $data['implementation_steps'];
+		   return array_slice( $steps, 0, 4 );
+	   }
 
-       return [
-           __( 'Issue RFP to qualified vendors', 'rtbcb' ),
-           __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
-           __( 'Negotiate contracts and terms', 'rtbcb' ),
-           __( 'Begin system implementation planning', 'rtbcb' ),
-       ];
-   }
+	   return [
+		   __( 'Issue RFP to qualified vendors', 'rtbcb' ),
+		   __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
+		   __( 'Negotiate contracts and terms', 'rtbcb' ),
+		   __( 'Begin system implementation planning', 'rtbcb' ),
+	   ];
+	}
 
-   /**
-    * Extract long term action steps.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
-   private function extract_long_term_steps( $data ) {
-       return [
-           __( 'Complete system implementation and testing', 'rtbcb' ),
-           __( 'Conduct user training and change management', 'rtbcb' ),
-           __( 'Measure and optimize system performance', 'rtbcb' ),
-           __( 'Expand functionality and integration capabilities', 'rtbcb' ),
-       ];
-   }
+	/**
+	* Extract long term action steps.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
+	private function extract_long_term_steps( $data ) {
+	   return [
+		   __( 'Complete system implementation and testing', 'rtbcb' ),
+		   __( 'Conduct user training and change management', 'rtbcb' ),
+		   __( 'Measure and optimize system performance', 'rtbcb' ),
+		   __( 'Expand functionality and integration capabilities', 'rtbcb' ),
+	   ];
+	}
 }
 

--- a/inc/class-rtbcb-settings.php
+++ b/inc/class-rtbcb-settings.php
@@ -2,52 +2,52 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Settings management for default ROI assumptions.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Settings management for default ROI assumptions.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 /**
- * Class RTBCB_Settings.
- */
+	* Class RTBCB_Settings.
+	*/
 class RTBCB_Settings {
-    /**
-     * Default settings.
-     *
-     * @var array
-     */
-    const DEFAULTS = [
-        'labor_cost_per_hour'       => 100,
-        'efficiency_ranges'         => [
-            'cash_positioning'       => [ 'min' => 70, 'max' => 80 ],
-            'reconciliation'         => [ 'min' => 60, 'max' => 75 ],
-            'payments'               => [ 'min' => 40, 'max' => 60 ],
-            'forecast_error_reduction' => [ 'min' => 20, 'max' => 30 ],
-        ],
-        'bank_fee_reduction'        => [ 'min' => 5, 'max' => 10 ],
-        'baseline_bank_fee_multiplier' => 15000,
-        'enable_ai_analysis'        => true,
-        'enable_charts'            => true,
-    ];
+	/**
+	 * Default settings.
+	 *
+	 * @var array
+	 */
+	const DEFAULTS = [
+		'labor_cost_per_hour'       => 100,
+		'efficiency_ranges'         => [
+			'cash_positioning'       => [ 'min' => 70, 'max' => 80 ],
+			'reconciliation'         => [ 'min' => 60, 'max' => 75 ],
+			'payments'               => [ 'min' => 40, 'max' => 60 ],
+			'forecast_error_reduction' => [ 'min' => 20, 'max' => 30 ],
+		],
+		'bank_fee_reduction'        => [ 'min' => 5, 'max' => 10 ],
+		'baseline_bank_fee_multiplier' => 15000,
+		'enable_ai_analysis'        => true,
+		'enable_charts'            => true,
+	];
 
-    /**
-     * Retrieve a setting value.
-     *
-     * @param string $key     Setting key.
-     * @param mixed  $default Default value.
-     * @return mixed
-     */
-    public static function get_setting( $key, $default = null ) {
-        $settings = get_option( 'rtbcb_settings', self::DEFAULTS );
-        return $settings[ $key ] ?? $default;
-    }
+	/**
+	 * Retrieve a setting value.
+	 *
+	 * @param string $key     Setting key.
+	 * @param mixed  $default Default value.
+	 * @return mixed
+	 */
+	public static function get_setting( $key, $default = null ) {
+		$settings = get_option( 'rtbcb_settings', self::DEFAULTS );
+		return $settings[ $key ] ?? $default;
+	}
 
-    /**
-     * Retrieve all settings.
-     *
-     * @return array
-     */
-    public static function get_all() {
-        return get_option( 'rtbcb_settings', self::DEFAULTS );
-    }
+	/**
+	 * Retrieve all settings.
+	 *
+	 * @return array
+	 */
+	public static function get_all() {
+		return get_option( 'rtbcb_settings', self::DEFAULTS );
+	}
 }

--- a/inc/class-rtbcb-tests.php
+++ b/inc/class-rtbcb-tests.php
@@ -2,146 +2,146 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Integration test utilities.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Integration test utilities.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 /**
- * Class RTBCB_Tests.
- */
+	* Class RTBCB_Tests.
+	*/
 class RTBCB_Tests {
-    /**
-     * Run all integration tests.
-     *
-     * @return array
-     */
-    public static function run_integration_tests() {
-        $results = [];
+	/**
+	 * Run all integration tests.
+	 *
+	 * @return array
+	 */
+	public static function run_integration_tests() {
+		$results = [];
 
-        $results['portal_integration'] = self::test_portal_integration();
-        $results['roi_calculations']  = self::test_roi_calculations();
-        $results['llm_integration']   = self::test_llm_integration();
-        $results['rag_index']         = self::test_rag_index();
+		$results['portal_integration'] = self::test_portal_integration();
+		$results['roi_calculations']  = self::test_roi_calculations();
+		$results['llm_integration']   = self::test_llm_integration();
+		$results['rag_index']         = self::test_rag_index();
 
-        return $results;
-    }
+		return $results;
+	}
 
-    /**
-     * Verify portal integration hooks return data.
-     *
-     * @return array Test result.
-     */
-    private static function test_portal_integration() {
-        $vendors = apply_filters( 'rt_portal_get_vendors', [] );
+	/**
+	 * Verify portal integration hooks return data.
+	 *
+	 * @return array Test result.
+	 */
+	private static function test_portal_integration() {
+		$vendors = apply_filters( 'rt_portal_get_vendors', [] );
 
-        if ( is_array( $vendors ) ) {
-            return [
-                'passed'  => true,
-                'message' => sprintf( __( 'Portal returned %d vendors.', 'rtbcb' ), count( $vendors ) ),
-            ];
-        }
+		if ( is_array( $vendors ) ) {
+			return [
+				'passed'  => true,
+				'message' => sprintf( __( 'Portal returned %d vendors.', 'rtbcb' ), count( $vendors ) ),
+			];
+		}
 
-        return [
-            'passed'  => false,
-            'message' => __( 'Portal did not return expected data.', 'rtbcb' ),
-        ];
-    }
+		return [
+			'passed'  => false,
+			'message' => __( 'Portal did not return expected data.', 'rtbcb' ),
+		];
+	}
 
-    /**
-     * Ensure ROI calculator static method is available.
-     *
-     * @return array Test result.
-     */
-    private static function test_roi_calculations() {
-        if ( ! class_exists( 'RTBCB_Calculator' ) || ! is_callable( [ 'RTBCB_Calculator', 'calculate_roi' ] ) ) {
-            return [
-                'passed'  => false,
-                'message' => __( 'ROI calculator unavailable.', 'rtbcb' ),
-            ];
-        }
+	/**
+	 * Ensure ROI calculator static method is available.
+	 *
+	 * @return array Test result.
+	 */
+	private static function test_roi_calculations() {
+		if ( ! class_exists( 'RTBCB_Calculator' ) || ! is_callable( [ 'RTBCB_Calculator', 'calculate_roi' ] ) ) {
+			return [
+				'passed'  => false,
+				'message' => __( 'ROI calculator unavailable.', 'rtbcb' ),
+			];
+		}
 
-        return [
-            'passed'  => true,
-            'message' => __( 'ROI calculator static method available.', 'rtbcb' ),
-        ];
-    }
+		return [
+			'passed'  => true,
+			'message' => __( 'ROI calculator static method available.', 'rtbcb' ),
+		];
+	}
 
-    /**
-     * Check LLM integration readiness.
-     *
-     * @return array Test result.
-     */
-    private static function test_llm_integration() {
-        if ( ! class_exists( 'RTBCB_LLM' ) ) {
-            return [
-                'passed'  => false,
-                'message' => __( 'LLM integration class missing.', 'rtbcb' ),
-            ];
-        }
+	/**
+	 * Check LLM integration readiness.
+	 *
+	 * @return array Test result.
+	 */
+	private static function test_llm_integration() {
+		if ( ! class_exists( 'RTBCB_LLM' ) ) {
+			return [
+				'passed'  => false,
+				'message' => __( 'LLM integration class missing.', 'rtbcb' ),
+			];
+		}
 
-        if ( ! method_exists( 'RTBCB_Router', 'route_model' ) ) {
-            return [
-                'passed'  => false,
-                'message' => __( 'Model routing not available.', 'rtbcb' ),
-            ];
-        }
+		if ( ! method_exists( 'RTBCB_Router', 'route_model' ) ) {
+			return [
+				'passed'  => false,
+				'message' => __( 'Model routing not available.', 'rtbcb' ),
+			];
+		}
 
-        $llm = new RTBCB_LLM();
+		$llm = new RTBCB_LLM();
 
-        $user_inputs = rtbcb_get_sample_inputs();
+		$user_inputs = rtbcb_get_sample_inputs();
 
-        $roi_data = [
-            'base' => [
-                'labor_savings'        => 50000,
-                'fee_savings'          => 10000,
-                'error_reduction'      => 20000,
-                'total_annual_benefit' => 80000,
-                'roi_percentage'       => 160,
-                'assumptions'          => [],
-            ],
-        ];
+		$roi_data = [
+			'base' => [
+				'labor_savings'        => 50000,
+				'fee_savings'          => 10000,
+				'error_reduction'      => 20000,
+				'total_annual_benefit' => 80000,
+				'roi_percentage'       => 160,
+				'assumptions'          => [],
+			],
+		];
 
-        $response = $llm->generate_business_case( $user_inputs, $roi_data );
+		$response = $llm->generate_business_case( $user_inputs, $roi_data );
 
-        if ( is_wp_error( $response ) ) {
-            return [
-                'passed'  => false,
-                'message' => $response->get_error_message(),
-            ];
-        }
+		if ( is_wp_error( $response ) ) {
+			return [
+				'passed'  => false,
+				'message' => $response->get_error_message(),
+			];
+		}
 
-        $passed  = is_array( $response );
-        $message = $passed ? __( 'LLM call executed.', 'rtbcb' ) : __( 'LLM call failed.', 'rtbcb' );
+		$passed  = is_array( $response );
+		$message = $passed ? __( 'LLM call executed.', 'rtbcb' ) : __( 'LLM call failed.', 'rtbcb' );
 
-        return [
-            'passed'  => $passed,
-            'message' => $message,
-        ];
-    }
+		return [
+			'passed'  => $passed,
+			'message' => $message,
+		];
+	}
 
-    /**
-     * Verify RAG index search runs.
-     *
-     * @return array Test result.
-     */
-    private static function test_rag_index() {
-        if ( ! class_exists( 'RTBCB_RAG' ) ) {
-            return [
-                'passed'  => false,
-                'message' => __( 'RAG class missing.', 'rtbcb' ),
-            ];
-        }
+	/**
+	 * Verify RAG index search runs.
+	 *
+	 * @return array Test result.
+	 */
+	private static function test_rag_index() {
+		if ( ! class_exists( 'RTBCB_RAG' ) ) {
+			return [
+				'passed'  => false,
+				'message' => __( 'RAG class missing.', 'rtbcb' ),
+			];
+		}
 
-        $rag     = new RTBCB_RAG();
-        $results = $rag->search_similar( 'test', 1 );
+		$rag     = new RTBCB_RAG();
+		$results = $rag->search_similar( 'test', 1 );
 
-        $passed  = is_array( $results );
-        $message = $passed ? __( 'RAG search executed.', 'rtbcb' ) : __( 'RAG search failed.', 'rtbcb' );
+		$passed  = is_array( $results );
+		$message = $passed ? __( 'RAG search executed.', 'rtbcb' ) : __( 'RAG search failed.', 'rtbcb' );
 
-        return [
-            'passed'  => $passed,
-            'message' => $message,
-        ];
-    }
+		return [
+			'passed'  => $passed,
+			'message' => $message,
+		];
+	}
 }

--- a/inc/class-rtbcb-validator.php
+++ b/inc/class-rtbcb-validator.php
@@ -2,83 +2,83 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Data validation utilities.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Data validation utilities.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 /**
- * Class RTBCB_Validator.
- */
+	* Class RTBCB_Validator.
+	*/
 class RTBCB_Validator {
-    /**
-     * Validate and sanitize form data.
-     *
-     * @param array $data Raw form data.
-     * @return array Sanitized data or array with 'error' key.
-     */
-    public function validate( array $data ): array {
-        $sanitized = rtbcb_sanitize_form_data( wp_unslash( $data ) );
+	/**
+	 * Validate and sanitize form data.
+	 *
+	 * @param array $data Raw form data.
+	 * @return array Sanitized data or array with 'error' key.
+	 */
+	public function validate( array $data ): array {
+		$sanitized = rtbcb_sanitize_form_data( wp_unslash( $data ) );
 
-        if ( isset( $data['company_name'] ) ) {
-            $sanitized['company_name'] = sanitize_text_field( wp_unslash( $data['company_name'] ) );
-        }
+		if ( isset( $data['company_name'] ) ) {
+			$sanitized['company_name'] = sanitize_text_field( wp_unslash( $data['company_name'] ) );
+		}
 
-        $required_fields = [
-            'company_name' => __( 'Company name is required.', 'rtbcb' ),
-            'email'        => __( 'Email is required.', 'rtbcb' ),
-            'company_size' => __( 'Company size is required.', 'rtbcb' ),
-        ];
+		$required_fields = [
+			'company_name' => __( 'Company name is required.', 'rtbcb' ),
+			'email'        => __( 'Email is required.', 'rtbcb' ),
+			'company_size' => __( 'Company size is required.', 'rtbcb' ),
+		];
 
-        foreach ( $required_fields as $field => $message ) {
-            if ( empty( $sanitized[ $field ] ) ) {
-                return [
-                    'error' => $message,
-                ];
-            }
-        }
+		foreach ( $required_fields as $field => $message ) {
+			if ( empty( $sanitized[ $field ] ) ) {
+				return [
+					'error' => $message,
+				];
+			}
+		}
 
-       $numeric_fields = [
-               'hours_reconciliation',
-               'hours_cash_positioning',
-               'num_banks',
-               'ftes',
-       ];
+	   $numeric_fields = [
+			   'hours_reconciliation',
+			   'hours_cash_positioning',
+			   'num_banks',
+			   'ftes',
+	   ];
 
-       foreach ( $numeric_fields as $field ) {
-               if ( isset( $data[ $field ] ) && '' !== $data[ $field ] && ! is_numeric( $data[ $field ] ) ) {
-                       return [
-                               'error' => sprintf(
-                                       __( '%s must be a numeric value.', 'rtbcb' ),
-                                       ucwords( str_replace( '_', ' ', $field ) )
-                               ),
-                       ];
-               }
-       }
+	   foreach ( $numeric_fields as $field ) {
+			   if ( isset( $data[ $field ] ) && '' !== $data[ $field ] && ! is_numeric( $data[ $field ] ) ) {
+					   return [
+							   'error' => sprintf(
+									   __( '%s must be a numeric value.', 'rtbcb' ),
+									   ucwords( str_replace( '_', ' ', $field ) )
+							   ),
+					   ];
+			   }
+	   }
 
-        if ( ! rtbcb_is_business_email( $sanitized['email'] ) ) {
-            return [
-                'error' => __( 'Please use your business email address.', 'rtbcb' ),
-            ];
-        }
+		if ( ! rtbcb_is_business_email( $sanitized['email'] ) ) {
+			return [
+				'error' => __( 'Please use your business email address.', 'rtbcb' ),
+			];
+		}
 
-        $length_limits = [
-            'company_name' => 255,
-            'email'        => 254,
-        ];
+		$length_limits = [
+			'company_name' => 255,
+			'email'        => 254,
+		];
 
-        foreach ( $length_limits as $field => $limit ) {
-            if ( isset( $sanitized[ $field ] ) && strlen( $sanitized[ $field ] ) > $limit ) {
-                return [
-                    'error' => sprintf(
-                        __( '%s cannot exceed %d characters.', 'rtbcb' ),
-                        ucwords( str_replace( '_', ' ', $field ) ),
-                        $limit
-                    ),
-                ];
-            }
-        }
+		foreach ( $length_limits as $field => $limit ) {
+			if ( isset( $sanitized[ $field ] ) && strlen( $sanitized[ $field ] ) > $limit ) {
+				return [
+					'error' => sprintf(
+						__( '%s cannot exceed %d characters.', 'rtbcb' ),
+						ucwords( str_replace( '_', ' ', $field ) ),
+						$limit
+					),
+				];
+			}
+		}
 
-        return $sanitized;
-    }
+		return $sanitized;
+	}
 }

--- a/inc/class-rtbcb-workflow-tracker.php
+++ b/inc/class-rtbcb-workflow-tracker.php
@@ -2,74 +2,74 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Workflow Tracker for monitoring and debugging the report generation process.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Workflow Tracker for monitoring and debugging the report generation process.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 class RTBCB_Workflow_Tracker {
 /**
- * Recorded steps.
- *
- * @var array
- */
+	* Recorded steps.
+	*
+	* @var array
+	*/
 private $steps = [];
 
 /**
- * Currently running step.
- *
- * @var array|null
- */
+	* Currently running step.
+	*
+	* @var array|null
+	*/
 private $current_step = null;
 
 /**
- * Workflow start time.
- *
- * @var float
- */
+	* Workflow start time.
+	*
+	* @var float
+	*/
 private $start_time;
 
 /**
- * Recorded warnings.
- *
- * @var array
- */
+	* Recorded warnings.
+	*
+	* @var array
+	*/
 private $warnings = [];
 
 /**
- * Recorded errors.
- *
- * @var array
- */
+	* Recorded errors.
+	*
+	* @var array
+	*/
 private $errors = [];
 
 /**
- * Count of AI calls made.
- *
- * @var int
- */
+	* Count of AI calls made.
+	*
+	* @var int
+	*/
 private $ai_calls = 0;
 
 /**
- * Recorded prompts sent to the AI.
- *
- * @var array
- */
+	* Recorded prompts sent to the AI.
+	*
+	* @var array
+	*/
 private $prompts = [];
 
 /**
- * Constructor.
- */
+	* Constructor.
+	*/
 public function __construct() {
 $this->start_time = microtime( true );
 }
 
 /**
- * Start a new workflow step.
- *
- * @param string $step_name  Step identifier.
- * @param mixed  $input_data Optional input data.
- * @return void
- */
+	* Start a new workflow step.
+	*
+	* @param string $step_name  Step identifier.
+	* @param mixed  $input_data Optional input data.
+	* @return void
+	*/
 public function start_step( $step_name, $input_data = null ) {
 $this->current_step = [
 'name'       => $step_name,
@@ -82,12 +82,12 @@ error_log( "RTBCB Workflow: Starting step '{$step_name}'" );
 }
 
 /**
- * Complete the current workflow step.
- *
- * @param string $step_name   Step identifier.
- * @param mixed  $output_data Optional output data.
- * @return void
- */
+	* Complete the current workflow step.
+	*
+	* @param string $step_name   Step identifier.
+	* @param mixed  $output_data Optional output data.
+	* @return void
+	*/
 public function complete_step( $step_name, $output_data = null ) {
 if ( $this->current_step && $this->current_step['name'] === $step_name ) {
 $this->current_step['end_time']     = microtime( true );
@@ -110,12 +110,12 @@ error_log( 'RTBCB Workflow: Completed step ' . $step_name . ' in ' . round( $thi
 }
 
 /**
- * Add a warning to the current or last step.
- *
- * @param string $code    Warning code.
- * @param string $message Warning message.
- * @return void
- */
+	* Add a warning to the current or last step.
+	*
+	* @param string $code    Warning code.
+	* @param string $message Warning message.
+	* @return void
+	*/
 public function add_warning( $code, $message ) {
 $step_name = $this->current_step ? $this->current_step['name'] : ( $this->steps ? end( $this->steps )['name'] : 'unknown' );
 $warning   = [
@@ -130,12 +130,12 @@ error_log( "RTBCB Workflow Warning [{$code}]: {$message}" );
 }
 
 /**
- * Add an error to the workflow.
- *
- * @param string $code    Error code.
- * @param string $message Error message.
- * @return void
- */
+	* Add an error to the workflow.
+	*
+	* @param string $code    Error code.
+	* @param string $message Error message.
+	* @return void
+	*/
 public function add_error( $code, $message ) {
 $step_name = $this->current_step ? $this->current_step['name'] : ( $this->steps ? end( $this->steps )['name'] : 'unknown' );
 $error     = [
@@ -150,10 +150,10 @@ error_log( "RTBCB Workflow Error [{$code}]: {$message}" );
 }
 
 /**
- * Get completed steps summary.
- *
- * @return array
- */
+	* Get completed steps summary.
+	*
+	* @return array
+	*/
 public function get_completed_steps() {
 return array_map(
 function( $step ) {
@@ -169,11 +169,11 @@ $this->steps
 }
 
 /**
- * Record a prompt sent to the AI service.
- *
- * @param array $prompt Prompt data containing 'instructions' and 'input'.
- * @return void
- */
+	* Record a prompt sent to the AI service.
+	*
+	* @param array $prompt Prompt data containing 'instructions' and 'input'.
+	* @return void
+	*/
 public function add_prompt( $prompt ) {
 $step_name      = $this->current_step ? $this->current_step['name'] : 'unknown';
 $this->prompts[] = [
@@ -185,37 +185,37 @@ $this->prompts[] = [
 }
 
 /**
- * Retrieve recorded prompts.
- *
- * @return array
- */
+	* Retrieve recorded prompts.
+	*
+	* @return array
+	*/
 public function get_prompts() {
 return $this->prompts;
 }
 
 /**
- * Get AI call count.
- *
- * @return int
- */
+	* Get AI call count.
+	*
+	* @return int
+	*/
 public function get_ai_call_count() {
 return $this->ai_calls;
 }
 
 /**
- * Get warnings.
- *
- * @return array
- */
+	* Get warnings.
+	*
+	* @return array
+	*/
 public function get_warnings() {
 return $this->warnings;
 }
 
 /**
- * Get debug information.
- *
- * @return array
- */
+	* Get debug information.
+	*
+	* @return array
+	*/
 public function get_debug_info() {
 return [
 'total_steps'    => count( $this->steps ),
@@ -231,11 +231,11 @@ return [
 }
 
 /**
- * Check if step involves AI calls.
- *
- * @param string $step_name Step identifier.
- * @return bool
- */
+	* Check if step involves AI calls.
+	*
+	* @param string $step_name Step identifier.
+	* @return bool
+	*/
 private function is_ai_step( $step_name ) {
 $ai_steps = [ 'ai_enrichment', 'hybrid_rag_analysis', 'strategic_analysis' ];
 return in_array( $step_name, $ai_steps, true );

--- a/inc/config.php
+++ b/inc/config.php
@@ -6,92 +6,92 @@ if ( ! defined( 'RTBCB_ALLOWED_TIERS' ) ) {
 }
 
 /**
- * Configuration defaults for Real Treasury Business Case Builder.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Configuration defaults for Real Treasury Business Case Builder.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 /**
- * Retrieve the default model for a given tier.
- *
- * Centralizes model defaults so they can be overridden in one place.
- *
- * @param string $tier Model tier identifier.
- * @return string Default model name.
- */
+	* Retrieve the default model for a given tier.
+	*
+	* Centralizes model defaults so they can be overridden in one place.
+	*
+	* @param string $tier Model tier identifier.
+	* @return string Default model name.
+	*/
 function rtbcb_get_default_model( $tier ) {
-    $defaults = [
-        'mini'      => 'gpt-4o-mini',
-        'premium'   => 'gpt-4o',
-        'advanced'  => 'gpt-5-mini',
-        'gpt5_mini' => 'gpt-5-mini',
-        'embedding' => 'text-embedding-3-small',
-    ];
+	$defaults = [
+		'mini'      => 'gpt-4o-mini',
+		'premium'   => 'gpt-4o',
+		'advanced'  => 'gpt-5-mini',
+		'gpt5_mini' => 'gpt-5-mini',
+		'embedding' => 'text-embedding-3-small',
+	];
 
-    $tier = sanitize_key( $tier );
+	$tier = sanitize_key( $tier );
 
-    return $defaults[ $tier ] ?? '';
+	return $defaults[ $tier ] ?? '';
 }
 
 /**
- * Retrieve GPT-5 configuration defaults.
- *
- * @param array $overrides Optional overrides.
- * @return array GPT-5 configuration.
- */
+	* Retrieve GPT-5 configuration defaults.
+	*
+	* @param array $overrides Optional overrides.
+	* @return array GPT-5 configuration.
+	*/
 function rtbcb_get_gpt5_config( $overrides = [] ) {
-    $defaults = [
-        'model'             => 'gpt-5-mini',
-        'max_output_tokens' => 8000,
-        'min_output_tokens' => 256,
-        'temperature'       => 0.7,
-        'store'             => true,
-        'timeout'           => function_exists( 'rtbcb_get_api_timeout' ) ? rtbcb_get_api_timeout() : (int) get_option( 'rtbcb_gpt5_timeout', 300 ),
-        'max_retries'       => 2,
-        'max_retry_time'    => function_exists( 'rtbcb_get_api_timeout' ) ? rtbcb_get_api_timeout() : (int) get_option( 'rtbcb_gpt5_timeout', 300 ),
-        'reasoning_effort'  => 'medium',
-        'text_verbosity'    => 'medium',
-    ];
+	$defaults = [
+		'model'             => 'gpt-5-mini',
+		'max_output_tokens' => 8000,
+		'min_output_tokens' => 256,
+		'temperature'       => 0.7,
+		'store'             => true,
+		'timeout'           => function_exists( 'rtbcb_get_api_timeout' ) ? rtbcb_get_api_timeout() : (int) get_option( 'rtbcb_gpt5_timeout', 300 ),
+		'max_retries'       => 2,
+		'max_retry_time'    => function_exists( 'rtbcb_get_api_timeout' ) ? rtbcb_get_api_timeout() : (int) get_option( 'rtbcb_gpt5_timeout', 300 ),
+		'reasoning_effort'  => 'medium',
+		'text_verbosity'    => 'medium',
+	];
 
-    $file_overrides = [];
-    $config_path    = dirname( __DIR__ ) . '/rtbcb-config.json';
-    if ( file_exists( $config_path ) ) {
-        $decoded = json_decode( file_get_contents( $config_path ), true );
-        if ( is_array( $decoded ) ) {
-            if ( isset( $decoded['max_output_tokens'] ) ) {
-                $file_overrides['max_output_tokens'] = $decoded['max_output_tokens'];
-            }
-            if ( isset( $decoded['min_output_tokens'] ) ) {
-                $file_overrides['min_output_tokens'] = $decoded['min_output_tokens'];
-            }
-        }
-    }
+	$file_overrides = [];
+	$config_path    = dirname( __DIR__ ) . '/rtbcb-config.json';
+	if ( file_exists( $config_path ) ) {
+		$decoded = json_decode( file_get_contents( $config_path ), true );
+		if ( is_array( $decoded ) ) {
+			if ( isset( $decoded['max_output_tokens'] ) ) {
+				$file_overrides['max_output_tokens'] = $decoded['max_output_tokens'];
+			}
+			if ( isset( $decoded['min_output_tokens'] ) ) {
+				$file_overrides['min_output_tokens'] = $decoded['min_output_tokens'];
+			}
+		}
+	}
 
-    $env_tokens = getenv( 'RTBCB_MAX_OUTPUT_TOKENS' );
-    if ( false !== $env_tokens ) {
-        $file_overrides['max_output_tokens'] = $env_tokens;
-    }
-    $env_min_tokens = getenv( 'RTBCB_MIN_OUTPUT_TOKENS' );
-    if ( false !== $env_min_tokens ) {
-        $file_overrides['min_output_tokens'] = $env_min_tokens;
-    }
+	$env_tokens = getenv( 'RTBCB_MAX_OUTPUT_TOKENS' );
+	if ( false !== $env_tokens ) {
+		$file_overrides['max_output_tokens'] = $env_tokens;
+	}
+	$env_min_tokens = getenv( 'RTBCB_MIN_OUTPUT_TOKENS' );
+	if ( false !== $env_min_tokens ) {
+		$file_overrides['min_output_tokens'] = $env_min_tokens;
+	}
 
-    $option_tokens = get_option( 'rtbcb_gpt5_max_output_tokens', false );
-    if ( false !== $option_tokens && '' !== $option_tokens ) {
-        $file_overrides['max_output_tokens'] = $option_tokens;
-    }
-    $option_min_tokens = get_option( 'rtbcb_gpt5_min_output_tokens', false );
-    if ( false !== $option_min_tokens && '' !== $option_min_tokens ) {
-        $file_overrides['min_output_tokens'] = $option_min_tokens;
-    }
+	$option_tokens = get_option( 'rtbcb_gpt5_max_output_tokens', false );
+	if ( false !== $option_tokens && '' !== $option_tokens ) {
+		$file_overrides['max_output_tokens'] = $option_tokens;
+	}
+	$option_min_tokens = get_option( 'rtbcb_gpt5_min_output_tokens', false );
+	if ( false !== $option_min_tokens && '' !== $option_min_tokens ) {
+		$file_overrides['min_output_tokens'] = $option_min_tokens;
+	}
 
-    $overrides = array_merge( $file_overrides, $overrides );
+	$overrides = array_merge( $file_overrides, $overrides );
 
-    $config = array_merge( $defaults, array_intersect_key( $overrides, $defaults ) );
-    $config['min_output_tokens'] = min( 128000, max( 1, intval( $config['min_output_tokens'] ) ) );
-    $config['max_output_tokens'] = min( 128000, max( $config['min_output_tokens'], intval( $config['max_output_tokens'] ) ) );
-    $config['max_retry_time']    = max( 1, intval( $config['max_retry_time'] ) );
+	$config = array_merge( $defaults, array_intersect_key( $overrides, $defaults ) );
+	$config['min_output_tokens'] = min( 128000, max( 1, intval( $config['min_output_tokens'] ) ) );
+	$config['max_output_tokens'] = min( 128000, max( $config['min_output_tokens'], intval( $config['max_output_tokens'] ) ) );
+	$config['max_retry_time']    = max( 1, intval( $config['max_retry_time'] ) );
 
-    return $config;
+	return $config;
 }
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -2,17 +2,17 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Helper functions for the Real Treasury Business Case Builder plugin.
- */
+	* Helper functions for the Real Treasury Business Case Builder plugin.
+	*/
 
 /**
- * Get the timeout for external API requests.
- *
- * Allows filtering via `rtbcb_api_timeout` to adjust how long remote
- * requests may take before failing.
- *
- * @return int Timeout in seconds.
- */
+	* Get the timeout for external API requests.
+	*
+	* Allows filtering via `rtbcb_api_timeout` to adjust how long remote
+	* requests may take before failing.
+	*
+	* @return int Timeout in seconds.
+	*/
 function rtbcb_get_api_timeout() {
 	$timeout = (int) get_option( 'rtbcb_gpt5_timeout', 300 );
 	$timeout = rtbcb_sanitize_api_timeout( $timeout );
@@ -32,13 +32,13 @@ function rtbcb_get_api_timeout() {
 require_once __DIR__ . '/config.php';
 
 /**
- * Determine the current analysis tier.
- *
- * Uses plugin settings to detect enabled features and maps them to one of
- * the allowed tiers. The value can be filtered via `rtbcb_analysis_type`.
- *
- * @return string Analysis type.
- */
+	* Determine the current analysis tier.
+	*
+	* Uses plugin settings to detect enabled features and maps them to one of
+	* the allowed tiers. The value can be filtered via `rtbcb_analysis_type`.
+	*
+	* @return string Analysis type.
+	*/
 function rtbcb_get_analysis_type() {
 	$analysis_type = 'basic';
 
@@ -60,12 +60,12 @@ function rtbcb_get_analysis_type() {
 }
 
 /**
- * Retrieve the OpenAI API key from plugin settings.
- *
- * Reads the value stored in the WordPress options table.
- *
- * @return string Sanitized API key.
- */
+	* Retrieve the OpenAI API key from plugin settings.
+	*
+	* Reads the value stored in the WordPress options table.
+	*
+	* @return string Sanitized API key.
+	*/
 function rtbcb_get_openai_api_key() {
 	$api_key = get_option( 'rtbcb_openai_api_key', '' );
 
@@ -73,35 +73,35 @@ function rtbcb_get_openai_api_key() {
 }
 
 /**
- * Determine if an OpenAI API key is configured.
- *
- * @return bool True if the API key is present.
- */
+	* Determine if an OpenAI API key is configured.
+	*
+	* @return bool True if the API key is present.
+	*/
 function rtbcb_has_openai_api_key() {
 	return ! empty( rtbcb_get_openai_api_key() );
 }
 
 /**
- * Check if heavy AI features are disabled.
- *
- * @return bool True if heavy features should be bypassed.
- */
+	* Check if heavy AI features are disabled.
+	*
+	* @return bool True if heavy features should be bypassed.
+	*/
 function rtbcb_heavy_features_disabled() {
 	return (bool) ( get_option( 'rtbcb_disable_heavy_features', 0 ) || get_option( 'rtbcb_fast_mode', 0 ) );
 }
 
 /**
- * Perform a remote POST request with retry logic.
- *
- * Uses exponential backoff with jitter between attempts. Retries are
- * triggered for transport errors, HTTP 429 responses and server errors.
- * Client errors (4xx) other than 429 will return immediately.
- *
- * @param string $url         Endpoint URL.
- * @param array  $args        Arguments for {@see wp_remote_post()}.
- * @param int    $max_retries Optional. Number of attempts. Default 3.
- * @return array|WP_Error HTTP response array or WP_Error on failure.
- */
+	* Perform a remote POST request with retry logic.
+	*
+	* Uses exponential backoff with jitter between attempts. Retries are
+	* triggered for transport errors, HTTP 429 responses and server errors.
+	* Client errors (4xx) other than 429 will return immediately.
+	*
+	* @param string $url         Endpoint URL.
+	* @param array  $args        Arguments for {@see wp_remote_post()}.
+	* @param int    $max_retries Optional. Number of attempts. Default 3.
+	* @return array|WP_Error HTTP response array or WP_Error on failure.
+	*/
 function rtbcb_wp_remote_post_with_retry( $url, $args = [], $max_retries = 3 ) {
 	$url         = function_exists( 'esc_url_raw' ) ? esc_url_raw( $url ) : $url;
 	$max_retries = max( 1, (int) $max_retries );
@@ -161,13 +161,13 @@ function rtbcb_wp_remote_post_with_retry( $url, $args = [], $max_retries = 3 ) {
 }
 
 /**
- * Determine if an error indicates an OpenAI configuration issue.
- *
- * Checks for common phrases like a missing API key or invalid model.
- *
- * @param Throwable $e Thrown error or exception.
- * @return bool True if the error appears configuration related.
- */
+	* Determine if an error indicates an OpenAI configuration issue.
+	*
+	* Checks for common phrases like a missing API key or invalid model.
+	*
+	* @param Throwable $e Thrown error or exception.
+	* @return bool True if the error appears configuration related.
+	*/
 function rtbcb_is_openai_configuration_error( $e ) {
 	$message = strtolower( $e->getMessage() );
 
@@ -175,19 +175,19 @@ function rtbcb_is_openai_configuration_error( $e ) {
 }
 
 /**
- * Retrieve current company data.
- *
- * @return array Current company data.
- */
+	* Retrieve current company data.
+	*
+	* @return array Current company data.
+	*/
 function rtbcb_get_current_company() {
 	return get_option( 'rtbcb_current_company', [] );
 }
 
 /**
- * Clear stored company data and reset test progress.
- *
- * @return void
- */
+	* Clear stored company data and reset test progress.
+	*
+	* @return void
+	*/
 function rtbcb_clear_current_company() {
 	$sections = rtbcb_get_dashboard_sections( [] );
 
@@ -210,38 +210,38 @@ function rtbcb_clear_current_company() {
 }
 
 /**
- * Retrieve model capability configuration.
- *
- * @return array Model capability data.
- */
+	* Retrieve model capability configuration.
+	*
+	* @return array Model capability data.
+	*/
 function rtbcb_get_model_capabilities() {
 	return include RTBCB_DIR . 'inc/model-capabilities.php';
 }
 
 /**
- * Determine if a model supports the temperature parameter.
- *
- * Attempts to query the OpenAI models endpoint and caches the result. Falls
- * back to a static list of unsupported models if the request fails.
- *
- * @param string $model Model identifier.
- * @return bool Whether the model supports temperature.
- */
+	* Determine if a model supports the temperature parameter.
+	*
+	* Attempts to query the OpenAI models endpoint and caches the result. Falls
+	* back to a static list of unsupported models if the request fails.
+	*
+	* @param string $model Model identifier.
+	* @return bool Whether the model supports temperature.
+	*/
 function rtbcb_model_supports_temperature( $model ) {
-        $capabilities = include RTBCB_DIR . 'inc/model-capabilities.php';
-        $unsupported = $capabilities['temperature']['unsupported'] ?? [];
-        return ! in_array( $model, $unsupported, true );
+		$capabilities = include RTBCB_DIR . 'inc/model-capabilities.php';
+		$unsupported = $capabilities['temperature']['unsupported'] ?? [];
+		return ! in_array( $model, $unsupported, true );
 }
 
 /**
- * Sanitize the API timeout option.
- *
- * Ensures the value stays within the allowed 1-600 second range while
- * preserving legacy zero values by falling back to the default 300 seconds.
- *
- * @param mixed $value Raw option value.
- * @return int Sanitized timeout in seconds.
- */
+	* Sanitize the API timeout option.
+	*
+	* Ensures the value stays within the allowed 1-600 second range while
+	* preserving legacy zero values by falling back to the default 300 seconds.
+	*
+	* @param mixed $value Raw option value.
+	* @return int Sanitized timeout in seconds.
+	*/
 function rtbcb_sanitize_api_timeout( $value ) {
 	$value = intval( $value );
 
@@ -253,13 +253,13 @@ function rtbcb_sanitize_api_timeout( $value ) {
 }
 
 /**
- * Sanitize the max output tokens option.
- *
- * Ensures the value stays within the allowed 256-128000 token range.
- *
- * @param mixed $value Raw option value.
- * @return int Sanitized token count.
- */
+	* Sanitize the max output tokens option.
+	*
+	* Ensures the value stays within the allowed 256-128000 token range.
+	*
+	* @param mixed $value Raw option value.
+	* @return int Sanitized token count.
+	*/
 function rtbcb_sanitize_max_output_tokens( $value ) {
 	$value = intval( $value );
 
@@ -267,13 +267,13 @@ function rtbcb_sanitize_max_output_tokens( $value ) {
 }
 
 /**
- * Sanitize the min output tokens option.
- *
- * Ensures the value stays within the allowed 1-128000 token range.
- *
- * @param mixed $value Raw option value.
- * @return int Sanitized token count.
- */
+	* Sanitize the min output tokens option.
+	*
+	* Ensures the value stays within the allowed 1-128000 token range.
+	*
+	* @param mixed $value Raw option value.
+	* @return int Sanitized token count.
+	*/
 function rtbcb_sanitize_min_output_tokens( $value ) {
 	$value = intval( $value );
 
@@ -281,15 +281,15 @@ function rtbcb_sanitize_min_output_tokens( $value ) {
 }
 
 /**
- * Get testing dashboard sections and their completion state.
- *
- * The returned array is keyed by section ID and contains the section label,
- * related option key, AJAX action, dependencies, and whether the section has
- * been completed.
- *
- * @param array|null $test_results Optional preloaded test results.
- * @return array[] Section data keyed by section ID.
- */
+	* Get testing dashboard sections and their completion state.
+	*
+	* The returned array is keyed by section ID and contains the section label,
+	* related option key, AJAX action, dependencies, and whether the section has
+	* been completed.
+	*
+	* @param array|null $test_results Optional preloaded test results.
+	* @return array[] Section data keyed by section ID.
+	*/
 function rtbcb_get_dashboard_sections( $test_results = null ) {
 	$empty = [];
 
@@ -407,9 +407,9 @@ function rtbcb_get_dashboard_sections( $test_results = null ) {
 	];
 
 		foreach ( $sections as $id => &$section ) {
-			    $result               = rtbcb_get_last_test_result( $id, $test_results );
-			    $status               = $result['status'] ?? '';
-			    $section['completed'] = ( 'success' === $status );
+				$result               = rtbcb_get_last_test_result( $id, $test_results );
+				$status               = $result['status'] ?? '';
+				$section['completed'] = ( 'success' === $status );
 		}
 
 		return $sections;
@@ -420,12 +420,12 @@ function rtbcb_get_dashboard_sections( $test_results = null ) {
 }
 
 /**
- * Calculate completion percentages for each phase.
- *
- * @param array $sections Dashboard sections.
- * @param array $phases   Optional phase numbers to include in the result.
- * @return array Percentages keyed by phase number.
- */
+	* Calculate completion percentages for each phase.
+	*
+	* @param array $sections Dashboard sections.
+	* @param array $phases   Optional phase numbers to include in the result.
+	* @return array Percentages keyed by phase number.
+	*/
 function rtbcb_calculate_phase_completion( $sections, $phases = [] ) {
 	$totals = [];
 	$done   = [];
@@ -457,15 +457,15 @@ function rtbcb_calculate_phase_completion( $sections, $phases = [] ) {
 }
 
 /**
- * Get the first incomplete dependency for a section.
- *
- * Recursively checks the dependency chain and returns the earliest section
- * that has not been completed.
- *
- * @param string $section_id Section identifier to check.
- * @param array  $sections   All dashboard sections.
- * @return string|null The first incomplete dependency or null if all met.
- */
+	* Get the first incomplete dependency for a section.
+	*
+	* Recursively checks the dependency chain and returns the earliest section
+	* that has not been completed.
+	*
+	* @param string $section_id Section identifier to check.
+	* @param array  $sections   All dashboard sections.
+	* @return string|null The first incomplete dependency or null if all met.
+	*/
 function rtbcb_get_first_incomplete_dependency( $section_id, $sections, $visited = [] ) {
 	if ( in_array( $section_id, $visited, true ) ) {
 		return null;
@@ -491,16 +491,16 @@ function rtbcb_get_first_incomplete_dependency( $section_id, $sections, $visited
 }
 
 /**
- * Ensure required sections are complete before rendering a dashboard section.
- *
- * Outputs a warning linking to the first incomplete section when prerequisites
- * are missing.
- *
- * @param string $current_section Current section ID.
- * @param bool   $display_notice  Optional. Whether to show an admin notice.
- *                                Defaults to true.
- * @return bool True when allowed, false otherwise.
- */
+	* Ensure required sections are complete before rendering a dashboard section.
+	*
+	* Outputs a warning linking to the first incomplete section when prerequisites
+	* are missing.
+	*
+	* @param string $current_section Current section ID.
+	* @param bool   $display_notice  Optional. Whether to show an admin notice.
+	*                                Defaults to true.
+	* @return bool True when allowed, false otherwise.
+	*/
 function rtbcb_require_completed_steps( $current_section, $display_notice = true ) {
 	static $displayed = [];
 
@@ -529,12 +529,12 @@ function rtbcb_require_completed_steps( $current_section, $display_notice = true
 }
 
 /**
- * Retrieve the most recent test result for a section.
- *
- * @param string     $section_id   Section identifier.
- * @param array|null $test_results Optional preloaded test results.
- * @return array|null Matching result or null when none found.
- */
+	* Retrieve the most recent test result for a section.
+	*
+	* @param string     $section_id   Section identifier.
+	* @param array|null $test_results Optional preloaded test results.
+	* @return array|null Matching result or null when none found.
+	*/
 function rtbcb_get_last_test_result( $section_id, $test_results = null ) {
 	if ( null === $test_results ) {
 		$test_results = get_option( 'rtbcb_test_results', [] );
@@ -554,13 +554,13 @@ function rtbcb_get_last_test_result( $section_id, $test_results = null ) {
 }
 
 /**
- * Render a button to start a new company analysis.
- *
- * The button clears existing company data and navigates to the Company
- * Overview section of the testing dashboard so a new analysis can begin.
- *
- * @return void
- */
+	* Render a button to start a new company analysis.
+	*
+	* The button clears existing company data and navigates to the Company
+	* Overview section of the testing dashboard so a new analysis can begin.
+	*
+	* @return void
+	*/
 function rtbcb_render_start_new_analysis_button() {
 	echo '<p>';
 	echo '<button type="button" id="rtbcb-start-new-analysis" class="button">' .
@@ -591,11 +591,11 @@ function rtbcb_check_database_health() {
 }
 
 /**
- * Sanitize form input data
- *
- * @param array $data Raw form data
- * @return array Sanitized data
- */
+	* Sanitize form input data
+	*
+	* @param array $data Raw form data
+	* @return array Sanitized data
+	*/
 function rtbcb_sanitize_form_data( $data ) {
 	$sanitized = [];
 	
@@ -651,11 +651,11 @@ function rtbcb_sanitize_form_data( $data ) {
 }
 
 /**
- * Validate email domain
- *
- * @param string $email Email address
- * @return bool True if valid business email
- */
+	* Validate email domain
+	*
+	* @param string $email Email address
+	* @return bool True if valid business email
+	*/
 function rtbcb_is_business_email( $email ) {
 	$consumer_domains = [
 		'gmail.com', 'yahoo.com', 'hotmail.com', 'outlook.com',
@@ -667,44 +667,44 @@ function rtbcb_is_business_email( $email ) {
 }
 
 /**
- * Validate OpenAI API key format.
- *
- * Accepts standard and project-scoped keys which start with "sk-" and may
- * include letters, numbers, hyphens, colons, and underscores.
- *
- * @param string $api_key API key.
- * @return bool Whether the format is valid.
- */
+	* Validate OpenAI API key format.
+	*
+	* Accepts standard and project-scoped keys which start with "sk-" and may
+	* include letters, numbers, hyphens, colons, and underscores.
+	*
+	* @param string $api_key API key.
+	* @return bool Whether the format is valid.
+	*/
 function rtbcb_is_valid_openai_api_key( $api_key ) {
 	return preg_match( '/^sk-[A-Za-z0-9_:-]{48,}$/', $api_key );
 }
 
 /**
- * Normalize a model name by stripping date suffixes.
- *
- * @param string $model Raw model identifier.
- * @return string Model name without version date.
- */
+	* Normalize a model name by stripping date suffixes.
+	*
+	* @param string $model Raw model identifier.
+	* @return string Model name without version date.
+	*/
 function rtbcb_normalize_model_name( $model ) {
 	$model = sanitize_text_field( $model );
 	return preg_replace( '/^(gpt-[^\s]+?)(?:-\d{4}-\d{2}-\d{2})$/', '$1', $model );
 }
 
 /**
- * Send the generated report to the user via email.
- *
- * @param array  $form_data   Form submission data.
- * @param string $report_path Absolute path to the HTML report file.
- *
- * @return void
- */
+	* Send the generated report to the user via email.
+	*
+	* @param array  $form_data   Form submission data.
+	* @param string $report_path Absolute path to the HTML report file.
+	*
+	* @return void
+	*/
 /**
- * Send the generated report to the user via email.
- *
- * @param array    $form_data   Submitted form data.
- * @param string   $report_path Path to the generated report file.
- * @param callable $mailer      Optional mailer function for testing.
- */
+	* Send the generated report to the user via email.
+	*
+	* @param array    $form_data   Submitted form data.
+	* @param string   $report_path Path to the generated report file.
+	* @param callable $mailer      Optional mailer function for testing.
+	*/
 function rtbcb_send_report_email( $form_data, $report_path, $mailer = 'wp_mail' ) {
 	$email = isset( $form_data['email'] ) ? sanitize_email( $form_data['email'] ) : '';
 
@@ -721,10 +721,10 @@ function rtbcb_send_report_email( $form_data, $report_path, $mailer = 'wp_mail' 
 }
 
 /**
- * Get client information for analytics
- *
- * @return array Client data
- */
+	* Get client information for analytics
+	*
+	* @return array Client data
+	*/
 function rtbcb_get_client_info() {
 	return [
 		'ip'          => rtbcb_get_client_ip(),
@@ -742,10 +742,10 @@ function rtbcb_get_client_info() {
 }
 
 /**
- * Get client IP address
- *
- * @return string IP address
- */
+	* Get client IP address
+	*
+	* @return string IP address
+	*/
 function rtbcb_get_client_ip() {
 	$ip_keys = [ 'HTTP_X_FORWARDED_FOR', 'HTTP_X_REAL_IP', 'HTTP_CLIENT_IP', 'REMOTE_ADDR' ];
 	
@@ -773,11 +773,11 @@ function rtbcb_get_client_ip() {
 }
 
 /**
- * Recursively sanitize values using sanitize_text_field.
- *
- * @param mixed $data Data to sanitize.
- * @return mixed Sanitized data.
- */
+	* Recursively sanitize values using sanitize_text_field.
+	*
+	* @param mixed $data Data to sanitize.
+	* @return mixed Sanitized data.
+	*/
 function rtbcb_recursive_sanitize_text_field( $data ) {
 	if ( is_array( $data ) ) {
 		foreach ( $data as $key => $value ) {
@@ -791,12 +791,12 @@ function rtbcb_recursive_sanitize_text_field( $data ) {
 }
 
 /**
- * Log API debug messages.
- *
- * @param string $message Log message.
- * @param mixed  $data    Optional data.
- * @return void
- */
+	* Log API debug messages.
+	*
+	* @param string $message Log message.
+	* @param mixed  $data    Optional data.
+	* @return void
+	*/
 function rtbcb_log_api_debug( $message, $data = null ) {
 	$log_message = 'RTBCB API Debug: ' . $message;
 	if ( $data ) {
@@ -846,29 +846,29 @@ function rtbcb_log_memory_usage( $stage ) {
 
 function rtbcb_get_memory_status() {
 		return [
-		        'current' => memory_get_usage( true ),
-		        'peak'    => memory_get_peak_usage( true ),
-		        'limit'   => wp_convert_hr_to_bytes( ini_get( 'memory_limit' ) ),
+				'current' => memory_get_usage( true ),
+				'peak'    => memory_get_peak_usage( true ),
+				'limit'   => wp_convert_hr_to_bytes( ini_get( 'memory_limit' ) ),
 		];
 }
 
 /**
- * Determine if provided inputs qualify for synchronous processing.
- *
- * Simple cases with minimal data can be handled without background jobs.
- * A case is considered "simple" when all of the following are under their
- * respective thresholds:
- * - Number of banks involved.
- * - Full-time equivalents (FTEs) required.
- * - Combined weekly hours spent on reconciliation and cash positioning.
- *
- * These thresholds are intentionally conservative to keep synchronous
- * processing fast. Adjust the values below or use the `rtbcb_is_simple_case`
- * filter to customize the behavior.
- *
- * @param array $user_inputs Sanitized user inputs.
- * @return bool True when synchronous execution is allowed.
- */
+	* Determine if provided inputs qualify for synchronous processing.
+	*
+	* Simple cases with minimal data can be handled without background jobs.
+	* A case is considered "simple" when all of the following are under their
+	* respective thresholds:
+	* - Number of banks involved.
+	* - Full-time equivalents (FTEs) required.
+	* - Combined weekly hours spent on reconciliation and cash positioning.
+	*
+	* These thresholds are intentionally conservative to keep synchronous
+	* processing fast. Adjust the values below or use the `rtbcb_is_simple_case`
+	* filter to customize the behavior.
+	*
+	* @param array $user_inputs Sanitized user inputs.
+	* @return bool True when synchronous execution is allowed.
+	*/
 function rtbcb_is_simple_case( $user_inputs ) {
 		$user_inputs = is_array( $user_inputs ) ? $user_inputs : [];
 
@@ -893,10 +893,10 @@ function rtbcb_is_simple_case( $user_inputs ) {
 }
 
 /**
- * Retrieve sample user inputs for testing purposes.
- *
- * @return array Sample user inputs.
- */
+	* Retrieve sample user inputs for testing purposes.
+	*
+	* @return array Sample user inputs.
+	*/
 function rtbcb_get_sample_inputs() {
 	return [
 		'company_name'           => 'Acme Manufacturing Corp',
@@ -918,10 +918,10 @@ function rtbcb_get_sample_inputs() {
 }
 
 /**
- * Retrieve predefined sample report scenarios.
- *
- * @return array Map of scenario keys to labels and input data.
- */
+	* Retrieve predefined sample report scenarios.
+	*
+	* @return array Map of scenario keys to labels and input data.
+	*/
 function rtbcb_get_sample_report_forms() {
 	return [
 		'enterprise_manufacturer' => [
@@ -948,12 +948,12 @@ function rtbcb_get_sample_report_forms() {
 }
 
 /**
- * Map scenario keys to sample report inputs.
- *
- * @param array  $inputs       Default inputs.
- * @param string $scenario_key Scenario identifier.
- * @return array Filtered inputs.
- */
+	* Map scenario keys to sample report inputs.
+	*
+	* @param array  $inputs       Default inputs.
+	* @param string $scenario_key Scenario identifier.
+	* @return array Filtered inputs.
+	*/
 function rtbcb_map_sample_report_inputs( $inputs, $scenario_key ) {
 	$empty = [];
 
@@ -977,15 +977,15 @@ function rtbcb_map_sample_report_inputs( $inputs, $scenario_key ) {
 add_filter( 'rtbcb_sample_report_inputs', 'rtbcb_map_sample_report_inputs', 10, 2 );
 
 /**
- * Generate a category recommendation with enriched context for testing.
- *
- * Sanitizes requirement inputs, runs the category recommender, augments the
- * response with human readable names, reasoning, alternative categories,
- * confidence and scoring data, and optional implementation guidance.
- *
- * @param array $requirements User provided requirement data.
- * @return array Structured recommendation data.
- */
+	* Generate a category recommendation with enriched context for testing.
+	*
+	* Sanitizes requirement inputs, runs the category recommender, augments the
+	* response with human readable names, reasoning, alternative categories,
+	* confidence and scoring data, and optional implementation guidance.
+	*
+	* @param array $requirements User provided requirement data.
+	* @return array Structured recommendation data.
+	*/
 function rtbcb_test_generate_category_recommendation( $analysis ) {
 	$analysis = is_array( $analysis ) ? $analysis : [];
 
@@ -1015,23 +1015,23 @@ function rtbcb_test_generate_category_recommendation( $analysis ) {
 			$input .= "\nExtra Requirements: {$payload['extra_requirements']}";
 		}
 
-		        $response = rtbcb_wp_remote_post_with_retry(
-		                'https://api.openai.com/v1/responses',
-		                [
-		                        'headers' => [
-		                                'Content-Type'  => 'application/json',
-		                                'Authorization' => 'Bearer ' . $api_key,
-		                        ],
-		                        'body'    => wp_json_encode(
-		                                [
-		                                        'model'        => $model,
-		                                        'instructions' => $system_prompt,
-		                                        'input'        => $input,
-		                                ]
-		                        ),
-		                        'timeout' => rtbcb_get_api_timeout(),
-		                ]
-		        );
+				$response = rtbcb_wp_remote_post_with_retry(
+						'https://api.openai.com/v1/responses',
+						[
+								'headers' => [
+										'Content-Type'  => 'application/json',
+										'Authorization' => 'Bearer ' . $api_key,
+								],
+								'body'    => wp_json_encode(
+										[
+												'model'        => $model,
+												'instructions' => $system_prompt,
+												'input'        => $input,
+										]
+								),
+								'timeout' => rtbcb_get_api_timeout(),
+						]
+				);
 
 		if ( is_wp_error( $response ) ) {
 			return new WP_Error( 'llm_failure', __( 'Unable to generate recommendation at this time.', 'rtbcb' ) );
@@ -1104,11 +1104,11 @@ function rtbcb_test_generate_category_recommendation( $analysis ) {
 }
 
 /**
- * Test generating industry commentary using the LLM.
- *
- * @param string $industry Industry slug.
- * @return string|WP_Error Commentary text or error object.
- */
+	* Test generating industry commentary using the LLM.
+	*
+	* @param string $industry Industry slug.
+	* @return string|WP_Error Commentary text or error object.
+	*/
 function rtbcb_test_generate_industry_commentary( $industry ) {
 	$industry = sanitize_text_field( $industry );
 
@@ -1123,11 +1123,11 @@ function rtbcb_test_generate_industry_commentary( $industry ) {
 }
 
 /**
- * Test generating a company overview using the LLM.
- *
- * @param string $company_name Company name.
- * @return array|WP_Error Structured overview array or error object.
- */
+	* Test generating a company overview using the LLM.
+	*
+	* @param string $company_name Company name.
+	* @return array|WP_Error Structured overview array or error object.
+	*/
 function rtbcb_test_generate_company_overview( $company_name ) {
 	if ( ! class_exists( 'RTBCB_LLM' ) ) {
 		return new WP_Error( 'missing_class', __( 'LLM class not available', 'rtbcb' ) );
@@ -1146,17 +1146,17 @@ function rtbcb_test_generate_company_overview( $company_name ) {
 }
 
 /**
- * Test generating a treasury tech overview using the LLM.
- *
- * @param array $company_data Company data including focus areas and complexity.
- * @return string|WP_Error Overview text or error object.
- */
+	* Test generating a treasury tech overview using the LLM.
+	*
+	* @param array $company_data Company data including focus areas and complexity.
+	* @return string|WP_Error Overview text or error object.
+	*/
 /**
- * Test assessing treasury maturity.
- *
- * @param array $company_data Company information.
- * @return array|WP_Error Assessment data or error.
- */
+	* Test assessing treasury maturity.
+	*
+	* @param array $company_data Company information.
+	* @return array|WP_Error Assessment data or error.
+	*/
 function rtbcb_test_generate_maturity_model( $company_data ) {
 	if ( ! class_exists( 'RTBCB_Maturity_Model' ) ) {
 		return new WP_Error( 'missing_class', __( 'Maturity model class not available', 'rtbcb' ) );
@@ -1168,11 +1168,11 @@ function rtbcb_test_generate_maturity_model( $company_data ) {
 }
 
 /**
- * Test running RAG market analysis.
- *
- * @param string $query Search query.
- * @return array|WP_Error Vendor shortlist or error.
- */
+	* Test running RAG market analysis.
+	*
+	* @param string $query Search query.
+	* @return array|WP_Error Vendor shortlist or error.
+	*/
 function rtbcb_test_rag_market_analysis( $query ) {
 	if ( ! class_exists( 'RTBCB_RAG' ) ) {
 		return new WP_Error( 'missing_class', __( 'RAG class not available', 'rtbcb' ) );
@@ -1193,11 +1193,11 @@ function rtbcb_test_rag_market_analysis( $query ) {
 }
 
 /**
- * Test generating a value proposition.
- *
- * @param array $company_data Company information.
- * @return string|WP_Error Opening paragraph or error.
- */
+	* Test generating a value proposition.
+	*
+	* @param array $company_data Company information.
+	* @return string|WP_Error Opening paragraph or error.
+	*/
 function rtbcb_test_generate_value_proposition( $company_data ) {
 	$company_data = is_array( $company_data ) ? $company_data : [];
 	$company_name = isset( $company_data['name'] ) ? sanitize_text_field( $company_data['name'] ) : '';
@@ -1233,12 +1233,12 @@ function rtbcb_test_generate_value_proposition( $company_data ) {
 }
 
 /**
- * Test generating an industry overview using company data.
- *
- * @param array $company_data Company information including industry, size,
- *                            geography, and business model.
- * @return string|WP_Error Overview text or error object.
- */
+	* Test generating an industry overview using company data.
+	*
+	* @param array $company_data Company information including industry, size,
+	*                            geography, and business model.
+	* @return string|WP_Error Overview text or error object.
+	*/
 function rtbcb_test_generate_industry_overview( $company_data ) {
 	if ( ! class_exists( 'RTBCB_LLM' ) ) {
 		return new WP_Error( 'missing_class', __( 'LLM class not available', 'rtbcb' ) );
@@ -1257,19 +1257,19 @@ function rtbcb_test_generate_industry_overview( $company_data ) {
 }
 
 /**
- * Test generating a Real Treasury overview using the LLM.
- *
- * @param array $company_data {
- *     Company context data.
- *
- *     @type bool   $include_portal Include portal integration details.
- *     @type string $company_size   Company size description.
- *     @type string $industry       Company industry.
- *     @type array  $challenges     List of identified challenges.
- *     @type array  $categories     Optional vendor categories to highlight.
- * }
- * @return string|WP_Error Overview text or error object.
- */
+	* Test generating a Real Treasury overview using the LLM.
+	*
+	* @param array $company_data {
+	*     Company context data.
+	*
+	*     @type bool   $include_portal Include portal integration details.
+	*     @type string $company_size   Company size description.
+	*     @type string $industry       Company industry.
+	*     @type array  $challenges     List of identified challenges.
+	*     @type array  $categories     Optional vendor categories to highlight.
+	* }
+	* @return string|WP_Error Overview text or error object.
+	*/
 function rtbcb_test_generate_real_treasury_overview( $include_portal = false, $categories = [] ) {
 	if ( ! class_exists( 'RTBCB_LLM' ) ) {
 		return new WP_Error( 'missing_class', __( 'LLM class not available', 'rtbcb' ) );
@@ -1293,12 +1293,12 @@ function rtbcb_test_generate_real_treasury_overview( $include_portal = false, $c
 }
 
 /**
- * Test generating a benefits estimate using the LLM.
- *
- * @param array  $company_data        Company context including revenue, staff count and efficiency.
- * @param string $recommended_category Solution category.
- * @return array|WP_Error Structured estimate array or error object.
- */
+	* Test generating a benefits estimate using the LLM.
+	*
+	* @param array  $company_data        Company context including revenue, staff count and efficiency.
+	* @param string $recommended_category Solution category.
+	* @return array|WP_Error Structured estimate array or error object.
+	*/
 function rtbcb_test_generate_benefits_estimate( $company_data, $recommended_category ) {
 	$company_data = is_array( $company_data ) ? $company_data : [];
 	$revenue      = isset( $company_data['revenue'] ) ? floatval( $company_data['revenue'] ) : 0;
@@ -1317,10 +1317,10 @@ function rtbcb_test_generate_benefits_estimate( $company_data, $recommended_cate
 }
 
 /**
- * Test generating executive summary via the LLM.
- *
- * @return array|WP_Error Summary data or error object.
- */
+	* Test generating executive summary via the LLM.
+	*
+	* @return array|WP_Error Summary data or error object.
+	*/
 function rtbcb_test_generate_executive_summary() {
 	if ( ! class_exists( 'RTBCB_LLM' ) ) {
 		return new WP_Error( 'missing_class', __( 'LLM class not available', 'rtbcb' ) );
@@ -1329,8 +1329,8 @@ function rtbcb_test_generate_executive_summary() {
 	$company = rtbcb_get_current_company();
 	$roi     = get_option( 'rtbcb_roi_results', [] );
 
-       $llm    = new RTBCB_LLM();
-       $result = $llm->generate_comprehensive_business_case( $company, $roi, [], null );
+	   $llm    = new RTBCB_LLM();
+	   $result = $llm->generate_comprehensive_business_case( $company, $roi, [], null );
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
@@ -1351,12 +1351,12 @@ function rtbcb_test_generate_executive_summary() {
 }
 
 /**
- * Parse GPT-5 Responses API output with quality validation.
- *
- * @param array $response Response data from GPT-5 API.
- *
- * @return array Parsed response with quality information.
- */
+	* Parse GPT-5 Responses API output with quality validation.
+	*
+	* @param array $response Response data from GPT-5 API.
+	*
+	* @return array Parsed response with quality information.
+	*/
 function rtbcb_parse_gpt5_business_case_response( $response ) {
 	$parsed = rtbcb_parse_gpt5_response( $response );
 
@@ -1416,13 +1416,13 @@ function rtbcb_parse_gpt5_business_case_response( $response ) {
 }
 
 /**
- * Proxy requests to the OpenAI Responses API.
- *
- * Reads the API key from options and forwards the provided request body to
- * the OpenAI endpoint.
- *
- * @return void
- */
+	* Proxy requests to the OpenAI Responses API.
+	*
+	* Reads the API key from options and forwards the provided request body to
+	* the OpenAI endpoint.
+	*
+	* @return void
+	*/
 function rtbcb_proxy_openai_responses() {
 	$api_key = get_option( 'rtbcb_openai_api_key' );
 	if ( empty( $api_key ) ) {
@@ -1440,7 +1440,7 @@ function rtbcb_proxy_openai_responses() {
 
 		$body_array = json_decode( $body, true );
 		if ( ! is_array( $body_array ) ) {
-			    $body_array = [];
+				$body_array = [];
 		}
 
 		$company      = rtbcb_get_current_company();
@@ -1494,12 +1494,12 @@ function rtbcb_proxy_openai_responses() {
 }
 
 /**
- * Background handler for OpenAI response jobs.
- *
- * @param string $job_id  Job identifier.
- * @param int    $user_id User identifier.
- * @return void
- */
+	* Background handler for OpenAI response jobs.
+	*
+	* @param string $job_id  Job identifier.
+	* @param int    $user_id User identifier.
+	* @return void
+	*/
 function rtbcb_handle_openai_responses_job( $job_id, $user_id ) {
 	$job_id  = sanitize_key( $job_id );
 	$user_id = intval( $user_id );
@@ -1533,7 +1533,7 @@ function rtbcb_handle_openai_responses_job( $job_id, $user_id ) {
 
 		$body_array = json_decode( $body, true );
 		if ( ! is_array( $body_array ) ) {
-			    $body_array = [];
+				$body_array = [];
 		}
 
 		$company      = rtbcb_get_current_company();
@@ -1546,21 +1546,21 @@ function rtbcb_handle_openai_responses_job( $job_id, $user_id ) {
 	}
 
 		$response = rtbcb_wp_remote_post_with_retry(
-		        'https://api.openai.com/v1/responses',
-		        [
-		                'headers' => [
-		                        'Content-Type'  => 'application/json',
-		                        'Authorization' => 'Bearer ' . $api_key,
-		                ],
-		                'body'    => $body,
-		                'timeout' => $timeout,
-		        ]
+				'https://api.openai.com/v1/responses',
+				[
+						'headers' => [
+								'Content-Type'  => 'application/json',
+								'Authorization' => 'Bearer ' . $api_key,
+						],
+						'body'    => $body,
+						'timeout' => $timeout,
+				]
 		);
 
 	if ( is_wp_error( $response ) ) {
-			    if ( class_exists( 'RTBCB_API_Log' ) ) {
-				    RTBCB_API_Log::save_log( $body_array, [ 'error' => $response->get_error_message() ], $user_id, $user_email, $company_name );
-			    }
+				if ( class_exists( 'RTBCB_API_Log' ) ) {
+					RTBCB_API_Log::save_log( $body_array, [ 'error' => $response->get_error_message() ], $user_id, $user_email, $company_name );
+				}
 		set_transient(
 			'rtbcb_openai_job_' . $job_id,
 			[
@@ -1580,7 +1580,7 @@ function rtbcb_handle_openai_responses_job( $job_id, $user_id ) {
 	}
 
 		if ( class_exists( 'RTBCB_API_Log' ) ) {
-			    RTBCB_API_Log::save_log( $body_array, $decoded, $user_id, $user_email, $company_name );
+				RTBCB_API_Log::save_log( $body_array, $decoded, $user_id, $user_email, $company_name );
 		}
 
 	set_transient(
@@ -1598,10 +1598,10 @@ if ( function_exists( 'add_action' ) ) {
 }
 
 /**
- * Retrieve the status or result of an OpenAI response job.
- *
- * @return void
- */
+	* Retrieve the status or result of an OpenAI response job.
+	*
+	* @return void
+	*/
 function rtbcb_get_openai_responses_status() {
 	$job_id = isset( $_REQUEST['job_id'] ) ? sanitize_key( wp_unslash( $_REQUEST['job_id'] ) ) : '';
 	if ( '' === $job_id ) {
@@ -1622,11 +1622,11 @@ function rtbcb_get_openai_responses_status() {
 }
 
 /**
- * Queue comprehensive analysis generation in the background.
- *
- * @param string $company_name Company name.
- * @return string|WP_Error Job identifier on success or WP_Error on failure.
- */
+	* Queue comprehensive analysis generation in the background.
+	*
+	* @param string $company_name Company name.
+	* @return string|WP_Error Job identifier on success or WP_Error on failure.
+	*/
 function rtbcb_queue_comprehensive_analysis( $company_name ) {
 	$company_name = sanitize_text_field( $company_name );
 	if ( '' === $company_name ) {
@@ -1644,12 +1644,12 @@ function rtbcb_queue_comprehensive_analysis( $company_name ) {
 }
 
 /**
- * Background handler for comprehensive analysis jobs.
- *
- * @param string $company_name Company name.
- * @param string $job_id       Job identifier.
- * @return void
- */
+	* Background handler for comprehensive analysis jobs.
+	*
+	* @param string $company_name Company name.
+	* @param string $job_id       Job identifier.
+	* @return void
+	*/
 function rtbcb_handle_comprehensive_analysis( $company_name, $job_id ) {
 	$company_name = sanitize_text_field( $company_name );
 	$job_id       = sanitize_key( $job_id );
@@ -1687,8 +1687,8 @@ function rtbcb_handle_comprehensive_analysis( $company_name, $job_id ) {
 		$rag_context = array_map( 'sanitize_text_field', $vendor_list );
 	}
 
-       $llm      = new RTBCB_LLM();
-       $analysis = $llm->generate_comprehensive_business_case( [ 'company_name' => $company_name ], [], $rag_context, null );
+	   $llm      = new RTBCB_LLM();
+	   $analysis = $llm->generate_comprehensive_business_case( [ 'company_name' => $company_name ], [], $rag_context, null );
 
 	if ( is_wp_error( $analysis ) ) {
 		update_option(
@@ -1775,25 +1775,25 @@ if ( function_exists( 'add_action' ) ) {
 }
 
 /**
- * Get the result of a queued analysis job.
- *
- * @param string $job_id Job identifier.
- * @return mixed|null Stored result array or null if pending.
- */
+	* Get the result of a queued analysis job.
+	*
+	* @param string $job_id Job identifier.
+	* @return mixed|null Stored result array or null if pending.
+	*/
 function rtbcb_get_analysis_job_result( $job_id ) {
 	$job_id = sanitize_key( $job_id );
 	return get_option( 'rtbcb_analysis_job_' . $job_id, null );
 }
 
 /**
- * Build a cache key for LLM research results.
- *
- * @param string $company  Company name.
- * @param string $industry Industry name.
- * @param string $type     Cache segment identifier.
- *
- * @return string Cache key.
- */
+	* Build a cache key for LLM research results.
+	*
+	* @param string $company  Company name.
+	* @param string $industry Industry name.
+	* @param string $type     Cache segment identifier.
+	*
+	* @return string Cache key.
+	*/
 function rtbcb_get_research_cache_key( $company, $industry, $type ) {
 	$company  = sanitize_title( $company );
 	$industry = sanitize_title( $industry );
@@ -1803,28 +1803,28 @@ function rtbcb_get_research_cache_key( $company, $industry, $type ) {
 }
 
 /**
- * Retrieve cached LLM research data.
- *
- * @param string $company  Company name.
- * @param string $industry Industry name.
- * @param string $type     Cache segment identifier.
- *
- * @return mixed Cached data or false when not found.
- */
+	* Retrieve cached LLM research data.
+	*
+	* @param string $company  Company name.
+	* @param string $industry Industry name.
+	* @param string $type     Cache segment identifier.
+	*
+	* @return mixed Cached data or false when not found.
+	*/
 function rtbcb_get_research_cache( $company, $industry, $type ) {
 	$key = rtbcb_get_research_cache_key( $company, $industry, $type );
 	return get_transient( $key );
 }
 
 /**
- * Store LLM research data in cache.
- *
- * @param string $company  Company name.
- * @param string $industry Industry name.
- * @param string $type     Cache segment identifier.
- * @param mixed  $data     Data to cache.
- * @param int    $ttl      Optional TTL in seconds.
- */
+	* Store LLM research data in cache.
+	*
+	* @param string $company  Company name.
+	* @param string $industry Industry name.
+	* @param string $type     Cache segment identifier.
+	* @param mixed  $data     Data to cache.
+	* @param int    $ttl      Optional TTL in seconds.
+	*/
 function rtbcb_set_research_cache( $company, $industry, $type, $data, $ttl = 0 ) {
 	$key = rtbcb_get_research_cache_key( $company, $industry, $type );
 	$ttl = (int) $ttl;
@@ -1846,24 +1846,24 @@ function rtbcb_set_research_cache( $company, $industry, $type, $data, $ttl = 0 )
 }
 
 /**
- * Delete cached LLM research data.
- *
- * @param string $company  Company name.
- * @param string $industry Industry name.
- * @param string $type     Cache segment identifier.
- */
+	* Delete cached LLM research data.
+	*
+	* @param string $company  Company name.
+	* @param string $industry Industry name.
+	* @param string $type     Cache segment identifier.
+	*/
 function rtbcb_delete_research_cache( $company, $industry, $type ) {
 $key = rtbcb_get_research_cache_key( $company, $industry, $type );
 delete_transient( $key );
 }
 
 /**
- * Get allowed HTML tags and attributes for report templates.
- *
- * Adds canvas and button elements and permits data-* attributes.
- *
- * @return array Allowed HTML tags and attributes.
- */
+	* Get allowed HTML tags and attributes for report templates.
+	*
+	* Adds canvas and button elements and permits data-* attributes.
+	*
+	* @return array Allowed HTML tags and attributes.
+	*/
 function rtbcb_get_report_allowed_html() {
 	$allowed = wp_kses_allowed_html( 'post' );
 
@@ -1894,24 +1894,24 @@ function rtbcb_get_report_allowed_html() {
 }
 
 /**
- * Increment the RAG search cache version to invalidate cached results.
- *
- * @return void
- */
+	* Increment the RAG search cache version to invalidate cached results.
+	*
+	* @return void
+	*/
 function rtbcb_invalidate_rag_cache() {
 		if ( function_exists( 'get_option' ) && function_exists( 'update_option' ) ) {
-		        $version = (int) get_option( 'rtbcb_rag_cache_version', 1 );
-		        update_option( 'rtbcb_rag_cache_version', $version + 1 );
+				$version = (int) get_option( 'rtbcb_rag_cache_version', 1 );
+				update_option( 'rtbcb_rag_cache_version', $version + 1 );
 		}
 }
 
 /**
- * Clear cached report HTML entries.
- *
- * Retrieves the current report cache version for versioned cache keys.
- *
- * @return int
- */
+	* Clear cached report HTML entries.
+	*
+	* Retrieves the current report cache version for versioned cache keys.
+	*
+	* @return int
+	*/
 function rtbcb_get_report_cache_version() {
 	$version = wp_cache_get( 'report_cache_version', 'rtbcb_reports' );
 
@@ -1924,12 +1924,12 @@ function rtbcb_get_report_cache_version() {
 }
 
 /**
- * Clear cached report HTML entries.
- *
- * Bumps the report cache version so previously cached templates are ignored.
- *
- * @return void
- */
+	* Clear cached report HTML entries.
+	*
+	* Bumps the report cache version so previously cached templates are ignored.
+	*
+	* @return void
+	*/
 function rtbcb_clear_report_cache() {
 	$version = rtbcb_get_report_cache_version();
 	wp_cache_set( 'report_cache_version', $version + 1, 'rtbcb_reports' );
@@ -1937,14 +1937,14 @@ function rtbcb_clear_report_cache() {
 
 
 /**
- * Enable persistent database connections when supported.
- *
- * Reconnects using a host prefixed with `p:` if the current connection is
- * not already persistent and persistent connections are allowed. Behavior can
- * be filtered with `rtbcb_enable_persistent_connection`.
- *
- * @return void
- */
+	* Enable persistent database connections when supported.
+	*
+	* Reconnects using a host prefixed with `p:` if the current connection is
+	* not already persistent and persistent connections are allowed. Behavior can
+	* be filtered with `rtbcb_enable_persistent_connection`.
+	*
+	* @return void
+	*/
 function rtbcb_enable_persistent_connection() {
 	global $wpdb;
 

--- a/inc/model-capabilities.php
+++ b/inc/model-capabilities.php
@@ -2,19 +2,19 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Model capability configuration.
- *
- * Lists models that lack support for specific features.
- *
- * @return array
- */
+	* Model capability configuration.
+	*
+	* Lists models that lack support for specific features.
+	*
+	* @return array
+	*/
 return [
-    'temperature' => [
-        'unsupported' => [
-            'gpt-4.1',
-            'gpt-4.1-mini',
-            'gpt-5',
-            'gpt-5-mini',
-        ],
-    ],
+	'temperature' => [
+		'unsupported' => [
+			'gpt-4.1',
+			'gpt-4.1-mini',
+			'gpt-5',
+			'gpt-5-mini',
+		],
+	],
 ];

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Plugin Name: Real Treasury - Business Case Builder (Enhanced Pro)
- * Description: Professional-grade ROI calculator and comprehensive business case generator for treasury technology with advanced analysis and consultant-style reports.
- * Version: 2.1.8
- * Requires PHP: 7.4
- * Author: Real Treasury
- * Text Domain: rtbcb
- * License: GPL v2 or later
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Plugin Name: Real Treasury - Business Case Builder (Enhanced Pro)
+	* Description: Professional-grade ROI calculator and comprehensive business case generator for treasury technology with advanced analysis and consultant-style reports.
+	* Version: 2.1.8
+	* Requires PHP: 7.4
+	* Author: Real Treasury
+	* Text Domain: rtbcb
+	* License: GPL v2 or later
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
@@ -19,226 +19,226 @@ define( 'RTBCB_URL', plugin_dir_url( RTBCB_FILE ) );
 define( 'RTBCB_DIR', plugin_dir_path( RTBCB_FILE ) );
 
 if ( ! defined( 'RTBCB_DEBUG' ) ) {
-    define( 'RTBCB_DEBUG', false );
+	define( 'RTBCB_DEBUG', false );
 }
 
 /**
- * Enhanced main plugin class.
- */
+	* Enhanced main plugin class.
+	*/
 class RTBCB_Main {
-    /**
-     * Singleton instance.
-     *
-     * @var RTBCB_Main|null
-     */
-    private static $instance = null;
+	/**
+	 * Singleton instance.
+	 *
+	 * @var RTBCB_Main|null
+	 */
+	private static $instance = null;
 
-    /**
-     * Plugin data.
-     *
-     * @var array
-     */
-    private $plugin_data = [];
+	/**
+	 * Plugin data.
+	 *
+	 * @var array
+	 */
+	private $plugin_data = [];
 
-    /**
-     * Request start time.
-     *
-     * @var float
-     */
-    private $request_start_time = 0.0;
+	/**
+	 * Request start time.
+	 *
+	 * @var float
+	 */
+	private $request_start_time = 0.0;
 
-    /**
-     * Get plugin instance.
-     *
-     * @return RTBCB_Main
-     */
-    public static function instance() {
-        if ( null === self::$instance ) {
-            self::$instance = new self();
-        }
+	/**
+	 * Get plugin instance.
+	 *
+	 * @return RTBCB_Main
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
 
-        return self::$instance;
-    }
+		return self::$instance;
+	}
 
-    /**
-     * Constructor.
-     */
-    private function __construct() {
-        $this->plugin_data = get_file_data( RTBCB_FILE, [
-            'Name'        => 'Plugin Name',
-            'Version'     => 'Version',
-            'Description' => 'Description',
-            'Author'      => 'Author',
-            'RequiresWP'  => 'Requires at least',
-            'RequiresPHP' => 'Requires PHP',
-        ] );
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		$this->plugin_data = get_file_data( RTBCB_FILE, [
+			'Name'        => 'Plugin Name',
+			'Version'     => 'Version',
+			'Description' => 'Description',
+			'Author'      => 'Author',
+			'RequiresWP'  => 'Requires at least',
+			'RequiresPHP' => 'Requires PHP',
+		] );
 
-        $this->init_hooks();
-        $this->includes();
-    }
+		$this->init_hooks();
+		$this->includes();
+	}
 
-    /**
-     * Initialize hooks.
-     *
-     * @return void
-     */
-    private function init_hooks() {
-        register_activation_hook( RTBCB_FILE, [ $this, 'activate' ] );
-        register_deactivation_hook( RTBCB_FILE, [ $this, 'deactivate' ] );
-        register_uninstall_hook( RTBCB_FILE, [ __CLASS__, 'uninstall' ] );
+	/**
+	 * Initialize hooks.
+	 *
+	 * @return void
+	 */
+	private function init_hooks() {
+		register_activation_hook( RTBCB_FILE, [ $this, 'activate' ] );
+		register_deactivation_hook( RTBCB_FILE, [ $this, 'deactivate' ] );
+		register_uninstall_hook( RTBCB_FILE, [ __CLASS__, 'uninstall' ] );
 
-        add_action( 'init', [ $this, 'init' ] );
-        add_action( 'plugins_loaded', [ $this, 'plugins_loaded' ] );
-        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+		add_action( 'init', [ $this, 'init' ] );
+		add_action( 'plugins_loaded', [ $this, 'plugins_loaded' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 
-        // Shortcode
-        add_shortcode( 'rt_business_case_builder', [ $this, 'shortcode_handler' ] );
+		// Shortcode
+		add_shortcode( 'rt_business_case_builder', [ $this, 'shortcode_handler' ] );
 
-        // Portal integration hooks
-        add_action( 'rt_portal_data_changed', [ $this, 'handle_portal_data_change' ] );
+		// Portal integration hooks
+		add_action( 'rt_portal_data_changed', [ $this, 'handle_portal_data_change' ] );
 
-        // Admin notices
-        add_action( 'admin_notices', [ $this, 'admin_notices' ] );
+		// Admin notices
+		add_action( 'admin_notices', [ $this, 'admin_notices' ] );
 
-        // Plugin action links
-        add_filter( 'plugin_action_links_' . plugin_basename( RTBCB_FILE ), [ $this, 'plugin_action_links' ] );
+		// Plugin action links
+		add_filter( 'plugin_action_links_' . plugin_basename( RTBCB_FILE ), [ $this, 'plugin_action_links' ] );
 
 		// AJAX handlers - Use the enhanced version
-                add_action( 'wp_ajax_rtbcb_generate_case', [ $this, 'ajax_generate_comprehensive_case_enhanced' ] );
-                add_action( 'wp_ajax_nopriv_rtbcb_generate_case', [ $this, 'ajax_generate_comprehensive_case_enhanced' ] );
+				add_action( 'wp_ajax_rtbcb_generate_case', [ $this, 'ajax_generate_comprehensive_case_enhanced' ] );
+				add_action( 'wp_ajax_nopriv_rtbcb_generate_case', [ $this, 'ajax_generate_comprehensive_case_enhanced' ] );
 
-                // Job status handlers
-                add_action( 'wp_ajax_rtbcb_job_status', [ 'RTBCB_Ajax', 'get_job_status' ] );
-                add_action( 'wp_ajax_nopriv_rtbcb_job_status', [ 'RTBCB_Ajax', 'get_job_status' ] );
+				// Job status handlers
+				add_action( 'wp_ajax_rtbcb_job_status', [ 'RTBCB_Ajax', 'get_job_status' ] );
+				add_action( 'wp_ajax_nopriv_rtbcb_job_status', [ 'RTBCB_Ajax', 'get_job_status' ] );
 
-                // Streamed analysis handler
-                add_action( 'wp_ajax_rtbcb_stream_analysis', [ 'RTBCB_Ajax', 'stream_analysis' ] );
-                add_action( 'wp_ajax_nopriv_rtbcb_stream_analysis', [ 'RTBCB_Ajax', 'stream_analysis' ] );
+				// Streamed analysis handler
+				add_action( 'wp_ajax_rtbcb_stream_analysis', [ 'RTBCB_Ajax', 'stream_analysis' ] );
+				add_action( 'wp_ajax_nopriv_rtbcb_stream_analysis', [ 'RTBCB_Ajax', 'stream_analysis' ] );
 
-                // OpenAI proxy handlers
-                add_action( 'wp_ajax_rtbcb_openai_responses', 'rtbcb_proxy_openai_responses' );
-                add_action( 'wp_ajax_nopriv_rtbcb_openai_responses', 'rtbcb_proxy_openai_responses' );
+				// OpenAI proxy handlers
+				add_action( 'wp_ajax_rtbcb_openai_responses', 'rtbcb_proxy_openai_responses' );
+				add_action( 'wp_ajax_nopriv_rtbcb_openai_responses', 'rtbcb_proxy_openai_responses' );
 
-                // Debug handlers
-                if ( defined( 'RTBCB_DEBUG' ) && RTBCB_DEBUG && function_exists( 'current_user_can' ) && current_user_can( 'manage_options' ) ) {
-                    $this->init_hooks_debug();
-                }
-    }
+				// Debug handlers
+				if ( defined( 'RTBCB_DEBUG' ) && RTBCB_DEBUG && function_exists( 'current_user_can' ) && current_user_can( 'manage_options' ) ) {
+					$this->init_hooks_debug();
+				}
+	}
 
-    /**
-     * Initialize debug-related hooks.
-     *
-     * @return void
-     */
-                private function init_hooks_debug() {
-                    add_action( 'wp_ajax_rtbcb_debug_test', [ $this, 'debug_ajax_handler' ] );
-                    add_action( 'wp_ajax_rtbcb_simple_test', [ $this, 'ajax_generate_case_simple' ] );
-                    add_action( 'wp_ajax_rtbcb_debug_report', [ $this, 'debug_report_generation' ] );
-                }
+	/**
+	 * Initialize debug-related hooks.
+	 *
+	 * @return void
+	 */
+				private function init_hooks_debug() {
+					add_action( 'wp_ajax_rtbcb_debug_test', [ $this, 'debug_ajax_handler' ] );
+					add_action( 'wp_ajax_rtbcb_simple_test', [ $this, 'ajax_generate_case_simple' ] );
+					add_action( 'wp_ajax_rtbcb_debug_report', [ $this, 'debug_report_generation' ] );
+				}
 
-    /**
-     * Include required files.
-     *
-     * @return void
-     */
-    private function includes() {
-        // Core classes
-        require_once RTBCB_DIR . 'inc/helpers.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-settings.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-calculator.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-router.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-llm.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-rag.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-leads.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-api-log.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-db.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-category-recommender.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-tests.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-maturity-model.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-validator.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-api-tester.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-workflow-tracker.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-enhanced-calculator.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-intelligent-recommender.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-background-job.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-ajax.php';
-        require_once RTBCB_DIR . 'inc/class-rtbcb-logger.php';
+	/**
+	 * Include required files.
+	 *
+	 * @return void
+	 */
+	private function includes() {
+		// Core classes
+		require_once RTBCB_DIR . 'inc/helpers.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-settings.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-calculator.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-router.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-llm.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-rag.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-leads.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-api-log.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-db.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-category-recommender.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-tests.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-maturity-model.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-validator.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-api-tester.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-workflow-tracker.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-enhanced-calculator.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-intelligent-recommender.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-background-job.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-ajax.php';
+		require_once RTBCB_DIR . 'inc/class-rtbcb-logger.php';
 
-        // Admin functionality
-        if ( is_admin() ) {
-            require_once RTBCB_DIR . 'admin/class-rtbcb-admin.php';
-            new RTBCB_Admin();
-        }
-    }
+		// Admin functionality
+		if ( is_admin() ) {
+			require_once RTBCB_DIR . 'admin/class-rtbcb-admin.php';
+			new RTBCB_Admin();
+		}
+	}
 
-    /**
-     * Plugin initialization.
-     *
-     * @return void
-     */
-    public function init() {
-        // Load text domain
-        load_plugin_textdomain( 'rtbcb', false, dirname( plugin_basename( RTBCB_FILE ) ) . '/languages' );
+	/**
+	 * Plugin initialization.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		// Load text domain
+		load_plugin_textdomain( 'rtbcb', false, dirname( plugin_basename( RTBCB_FILE ) ) . '/languages' );
 
-        // Initialize components that need early loading
-        $this->maybe_upgrade();
-        $this->setup_capabilities();
-    }
+		// Initialize components that need early loading
+		$this->maybe_upgrade();
+		$this->setup_capabilities();
+	}
 
-    /**
-     * Initialize components after plugins are loaded.
-     *
-     * @return void
-     */
-    public function plugins_loaded() {
-        // Check compatibility
-        if ( ! $this->check_compatibility() ) {
-            return;
-        }
+	/**
+	 * Initialize components after plugins are loaded.
+	 *
+	 * @return void
+	 */
+	public function plugins_loaded() {
+		// Check compatibility
+		if ( ! $this->check_compatibility() ) {
+			return;
+		}
 
-        // Initialize database tables and data
-        $this->init_database();
+		// Initialize database tables and data
+		$this->init_database();
 
-        // Setup cron jobs
-        $this->setup_cron_jobs();
+		// Setup cron jobs
+		$this->setup_cron_jobs();
 
-        // Fire action for other plugins to hook into
-        do_action( 'rtbcb_loaded' );
-    }
+		// Fire action for other plugins to hook into
+		do_action( 'rtbcb_loaded' );
+	}
 
-    /**
-     * Check plugin compatibility.
-     *
-     * @return bool
-     */
-    private function check_compatibility() {
-        // Check PHP version
-        if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
-            add_action( 'admin_notices', function() {
-                echo '<div class="notice notice-error"><p>';
-                printf(
-                    esc_html__( 'Real Treasury Business Case Builder requires PHP %1$s or higher. You are running %2$s.', 'rtbcb' ),
-                    '7.4',
-                    PHP_VERSION
-                );
-                echo '</p></div>';
-            } );
-            return false;
-        }
+	/**
+	 * Check plugin compatibility.
+	 *
+	 * @return bool
+	 */
+	private function check_compatibility() {
+		// Check PHP version
+		if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
+			add_action( 'admin_notices', function() {
+				echo '<div class="notice notice-error"><p>';
+				printf(
+					esc_html__( 'Real Treasury Business Case Builder requires PHP %1$s or higher. You are running %2$s.', 'rtbcb' ),
+					'7.4',
+					PHP_VERSION
+				);
+				echo '</p></div>';
+			} );
+			return false;
+		}
 
-        // Check WordPress version
-        if ( version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ) {
-            add_action( 'admin_notices', function() {
-                echo '<div class="notice notice-error"><p>';
-                printf(
-                    esc_html__( 'Real Treasury Business Case Builder requires WordPress %1$s or higher. You are running %2$s.', 'rtbcb' ),
-                    '5.0',
-                    get_bloginfo( 'version' )
-                );
-                echo '</p></div>';
-            } );
-            return false;
-        }
+		// Check WordPress version
+		if ( version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ) {
+			add_action( 'admin_notices', function() {
+				echo '<div class="notice notice-error"><p>';
+				printf(
+					esc_html__( 'Real Treasury Business Case Builder requires WordPress %1$s or higher. You are running %2$s.', 'rtbcb' ),
+					'5.0',
+					get_bloginfo( 'version' )
+				);
+				echo '</p></div>';
+			} );
+			return false;
+		}
 
 		// Check required PHP extensions.
 		$required_extensions = [ 'curl', 'mbstring' ];
@@ -269,50 +269,50 @@ class RTBCB_Main {
 			return false;
 		}
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Initialize database tables.
-     *
-     * @return void
-     */
-    private function init_database() {
-        // Initialize database and tables
-        RTBCB_DB::init();
+	/**
+	 * Initialize database tables.
+	 *
+	 * @return void
+	 */
+	private function init_database() {
+		// Initialize database and tables
+		RTBCB_DB::init();
 
-        // Initialize RAG database if needed
-        if ( class_exists( 'RTBCB_RAG' ) ) {
-            new RTBCB_RAG();
-        }
-    }
+		// Initialize RAG database if needed
+		if ( class_exists( 'RTBCB_RAG' ) ) {
+			new RTBCB_RAG();
+		}
+	}
 
-    /**
-     * Setup user capabilities.
-     *
-     * @return void
-     */
-    private function setup_capabilities() {
-        $admin = get_role( 'administrator' );
-        if ( $admin ) {
-            $admin->add_cap( 'manage_rtbcb' );
-            $admin->add_cap( 'view_rtbcb_leads' );
-            $admin->add_cap( 'export_rtbcb_data' );
-        }
-    }
+	/**
+	 * Setup user capabilities.
+	 *
+	 * @return void
+	 */
+	private function setup_capabilities() {
+		$admin = get_role( 'administrator' );
+		if ( $admin ) {
+			$admin->add_cap( 'manage_rtbcb' );
+			$admin->add_cap( 'view_rtbcb_leads' );
+			$admin->add_cap( 'export_rtbcb_data' );
+		}
+	}
 
-    /**
-     * Setup cron jobs for maintenance tasks.
-     *
-     * @return void
-     */
-    private function setup_cron_jobs() {
-        // Schedule RAG index rebuilds
-        if ( ! wp_next_scheduled( 'rtbcb_rebuild_rag_index' ) ) {
-            wp_schedule_event( time(), 'daily', 'rtbcb_rebuild_rag_index' );
-        }
+	/**
+	 * Setup cron jobs for maintenance tasks.
+	 *
+	 * @return void
+	 */
+	private function setup_cron_jobs() {
+		// Schedule RAG index rebuilds
+		if ( ! wp_next_scheduled( 'rtbcb_rebuild_rag_index' ) ) {
+			wp_schedule_event( time(), 'daily', 'rtbcb_rebuild_rag_index' );
+		}
 
-        add_action( 'rtbcb_rebuild_rag_index', [ $this, 'scheduled_rag_rebuild' ] );
+		add_action( 'rtbcb_rebuild_rag_index', [ $this, 'scheduled_rag_rebuild' ] );
 
 // Schedule data cleanup
 if ( ! wp_next_scheduled( 'rtbcb_cleanup_data' ) ) {
@@ -328,123 +328,123 @@ wp_schedule_event( time(), 'hourly', 'rtbcb_cleanup_jobs' );
 
 add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 
-        // Schedule lead metrics refresh
-        if ( ! wp_next_scheduled( 'rtbcb_refresh_lead_metrics' ) ) {
-            wp_schedule_event( time(), 'hourly', 'rtbcb_refresh_lead_metrics' );
-        }
+		// Schedule lead metrics refresh
+		if ( ! wp_next_scheduled( 'rtbcb_refresh_lead_metrics' ) ) {
+			wp_schedule_event( time(), 'hourly', 'rtbcb_refresh_lead_metrics' );
+		}
 
-        add_action( 'rtbcb_refresh_lead_metrics', [ 'RTBCB_Leads', 'update_cached_statistics' ] );
+		add_action( 'rtbcb_refresh_lead_metrics', [ 'RTBCB_Leads', 'update_cached_statistics' ] );
 }
 
-    /**
-     * Handle version upgrades.
-     *
-     * @return void
-     */
-    private function maybe_upgrade() {
-        $current_version = get_option( 'rtbcb_version', '1.0.0' );
+	/**
+	 * Handle version upgrades.
+	 *
+	 * @return void
+	 */
+	private function maybe_upgrade() {
+		$current_version = get_option( 'rtbcb_version', '1.0.0' );
 
-        if ( version_compare( $current_version, RTBCB_VERSION, '<' ) ) {
-            $this->upgrade_plugin( $current_version );
-            update_option( 'rtbcb_version', RTBCB_VERSION );
-        }
-    }
+		if ( version_compare( $current_version, RTBCB_VERSION, '<' ) ) {
+			$this->upgrade_plugin( $current_version );
+			update_option( 'rtbcb_version', RTBCB_VERSION );
+		}
+	}
 
-    /**
-     * Upgrade plugin data and settings.
-     *
-     * @param string $from_version Previous version.
-     * @return void
-     */
-    private function upgrade_plugin( $from_version ) {
-        // Upgrade from 1.x to 2.x
-        if ( version_compare( $from_version, '2.0.0', '<' ) ) {
-            $this->migrate_v1_settings();
-            $this->init_database();
-            $this->set_default_options();
-        }
+	/**
+	 * Upgrade plugin data and settings.
+	 *
+	 * @param string $from_version Previous version.
+	 * @return void
+	 */
+	private function upgrade_plugin( $from_version ) {
+		// Upgrade from 1.x to 2.x
+		if ( version_compare( $from_version, '2.0.0', '<' ) ) {
+			$this->migrate_v1_settings();
+			$this->init_database();
+			$this->set_default_options();
+		}
 
-        // Add new options introduced in 2.1.0
-        if ( version_compare( $from_version, '2.1.0', '<' ) ) {
-            $new_options = [
-                'rtbcb_advanced_model'        => 'gpt-5-mini',
-                'rtbcb_comprehensive_analysis' => true,
-            ];
+		// Add new options introduced in 2.1.0
+		if ( version_compare( $from_version, '2.1.0', '<' ) ) {
+			$new_options = [
+				'rtbcb_advanced_model'        => 'gpt-5-mini',
+				'rtbcb_comprehensive_analysis' => true,
+			];
 
-            foreach ( $new_options as $option => $value ) {
-                if ( get_option( $option ) === false ) {
-                    add_option( $option, $value );
-                }
-            }
-        }
+			foreach ( $new_options as $option => $value ) {
+				if ( get_option( $option ) === false ) {
+					add_option( $option, $value );
+				}
+			}
+		}
 
-        // Clear any caches
-        wp_cache_flush();
+		// Clear any caches
+		wp_cache_flush();
 
-        // Log upgrade
-        error_log( "RTBCB: Upgraded from version {$from_version} to " . RTBCB_VERSION );
-    }
+		// Log upgrade
+		error_log( "RTBCB: Upgraded from version {$from_version} to " . RTBCB_VERSION );
+	}
 
-    /**
-     * Migrate v1 settings to v2 format.
-     *
-     * @return void
-     */
-    private function migrate_v1_settings() {
-        // Migration logic for old settings format
-        $old_settings = get_option( 'rtbcb_old_settings', [] );
+	/**
+	 * Migrate v1 settings to v2 format.
+	 *
+	 * @return void
+	 */
+	private function migrate_v1_settings() {
+		// Migration logic for old settings format
+		$old_settings = get_option( 'rtbcb_old_settings', [] );
 
-        if ( ! empty( $old_settings ) ) {
-            // Convert old format to new format
-            foreach ( $old_settings as $key => $value ) {
-                update_option( 'rtbcb_' . $key, $value );
-            }
+		if ( ! empty( $old_settings ) ) {
+			// Convert old format to new format
+			foreach ( $old_settings as $key => $value ) {
+				update_option( 'rtbcb_' . $key, $value );
+			}
 
-            // Remove old settings
-            delete_option( 'rtbcb_old_settings' );
-        }
-    }
+			// Remove old settings
+			delete_option( 'rtbcb_old_settings' );
+		}
+	}
 
-    /**
-     * Set default options for new installation.
-     *
-     * @return void
-     */
-    private function set_default_options() {
-        $defaults = [
-            'rtbcb_mini_model'         => rtbcb_get_default_model( 'mini' ),
-            'rtbcb_premium_model'      => rtbcb_get_default_model( 'premium' ),
-            'rtbcb_advanced_model'     => rtbcb_get_default_model( 'advanced' ),
-            'rtbcb_embedding_model'    => rtbcb_get_default_model( 'embedding' ),
-            'rtbcb_labor_cost_per_hour'=> 100,
-            'rtbcb_bank_fee_baseline'  => 15000,
-            'rtbcb_comprehensive_analysis' => true,
-        ];
+	/**
+	 * Set default options for new installation.
+	 *
+	 * @return void
+	 */
+	private function set_default_options() {
+		$defaults = [
+			'rtbcb_mini_model'         => rtbcb_get_default_model( 'mini' ),
+			'rtbcb_premium_model'      => rtbcb_get_default_model( 'premium' ),
+			'rtbcb_advanced_model'     => rtbcb_get_default_model( 'advanced' ),
+			'rtbcb_embedding_model'    => rtbcb_get_default_model( 'embedding' ),
+			'rtbcb_labor_cost_per_hour'=> 100,
+			'rtbcb_bank_fee_baseline'  => 15000,
+			'rtbcb_comprehensive_analysis' => true,
+		];
 
-        foreach ( $defaults as $option => $value ) {
-            if ( get_option( $option ) === false ) {
-                add_option( $option, $value );
-            }
-        }
-    }
+		foreach ( $defaults as $option => $value ) {
+			if ( get_option( $option ) === false ) {
+				add_option( $option, $value );
+			}
+		}
+	}
 
-    /**
-     * Enqueue frontend assets with enhanced report support.
+	/**
+	 * Enqueue frontend assets with enhanced report support.
 	 *
 	 * @return void
 	 */
 	public function enqueue_assets() {
-	    if ( ! $this->should_load_assets() ) {
-	        return;
-	    }
+		if ( ! $this->should_load_assets() ) {
+			return;
+		}
 
-	    // Base Styles
-	    wp_enqueue_style(
-	        'rtbcb-style',
-	        RTBCB_URL . 'public/css/rtbcb.css',
-	        [],
-	        RTBCB_VERSION
-	    );
+		// Base Styles
+		wp_enqueue_style(
+			'rtbcb-style',
+			RTBCB_URL . 'public/css/rtbcb.css',
+			[],
+			RTBCB_VERSION
+		);
 
 		// Enhanced Report Styles
 		if ( $this->should_use_comprehensive_template() ) {
@@ -457,57 +457,57 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 			);
 		}
 
-            $enable_charts = RTBCB_Settings::get_setting( 'enable_charts', true );
-            $report_deps   = [];
-            if ( $enable_charts ) {
-                // Chart.js for report visualizations
-                wp_enqueue_script(
-                    'chartjs',
-                    RTBCB_URL . 'public/js/chart.min.js',
-                    [],
-                    '3.9.1',
-                    true
-                );
-                $report_deps[] = 'chartjs';
-            }
+			$enable_charts = RTBCB_Settings::get_setting( 'enable_charts', true );
+			$report_deps   = [];
+			if ( $enable_charts ) {
+				// Chart.js for report visualizations
+				wp_enqueue_script(
+					'chartjs',
+					RTBCB_URL . 'public/js/chart.min.js',
+					[],
+					'3.9.1',
+					true
+				);
+				$report_deps[] = 'chartjs';
+			}
 
-	    // DOMPurify for sanitization with CDN fallback
-	    $dompurify_cdn   = 'https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.2/purify.min.js';
-	    $dompurify_local = RTBCB_URL . 'public/js/dompurify.min.js';
-	    wp_enqueue_script(
-	        'dompurify',
-	        $dompurify_cdn,
-	        [],
-	        '3.0.2',
-	        true
-	    );
-	    wp_add_inline_script(
-	        'dompurify',
-	        sprintf(
-	            'window.DOMPurify||function(){var s=document.createElement("script");s.src="%s";document.head.appendChild(s);}();',
-	            esc_url( $dompurify_local )
-	        )
-	    );
+		// DOMPurify for sanitization with CDN fallback
+		$dompurify_cdn   = 'https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.2/purify.min.js';
+		$dompurify_local = RTBCB_URL . 'public/js/dompurify.min.js';
+		wp_enqueue_script(
+			'dompurify',
+			$dompurify_cdn,
+			[],
+			'3.0.2',
+			true
+		);
+		wp_add_inline_script(
+			'dompurify',
+			sprintf(
+				'window.DOMPurify||function(){var s=document.createElement("script");s.src="%s";document.head.appendChild(s);}();',
+				esc_url( $dompurify_local )
+			)
+		);
 
-	    // Wizard script (loaded early for modal functions)
-	    $wizard_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb-wizard.js' : 'rtbcb-wizard.min.js';
-	    wp_enqueue_script(
-	        'rtbcb-wizard',
-	        RTBCB_URL . 'public/js/' . $wizard_file,
-	        [ 'jquery' ],
-	        RTBCB_VERSION,
-	        false // Load in header
-	    );
+		// Wizard script (loaded early for modal functions)
+		$wizard_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb-wizard.js' : 'rtbcb-wizard.min.js';
+		wp_enqueue_script(
+			'rtbcb-wizard',
+			RTBCB_URL . 'public/js/' . $wizard_file,
+			[ 'jquery' ],
+			RTBCB_VERSION,
+			false // Load in header
+		);
 
 		// Main report functionality
 		$report_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb-report.js' : 'rtbcb-report.min.js';
 		wp_enqueue_script(
-                'rtbcb-report',
-                RTBCB_URL . 'public/js/' . $report_file,
-                array_merge( $report_deps, [ 'dompurify' ] ),
-                RTBCB_VERSION,
-                true
-            );
+				'rtbcb-report',
+				RTBCB_URL . 'public/js/' . $report_file,
+				array_merge( $report_deps, [ 'dompurify' ] ),
+				RTBCB_VERSION,
+				true
+			);
 
 		// Main plugin script
 		$main_script = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb.js' : 'rtbcb.min.js';
@@ -518,70 +518,70 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 			RTBCB_VERSION,
 			true
 		);
-	    // Localize scripts with configuration
-	    $this->localize_scripts();
+		// Localize scripts with configuration
+		$this->localize_scripts();
 	}
 
 	/**
 	 * Localize scripts with proper configuration data.
 	 */
 	private function localize_scripts() {
-	    // Wizard configuration
-	    wp_localize_script(
-	        'rtbcb-wizard',
-	        'rtbcbAjax',
-	        [
-	            'ajax_url'    => admin_url( 'admin-ajax.php' ),
-	            'nonce'       => wp_create_nonce( 'rtbcb_generate' ),
-	            'strings'     => [
-	                'error'                   => __( 'An error occurred. Please try again.', 'rtbcb' ),
-	                'generating'              => __( 'Generating your comprehensive business case...', 'rtbcb' ),
-	                'analyzing'               => __( 'Analyzing your treasury operations...', 'rtbcb' ),
-	                'financial_modeling'      => __( 'Building financial models...', 'rtbcb' ),
-	                'risk_assessment'         => __( 'Conducting risk assessment...', 'rtbcb' ),
-	                'industry_benchmarking'   => __( 'Performing industry benchmarking...', 'rtbcb' ),
-	                'implementation_planning' => __( 'Creating implementation roadmap...', 'rtbcb' ),
-	                'vendor_evaluation'       => __( 'Preparing vendor evaluation framework...', 'rtbcb' ),
-	                'finalizing_report'       => __( 'Finalizing professional report...', 'rtbcb' ),
-	                'invalid_email'           => __( 'Please enter a valid email address.', 'rtbcb' ),
-	                'required_field'          => __( 'This field is required.', 'rtbcb' ),
-	                'select_pain_points'      => __( 'Please select at least one pain point.', 'rtbcb' ),
-	                'email_confirmation'      => __( 'Your report will arrive by email shortly.', 'rtbcb' ),
-	            ],
-                    'settings'    => [
-                        'pdf_enabled'            => get_option( 'rtbcb_pdf_enabled', true ),
-                        'comprehensive_analysis' => get_option( 'rtbcb_comprehensive_analysis', true ),
-                        'professional_reports'   => get_option( 'rtbcb_professional_reports', true ),
-                        'enable_ai_analysis'     => RTBCB_Settings::get_setting( 'enable_ai_analysis', true ),
-                        'enable_charts'          => RTBCB_Settings::get_setting( 'enable_charts', true ),
-                    ],
-                ]
-            );
+		// Wizard configuration
+		wp_localize_script(
+			'rtbcb-wizard',
+			'rtbcbAjax',
+			[
+				'ajax_url'    => admin_url( 'admin-ajax.php' ),
+				'nonce'       => wp_create_nonce( 'rtbcb_generate' ),
+				'strings'     => [
+					'error'                   => __( 'An error occurred. Please try again.', 'rtbcb' ),
+					'generating'              => __( 'Generating your comprehensive business case...', 'rtbcb' ),
+					'analyzing'               => __( 'Analyzing your treasury operations...', 'rtbcb' ),
+					'financial_modeling'      => __( 'Building financial models...', 'rtbcb' ),
+					'risk_assessment'         => __( 'Conducting risk assessment...', 'rtbcb' ),
+					'industry_benchmarking'   => __( 'Performing industry benchmarking...', 'rtbcb' ),
+					'implementation_planning' => __( 'Creating implementation roadmap...', 'rtbcb' ),
+					'vendor_evaluation'       => __( 'Preparing vendor evaluation framework...', 'rtbcb' ),
+					'finalizing_report'       => __( 'Finalizing professional report...', 'rtbcb' ),
+					'invalid_email'           => __( 'Please enter a valid email address.', 'rtbcb' ),
+					'required_field'          => __( 'This field is required.', 'rtbcb' ),
+					'select_pain_points'      => __( 'Please select at least one pain point.', 'rtbcb' ),
+					'email_confirmation'      => __( 'Your report will arrive by email shortly.', 'rtbcb' ),
+				],
+					'settings'    => [
+						'pdf_enabled'            => get_option( 'rtbcb_pdf_enabled', true ),
+						'comprehensive_analysis' => get_option( 'rtbcb_comprehensive_analysis', true ),
+						'professional_reports'   => get_option( 'rtbcb_professional_reports', true ),
+						'enable_ai_analysis'     => RTBCB_Settings::get_setting( 'enable_ai_analysis', true ),
+						'enable_charts'          => RTBCB_Settings::get_setting( 'enable_charts', true ),
+					],
+				]
+			);
 
-	    // Report configuration
-	    $config             = rtbcb_get_gpt5_config();
-	    $model_capabilities = rtbcb_get_model_capabilities();
+		// Report configuration
+		$config             = rtbcb_get_gpt5_config();
+		$model_capabilities = rtbcb_get_model_capabilities();
 
-	    wp_localize_script(
-	        'rtbcb-report',
-	        'rtbcbReport',
-	        [
-	            'report_model'       => get_option( 'rtbcb_advanced_model', 'gpt-5-mini' ),
-	            'max_output_tokens'  => intval( $config['max_output_tokens'] ),
-	            'min_output_tokens'  => intval( $config['min_output_tokens'] ),
-	            'model_capabilities' => $model_capabilities,
-	            'ajax_url'           => admin_url( 'admin-ajax.php' ),
-	            'template_url'       => RTBCB_URL . 'public/templates/report-template.html',
-	            'timeout_ms'         => rtbcb_get_api_timeout() * 1000,
-	            'nonce'              => wp_create_nonce( 'rtbcb_generate' ),
-	            'strings'            => [
-	                'exportPDF'      => __( 'Export as PDF', 'rtbcb' ),
-	                'printReport'    => __( 'Print Report', 'rtbcb' ),
-	                'expandSection'  => __( 'Expand Section', 'rtbcb' ),
-	                'collapseSection' => __( 'Collapse Section', 'rtbcb' ),
-	            ],
-	        ]
-	    );
+		wp_localize_script(
+			'rtbcb-report',
+			'rtbcbReport',
+			[
+				'report_model'       => get_option( 'rtbcb_advanced_model', 'gpt-5-mini' ),
+				'max_output_tokens'  => intval( $config['max_output_tokens'] ),
+				'min_output_tokens'  => intval( $config['min_output_tokens'] ),
+				'model_capabilities' => $model_capabilities,
+				'ajax_url'           => admin_url( 'admin-ajax.php' ),
+				'template_url'       => RTBCB_URL . 'public/templates/report-template.html',
+				'timeout_ms'         => rtbcb_get_api_timeout() * 1000,
+				'nonce'              => wp_create_nonce( 'rtbcb_generate' ),
+				'strings'            => [
+					'exportPDF'      => __( 'Export as PDF', 'rtbcb' ),
+					'printReport'    => __( 'Print Report', 'rtbcb' ),
+					'expandSection'  => __( 'Expand Section', 'rtbcb' ),
+					'collapseSection' => __( 'Collapse Section', 'rtbcb' ),
+				],
+			]
+		);
 	}
 
 	/**
@@ -618,12 +618,12 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 		return false;
 	}
 
-               /**
-                * Determine if comprehensive template should be used.
-                *
-                * @return bool
-                */
-               private function should_use_comprehensive_template() {
+			   /**
+				* Determine if comprehensive template should be used.
+				*
+				* @return bool
+				*/
+			   private function should_use_comprehensive_template() {
 $comprehensive_enabled = get_option( 'rtbcb_comprehensive_analysis', true );
 
 $template_path  = RTBCB_DIR . 'templates/comprehensive-report-template.php';
@@ -648,131 +648,131 @@ rtbcb_log_api_debug(
 return $use_comprehensive;
 }
 
-    /**
-     * Shortcode handler.
-     *
-     * @param array $atts Shortcode attributes.
-     * @return string
-     */
-    public function shortcode_handler( $atts = [] ) {
-        // Parse attributes
-        $atts = shortcode_atts( [
-            'style'    => 'default',
-            'title'    => __( 'Treasury Tech Business Case Builder', 'rtbcb' ),
-            'subtitle' => __( 'Generate a data-driven business case for your treasury technology investment.', 'rtbcb' ),
-        ], $atts, 'rt_business_case_builder' );
+	/**
+	 * Shortcode handler.
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string
+	 */
+	public function shortcode_handler( $atts = [] ) {
+		// Parse attributes
+		$atts = shortcode_atts( [
+			'style'    => 'default',
+			'title'    => __( 'Treasury Tech Business Case Builder', 'rtbcb' ),
+			'subtitle' => __( 'Generate a data-driven business case for your treasury technology investment.', 'rtbcb' ),
+		], $atts, 'rt_business_case_builder' );
 
-        // Start output buffering
-        ob_start();
+		// Start output buffering
+		ob_start();
 
-        // Pass attributes to template
-        $template_args = [
-            'style'    => sanitize_text_field( $atts['style'] ),
-            'title'    => sanitize_text_field( $atts['title'] ),
-            'subtitle' => sanitize_text_field( $atts['subtitle'] ),
-        ];
+		// Pass attributes to template
+		$template_args = [
+			'style'    => sanitize_text_field( $atts['style'] ),
+			'title'    => sanitize_text_field( $atts['title'] ),
+			'subtitle' => sanitize_text_field( $atts['subtitle'] ),
+		];
 
-        // Load template
-        $this->load_template( 'business-case-form', $template_args );
+		// Load template
+		$this->load_template( 'business-case-form', $template_args );
 
-        return ob_get_clean();
-    }
+		return ob_get_clean();
+	}
 
-    /**
-     * Load a template file with arguments.
-     *
-     * @param string $template Template name.
-     * @param array  $args     Template arguments.
-     * @return void
-     */
-    private function load_template( $template, $args = [] ) {
-        $template_path = RTBCB_DIR . "templates/{$template}.php";
+	/**
+	 * Load a template file with arguments.
+	 *
+	 * @param string $template Template name.
+	 * @param array  $args     Template arguments.
+	 * @return void
+	 */
+	private function load_template( $template, $args = [] ) {
+		$template_path = RTBCB_DIR . "templates/{$template}.php";
 
-        if ( file_exists( $template_path ) ) {
-            // Extract arguments to variables
-            extract( $args );
-            include $template_path;
-        } else {
-            echo '<div class="rtbcb-error">' . esc_html__( 'Template not found.', 'rtbcb' ) . '</div>';
-        }
-    }
+		if ( file_exists( $template_path ) ) {
+			// Extract arguments to variables
+			extract( $args );
+			include $template_path;
+		} else {
+			echo '<div class="rtbcb-error">' . esc_html__( 'Template not found.', 'rtbcb' ) . '</div>';
+		}
+	}
 
-    /**
-     * Handle portal data changes.
-     *
-     * @return void
-     */
-    public function handle_portal_data_change() {
-        // Rebuild RAG index when portal data changes
-        if ( class_exists( 'RTBCB_RAG' ) ) {
-            wp_schedule_single_event( time() + 60, 'rtbcb_rebuild_rag_index' );
-        }
+	/**
+	 * Handle portal data changes.
+	 *
+	 * @return void
+	 */
+	public function handle_portal_data_change() {
+		// Rebuild RAG index when portal data changes
+		if ( class_exists( 'RTBCB_RAG' ) ) {
+			wp_schedule_single_event( time() + 60, 'rtbcb_rebuild_rag_index' );
+		}
 
-        // Log the event
-        error_log( 'RTBCB: Portal data change detected, RAG index rebuild scheduled' );
-    }
+		// Log the event
+		error_log( 'RTBCB: Portal data change detected, RAG index rebuild scheduled' );
+	}
 
-    /**
-     * Scheduled RAG index rebuild.
-     *
-     * @return void
-     */
-    public function scheduled_rag_rebuild() {
-        if ( ! class_exists( 'RTBCB_RAG' ) ) {
-            return;
-        }
+	/**
+	 * Scheduled RAG index rebuild.
+	 *
+	 * @return void
+	 */
+	public function scheduled_rag_rebuild() {
+		if ( ! class_exists( 'RTBCB_RAG' ) ) {
+			return;
+		}
 
-        try {
-            $rag = new RTBCB_RAG();
-            $rag->rebuild_index();
-            error_log( 'RTBCB: Scheduled RAG index rebuild completed successfully' );
-        } catch ( Exception $e ) {
-            error_log( 'RTBCB: Scheduled RAG index rebuild failed: ' . $e->getMessage() );
-        }
-    }
+		try {
+			$rag = new RTBCB_RAG();
+			$rag->rebuild_index();
+			error_log( 'RTBCB: Scheduled RAG index rebuild completed successfully' );
+		} catch ( Exception $e ) {
+			error_log( 'RTBCB: Scheduled RAG index rebuild failed: ' . $e->getMessage() );
+		}
+	}
 
-    /**
-     * Scheduled data cleanup.
-     *
-     * @return void
-     */
-    public function scheduled_data_cleanup() {
-        global $wpdb;
+	/**
+	 * Scheduled data cleanup.
+	 *
+	 * @return void
+	 */
+	public function scheduled_data_cleanup() {
+		global $wpdb;
 
-        // Clean up old temporary files
-        $upload_dir = wp_get_upload_dir();
-        $temp_dir = $upload_dir['basedir'] . '/rtbcb-temp';
+		// Clean up old temporary files
+		$upload_dir = wp_get_upload_dir();
+		$temp_dir = $upload_dir['basedir'] . '/rtbcb-temp';
 
-        if ( is_dir( $temp_dir ) ) {
-            $files = glob( $temp_dir . '/*' );
-            $old_time = time() - ( 7 * DAY_IN_SECONDS ); // 7 days old
+		if ( is_dir( $temp_dir ) ) {
+			$files = glob( $temp_dir . '/*' );
+			$old_time = time() - ( 7 * DAY_IN_SECONDS ); // 7 days old
 
-            foreach ( $files as $file ) {
-                if ( is_file( $file ) && filemtime( $file ) < $old_time ) {
-                    unlink( $file );
-                }
-            }
-        }
+			foreach ( $files as $file ) {
+				if ( is_file( $file ) && filemtime( $file ) < $old_time ) {
+					unlink( $file );
+				}
+			}
+		}
 
-        // Clean up old lead data (optional, configurable)
-        $retention_days = apply_filters( 'rtbcb_lead_retention_days', 0 ); // 0 = keep forever
+		// Clean up old lead data (optional, configurable)
+		$retention_days = apply_filters( 'rtbcb_lead_retention_days', 0 ); // 0 = keep forever
 
-        if ( $retention_days > 0 ) {
-            $cutoff_date = date( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
-            $table_name = $wpdb->prefix . 'rtbcb_leads';
+		if ( $retention_days > 0 ) {
+			$cutoff_date = date( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
+			$table_name = $wpdb->prefix . 'rtbcb_leads';
 
-            $deleted = $wpdb->query(
-                $wpdb->prepare(
-                    "DELETE FROM {$table_name} WHERE created_at < %s",
-                    $cutoff_date
-                )
-            );
+			$deleted = $wpdb->query(
+				$wpdb->prepare(
+					"DELETE FROM {$table_name} WHERE created_at < %s",
+					$cutoff_date
+				)
+			);
 
-            if ( $deleted > 0 ) {
-                error_log( "RTBCB: Cleaned up {$deleted} old lead records" );
-            }
-        }
-    }
+			if ( $deleted > 0 ) {
+				error_log( "RTBCB: Cleaned up {$deleted} old lead records" );
+			}
+		}
+	}
 
 
 		/**
@@ -801,7 +801,7 @@ return $use_comprehensive;
 				return;
 			}
 
-                        // Handle simple inputs synchronously; queue complex cases for background processing.
+						// Handle simple inputs synchronously; queue complex cases for background processing.
 			if ( ! rtbcb_is_simple_case( $user_inputs ) ) {
 				$job_id = RTBCB_Background_Job::enqueue( $user_inputs );
 				wp_send_json_success( [ 'job_id' => $job_id ] );
@@ -815,38 +815,38 @@ return $use_comprehensive;
 					return;
 				}
 
-                                $scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
+								$scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
 
-                                // Get category recommendation.
-                                if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
-                                        wp_send_json_error( [ 'message' => __( 'System error: Recommender not available.', 'rtbcb' ) ], 500 );
-                                        return;
-                                }
+								// Get category recommendation.
+								if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
+										wp_send_json_error( [ 'message' => __( 'System error: Recommender not available.', 'rtbcb' ) ], 500 );
+										return;
+								}
 
-                               $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
-                               $scenarios      = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $recommendation['category_info'] );
+							   $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+							   $scenarios      = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $recommendation['category_info'] );
 
-                               // Generate business case analysis with lazy RAG loading.
-                               $analysis_data          = $this->generate_business_analysis( $user_inputs, $scenarios, $recommendation );
-                               $comprehensive_analysis = $analysis_data['analysis'];
-                               $rag_context            = $analysis_data['rag_context'];
+							   // Generate business case analysis with lazy RAG loading.
+							   $analysis_data          = $this->generate_business_analysis( $user_inputs, $scenarios, $recommendation );
+							   $comprehensive_analysis = $analysis_data['analysis'];
+							   $rag_context            = $analysis_data['rag_context'];
 
-                               if ( is_wp_error( $comprehensive_analysis ) ) {
-                                       wp_send_json_error( [ 'message' => $comprehensive_analysis->get_error_message() ], 500 );
-                                       return;
-                               }
+							   if ( is_wp_error( $comprehensive_analysis ) ) {
+									   wp_send_json_error( [ 'message' => $comprehensive_analysis->get_error_message() ], 500 );
+									   return;
+							   }
 
-                               // Merge all data for report generation.
-                               $report_data = array_merge(
-                                       $comprehensive_analysis,
-                                       [
-                                               'company_name'    => $user_inputs['company_name'],
-                                               'scenarios'       => $scenarios,
-                                               'recommendation'  => $recommendation,
-                                               'rag_context'     => $rag_context,
-                                               'processing_time' => microtime( true ) - $_SERVER['REQUEST_TIME_FLOAT'],
-                                       ]
-                               );
+							   // Merge all data for report generation.
+							   $report_data = array_merge(
+									   $comprehensive_analysis,
+									   [
+											   'company_name'    => $user_inputs['company_name'],
+											   'scenarios'       => $scenarios,
+											   'recommendation'  => $recommendation,
+											   'rag_context'     => $rag_context,
+											   'processing_time' => microtime( true ) - $_SERVER['REQUEST_TIME_FLOAT'],
+									   ]
+							   );
 
 				// Generate HTML report using our fixed method.
 				$report_html = $this->get_comprehensive_report_html( $report_data );
@@ -874,7 +874,7 @@ return $use_comprehensive;
 					'report_html'            => $report_html,
 					'lead_id'                => $lead_id,
 					'company_name'           => $user_inputs['company_name'],
-                                        'analysis_type'          => rtbcb_get_analysis_type(),
+										'analysis_type'          => rtbcb_get_analysis_type(),
 					'memory_info'            => rtbcb_get_memory_status(),
 				];
 
@@ -900,25 +900,25 @@ return $use_comprehensive;
 	$company_name = $company['name'];
 	}
 	
-        $raw_hours_reconciliation   = wp_unslash( $_POST['hours_reconciliation'] ?? '' );
-        $raw_hours_cash_positioning = wp_unslash( $_POST['hours_cash_positioning'] ?? '' );
-        $raw_num_banks              = wp_unslash( $_POST['num_banks'] ?? '' );
-        $raw_ftes                   = wp_unslash( $_POST['ftes'] ?? '' );
+		$raw_hours_reconciliation   = wp_unslash( $_POST['hours_reconciliation'] ?? '' );
+		$raw_hours_cash_positioning = wp_unslash( $_POST['hours_cash_positioning'] ?? '' );
+		$raw_num_banks              = wp_unslash( $_POST['num_banks'] ?? '' );
+		$raw_ftes                   = wp_unslash( $_POST['ftes'] ?? '' );
 
-        $user_inputs = [
-        'email'                  => sanitize_email( wp_unslash( $_POST['email'] ?? '' ) ),
-        'company_name'           => $company_name,
-        'company_size'           => sanitize_text_field( wp_unslash( $_POST['company_size'] ?? $company['size'] ?? '' ) ),
-        'industry'               => sanitize_text_field( wp_unslash( $_POST['industry'] ?? $company['industry'] ?? '' ) ),
-        'hours_reconciliation'   => '' === $raw_hours_reconciliation ? 0 : floatval( $raw_hours_reconciliation ),
-        'hours_cash_positioning' => max( 0, floatval( $raw_hours_cash_positioning ) ),
-        'num_banks'              => max( 0, intval( $raw_num_banks ) ),
-        'ftes'                   => max( 0, floatval( $raw_ftes ) ),
-        'pain_points'            => array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['pain_points'] ?? [] ) ),
-        'business_objective'     => sanitize_text_field( wp_unslash( $_POST['business_objective'] ?? '' ) ),
-        'implementation_timeline'=> sanitize_text_field( wp_unslash( $_POST['implementation_timeline'] ?? '' ) ),
-        'budget_range'           => sanitize_text_field( wp_unslash( $_POST['budget_range'] ?? '' ) ),
-        ];
+		$user_inputs = [
+		'email'                  => sanitize_email( wp_unslash( $_POST['email'] ?? '' ) ),
+		'company_name'           => $company_name,
+		'company_size'           => sanitize_text_field( wp_unslash( $_POST['company_size'] ?? $company['size'] ?? '' ) ),
+		'industry'               => sanitize_text_field( wp_unslash( $_POST['industry'] ?? $company['industry'] ?? '' ) ),
+		'hours_reconciliation'   => '' === $raw_hours_reconciliation ? 0 : floatval( $raw_hours_reconciliation ),
+		'hours_cash_positioning' => max( 0, floatval( $raw_hours_cash_positioning ) ),
+		'num_banks'              => max( 0, intval( $raw_num_banks ) ),
+		'ftes'                   => max( 0, floatval( $raw_ftes ) ),
+		'pain_points'            => array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['pain_points'] ?? [] ) ),
+		'business_objective'     => sanitize_text_field( wp_unslash( $_POST['business_objective'] ?? '' ) ),
+		'implementation_timeline'=> sanitize_text_field( wp_unslash( $_POST['implementation_timeline'] ?? '' ) ),
+		'budget_range'           => sanitize_text_field( wp_unslash( $_POST['budget_range'] ?? '' ) ),
+		];
 	
 	// Validate required fields
 	$validation_errors = [];
@@ -931,23 +931,23 @@ return $use_comprehensive;
 	$validation_errors[] = __( 'Please enter your company name.', 'rtbcb' );
 	}
 	
-        if ( '' !== $raw_hours_reconciliation && ! is_numeric( $raw_hours_reconciliation ) ) {
-                $validation_errors[] = __( 'Please enter valid reconciliation hours.', 'rtbcb' );
-        } elseif ( $user_inputs['hours_reconciliation'] < 0 ) {
-                $validation_errors[] = __( 'Please enter valid reconciliation hours.', 'rtbcb' );
-        }
+		if ( '' !== $raw_hours_reconciliation && ! is_numeric( $raw_hours_reconciliation ) ) {
+				$validation_errors[] = __( 'Please enter valid reconciliation hours.', 'rtbcb' );
+		} elseif ( $user_inputs['hours_reconciliation'] < 0 ) {
+				$validation_errors[] = __( 'Please enter valid reconciliation hours.', 'rtbcb' );
+		}
 
-        if ( '' !== $raw_hours_cash_positioning && ! is_numeric( $raw_hours_cash_positioning ) ) {
-                $validation_errors[] = __( 'Please enter valid cash positioning hours.', 'rtbcb' );
-        }
+		if ( '' !== $raw_hours_cash_positioning && ! is_numeric( $raw_hours_cash_positioning ) ) {
+				$validation_errors[] = __( 'Please enter valid cash positioning hours.', 'rtbcb' );
+		}
 
-        if ( '' !== $raw_num_banks && ! is_numeric( $raw_num_banks ) ) {
-                $validation_errors[] = __( 'Please enter a valid number of banks.', 'rtbcb' );
-        }
+		if ( '' !== $raw_num_banks && ! is_numeric( $raw_num_banks ) ) {
+				$validation_errors[] = __( 'Please enter a valid number of banks.', 'rtbcb' );
+		}
 
-        if ( '' !== $raw_ftes && ! is_numeric( $raw_ftes ) ) {
-                $validation_errors[] = __( 'Please enter valid FTEs.', 'rtbcb' );
-        }
+		if ( '' !== $raw_ftes && ! is_numeric( $raw_ftes ) ) {
+				$validation_errors[] = __( 'Please enter valid FTEs.', 'rtbcb' );
+		}
 
 	
 	if ( ! empty( $validation_errors ) ) {
@@ -966,140 +966,140 @@ return $use_comprehensive;
 	}
 	
 	try {
-        $rag          = new RTBCB_RAG();
-        $search_query = implode(
-            ' ',
-            array_merge(
-                [ $user_inputs['company_name'], $user_inputs['industry'] ],
-                $user_inputs['pain_points'],
-                [ $recommendation['recommended'] ?? '' ]
-            )
-        );
+		$rag          = new RTBCB_RAG();
+		$search_query = implode(
+			' ',
+			array_merge(
+				[ $user_inputs['company_name'], $user_inputs['industry'] ],
+				$user_inputs['pain_points'],
+				[ $recommendation['recommended'] ?? '' ]
+			)
+		);
 
-        $results   = $rag->search_similar( $search_query, 3 );
-        $sanitized = [];
+		$results   = $rag->search_similar( $search_query, 3 );
+		$sanitized = [];
 
-        foreach ( $results as $result ) {
-            $text = '';
+		foreach ( $results as $result ) {
+			$text = '';
 
-            if ( is_array( $result ) && isset( $result['metadata'] ) ) {
-                $metadata = $result['metadata'];
-                $text     = is_array( $metadata ) ? wp_json_encode( $metadata ) : (string) $metadata;
-            } elseif ( is_scalar( $result ) ) {
-                $text = (string) $result;
-            } else {
-                $text = wp_json_encode( $result );
-            }
+			if ( is_array( $result ) && isset( $result['metadata'] ) ) {
+				$metadata = $result['metadata'];
+				$text     = is_array( $metadata ) ? wp_json_encode( $metadata ) : (string) $metadata;
+			} elseif ( is_scalar( $result ) ) {
+				$text = (string) $result;
+			} else {
+				$text = wp_json_encode( $result );
+			}
 
-            $text        = sanitize_text_field( (string) $text );
-            $sanitized[] = mb_substr( $text, 0, 1000 );
-        }
+			$text        = sanitize_text_field( (string) $text );
+			$sanitized[] = mb_substr( $text, 0, 1000 );
+		}
 
-        return $sanitized;
+		return $sanitized;
 	} catch ( Exception $e ) {
 	rtbcb_log_error( 'RAG search failed', $e->getMessage() );
 	return [];
 	}
 	}
 	
-       /**
-        * Generate comprehensive business analysis using LLM.
-        *
-        * @param array $user_inputs    Sanitized user inputs.
-        * @param array $scenarios      ROI scenarios.
-        * @param array $recommendation Category recommendation data.
-        *
-        * @return array {
-        *     @type array|WP_Error $analysis    Analysis data or WP_Error.
-        *     @type array          $rag_context Context chunks used for RAG.
-        * }
-        */
-       private function generate_business_analysis( $user_inputs, $scenarios, $recommendation, $chunk_callback = null ) {
-           $start_time = microtime( true );
-           $timeout    = absint( rtbcb_get_api_timeout() );
+	   /**
+		* Generate comprehensive business analysis using LLM.
+		*
+		* @param array $user_inputs    Sanitized user inputs.
+		* @param array $scenarios      ROI scenarios.
+		* @param array $recommendation Category recommendation data.
+		*
+		* @return array {
+		*     @type array|WP_Error $analysis    Analysis data or WP_Error.
+		*     @type array          $rag_context Context chunks used for RAG.
+		* }
+		*/
+	   private function generate_business_analysis( $user_inputs, $scenarios, $recommendation, $chunk_callback = null ) {
+		   $start_time = microtime( true );
+		   $timeout    = absint( rtbcb_get_api_timeout() );
 
-           $time_remaining = static function() use ( $start_time, $timeout ) {
-               return $timeout - ( microtime( true ) - $start_time );
-           };
+		   $time_remaining = static function() use ( $start_time, $timeout ) {
+			   return $timeout - ( microtime( true ) - $start_time );
+		   };
 
-           if ( ! class_exists( 'RTBCB_LLM' ) ) {
-               return [
-                   'analysis'    => new WP_Error( 'llm_unavailable', __( 'AI analysis service unavailable.', 'rtbcb' ) ),
-                   'rag_context' => [],
-               ];
-           }
+		   if ( ! class_exists( 'RTBCB_LLM' ) ) {
+			   return [
+				   'analysis'    => new WP_Error( 'llm_unavailable', __( 'AI analysis service unavailable.', 'rtbcb' ) ),
+				   'rag_context' => [],
+			   ];
+		   }
 
-           if ( ! rtbcb_has_openai_api_key() ) {
-               return [
-                   'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
-                   'rag_context' => [],
-               ];
-           }
+		   if ( ! rtbcb_has_openai_api_key() ) {
+			   return [
+				   'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
+				   'rag_context' => [],
+			   ];
+		   }
 
-           if ( $time_remaining() < 5 ) {
-               return [
-                   'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
-                   'rag_context' => [],
-               ];
-           }
+		   if ( $time_remaining() < 5 ) {
+			   return [
+				   'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
+				   'rag_context' => [],
+			   ];
+		   }
 
-           $rag_context = [];
-           $rag_used    = false;
+		   $rag_context = [];
+		   $rag_used    = false;
 
-           $rag_loader = function() use ( $user_inputs, $recommendation, &$rag_context, &$rag_used, $time_remaining ) {
-               $rag_used = true;
-               if ( $time_remaining() < 10 ) {
-                   $rag_context = [];
-               } else {
-                   $rag_context = $this->get_rag_context( $user_inputs, $recommendation );
-               }
-               return $rag_context;
-           };
+		   $rag_loader = function() use ( $user_inputs, $recommendation, &$rag_context, &$rag_used, $time_remaining ) {
+			   $rag_used = true;
+			   if ( $time_remaining() < 10 ) {
+				   $rag_context = [];
+			   } else {
+				   $rag_context = $this->get_rag_context( $user_inputs, $recommendation );
+			   }
+			   return $rag_context;
+		   };
 
-           try {
-               $llm    = new RTBCB_LLM();
-               $result = $llm->generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_loader, $chunk_callback );
+		   try {
+			   $llm    = new RTBCB_LLM();
+			   $result = $llm->generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_loader, $chunk_callback );
 
-               if ( is_wp_error( $result ) ) {
-                   return [
-                       'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
-                       'rag_context' => [],
-                   ];
-               }
+			   if ( is_wp_error( $result ) ) {
+				   return [
+					   'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
+					   'rag_context' => [],
+				   ];
+			   }
 
-               if ( $time_remaining() < 2 ) {
-                   return [
-                       'analysis'    => [
-                           'executive_summary' => $result['executive_summary'] ?? '',
-                           'partial'          => true,
-                       ],
-                       'rag_context' => $rag_used ? $rag_context : [],
-                   ];
-               }
+			   if ( $time_remaining() < 2 ) {
+				   return [
+					   'analysis'    => [
+						   'executive_summary' => $result['executive_summary'] ?? '',
+						   'partial'          => true,
+					   ],
+					   'rag_context' => $rag_used ? $rag_context : [],
+				   ];
+			   }
 
-               $required_keys = [ 'executive_summary', 'financial_analysis', 'industry_analysis', 'implementation_roadmap', 'risk_mitigation', 'next_steps' ];
-               $missing_keys  = array_diff( $required_keys, array_keys( $result ) );
+			   $required_keys = [ 'executive_summary', 'financial_analysis', 'industry_analysis', 'implementation_roadmap', 'risk_mitigation', 'next_steps' ];
+			   $missing_keys  = array_diff( $required_keys, array_keys( $result ) );
 
-               if ( ! empty( $missing_keys ) ) {
-                   rtbcb_log_error( 'LLM missing required sections', [ 'missing' => $missing_keys ] );
-                   return [
-                       'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
-                       'rag_context' => [],
-                   ];
-               }
+			   if ( ! empty( $missing_keys ) ) {
+				   rtbcb_log_error( 'LLM missing required sections', [ 'missing' => $missing_keys ] );
+				   return [
+					   'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
+					   'rag_context' => [],
+				   ];
+			   }
 
-               return [
-                   'analysis'    => $result,
-                   'rag_context' => $rag_used ? $rag_context : [],
-               ];
-           } catch ( Exception $e ) {
-               rtbcb_log_error( 'LLM analysis failed', $e->getMessage() );
-               return [
-                   'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
-                   'rag_context' => [],
-               ];
-           }
-       }
+			   return [
+				   'analysis'    => $result,
+				   'rag_context' => $rag_used ? $rag_context : [],
+			   ];
+		   } catch ( Exception $e ) {
+			   rtbcb_log_error( 'LLM analysis failed', $e->getMessage() );
+			   return [
+				   'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
+				   'rag_context' => [],
+			   ];
+		   }
+	   }
 	
 	/**
 	 * Generate fallback analysis when LLM is unavailable.
@@ -1128,17 +1128,17 @@ return $use_comprehensive;
 	__( 'User adoption and change management challenges', 'rtbcb' ),
 	__( 'Integration complexity with existing systems', 'rtbcb' ),
 	],
-        'next_actions'      => [
-        __( 'Secure executive sponsorship and project funding', 'rtbcb' ),
-        __( 'Conduct detailed requirements analysis', 'rtbcb' ),
-        __( 'Evaluate treasury technology vendors', 'rtbcb' ),
-        __( 'Develop implementation roadmap and timeline', 'rtbcb' ),
-        ],
-       'company_name'      => $company_name,
-       'base_roi'          => $base_roi,
-        'confidence'        => 0.75,
-        'enhanced_fallback' => true,
-        ];
+		'next_actions'      => [
+		__( 'Secure executive sponsorship and project funding', 'rtbcb' ),
+		__( 'Conduct detailed requirements analysis', 'rtbcb' ),
+		__( 'Evaluate treasury technology vendors', 'rtbcb' ),
+		__( 'Develop implementation roadmap and timeline', 'rtbcb' ),
+		],
+	   'company_name'      => $company_name,
+	   'base_roi'          => $base_roi,
+		'confidence'        => 0.75,
+		'enhanced_fallback' => true,
+		];
 	}
 	
 	/**
@@ -1209,47 +1209,47 @@ return $use_comprehensive;
 	}
 	
 	
-	    /**
-     * Debug wrapper for comprehensive case generation AJAX handler.
-     */
-    public function ajax_generate_comprehensive_case_debug() {
-        error_log( 'RTBCB: Enter ajax_generate_comprehensive_case_debug' );
+		/**
+	 * Debug wrapper for comprehensive case generation AJAX handler.
+	 */
+	public function ajax_generate_comprehensive_case_debug() {
+		error_log( 'RTBCB: Enter ajax_generate_comprehensive_case_debug' );
 
-        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-            ini_set( 'display_errors', '1' );
-        }
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			ini_set( 'display_errors', '1' );
+		}
 
-        $post_keys = implode( ', ', array_keys( $_POST ) );
-        error_log( 'RTBCB: POST keys: ' . $post_keys );
+		$post_keys = implode( ', ', array_keys( $_POST ) );
+		error_log( 'RTBCB: POST keys: ' . $post_keys );
 
-        $nonce_present = isset( $_POST['rtbcb_nonce'] );
-        error_log( 'RTBCB: nonce present: ' . ( $nonce_present ? 'yes' : 'no' ) );
+		$nonce_present = isset( $_POST['rtbcb_nonce'] );
+		error_log( 'RTBCB: nonce present: ' . ( $nonce_present ? 'yes' : 'no' ) );
 
-        $nonce_valid = check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false );
-        error_log( 'RTBCB: nonce verification: ' . ( $nonce_valid ? 'passed' : 'failed' ) );
+		$nonce_valid = check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false );
+		error_log( 'RTBCB: nonce verification: ' . ( $nonce_valid ? 'passed' : 'failed' ) );
 
-        if ( ! $nonce_valid ) {
-            wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
-        }
+		if ( ! $nonce_valid ) {
+			wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
+		}
 
-        $company = rtbcb_get_current_company();
-        if ( empty( $company ) ) {
-            wp_send_json_error( __( 'No company data found. Please run the company overview first.', 'rtbcb' ), 400 );
-        }
+		$company = rtbcb_get_current_company();
+		if ( empty( $company ) ) {
+			wp_send_json_error( __( 'No company data found. Please run the company overview first.', 'rtbcb' ), 400 );
+		}
 
-        $required_classes = [ 'RTBCB_Calculator', 'RTBCB_DB' ];
-        $missing_classes  = [];
-        foreach ( $required_classes as $class ) {
-            $exists = class_exists( $class );
-            error_log( 'RTBCB: class ' . $class . ' exists: ' . ( $exists ? 'yes' : 'no' ) );
-            if ( ! $exists ) {
-                $missing_classes[] = $class;
-            }
-        }
+		$required_classes = [ 'RTBCB_Calculator', 'RTBCB_DB' ];
+		$missing_classes  = [];
+		foreach ( $required_classes as $class ) {
+			$exists = class_exists( $class );
+			error_log( 'RTBCB: class ' . $class . ' exists: ' . ( $exists ? 'yes' : 'no' ) );
+			if ( ! $exists ) {
+				$missing_classes[] = $class;
+			}
+		}
 
-        if ( ! empty( $missing_classes ) ) {
-            wp_send_json_error( __( 'Required components missing.', 'rtbcb' ), 500 );
-        }
+		if ( ! empty( $missing_classes ) ) {
+			wp_send_json_error( __( 'Required components missing.', 'rtbcb' ), 500 );
+		}
 
 	rtbcb_setup_ajax_logging();
 	rtbcb_increase_memory_limit();
@@ -1258,163 +1258,163 @@ return $use_comprehensive;
 		set_time_limit( $timeout );
 	}
 
-        try {
-            RTBCB_Ajax::generate_comprehensive_case();
-        } catch ( Exception $e ) {
-            error_log( 'RTBCB Exception: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );
-            wp_send_json_error( __( 'An error occurred. Please try again later.', 'rtbcb' ), 500 );
-        } catch ( Error $e ) {
-            error_log( 'RTBCB Error: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );
-            wp_send_json_error( __( 'An error occurred. Please try again later.', 'rtbcb' ), 500 );
-        }
+		try {
+			RTBCB_Ajax::generate_comprehensive_case();
+		} catch ( Exception $e ) {
+			error_log( 'RTBCB Exception: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );
+			wp_send_json_error( __( 'An error occurred. Please try again later.', 'rtbcb' ), 500 );
+		} catch ( Error $e ) {
+			error_log( 'RTBCB Error: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );
+			wp_send_json_error( __( 'An error occurred. Please try again later.', 'rtbcb' ), 500 );
+		}
 
-        error_log( 'RTBCB: Exit ajax_generate_comprehensive_case_debug' );
-    }
+		error_log( 'RTBCB: Exit ajax_generate_comprehensive_case_debug' );
+	}
 
 
-    /**
-     * Enhanced AJAX handler with memory management
-     */
-    public function ajax_generate_comprehensive_case_legacy() {
-        $request_start   = microtime( true );
-        $request_payload = rtbcb_recursive_sanitize_text_field( wp_unslash( $_POST ) );
-        register_shutdown_function( [ 'RTBCB_Logger', 'log_shutdown' ], $request_start, $request_payload );
+	/**
+	 * Enhanced AJAX handler with memory management
+	 */
+	public function ajax_generate_comprehensive_case_legacy() {
+		$request_start   = microtime( true );
+		$request_payload = rtbcb_recursive_sanitize_text_field( wp_unslash( $_POST ) );
+		register_shutdown_function( [ 'RTBCB_Logger', 'log_shutdown' ], $request_start, $request_payload );
 
-        rtbcb_setup_ajax_logging();
+		rtbcb_setup_ajax_logging();
 
-        // STEP 1: Increase memory limit and log initial state
-        rtbcb_increase_memory_limit();
-        rtbcb_log_memory_usage( 'start' );
+		// STEP 1: Increase memory limit and log initial state
+		rtbcb_increase_memory_limit();
+		rtbcb_log_memory_usage( 'start' );
 
-        // STEP 2: Set longer execution time
-        $timeout    = absint( rtbcb_get_api_timeout() );
-        $start_time = time();
+		// STEP 2: Set longer execution time
+		$timeout    = absint( rtbcb_get_api_timeout() );
+		$start_time = time();
 
-        if ( ! ini_get( 'safe_mode' ) ) {
-            if ( $timeout <= 0 ) {
-                wp_send_json_error(
-                    [ 'message' => __( 'Request timed out; please retry.', 'rtbcb' ) ],
-                    504
-                );
-                return;
-            }
-            set_time_limit( $timeout );
-        }
+		if ( ! ini_get( 'safe_mode' ) ) {
+			if ( $timeout <= 0 ) {
+				wp_send_json_error(
+					[ 'message' => __( 'Request timed out; please retry.', 'rtbcb' ) ],
+					504
+				);
+				return;
+			}
+			set_time_limit( $timeout );
+		}
 
-        // Clear any buffered output before sending JSON responses.
-        $buffer_content = ob_get_level() ? ob_get_clean() : '';
-        if ( '' !== $buffer_content ) {
-            rtbcb_log_api_debug( 'Output buffer not empty before JSON response', $buffer_content );
-        }
+		// Clear any buffered output before sending JSON responses.
+		$buffer_content = ob_get_level() ? ob_get_clean() : '';
+		if ( '' !== $buffer_content ) {
+			rtbcb_log_api_debug( 'Output buffer not empty before JSON response', $buffer_content );
+		}
 
-        try {
-            // Verify nonce
-            if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
-                rtbcb_log_error( 'Nonce verification failed', $_POST );
-                wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
-                return;
-            }
+		try {
+			// Verify nonce
+			if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
+				rtbcb_log_error( 'Nonce verification failed', $_POST );
+				wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
+				return;
+			}
 
-            $company_name = sanitize_text_field( wp_unslash( $_POST['company_name'] ?? '' ) );
-            $company_size = sanitize_text_field( wp_unslash( $_POST['company_size'] ?? '' ) );
-            $industry     = sanitize_text_field( wp_unslash( $_POST['industry'] ?? '' ) );
+			$company_name = sanitize_text_field( wp_unslash( $_POST['company_name'] ?? '' ) );
+			$company_size = sanitize_text_field( wp_unslash( $_POST['company_size'] ?? '' ) );
+			$industry     = sanitize_text_field( wp_unslash( $_POST['industry'] ?? '' ) );
 
-            $company = rtbcb_get_current_company();
-            if ( empty( $company ) ) {
-                if ( $company_name && $company_size && $industry ) {
-                    $company = [
-                        'name'     => $company_name,
-                        'size'     => $company_size,
-                        'industry' => $industry,
-                    ];
-                    update_option( 'rtbcb_current_company', $company );
-                } else {
-                    if ( empty( $company_name ) ) {
-                        wp_send_json_error( __( 'Please enter your company name.', 'rtbcb' ), 400 );
-                        return;
-                    }
+			$company = rtbcb_get_current_company();
+			if ( empty( $company ) ) {
+				if ( $company_name && $company_size && $industry ) {
+					$company = [
+						'name'     => $company_name,
+						'size'     => $company_size,
+						'industry' => $industry,
+					];
+					update_option( 'rtbcb_current_company', $company );
+				} else {
+					if ( empty( $company_name ) ) {
+						wp_send_json_error( __( 'Please enter your company name.', 'rtbcb' ), 400 );
+						return;
+					}
 
-                    if ( empty( $company_size ) ) {
-                        wp_send_json_error( __( 'Please select your company size.', 'rtbcb' ), 400 );
-                        return;
-                    }
+					if ( empty( $company_size ) ) {
+						wp_send_json_error( __( 'Please select your company size.', 'rtbcb' ), 400 );
+						return;
+					}
 
-                    if ( empty( $industry ) ) {
-                        wp_send_json_error( __( 'Please select your industry.', 'rtbcb' ), 400 );
-                        return;
-                    }
-                }
-            }
+					if ( empty( $industry ) ) {
+						wp_send_json_error( __( 'Please select your industry.', 'rtbcb' ), 400 );
+						return;
+					}
+				}
+			}
 
-            rtbcb_log_memory_usage( 'after_nonce_verification' );
+			rtbcb_log_memory_usage( 'after_nonce_verification' );
 
-            // Collect and validate form data
-            $hours_reconciliation_raw   = isset( $_POST['hours_reconciliation'] ) ? wp_unslash( $_POST['hours_reconciliation'] ) : null;
-            $hours_cash_positioning_raw = isset( $_POST['hours_cash_positioning'] ) ? wp_unslash( $_POST['hours_cash_positioning'] ) : null;
-            $num_banks_raw              = isset( $_POST['num_banks'] ) ? wp_unslash( $_POST['num_banks'] ) : null;
-            $ftes_raw                   = isset( $_POST['ftes'] ) ? wp_unslash( $_POST['ftes'] ) : null;
+			// Collect and validate form data
+			$hours_reconciliation_raw   = isset( $_POST['hours_reconciliation'] ) ? wp_unslash( $_POST['hours_reconciliation'] ) : null;
+			$hours_cash_positioning_raw = isset( $_POST['hours_cash_positioning'] ) ? wp_unslash( $_POST['hours_cash_positioning'] ) : null;
+			$num_banks_raw              = isset( $_POST['num_banks'] ) ? wp_unslash( $_POST['num_banks'] ) : null;
+			$ftes_raw                   = isset( $_POST['ftes'] ) ? wp_unslash( $_POST['ftes'] ) : null;
 
-            if ( ! is_numeric( $hours_reconciliation_raw ) ) {
-                wp_send_json_error( __( 'Please enter your weekly reconciliation hours.', 'rtbcb' ), 400 );
-                return;
-            }
-            if ( ! is_numeric( $hours_cash_positioning_raw ) ) {
-                wp_send_json_error( __( 'Please enter your weekly cash positioning hours.', 'rtbcb' ), 400 );
-                return;
-            }
-            if ( ! is_numeric( $num_banks_raw ) ) {
-                wp_send_json_error( __( 'Please enter the number of banking relationships.', 'rtbcb' ), 400 );
-                return;
-            }
-            if ( ! is_numeric( $ftes_raw ) ) {
-                wp_send_json_error( __( 'Please enter your treasury team size.', 'rtbcb' ), 400 );
-                return;
-            }
+			if ( ! is_numeric( $hours_reconciliation_raw ) ) {
+				wp_send_json_error( __( 'Please enter your weekly reconciliation hours.', 'rtbcb' ), 400 );
+				return;
+			}
+			if ( ! is_numeric( $hours_cash_positioning_raw ) ) {
+				wp_send_json_error( __( 'Please enter your weekly cash positioning hours.', 'rtbcb' ), 400 );
+				return;
+			}
+			if ( ! is_numeric( $num_banks_raw ) ) {
+				wp_send_json_error( __( 'Please enter the number of banking relationships.', 'rtbcb' ), 400 );
+				return;
+			}
+			if ( ! is_numeric( $ftes_raw ) ) {
+				wp_send_json_error( __( 'Please enter your treasury team size.', 'rtbcb' ), 400 );
+				return;
+			}
 
-            $user_inputs = [
-                'email'                  => sanitize_email( wp_unslash( $_POST['email'] ?? '' ) ),
-                'company_name'           => $company_name,
-                'company_size'           => $company_size,
-                'industry'               => $industry,
-                'job_title'              => sanitize_text_field( wp_unslash( $_POST['job_title'] ?? '' ) ),
-                'hours_reconciliation'   => floatval( $hours_reconciliation_raw ),
-                'hours_cash_positioning' => floatval( $hours_cash_positioning_raw ),
-                'num_banks'              => intval( $num_banks_raw ),
-                'ftes'                   => floatval( $ftes_raw ),
-                'pain_points'            => array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['pain_points'] ?? [] ) ),
-                'business_objective'     => sanitize_text_field( wp_unslash( $_POST['business_objective'] ?? '' ) ),
-                'implementation_timeline'=> sanitize_text_field( wp_unslash( $_POST['implementation_timeline'] ?? '' ) ),
-                'budget_range'           => sanitize_text_field( wp_unslash( $_POST['budget_range'] ?? '' ) ),
-            ];
+			$user_inputs = [
+				'email'                  => sanitize_email( wp_unslash( $_POST['email'] ?? '' ) ),
+				'company_name'           => $company_name,
+				'company_size'           => $company_size,
+				'industry'               => $industry,
+				'job_title'              => sanitize_text_field( wp_unslash( $_POST['job_title'] ?? '' ) ),
+				'hours_reconciliation'   => floatval( $hours_reconciliation_raw ),
+				'hours_cash_positioning' => floatval( $hours_cash_positioning_raw ),
+				'num_banks'              => intval( $num_banks_raw ),
+				'ftes'                   => floatval( $ftes_raw ),
+				'pain_points'            => array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['pain_points'] ?? [] ) ),
+				'business_objective'     => sanitize_text_field( wp_unslash( $_POST['business_objective'] ?? '' ) ),
+				'implementation_timeline'=> sanitize_text_field( wp_unslash( $_POST['implementation_timeline'] ?? '' ) ),
+				'budget_range'           => sanitize_text_field( wp_unslash( $_POST['budget_range'] ?? '' ) ),
+			];
 
-            rtbcb_log_api_debug( 'Collected user inputs', $user_inputs );
+			rtbcb_log_api_debug( 'Collected user inputs', $user_inputs );
 
-            rtbcb_log_api_debug( 'Validating user inputs' );
+			rtbcb_log_api_debug( 'Validating user inputs' );
 
-            // Validate required fields
-            if ( empty( $user_inputs['email'] ) || ! is_email( $user_inputs['email'] ) ) {
-                rtbcb_log_error( 'Invalid email address', $user_inputs );
-                wp_send_json_error( __( 'Please enter a valid email address.', 'rtbcb' ), 400 );
-                return;
-            }
+			// Validate required fields
+			if ( empty( $user_inputs['email'] ) || ! is_email( $user_inputs['email'] ) ) {
+				rtbcb_log_error( 'Invalid email address', $user_inputs );
+				wp_send_json_error( __( 'Please enter a valid email address.', 'rtbcb' ), 400 );
+				return;
+			}
 
-            if ( empty( $user_inputs['company_name'] ) ) {
-                rtbcb_log_error( 'Missing company name', $user_inputs );
-                wp_send_json_error( __( 'Please enter your company name.', 'rtbcb' ), 400 );
-                return;
-            }
+			if ( empty( $user_inputs['company_name'] ) ) {
+				rtbcb_log_error( 'Missing company name', $user_inputs );
+				wp_send_json_error( __( 'Please enter your company name.', 'rtbcb' ), 400 );
+				return;
+			}
 
-            if ( empty( $user_inputs['company_size'] ) ) {
-                rtbcb_log_error( 'Missing company size', $user_inputs );
-                wp_send_json_error( __( 'Please select your company size.', 'rtbcb' ), 400 );
-                return;
-            }
+			if ( empty( $user_inputs['company_size'] ) ) {
+				rtbcb_log_error( 'Missing company size', $user_inputs );
+				wp_send_json_error( __( 'Please select your company size.', 'rtbcb' ), 400 );
+				return;
+			}
 
-            if ( empty( $user_inputs['industry'] ) ) {
-                rtbcb_log_error( 'Missing industry', $user_inputs );
-                wp_send_json_error( __( 'Please select your industry.', 'rtbcb' ), 400 );
-                return;
-            }
+			if ( empty( $user_inputs['industry'] ) ) {
+				rtbcb_log_error( 'Missing industry', $user_inputs );
+				wp_send_json_error( __( 'Please select your industry.', 'rtbcb' ), 400 );
+				return;
+			}
 
 			if ( $user_inputs['hours_reconciliation'] < 0 ) {
 				rtbcb_log_error( 'Invalid reconciliation hours', $user_inputs );
@@ -1422,23 +1422,23 @@ return $use_comprehensive;
 				return;
 			}
 
-            if ( $user_inputs['hours_cash_positioning'] <= 0 ) {
-                rtbcb_log_error( 'Invalid cash positioning hours', $user_inputs );
-                wp_send_json_error( __( 'Please enter your weekly cash positioning hours.', 'rtbcb' ), 400 );
-                return;
-            }
+			if ( $user_inputs['hours_cash_positioning'] <= 0 ) {
+				rtbcb_log_error( 'Invalid cash positioning hours', $user_inputs );
+				wp_send_json_error( __( 'Please enter your weekly cash positioning hours.', 'rtbcb' ), 400 );
+				return;
+			}
 
-            if ( $user_inputs['num_banks'] <= 0 ) {
-                rtbcb_log_error( 'Invalid number of banks', $user_inputs );
-                wp_send_json_error( __( 'Please enter the number of banking relationships.', 'rtbcb' ), 400 );
-                return;
-            }
+			if ( $user_inputs['num_banks'] <= 0 ) {
+				rtbcb_log_error( 'Invalid number of banks', $user_inputs );
+				wp_send_json_error( __( 'Please enter the number of banking relationships.', 'rtbcb' ), 400 );
+				return;
+			}
 
-            if ( $user_inputs['ftes'] <= 0 ) {
-                rtbcb_log_error( 'Invalid treasury team size', $user_inputs );
-                wp_send_json_error( __( 'Please enter your treasury team size.', 'rtbcb' ), 400 );
-                return;
-            }
+			if ( $user_inputs['ftes'] <= 0 ) {
+				rtbcb_log_error( 'Invalid treasury team size', $user_inputs );
+				wp_send_json_error( __( 'Please enter your treasury team size.', 'rtbcb' ), 400 );
+				return;
+			}
 
 			if ( empty( $user_inputs['business_objective'] ) ) {
 				rtbcb_log_error( 'Missing business objective', $user_inputs );
@@ -1446,390 +1446,390 @@ return $use_comprehensive;
 				return;
 			}
 
-            if ( empty( $user_inputs['implementation_timeline'] ) ) {
-                rtbcb_log_error( 'Missing implementation timeline', $user_inputs );
-                wp_send_json_error( __( 'Please select an implementation timeline.', 'rtbcb' ), 400 );
-                return;
-            }
+			if ( empty( $user_inputs['implementation_timeline'] ) ) {
+				rtbcb_log_error( 'Missing implementation timeline', $user_inputs );
+				wp_send_json_error( __( 'Please select an implementation timeline.', 'rtbcb' ), 400 );
+				return;
+			}
 
-            if ( empty( $user_inputs['budget_range'] ) ) {
-                rtbcb_log_error( 'Missing budget range', $user_inputs );
-                wp_send_json_error( __( 'Please select a budget range.', 'rtbcb' ), 400 );
-                return;
-            }
+			if ( empty( $user_inputs['budget_range'] ) ) {
+				rtbcb_log_error( 'Missing budget range', $user_inputs );
+				wp_send_json_error( __( 'Please select a budget range.', 'rtbcb' ), 400 );
+				return;
+			}
 
-            rtbcb_log_api_debug( 'Validation passed', $user_inputs );
-            rtbcb_log_memory_usage( 'after_validation' );
+			rtbcb_log_api_debug( 'Validation passed', $user_inputs );
+			rtbcb_log_memory_usage( 'after_validation' );
 
-            // Calculate ROI scenarios
-            if ( ! class_exists( 'RTBCB_Calculator' ) ) {
-                rtbcb_log_error( 'Calculator class not found' );
-                wp_send_json_error( __( 'System error: Calculator not available.', 'rtbcb' ), 500 );
-                return;
-            }
+			// Calculate ROI scenarios
+			if ( ! class_exists( 'RTBCB_Calculator' ) ) {
+				rtbcb_log_error( 'Calculator class not found' );
+				wp_send_json_error( __( 'System error: Calculator not available.', 'rtbcb' ), 500 );
+				return;
+			}
 
-            rtbcb_log_api_debug( 'Starting ROI calculation' );
-            $scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
-            rtbcb_log_api_debug( 'ROI scenarios calculated', $scenarios );
-            rtbcb_log_memory_usage( 'after_roi_calculation' );
+			rtbcb_log_api_debug( 'Starting ROI calculation' );
+			$scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
+			rtbcb_log_api_debug( 'ROI scenarios calculated', $scenarios );
+			rtbcb_log_memory_usage( 'after_roi_calculation' );
 
-            // Get category recommendation
-            if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
-                rtbcb_log_error( 'Category Recommender class not found' );
-                wp_send_json_error( __( 'System error: Recommender not available.', 'rtbcb' ), 500 );
-                return;
-            }
+			// Get category recommendation
+			if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
+				rtbcb_log_error( 'Category Recommender class not found' );
+				wp_send_json_error( __( 'System error: Recommender not available.', 'rtbcb' ), 500 );
+				return;
+			}
 
-            rtbcb_log_api_debug( 'Running category recommendation' );
-            $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
-            $scenarios      = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $recommendation['category_info'] );
-            rtbcb_log_api_debug( 'Category recommendation result', $recommendation );
-            rtbcb_log_memory_usage( 'after_category_recommendation' );
+			rtbcb_log_api_debug( 'Running category recommendation' );
+			$recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+			$scenarios      = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $recommendation['category_info'] );
+			rtbcb_log_api_debug( 'Category recommendation result', $recommendation );
+			rtbcb_log_memory_usage( 'after_category_recommendation' );
 
-            // Get RAG context (with memory monitoring)
-            $rag_context = [];
-            if ( class_exists( 'RTBCB_RAG' ) ) {
-                try {
-                    $rag = new RTBCB_RAG();
-                    $search_query = implode(
-                        ' ',
-                        array_merge(
-                            [ $user_inputs['company_name'], $user_inputs['industry'] ],
-                            $user_inputs['pain_points'],
-                            [ $recommendation['recommended'] ?? '' ]
-                        )
-                    );
-                    rtbcb_log_api_debug( 'Performing RAG search', [ 'query' => $search_query ] );
-                    $rag_context = $rag->search_similar( $search_query, 3 );
-                    rtbcb_log_api_debug( 'RAG search results', $rag_context );
-                    rtbcb_log_memory_usage( 'after_rag_search' );
-                } catch ( Exception $e ) {
-                    rtbcb_log_error( 'RAG search failed', $e->getMessage() );
-                } catch ( Error $e ) {
-                    rtbcb_log_error( 'RAG search fatal error', $e->getMessage() );
-                }
-            }
+			// Get RAG context (with memory monitoring)
+			$rag_context = [];
+			if ( class_exists( 'RTBCB_RAG' ) ) {
+				try {
+					$rag = new RTBCB_RAG();
+					$search_query = implode(
+						' ',
+						array_merge(
+							[ $user_inputs['company_name'], $user_inputs['industry'] ],
+							$user_inputs['pain_points'],
+							[ $recommendation['recommended'] ?? '' ]
+						)
+					);
+					rtbcb_log_api_debug( 'Performing RAG search', [ 'query' => $search_query ] );
+					$rag_context = $rag->search_similar( $search_query, 3 );
+					rtbcb_log_api_debug( 'RAG search results', $rag_context );
+					rtbcb_log_memory_usage( 'after_rag_search' );
+				} catch ( Exception $e ) {
+					rtbcb_log_error( 'RAG search failed', $e->getMessage() );
+				} catch ( Error $e ) {
+					rtbcb_log_error( 'RAG search fatal error', $e->getMessage() );
+				}
+			}
 
-            // Generate business case with memory optimization
-            $comprehensive_analysis = null;
-            if ( class_exists( 'RTBCB_LLM' ) ) {
-                try {
-                    if ( function_exists( 'gc_collect_cycles' ) ) {
-                        gc_collect_cycles();
-                    }
+			// Generate business case with memory optimization
+			$comprehensive_analysis = null;
+			if ( class_exists( 'RTBCB_LLM' ) ) {
+				try {
+					if ( function_exists( 'gc_collect_cycles' ) ) {
+						gc_collect_cycles();
+					}
 
-                    rtbcb_log_memory_usage( 'before_llm_generation' );
+					rtbcb_log_memory_usage( 'before_llm_generation' );
 
-                    if ( ! rtbcb_has_openai_api_key() ) {
-                        $error_code = 'E_API_KEY_MISSING';
-                        rtbcb_log_error( $error_code . ': ' . __( 'OpenAI API key not configured.', 'rtbcb' ) );
-                        wp_send_json_error(
-                            [
-                                'message'    => __( 'OpenAI API key not configured.', 'rtbcb' ),
-                                'error_code' => $error_code,
-                            ],
-                            500
-                        );
-                        return;
-                    }
+					if ( ! rtbcb_has_openai_api_key() ) {
+						$error_code = 'E_API_KEY_MISSING';
+						rtbcb_log_error( $error_code . ': ' . __( 'OpenAI API key not configured.', 'rtbcb' ) );
+						wp_send_json_error(
+							[
+								'message'    => __( 'OpenAI API key not configured.', 'rtbcb' ),
+								'error_code' => $error_code,
+							],
+							500
+						);
+						return;
+					}
 
-                    $api_key = rtbcb_get_openai_api_key();
-                    if ( class_exists( 'RTBCB_API_Tester' ) ) {
-                        $connection_test = RTBCB_API_Tester::test_connection( $api_key );
-                        if ( empty( $connection_test['success'] ) ) {
-                            $error_code = 'E_API_TEST_FAILURE';
-                            rtbcb_log_error( $error_code . ': ' . $connection_test['message'] );
-                            wp_send_json_error(
-                                [
-                                    'message'    => $connection_test['message'],
-                                    'details'    => $connection_test['details'] ?? '',
-                                    'error_code' => $error_code,
-                                ],
-                                500
-                            );
-                            return;
-                        }
-                    }
+					$api_key = rtbcb_get_openai_api_key();
+					if ( class_exists( 'RTBCB_API_Tester' ) ) {
+						$connection_test = RTBCB_API_Tester::test_connection( $api_key );
+						if ( empty( $connection_test['success'] ) ) {
+							$error_code = 'E_API_TEST_FAILURE';
+							rtbcb_log_error( $error_code . ': ' . $connection_test['message'] );
+							wp_send_json_error(
+								[
+									'message'    => $connection_test['message'],
+									'details'    => $connection_test['details'] ?? '',
+									'error_code' => $error_code,
+								],
+								500
+							);
+							return;
+						}
+					}
 
-                    // Short-circuit if the remaining time is insufficient for LLM processing.
-                    if ( ( time() - $start_time ) > ( $timeout - 5 ) ) {
-                        wp_send_json_error(
-                            [ 'message' => __( 'Request timed out; please retry.', 'rtbcb' ) ],
-                            504
-                        );
-                        return;
-                    }
+					// Short-circuit if the remaining time is insufficient for LLM processing.
+					if ( ( time() - $start_time ) > ( $timeout - 5 ) ) {
+						wp_send_json_error(
+							[ 'message' => __( 'Request timed out; please retry.', 'rtbcb' ) ],
+							504
+						);
+						return;
+					}
 
-                    // Consider offloading this LLM call to a background task and polling for completion to
-                    // avoid keeping the HTTP connection open.
-                    rtbcb_log_api_debug( 'Calling LLM for comprehensive business case' );
-                    $llm = new RTBCB_LLM();
-                    $comprehensive_analysis = $llm->generate_comprehensive_business_case(
-                        $user_inputs,
-                        $scenarios,
-                        $rag_context
-                    );
+					// Consider offloading this LLM call to a background task and polling for completion to
+					// avoid keeping the HTTP connection open.
+					rtbcb_log_api_debug( 'Calling LLM for comprehensive business case' );
+					$llm = new RTBCB_LLM();
+					$comprehensive_analysis = $llm->generate_comprehensive_business_case(
+						$user_inputs,
+						$scenarios,
+						$rag_context
+					);
 
-                    rtbcb_log_memory_usage( 'after_llm_generation' );
+					rtbcb_log_memory_usage( 'after_llm_generation' );
 
-                    if ( is_wp_error( $comprehensive_analysis ) ) {
-                        $error_message  = $comprehensive_analysis->get_error_message();
-                        $llm_error_code = method_exists( $comprehensive_analysis, 'get_error_code' ) ? $comprehensive_analysis->get_error_code() : '';
-                        $error_data     = $comprehensive_analysis->get_error_data();
-                        $status         = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
+					if ( is_wp_error( $comprehensive_analysis ) ) {
+						$error_message  = $comprehensive_analysis->get_error_message();
+						$llm_error_code = method_exists( $comprehensive_analysis, 'get_error_code' ) ? $comprehensive_analysis->get_error_code() : '';
+						$error_data     = $comprehensive_analysis->get_error_data();
+						$status         = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
 
-                        if ( 'llm_http_status' === $llm_error_code ) {
-                            rtbcb_log_error( 'E_LLM_HTTP_STATUS: ' . $error_message, [ 'status' => $status ] );
-                            wp_send_json_error(
-                                [
-                                    'message'    => $error_message,
-                                    'error_code' => 'E_LLM_HTTP_STATUS',
-                                ],
-                                $status
-                            );
-                            return;
-                        }
+						if ( 'llm_http_status' === $llm_error_code ) {
+							rtbcb_log_error( 'E_LLM_HTTP_STATUS: ' . $error_message, [ 'status' => $status ] );
+							wp_send_json_error(
+								[
+									'message'    => $error_message,
+									'error_code' => 'E_LLM_HTTP_STATUS',
+								],
+								$status
+							);
+							return;
+						}
 
-                        $error_code      = 'no_api_key' === $llm_error_code ? 'E_NO_API_KEY' : 'E_LLM_WP_ERROR';
-                        rtbcb_log_error( $error_code . ': ' . $error_message, [ 'wp_error_code' => $llm_error_code ] );
-                        $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
-                        $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
-                        if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
-                            $response_message = $error_message . ' ' . $guidance;
-                        }
-                        wp_send_json_error(
-                            [
-                                'message'    => $response_message,
-                                'error_code' => $error_code,
-                            ],
-                            500
-                        );
-                        return;
-                    }
+						$error_code      = 'no_api_key' === $llm_error_code ? 'E_NO_API_KEY' : 'E_LLM_WP_ERROR';
+						rtbcb_log_error( $error_code . ': ' . $error_message, [ 'wp_error_code' => $llm_error_code ] );
+						$guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
+						$response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
+						if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+							$response_message = $error_message . ' ' . $guidance;
+						}
+						wp_send_json_error(
+							[
+								'message'    => $response_message,
+								'error_code' => $error_code,
+							],
+							500
+						);
+						return;
+					}
 
-                    if ( isset( $comprehensive_analysis['error'] ) ) {
-                        $error_code = 'E_LLM_RESPONSE_ERROR';
-                        rtbcb_log_error( $error_code . ': ' . $comprehensive_analysis['error'] );
-                        $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
-                        $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
-                        if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
-                            $response_message = $comprehensive_analysis['error'] . ' ' . $guidance;
-                        }
-                        wp_send_json_error(
-                            [
-                                'message'    => $response_message,
-                                'error_code' => $error_code,
-                            ],
-                            500
-                        );
-                        return;
-                    }
-                    $required_sections = [ 'executive_summary', 'financial_analysis', 'industry_analysis', 'implementation_roadmap', 'risk_mitigation', 'next_steps' ];
-                    $missing_sections  = array_diff( $required_sections, array_keys( $comprehensive_analysis ) );
+					if ( isset( $comprehensive_analysis['error'] ) ) {
+						$error_code = 'E_LLM_RESPONSE_ERROR';
+						rtbcb_log_error( $error_code . ': ' . $comprehensive_analysis['error'] );
+						$guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
+						$response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
+						if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+							$response_message = $comprehensive_analysis['error'] . ' ' . $guidance;
+						}
+						wp_send_json_error(
+							[
+								'message'    => $response_message,
+								'error_code' => $error_code,
+							],
+							500
+						);
+						return;
+					}
+					$required_sections = [ 'executive_summary', 'financial_analysis', 'industry_analysis', 'implementation_roadmap', 'risk_mitigation', 'next_steps' ];
+					$missing_sections  = array_diff( $required_sections, array_keys( $comprehensive_analysis ) );
 
-                    if ( ! empty( $missing_sections ) ) {
-                        rtbcb_log_error( 'LLM missing required sections', [ 'missing' => $missing_sections ] );
-                        $comprehensive_analysis = $this->generate_fallback_analysis( $user_inputs, $scenarios );
-                    } else {
-                        rtbcb_log_api_debug( 'LLM generation succeeded' );
-                    }
-                } catch ( Exception $e ) {
-                    $error_code = 'E_LLM_EXCEPTION';
-                    rtbcb_log_error( $error_code . ': ' . $e->getMessage() );
-                    $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
-                    $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
-                    if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
-                        $response_message = $e->getMessage() . ' ' . $guidance;
-                    }
-                    wp_send_json_error(
-                        [
-                            'message'    => $response_message,
-                            'error_code' => $error_code,
-                        ],
-                        500
-                    );
-                    return;
-                } catch ( Error $e ) {
-                    // Developers: check server logs for E_LLM_FATAL stack trace.
-                    $error_code    = 'E_LLM_FATAL';
-                    $error_message = $e->getMessage();
+					if ( ! empty( $missing_sections ) ) {
+						rtbcb_log_error( 'LLM missing required sections', [ 'missing' => $missing_sections ] );
+						$comprehensive_analysis = $this->generate_fallback_analysis( $user_inputs, $scenarios );
+					} else {
+						rtbcb_log_api_debug( 'LLM generation succeeded' );
+					}
+				} catch ( Exception $e ) {
+					$error_code = 'E_LLM_EXCEPTION';
+					rtbcb_log_error( $error_code . ': ' . $e->getMessage() );
+					$guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
+					$response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
+					if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+						$response_message = $e->getMessage() . ' ' . $guidance;
+					}
+					wp_send_json_error(
+						[
+							'message'    => $response_message,
+							'error_code' => $error_code,
+						],
+						500
+					);
+					return;
+				} catch ( Error $e ) {
+					// Developers: check server logs for E_LLM_FATAL stack trace.
+					$error_code    = 'E_LLM_FATAL';
+					$error_message = $e->getMessage();
 
-                    rtbcb_log_error( $error_code . ': ' . $error_message, $e->getTraceAsString() );
+					rtbcb_log_error( $error_code . ': ' . $error_message, $e->getTraceAsString() );
 
-                    if ( rtbcb_is_openai_configuration_error( $e ) ) {
-                        $guidance          = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
-                        $sanitized_message = esc_html( $error_message );
-                        $response_message  = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
+					if ( rtbcb_is_openai_configuration_error( $e ) ) {
+						$guidance          = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
+						$sanitized_message = esc_html( $error_message );
+						$response_message  = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
 
-                        if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
-                            $response_message = $sanitized_message . ' ' . $guidance;
-                        } elseif ( current_user_can( 'manage_options' ) ) {
-                            $response_message .= ' ' . $sanitized_message;
-                        }
-                    } else {
-                        $response_message = __( 'Internal error. Please try again later.', 'rtbcb' );
-                    }
+						if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+							$response_message = $sanitized_message . ' ' . $guidance;
+						} elseif ( current_user_can( 'manage_options' ) ) {
+							$response_message .= ' ' . $sanitized_message;
+						}
+					} else {
+						$response_message = __( 'Internal error. Please try again later.', 'rtbcb' );
+					}
 
-                        wp_send_json_error(
-                            [
-                                'message'    => $response_message,
-                                'error_code' => $error_code,
-                            ],
-                            500
-                        );
-                        return;
-                    }
-                }
+						wp_send_json_error(
+							[
+								'message'    => $response_message,
+								'error_code' => $error_code,
+							],
+							500
+						);
+						return;
+					}
+				}
 
-            if ( empty( $comprehensive_analysis ) ) {
-                $error_code = 'E_LLM_EMPTY';
-                rtbcb_log_error( $error_code . ': LLM returned empty analysis', $user_inputs );
-                $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
-                $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
-                if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
-                    $response_message = __( 'LLM returned empty analysis.', 'rtbcb' ) . ' ' . $guidance;
-                }
-                wp_send_json_error(
-                    [
-                        'message'    => $response_message,
-                        'error_code' => $error_code,
-                    ],
-                    500
-                );
-                return;
-            }
+			if ( empty( $comprehensive_analysis ) ) {
+				$error_code = 'E_LLM_EMPTY';
+				rtbcb_log_error( $error_code . ': LLM returned empty analysis', $user_inputs );
+				$guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
+				$response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
+				if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+					$response_message = __( 'LLM returned empty analysis.', 'rtbcb' ) . ' ' . $guidance;
+				}
+				wp_send_json_error(
+					[
+						'message'    => $response_message,
+						'error_code' => $error_code,
+					],
+					500
+				);
+				return;
+			}
 
-            if ( empty( $comprehensive_analysis['company_name'] ) ) {
-                $comprehensive_analysis['company_name'] = $user_inputs['company_name'];
-            }
+			if ( empty( $comprehensive_analysis['company_name'] ) ) {
+				$comprehensive_analysis['company_name'] = $user_inputs['company_name'];
+			}
 
-            // Format scenarios
-            $formatted_scenarios = [
-                'low'  => [
-                    'total_annual_benefit' => $scenarios['conservative']['total_annual_benefit'] ?? 0,
-                    'labor_savings'        => $scenarios['conservative']['labor_savings'] ?? 0,
-                    'fee_savings'          => $scenarios['conservative']['fee_savings'] ?? 0,
-                    'error_reduction'      => $scenarios['conservative']['error_reduction'] ?? 0,
-                ],
-                'base' => [
-                    'total_annual_benefit' => $scenarios['base']['total_annual_benefit'] ?? 0,
-                    'labor_savings'        => $scenarios['base']['labor_savings'] ?? 0,
-                    'fee_savings'          => $scenarios['base']['fee_savings'] ?? 0,
-                    'error_reduction'      => $scenarios['base']['error_reduction'] ?? 0,
-                ],
-                'high' => [
-                    'total_annual_benefit' => $scenarios['optimistic']['total_annual_benefit'] ?? 0,
-                    'labor_savings'        => $scenarios['optimistic']['labor_savings'] ?? 0,
-                    'fee_savings'          => $scenarios['optimistic']['fee_savings'] ?? 0,
-                    'error_reduction'      => $scenarios['optimistic']['error_reduction'] ?? 0,
-                ],
-            ];
+			// Format scenarios
+			$formatted_scenarios = [
+				'low'  => [
+					'total_annual_benefit' => $scenarios['conservative']['total_annual_benefit'] ?? 0,
+					'labor_savings'        => $scenarios['conservative']['labor_savings'] ?? 0,
+					'fee_savings'          => $scenarios['conservative']['fee_savings'] ?? 0,
+					'error_reduction'      => $scenarios['conservative']['error_reduction'] ?? 0,
+				],
+				'base' => [
+					'total_annual_benefit' => $scenarios['base']['total_annual_benefit'] ?? 0,
+					'labor_savings'        => $scenarios['base']['labor_savings'] ?? 0,
+					'fee_savings'          => $scenarios['base']['fee_savings'] ?? 0,
+					'error_reduction'      => $scenarios['base']['error_reduction'] ?? 0,
+				],
+				'high' => [
+					'total_annual_benefit' => $scenarios['optimistic']['total_annual_benefit'] ?? 0,
+					'labor_savings'        => $scenarios['optimistic']['labor_savings'] ?? 0,
+					'fee_savings'          => $scenarios['optimistic']['fee_savings'] ?? 0,
+					'error_reduction'      => $scenarios['optimistic']['error_reduction'] ?? 0,
+				],
+			];
 
-            rtbcb_log_memory_usage( 'after_scenario_formatting' );
+			rtbcb_log_memory_usage( 'after_scenario_formatting' );
 
-            // Generate HTML report
-            $report_html = '';
-            try {
-                $report_html = $this->get_comprehensive_report_html( $comprehensive_analysis );
-                if ( is_wp_error( $report_html ) || empty( $report_html ) ) {
-                    rtbcb_log_error(
-                        'Report HTML generation failed',
-                        is_wp_error( $report_html ) ? $report_html->get_error_message() : $comprehensive_analysis
-                    );
-                    wp_send_json_error(
-                        [ 'message' => __( 'Failed to render business case report.', 'rtbcb' ) ],
-                        500
-                    );
-                    return;
-                }
-                rtbcb_log_memory_usage( 'after_report_generation' );
-            } catch ( Exception $e ) {
-                rtbcb_log_error( 'Report generation failed', $e->getMessage() );
-                wp_send_json_error(
-                    [ 'message' => __( 'Failed to render business case report.', 'rtbcb' ) ],
-                    500
-                );
-                return;
-            }
+			// Generate HTML report
+			$report_html = '';
+			try {
+				$report_html = $this->get_comprehensive_report_html( $comprehensive_analysis );
+				if ( is_wp_error( $report_html ) || empty( $report_html ) ) {
+					rtbcb_log_error(
+						'Report HTML generation failed',
+						is_wp_error( $report_html ) ? $report_html->get_error_message() : $comprehensive_analysis
+					);
+					wp_send_json_error(
+						[ 'message' => __( 'Failed to render business case report.', 'rtbcb' ) ],
+						500
+					);
+					return;
+				}
+				rtbcb_log_memory_usage( 'after_report_generation' );
+			} catch ( Exception $e ) {
+				rtbcb_log_error( 'Report generation failed', $e->getMessage() );
+				wp_send_json_error(
+					[ 'message' => __( 'Failed to render business case report.', 'rtbcb' ) ],
+					500
+				);
+				return;
+			}
 
-            // Save lead data (non-blocking)
-            $lead_id = null;
-            if ( class_exists( 'RTBCB_Leads' ) ) {
-                try {
-                    $lead_data = [
-                        'email'                  => $user_inputs['email'],
-                        'company_size'           => $user_inputs['company_size'],
-                        'industry'               => $user_inputs['industry'],
-                        'hours_reconciliation'   => $user_inputs['hours_reconciliation'],
-                        'hours_cash_positioning' => $user_inputs['hours_cash_positioning'],
-                        'num_banks'              => $user_inputs['num_banks'],
-                        'ftes'                   => $user_inputs['ftes'],
-                        'pain_points'            => $user_inputs['pain_points'],
-                        'recommended_category'   => $recommendation['recommended'] ?? '',
-                        'roi_low'                => $formatted_scenarios['low']['total_annual_benefit'],
-                        'roi_base'               => $formatted_scenarios['base']['total_annual_benefit'],
-                        'roi_high'               => $formatted_scenarios['high']['total_annual_benefit'],
-                        'report_html'            => $report_html,
-                    ];
+			// Save lead data (non-blocking)
+			$lead_id = null;
+			if ( class_exists( 'RTBCB_Leads' ) ) {
+				try {
+					$lead_data = [
+						'email'                  => $user_inputs['email'],
+						'company_size'           => $user_inputs['company_size'],
+						'industry'               => $user_inputs['industry'],
+						'hours_reconciliation'   => $user_inputs['hours_reconciliation'],
+						'hours_cash_positioning' => $user_inputs['hours_cash_positioning'],
+						'num_banks'              => $user_inputs['num_banks'],
+						'ftes'                   => $user_inputs['ftes'],
+						'pain_points'            => $user_inputs['pain_points'],
+						'recommended_category'   => $recommendation['recommended'] ?? '',
+						'roi_low'                => $formatted_scenarios['low']['total_annual_benefit'],
+						'roi_base'               => $formatted_scenarios['base']['total_annual_benefit'],
+						'roi_high'               => $formatted_scenarios['high']['total_annual_benefit'],
+						'report_html'            => $report_html,
+					];
 
-                    $lead_id = RTBCB_Leads::save_lead( $lead_data );
-                    if ( false === $lead_id ) {
-                        rtbcb_log_error( 'Failed to save lead', $lead_data );
-                    }
-                    rtbcb_log_memory_usage( 'after_lead_save' );
-                } catch ( Throwable $e ) {
-                    rtbcb_log_error( 'Failed to save lead', $e->getMessage() );
-                }
-            }
+					$lead_id = RTBCB_Leads::save_lead( $lead_data );
+					if ( false === $lead_id ) {
+						rtbcb_log_error( 'Failed to save lead', $lead_data );
+					}
+					rtbcb_log_memory_usage( 'after_lead_save' );
+				} catch ( Throwable $e ) {
+					rtbcb_log_error( 'Failed to save lead', $e->getMessage() );
+				}
+			}
 
-            // Prepare final response
-            $response_data = [
-                'scenarios'              => $formatted_scenarios,
-                'recommendation'         => $recommendation,
-                'comprehensive_analysis' => $comprehensive_analysis,
-                'narrative'              => $comprehensive_analysis,
-                'rag_context'            => $rag_context,
-                'report_html'            => $report_html,
-                'lead_id'                => $lead_id,
-                'company_name'           => $user_inputs['company_name'],
-                'analysis_type'          => rtbcb_get_analysis_type(),
-                'api_used'               => ! empty( get_option( 'rtbcb_openai_api_key' ) ),
-                'fallback_used'          => isset( $comprehensive_analysis['enhanced_fallback'] ),
-                'memory_info'            => rtbcb_get_memory_status(),
-            ];
+			// Prepare final response
+			$response_data = [
+				'scenarios'              => $formatted_scenarios,
+				'recommendation'         => $recommendation,
+				'comprehensive_analysis' => $comprehensive_analysis,
+				'narrative'              => $comprehensive_analysis,
+				'rag_context'            => $rag_context,
+				'report_html'            => $report_html,
+				'lead_id'                => $lead_id,
+				'company_name'           => $user_inputs['company_name'],
+				'analysis_type'          => rtbcb_get_analysis_type(),
+				'api_used'               => ! empty( get_option( 'rtbcb_openai_api_key' ) ),
+				'fallback_used'          => isset( $comprehensive_analysis['enhanced_fallback'] ),
+				'memory_info'            => rtbcb_get_memory_status(),
+			];
 
-            rtbcb_log_memory_usage( 'before_response' );
+			rtbcb_log_memory_usage( 'before_response' );
 
-            wp_send_json_success( $response_data );
-            return;
+			wp_send_json_success( $response_data );
+			return;
 
-        } catch ( Exception $e ) {
-            rtbcb_log_memory_usage( 'exception_occurred' );
-            rtbcb_log_error(
-                'Ajax exception',
-                $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
-            );
-            wp_send_json_error(
-                [ 'message' => __( 'An error occurred while generating your business case. Please try again.', 'rtbcb' ) ],
-                500
-            );
-            return;
-        } catch ( Error $e ) {
-            rtbcb_log_memory_usage( 'fatal_error_occurred' );
-            rtbcb_log_error(
-                'Ajax fatal error',
-                $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
-            );
-            wp_send_json_error(
-                [ 'message' => __( 'A system error occurred. Please contact support.', 'rtbcb' ) ],
-                500
-            );
-            return;
-        }
-    }
-   /**
-    * Generate comprehensive report HTML from template with proper data transformation.
-    *
+		} catch ( Exception $e ) {
+			rtbcb_log_memory_usage( 'exception_occurred' );
+			rtbcb_log_error(
+				'Ajax exception',
+				$e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
+			);
+			wp_send_json_error(
+				[ 'message' => __( 'An error occurred while generating your business case. Please try again.', 'rtbcb' ) ],
+				500
+			);
+			return;
+		} catch ( Error $e ) {
+			rtbcb_log_memory_usage( 'fatal_error_occurred' );
+			rtbcb_log_error(
+				'Ajax fatal error',
+				$e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
+			);
+			wp_send_json_error(
+				[ 'message' => __( 'A system error occurred. Please contact support.', 'rtbcb' ) ],
+				500
+			);
+			return;
+		}
+	}
+	/**
+	* Generate comprehensive report HTML from template with proper data transformation.
+	*
 	* @param array $business_case_data Business case data.
 	*
 	* @return string|WP_Error
@@ -1875,7 +1875,7 @@ return $use_comprehensive;
 	);
 	}
 
-        $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
+		$business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
 
 	$report_data = $business_case_data['report_data'] ?? null;
 	$hash_source = $report_data ?: $business_case_data;
@@ -1884,38 +1884,38 @@ return $use_comprehensive;
 	$cache_key  = md5( $template_path . ':' . $data_hash . ':' . $version );
 
 	$cached_html = wp_cache_get( $cache_key, 'rtbcb_reports' );
-        if ( false !== $cached_html ) {
-            return $cached_html;
-        }
+		if ( false !== $cached_html ) {
+			return $cached_html;
+		}
 
-        if ( null === $report_data ) {
-            // Transform data structure for template.
-            $report_data = $this->transform_data_for_template( $business_case_data );
+		if ( null === $report_data ) {
+			// Transform data structure for template.
+			$report_data = $this->transform_data_for_template( $business_case_data );
 
-            if ( is_wp_error( $report_data ) ) {
-                $error_data = $report_data->get_error_data();
-                rtbcb_log_error(
-                    'Report data transformation failed',
-                    [
-                        'error'        => $report_data->get_error_message(),
-                        'missing_keys' => $error_data['status']['missing_keys'] ?? [],
-                    ]
-                );
+			if ( is_wp_error( $report_data ) ) {
+				$error_data = $report_data->get_error_data();
+				rtbcb_log_error(
+					'Report data transformation failed',
+					[
+						'error'        => $report_data->get_error_message(),
+						'missing_keys' => $error_data['status']['missing_keys'] ?? [],
+					]
+				);
 
-                return $report_data;
-            }
+				return $report_data;
+			}
 
-            if ( isset( $report_data['status'] ) && empty( $report_data['status']['valid'] ) ) {
-                rtbcb_log_error(
-                    'Report data validation failed',
-                    [
-                        'missing_keys' => $report_data['status']['missing_keys'],
-                    ]
-                );
-            }
-        }
+			if ( isset( $report_data['status'] ) && empty( $report_data['status']['valid'] ) ) {
+				rtbcb_log_error(
+					'Report data validation failed',
+					[
+						'missing_keys' => $report_data['status']['missing_keys'],
+					]
+				);
+			}
+		}
 
-        try {
+		try {
 	set_error_handler(
 	static function ( $severity, $message, $file, $line ) {
 	throw new ErrorException( $message, 0, $severity, $file, $line );
@@ -1952,585 +1952,585 @@ return $use_comprehensive;
 	'rtbcb_template_include_failed',
 	__( 'Error rendering report template.', 'rtbcb' )
 	);
-        }
+		}
 
-        $html = wp_kses( $html, rtbcb_get_report_allowed_html() );
-        wp_cache_set( $cache_key, $html, 'rtbcb_reports', HOUR_IN_SECONDS );
+		$html = wp_kses( $html, rtbcb_get_report_allowed_html() );
+		wp_cache_set( $cache_key, $html, 'rtbcb_reports', HOUR_IN_SECONDS );
 
-        return $html;
+		return $html;
 }
 
-   /**
-    * Transform LLM response data into the structure expected by comprehensive template.
-    *
-    * @param array $business_case_data Business case data.
-    *
-    * @return array
-    */
-   private function transform_data_for_template( $business_case_data ) {
-       $defaults = [
-           'company_name'           => '',
-           'base_roi'               => 0,
-           'roi_base'               => 0,
-           'recommended_category'   => '',
-           'category_info'          => [],
-           'executive_summary'      => '',
-           'narrative'              => '',
-           'executive_recommendation' => '',
-           'recommendation'         => '',
-           'payback_months'         => 'N/A',
-           'sensitivity_analysis'   => [],
-           'company_analysis'       => '',
-           'maturity_level'         => 'intermediate',
-           'current_state_analysis' => '',
-           'market_analysis'        => '',
-           'tech_adoption_level'    => 'medium',
-           'operational_analysis'   => [],
-           'risks'                  => [],
-           'confidence'             => 0.85,
-           'processing_time'        => 0,
-       ];
-       $business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
+	/**
+	* Transform LLM response data into the structure expected by comprehensive template.
+	*
+	* @param array $business_case_data Business case data.
+	*
+	* @return array
+	*/
+	private function transform_data_for_template( $business_case_data ) {
+	   $defaults = [
+		   'company_name'           => '',
+		   'base_roi'               => 0,
+		   'roi_base'               => 0,
+		   'recommended_category'   => '',
+		   'category_info'          => [],
+		   'executive_summary'      => '',
+		   'narrative'              => '',
+		   'executive_recommendation' => '',
+		   'recommendation'         => '',
+		   'payback_months'         => 'N/A',
+		   'sensitivity_analysis'   => [],
+		   'company_analysis'       => '',
+		   'maturity_level'         => 'intermediate',
+		   'current_state_analysis' => '',
+		   'market_analysis'        => '',
+		   'tech_adoption_level'    => 'medium',
+		   'operational_analysis'   => [],
+		   'risks'                  => [],
+		   'confidence'             => 0.85,
+		   'processing_time'        => 0,
+	   ];
+	   $business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
 
-       // Get current company data.
-       $company      = rtbcb_get_current_company();
-       $company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
-       $base_roi     = floatval( $business_case_data['base_roi'] ?: $business_case_data['roi_base'] );
-       $business_case_data['roi_base'] = $base_roi;
+	   // Get current company data.
+	   $company      = rtbcb_get_current_company();
+	   $company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
+	   $base_roi     = floatval( $business_case_data['base_roi'] ?: $business_case_data['roi_base'] );
+	   $business_case_data['roi_base'] = $base_roi;
 
-       // Derive recommended category and details from recommendation if not provided.
-       $recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
-       $category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
+	   // Derive recommended category and details from recommendation if not provided.
+	   $recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
+	   $category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
 
-       // Prepare operational and risk data with fallbacks.
-       $operational_analysis = array_map( 'sanitize_text_field', (array) $business_case_data['operational_analysis'] );
-       if ( empty( $operational_analysis ) ) {
-           $operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
-       }
+	   // Prepare operational and risk data with fallbacks.
+	   $operational_analysis = array_map( 'sanitize_text_field', (array) $business_case_data['operational_analysis'] );
+	   if ( empty( $operational_analysis ) ) {
+		   $operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
+	   }
 
-       $implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
-       if ( empty( $implementation_risks ) ) {
-           $implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
-       }
+	   $implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
+	   if ( empty( $implementation_risks ) ) {
+		   $implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
+	   }
 
-       // Create structured data format expected by template.
-       $report_data = [
-           'metadata'           => [
-               'company_name'     => $company_name,
-               'analysis_date'    => current_time( 'Y-m-d' ),
-               'analysis_type'    => rtbcb_get_analysis_type(),
-               'confidence_level' => floatval( $business_case_data['confidence'] ),
-               'processing_time'  => intval( $business_case_data['processing_time'] ),
-           ],
-           'executive_summary'  => [
-               'strategic_positioning'    => wp_kses_post( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
-               'key_value_drivers'       => $this->extract_value_drivers( $business_case_data ),
-               'executive_recommendation' => wp_kses_post( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
-               'business_case_strength'  => $this->determine_business_case_strength( $business_case_data ),
-           ],
-           'financial_analysis' => [
-               'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
-               'payback_analysis'   => [
-                   'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
-               ],
-               'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
-           ],
-           'company_intelligence' => [
-               'enriched_profile' => [
-                   'enhanced_description' => wp_kses_post( $business_case_data['company_analysis'] ),
-                   'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
-                   'treasury_maturity'    => [
-                       'current_state' => wp_kses_post( $business_case_data['current_state_analysis'] ),
-                   ],
-               ],
-               'industry_context' => [
-                   'sector_analysis' => [
-                       'market_dynamics' => wp_kses_post( $business_case_data['market_analysis'] ),
-                   ],
-                   'benchmarking'   => [
-                       'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
-                   ],
-               ],
-           ],
-           'technology_strategy' => [
-               'recommended_category' => $recommended_category,
-               'category_details'     => $category_details,
-           ],
-           'operational_insights' => $operational_analysis,
-           'risk_analysis'        => [
-               'implementation_risks' => $implementation_risks,
-           ],
-           'action_plan'          => [
-               'immediate_steps'      => $this->extract_immediate_steps( $business_case_data ),
-               'short_term_milestones'=> $this->extract_short_term_steps( $business_case_data ),
-               'long_term_objectives' => $this->extract_long_term_steps( $business_case_data ),
-           ],
-       ];
+	   // Create structured data format expected by template.
+	   $report_data = [
+		   'metadata'           => [
+			   'company_name'     => $company_name,
+			   'analysis_date'    => current_time( 'Y-m-d' ),
+			   'analysis_type'    => rtbcb_get_analysis_type(),
+			   'confidence_level' => floatval( $business_case_data['confidence'] ),
+			   'processing_time'  => intval( $business_case_data['processing_time'] ),
+		   ],
+		   'executive_summary'  => [
+			   'strategic_positioning'    => wp_kses_post( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
+			   'key_value_drivers'       => $this->extract_value_drivers( $business_case_data ),
+			   'executive_recommendation' => wp_kses_post( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
+			   'business_case_strength'  => $this->determine_business_case_strength( $business_case_data ),
+		   ],
+		   'financial_analysis' => [
+			   'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
+			   'payback_analysis'   => [
+				   'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
+			   ],
+			   'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
+		   ],
+		   'company_intelligence' => [
+			   'enriched_profile' => [
+				   'enhanced_description' => wp_kses_post( $business_case_data['company_analysis'] ),
+				   'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
+				   'treasury_maturity'    => [
+					   'current_state' => wp_kses_post( $business_case_data['current_state_analysis'] ),
+				   ],
+			   ],
+			   'industry_context' => [
+				   'sector_analysis' => [
+					   'market_dynamics' => wp_kses_post( $business_case_data['market_analysis'] ),
+				   ],
+				   'benchmarking'   => [
+					   'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
+				   ],
+			   ],
+		   ],
+		   'technology_strategy' => [
+			   'recommended_category' => $recommended_category,
+			   'category_details'     => $category_details,
+		   ],
+		   'operational_insights' => $operational_analysis,
+		   'risk_analysis'        => [
+			   'implementation_risks' => $implementation_risks,
+		   ],
+		   'action_plan'          => [
+			   'immediate_steps'      => $this->extract_immediate_steps( $business_case_data ),
+			   'short_term_milestones'=> $this->extract_short_term_steps( $business_case_data ),
+			   'long_term_objectives' => $this->extract_long_term_steps( $business_case_data ),
+		   ],
+	   ];
 
-       $required_sections = [
-           'metadata',
-           'executive_summary',
-           'financial_analysis',
-           'company_intelligence',
-           'technology_strategy',
-           'operational_insights',
-           'risk_analysis',
-           'action_plan',
-       ];
+	   $required_sections = [
+		   'metadata',
+		   'executive_summary',
+		   'financial_analysis',
+		   'company_intelligence',
+		   'technology_strategy',
+		   'operational_insights',
+		   'risk_analysis',
+		   'action_plan',
+	   ];
 
-       $section_defaults = [
-           'metadata'           => [
-               'company_name'     => '',
-               'analysis_date'    => '',
-               'analysis_type'    => '',
-               'confidence_level' => 0,
-               'processing_time'  => 0,
-           ],
-           'executive_summary'  => [
-               'strategic_positioning'    => '',
-               'key_value_drivers'       => [],
-               'executive_recommendation' => '',
-               'business_case_strength'  => '',
-           ],
-           'financial_analysis' => [
-               'roi_scenarios'      => [],
-               'payback_analysis'   => [ 'payback_months' => '' ],
-               'sensitivity_analysis' => [],
-           ],
-           'company_intelligence' => [],
-           'technology_strategy'  => [],
-           'operational_insights' => [],
-           'risk_analysis'        => [ 'implementation_risks' => [] ],
-           'action_plan'          => [
-               'immediate_steps'       => [],
-               'short_term_milestones' => [],
-               'long_term_objectives'  => [],
-           ],
-       ];
+	   $section_defaults = [
+		   'metadata'           => [
+			   'company_name'     => '',
+			   'analysis_date'    => '',
+			   'analysis_type'    => '',
+			   'confidence_level' => 0,
+			   'processing_time'  => 0,
+		   ],
+		   'executive_summary'  => [
+			   'strategic_positioning'    => '',
+			   'key_value_drivers'       => [],
+			   'executive_recommendation' => '',
+			   'business_case_strength'  => '',
+		   ],
+		   'financial_analysis' => [
+			   'roi_scenarios'      => [],
+			   'payback_analysis'   => [ 'payback_months' => '' ],
+			   'sensitivity_analysis' => [],
+		   ],
+		   'company_intelligence' => [],
+		   'technology_strategy'  => [],
+		   'operational_insights' => [],
+		   'risk_analysis'        => [ 'implementation_risks' => [] ],
+		   'action_plan'          => [
+			   'immediate_steps'       => [],
+			   'short_term_milestones' => [],
+			   'long_term_objectives'  => [],
+		   ],
+	   ];
 
-       $missing_sections = [];
+	   $missing_sections = [];
 
-       foreach ( $required_sections as $section ) {
-           if ( empty( $report_data[ $section ] ) ) {
-               $missing_sections[] = $section;
-               rtbcb_log_error(
-                   'Missing report data section',
-                   [
-                       'section' => $section,
-                   ]
-               );
-               $report_data[ $section ] = $section_defaults[ $section ];
-           }
-       }
+	   foreach ( $required_sections as $section ) {
+		   if ( empty( $report_data[ $section ] ) ) {
+			   $missing_sections[] = $section;
+			   rtbcb_log_error(
+				   'Missing report data section',
+				   [
+					   'section' => $section,
+				   ]
+			   );
+			   $report_data[ $section ] = $section_defaults[ $section ];
+		   }
+	   }
 
-       $report_data['status'] = [
-           'valid'        => empty( $missing_sections ),
-           'missing_keys' => $missing_sections,
-       ];
+	   $report_data['status'] = [
+		   'valid'        => empty( $missing_sections ),
+		   'missing_keys' => $missing_sections,
+	   ];
 
-       if ( ! empty( $missing_sections ) ) {
-           return new WP_Error(
-               'rtbcb_missing_report_sections',
-               __( 'Missing required report sections.', 'rtbcb' ),
-               $report_data
-           );
-       }
+	   if ( ! empty( $missing_sections ) ) {
+		   return new WP_Error(
+			   'rtbcb_missing_report_sections',
+			   __( 'Missing required report sections.', 'rtbcb' ),
+			   $report_data
+		   );
+	   }
 
-       return $report_data;
-   }
+	   return $report_data;
+	}
 
-   /**
-    * Extract value drivers from business case data.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
-   private function extract_value_drivers( $data ) {
-       $drivers = [];
+	/**
+	* Extract value drivers from business case data.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
+	private function extract_value_drivers( $data ) {
+	   $drivers = [];
 
-       // Extract from various possible sources.
-       if ( ! empty( $data['value_drivers'] ) ) {
-           $drivers = (array) $data['value_drivers'];
-       } elseif ( ! empty( $data['key_benefits'] ) ) {
-           $drivers = (array) $data['key_benefits'];
-       } else {
-           // Default value drivers.
-           $drivers = [
-               __( 'Automated cash management processes', 'rtbcb' ),
-               __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
-               __( 'Reduced operational risk and errors', 'rtbcb' ),
-               __( 'Improved regulatory compliance', 'rtbcb' ),
-           ];
-       }
+	   // Extract from various possible sources.
+	   if ( ! empty( $data['value_drivers'] ) ) {
+		   $drivers = (array) $data['value_drivers'];
+	   } elseif ( ! empty( $data['key_benefits'] ) ) {
+		   $drivers = (array) $data['key_benefits'];
+	   } else {
+		   // Default value drivers.
+		   $drivers = [
+			   __( 'Automated cash management processes', 'rtbcb' ),
+			   __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
+			   __( 'Reduced operational risk and errors', 'rtbcb' ),
+			   __( 'Improved regulatory compliance', 'rtbcb' ),
+		   ];
+	   }
 
-       return array_slice( $drivers, 0, 4 );
-   }
+	   return array_slice( $drivers, 0, 4 );
+	}
 
-   /**
-    * Format ROI scenarios for template.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
-   private function format_roi_scenarios( $data ) {
-       // Try to get ROI data from various possible locations.
-       if ( ! empty( $data['scenarios'] ) ) {
-           return $data['scenarios'];
-       }
+	/**
+	* Format ROI scenarios for template.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
+	private function format_roi_scenarios( $data ) {
+	   // Try to get ROI data from various possible locations.
+	   if ( ! empty( $data['scenarios'] ) ) {
+		   return $data['scenarios'];
+	   }
 
-       if ( ! empty( $data['roi_scenarios'] ) ) {
-           return $data['roi_scenarios'];
-       }
+	   if ( ! empty( $data['roi_scenarios'] ) ) {
+		   return $data['roi_scenarios'];
+	   }
 
-       // Fallback to default structure.
-       return [
-           'conservative' => [
-               'total_annual_benefit' => $data['roi_low'] ?? 0,
-               'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
-           ],
-           'base' => [
-               'total_annual_benefit' => $data['roi_base'] ?? 0,
-               'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
-           ],
-           'optimistic' => [
-               'total_annual_benefit' => $data['roi_high'] ?? 0,
-               'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
-               'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
-               'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
-           ],
-       ];
-   }
+	   // Fallback to default structure.
+	   return [
+		   'conservative' => [
+			   'total_annual_benefit' => $data['roi_low'] ?? 0,
+			   'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
+			   'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
+			   'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
+		   ],
+		   'base' => [
+			   'total_annual_benefit' => $data['roi_base'] ?? 0,
+			   'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
+			   'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
+			   'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
+		   ],
+		   'optimistic' => [
+			   'total_annual_benefit' => $data['roi_high'] ?? 0,
+			   'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
+			   'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
+			   'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
+		   ],
+	   ];
+	}
 
-   /**
-    * Determine business case strength based on ROI.
-    *
-    * @param array $data Business case data.
-    *
-    * @return string
-    */
-   private function determine_business_case_strength( $data ) {
-       $base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
+	/**
+	* Determine business case strength based on ROI.
+	*
+	* @param array $data Business case data.
+	*
+	* @return string
+	*/
+	private function determine_business_case_strength( $data ) {
+	   $base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
 
-       if ( $base_roi > 500000 ) {
-           return 'Compelling';
-       } elseif ( $base_roi > 200000 ) {
-           return 'Strong';
-       } elseif ( $base_roi > 50000 ) {
-           return 'Moderate';
-       } else {
-           return 'Developing';
-       }
-   }
+	   if ( $base_roi > 500000 ) {
+		   return 'Compelling';
+	   } elseif ( $base_roi > 200000 ) {
+		   return 'Strong';
+	   } elseif ( $base_roi > 50000 ) {
+		   return 'Moderate';
+	   } else {
+		   return 'Developing';
+	   }
+	}
 
-   /**
-    * Extract action steps from business case data.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
-   private function extract_immediate_steps( $data ) {
-       if ( ! empty( $data['next_actions'] ) ) {
-           $all_actions = (array) $data['next_actions'];
-           return array_slice( $all_actions, 0, 3 );
-       }
+	/**
+	* Extract action steps from business case data.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
+	private function extract_immediate_steps( $data ) {
+	   if ( ! empty( $data['next_actions'] ) ) {
+		   $all_actions = (array) $data['next_actions'];
+		   return array_slice( $all_actions, 0, 3 );
+	   }
 
-       return [
-           __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
-           __( 'Form project steering committee', 'rtbcb' ),
-           __( 'Conduct detailed requirements gathering', 'rtbcb' ),
-       ];
-   }
+	   return [
+		   __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
+		   __( 'Form project steering committee', 'rtbcb' ),
+		   __( 'Conduct detailed requirements gathering', 'rtbcb' ),
+	   ];
+	}
 
-   /**
-    * Extract short term action steps.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
-   private function extract_short_term_steps( $data ) {
-       if ( ! empty( $data['implementation_steps'] ) ) {
-           $steps = (array) $data['implementation_steps'];
-           return array_slice( $steps, 0, 4 );
-       }
+	/**
+	* Extract short term action steps.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
+	private function extract_short_term_steps( $data ) {
+	   if ( ! empty( $data['implementation_steps'] ) ) {
+		   $steps = (array) $data['implementation_steps'];
+		   return array_slice( $steps, 0, 4 );
+	   }
 
-       return [
-           __( 'Issue RFP to qualified vendors', 'rtbcb' ),
-           __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
-           __( 'Negotiate contracts and terms', 'rtbcb' ),
-           __( 'Begin system implementation planning', 'rtbcb' ),
-       ];
-   }
+	   return [
+		   __( 'Issue RFP to qualified vendors', 'rtbcb' ),
+		   __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
+		   __( 'Negotiate contracts and terms', 'rtbcb' ),
+		   __( 'Begin system implementation planning', 'rtbcb' ),
+	   ];
+	}
 
-   /**
-    * Extract long term action steps.
-    *
-    * @param array $data Business case data.
-    *
-    * @return array
-    */
-   private function extract_long_term_steps( $data ) {
-       return [
-           __( 'Complete system implementation and testing', 'rtbcb' ),
-           __( 'Conduct user training and change management', 'rtbcb' ),
-           __( 'Measure and optimize system performance', 'rtbcb' ),
-           __( 'Expand functionality and integration capabilities', 'rtbcb' ),
-       ];
-   }
+	/**
+	* Extract long term action steps.
+	*
+	* @param array $data Business case data.
+	*
+	* @return array
+	*/
+	private function extract_long_term_steps( $data ) {
+	   return [
+		   __( 'Complete system implementation and testing', 'rtbcb' ),
+		   __( 'Conduct user training and change management', 'rtbcb' ),
+		   __( 'Measure and optimize system performance', 'rtbcb' ),
+		   __( 'Expand functionality and integration capabilities', 'rtbcb' ),
+	   ];
+	}
 
-    public function admin_notices() {
-        // Check if API key is configured
-        if ( current_user_can( 'manage_options' ) && empty( get_option( 'rtbcb_openai_api_key' ) ) ) {
-            $settings_url = admin_url( 'admin.php?page=rtbcb-settings' );
-            echo '<div class="notice notice-warning is-dismissible">';
-            echo '<p>';
-            printf(
-                wp_kses(
-                    __( '<strong>Real Treasury Business Case Builder:</strong> Please <a href="%s">configure your OpenAI API key</a> to enable business case generation.', 'rtbcb' ),
-                    [ 'strong' => [], 'a' => [ 'href' => [] ] ]
-                ),
-                esc_url( $settings_url )
-            );
-            echo '</p>';
-            echo '</div>';
-        }
+	public function admin_notices() {
+		// Check if API key is configured
+		if ( current_user_can( 'manage_options' ) && empty( get_option( 'rtbcb_openai_api_key' ) ) ) {
+			$settings_url = admin_url( 'admin.php?page=rtbcb-settings' );
+			echo '<div class="notice notice-warning is-dismissible">';
+			echo '<p>';
+			printf(
+				wp_kses(
+					__( '<strong>Real Treasury Business Case Builder:</strong> Please <a href="%s">configure your OpenAI API key</a> to enable business case generation.', 'rtbcb' ),
+					[ 'strong' => [], 'a' => [ 'href' => [] ] ]
+				),
+				esc_url( $settings_url )
+			);
+			echo '</p>';
+			echo '</div>';
+		}
 
-        // Show upgrade notice if applicable
-        if ( get_transient( 'rtbcb_show_upgrade_notice' ) ) {
-            echo '<div class="notice notice-success is-dismissible">';
-            echo '<p>';
-            printf(
-                esc_html__( 'Real Treasury Business Case Builder has been upgraded to version %s with new features including PDF reports, analytics, and enhanced lead tracking!', 'rtbcb' ),
-                RTBCB_VERSION
-            );
-            echo '</p>';
-            echo '</div>';
-            delete_transient( 'rtbcb_show_upgrade_notice' );
-        }
-    }
+		// Show upgrade notice if applicable
+		if ( get_transient( 'rtbcb_show_upgrade_notice' ) ) {
+			echo '<div class="notice notice-success is-dismissible">';
+			echo '<p>';
+			printf(
+				esc_html__( 'Real Treasury Business Case Builder has been upgraded to version %s with new features including PDF reports, analytics, and enhanced lead tracking!', 'rtbcb' ),
+				RTBCB_VERSION
+			);
+			echo '</p>';
+			echo '</div>';
+			delete_transient( 'rtbcb_show_upgrade_notice' );
+		}
+	}
 
-    /**
-     * Add plugin action links.
-     *
-     * @param array $links Existing links.
-     * @return array Modified links.
-     */
-    public function plugin_action_links( $links ) {
-        $custom_links = [
-            'settings' => sprintf(
-                '<a href="%s">%s</a>',
-                admin_url( 'admin.php?page=rtbcb-settings' ),
-                __( 'Settings', 'rtbcb' )
-            ),
-            'dashboard' => sprintf(
-                '<a href="%s">%s</a>',
-                admin_url( 'admin.php?page=rtbcb-dashboard' ),
-                __( 'Dashboard', 'rtbcb' )
-            ),
-        ];
+	/**
+	 * Add plugin action links.
+	 *
+	 * @param array $links Existing links.
+	 * @return array Modified links.
+	 */
+	public function plugin_action_links( $links ) {
+		$custom_links = [
+			'settings' => sprintf(
+				'<a href="%s">%s</a>',
+				admin_url( 'admin.php?page=rtbcb-settings' ),
+				__( 'Settings', 'rtbcb' )
+			),
+			'dashboard' => sprintf(
+				'<a href="%s">%s</a>',
+				admin_url( 'admin.php?page=rtbcb-dashboard' ),
+				__( 'Dashboard', 'rtbcb' )
+			),
+		];
 
-        return array_merge( $custom_links, $links );
-    }
+		return array_merge( $custom_links, $links );
+	}
 
-    /**
-     * Plugin activation.
-     *
-     * @return void
-     */
-    public function activate() {
-        // Create database tables
-        $this->init_database();
+	/**
+	 * Plugin activation.
+	 *
+	 * @return void
+	 */
+	public function activate() {
+		// Create database tables
+		$this->init_database();
 
-        // Set default options
-        $this->set_default_options();
+		// Set default options
+		$this->set_default_options();
 
-        // Setup capabilities
-        $this->setup_capabilities();
+		// Setup capabilities
+		$this->setup_capabilities();
 
-        // Schedule cron jobs
-        $this->setup_cron_jobs();
+		// Schedule cron jobs
+		$this->setup_cron_jobs();
 
-        // Set activation flag
-        set_transient( 'rtbcb_show_upgrade_notice', true, 30 );
+		// Set activation flag
+		set_transient( 'rtbcb_show_upgrade_notice', true, 30 );
 
-        // Flush rewrite rules
-        flush_rewrite_rules();
+		// Flush rewrite rules
+		flush_rewrite_rules();
 
-        error_log( 'RTBCB: Plugin activated successfully' );
-    }
+		error_log( 'RTBCB: Plugin activated successfully' );
+	}
 
-    /**
-     * Plugin deactivation.
-     *
-     * @return void
-     */
-    public function deactivate() {
-        // Clear scheduled events
-        wp_clear_scheduled_hook( 'rtbcb_rebuild_rag_index' );
-        wp_clear_scheduled_hook( 'rtbcb_cleanup_data' );
-        wp_clear_scheduled_hook( 'rtbcb_refresh_lead_metrics' );
+	/**
+	 * Plugin deactivation.
+	 *
+	 * @return void
+	 */
+	public function deactivate() {
+		// Clear scheduled events
+		wp_clear_scheduled_hook( 'rtbcb_rebuild_rag_index' );
+		wp_clear_scheduled_hook( 'rtbcb_cleanup_data' );
+		wp_clear_scheduled_hook( 'rtbcb_refresh_lead_metrics' );
 
-        // Flush rewrite rules
-        flush_rewrite_rules();
+		// Flush rewrite rules
+		flush_rewrite_rules();
 
-        error_log( 'RTBCB: Plugin deactivated' );
-    }
+		error_log( 'RTBCB: Plugin deactivated' );
+	}
 
-    /**
-     * Plugin uninstall.
-     *
-     * @return void
-     */
-    public static function uninstall() {
-        global $wpdb;
+	/**
+	 * Plugin uninstall.
+	 *
+	 * @return void
+	 */
+	public static function uninstall() {
+		global $wpdb;
 
-        // Remove database tables
-        $tables = [
-            $wpdb->prefix . 'rtbcb_leads',
-            $wpdb->prefix . 'rtbcb_rag_index',
-        ];
+		// Remove database tables
+		$tables = [
+			$wpdb->prefix . 'rtbcb_leads',
+			$wpdb->prefix . 'rtbcb_rag_index',
+		];
 
-        foreach ( $tables as $table ) {
-            $wpdb->query( "DROP TABLE IF EXISTS {$table}" );
-        }
+		foreach ( $tables as $table ) {
+			$wpdb->query( "DROP TABLE IF EXISTS {$table}" );
+		}
 
-        // Remove options
-        $options = [
-            'rtbcb_version',
-            'rtbcb_db_version',
-            'rtbcb_openai_api_key',
-            'rtbcb_mini_model',
-            'rtbcb_premium_model',
-            'rtbcb_embedding_model',
-            'rtbcb_labor_cost_per_hour',
-            'rtbcb_bank_fee_baseline',
-            'rtbcb_pdf_enabled',
-            'rtbcb_last_indexed',
-            'rtbcb_settings',
-            'rtbcb_contact_form_id',
-        ];
+		// Remove options
+		$options = [
+			'rtbcb_version',
+			'rtbcb_db_version',
+			'rtbcb_openai_api_key',
+			'rtbcb_mini_model',
+			'rtbcb_premium_model',
+			'rtbcb_embedding_model',
+			'rtbcb_labor_cost_per_hour',
+			'rtbcb_bank_fee_baseline',
+			'rtbcb_pdf_enabled',
+			'rtbcb_last_indexed',
+			'rtbcb_settings',
+			'rtbcb_contact_form_id',
+		];
 
-        foreach ( $options as $option ) {
-            delete_option( $option );
-        }
+		foreach ( $options as $option ) {
+			delete_option( $option );
+		}
 
-        // Remove user capabilities
-        $roles = wp_roles();
-        foreach ( $roles->roles as $role_name => $role_info ) {
-            $role = get_role( $role_name );
-            if ( $role ) {
-                $role->remove_cap( 'manage_rtbcb' );
-                $role->remove_cap( 'view_rtbcb_leads' );
-                $role->remove_cap( 'export_rtbcb_data' );
-            }
-        }
+		// Remove user capabilities
+		$roles = wp_roles();
+		foreach ( $roles->roles as $role_name => $role_info ) {
+			$role = get_role( $role_name );
+			if ( $role ) {
+				$role->remove_cap( 'manage_rtbcb' );
+				$role->remove_cap( 'view_rtbcb_leads' );
+				$role->remove_cap( 'export_rtbcb_data' );
+			}
+		}
 
-        // Remove uploaded files
-        $upload_dir = wp_get_upload_dir();
-        $plugin_dirs = [
-            $upload_dir['basedir'] . '/rtbcb-reports',
-            $upload_dir['basedir'] . '/rtbcb-temp',
-        ];
+		// Remove uploaded files
+		$upload_dir = wp_get_upload_dir();
+		$plugin_dirs = [
+			$upload_dir['basedir'] . '/rtbcb-reports',
+			$upload_dir['basedir'] . '/rtbcb-temp',
+		];
 
-        foreach ( $plugin_dirs as $dir ) {
-            if ( is_dir( $dir ) ) {
-                $files = glob( $dir . '/*' );
-                foreach ( $files as $file ) {
-                    if ( is_file( $file ) ) {
-                        unlink( $file );
-                    }
-                }
-                rmdir( $dir );
-            }
-        }
+		foreach ( $plugin_dirs as $dir ) {
+			if ( is_dir( $dir ) ) {
+				$files = glob( $dir . '/*' );
+				foreach ( $files as $file ) {
+					if ( is_file( $file ) ) {
+						unlink( $file );
+					}
+				}
+				rmdir( $dir );
+			}
+		}
 
-        error_log( 'RTBCB: Plugin uninstalled and data cleaned up' );
-    }
+		error_log( 'RTBCB: Plugin uninstalled and data cleaned up' );
+	}
 
-    /**
-     * Get plugin data.
-     *
-     * @param string $key Data key.
-     * @return mixed
-     */
-    public function get_plugin_data( $key = null ) {
-        if ( $key ) {
-            return $this->plugin_data[ $key ] ?? null;
-        }
-        return $this->plugin_data;
-    }
+	/**
+	 * Get plugin data.
+	 *
+	 * @param string $key Data key.
+	 * @return mixed
+	 */
+	public function get_plugin_data( $key = null ) {
+		if ( $key ) {
+			return $this->plugin_data[ $key ] ?? null;
+		}
+		return $this->plugin_data;
+	}
 
-    /**
-     * Handle debug diagnostics via AJAX.
-     *
-     * @return void
-     */
-    public function debug_ajax_handler() {
-        $nonce       = isset( $_POST['rtbcb_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ) : '';
-        $nonce_valid = wp_verify_nonce( $nonce, 'rtbcb_debug' );
+	/**
+	 * Handle debug diagnostics via AJAX.
+	 *
+	 * @return void
+	 */
+	public function debug_ajax_handler() {
+		$nonce       = isset( $_POST['rtbcb_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ) : '';
+		$nonce_valid = wp_verify_nonce( $nonce, 'rtbcb_debug' );
 
-        $post_keys = array_map( 'sanitize_key', array_keys( $_POST ) );
-        $api_key   = get_option( 'rtbcb_openai_api_key', '' );
+		$post_keys = array_map( 'sanitize_key', array_keys( $_POST ) );
+		$api_key   = get_option( 'rtbcb_openai_api_key', '' );
 
-        global $wpdb;
-        $table_name   = $wpdb->prefix . 'rtbcb_leads';
-        $table_exists = ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name );
+		global $wpdb;
+		$table_name   = $wpdb->prefix . 'rtbcb_leads';
+		$table_exists = ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name );
 
-        $diagnostics = [
-            'wp_functions'     => function_exists( 'add_action' ) && function_exists( 'wp_send_json_success' ),
-            'required_classes' => class_exists( 'RTBCB_Calculator' ) && class_exists( 'RTBCB_DB' ),
-            'nonce_valid'      => $nonce_valid,
-            'post_keys'        => $post_keys,
-            'api_key_present'  => ! empty( $api_key ),
-            'db_table_exists'  => $table_exists,
-            'memory_usage'     => size_format( memory_get_usage( true ) ),
-        ];
+		$diagnostics = [
+			'wp_functions'     => function_exists( 'add_action' ) && function_exists( 'wp_send_json_success' ),
+			'required_classes' => class_exists( 'RTBCB_Calculator' ) && class_exists( 'RTBCB_DB' ),
+			'nonce_valid'      => $nonce_valid,
+			'post_keys'        => $post_keys,
+			'api_key_present'  => ! empty( $api_key ),
+			'db_table_exists'  => $table_exists,
+			'memory_usage'     => size_format( memory_get_usage( true ) ),
+		];
 
-        wp_send_json_success( $diagnostics );
-    }
+		wp_send_json_success( $diagnostics );
+	}
 
-    /**
-     * Handle simplified ROI test via AJAX.
-     *
-     * @return void
-     */
-    public function ajax_generate_case_simple() {
-        if ( ! check_ajax_referer( 'rtbcb_simple', 'rtbcb_nonce', false ) ) {
-            wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
-        }
+	/**
+	 * Handle simplified ROI test via AJAX.
+	 *
+	 * @return void
+	 */
+	public function ajax_generate_case_simple() {
+		if ( ! check_ajax_referer( 'rtbcb_simple', 'rtbcb_nonce', false ) ) {
+			wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
+		}
 
-        $investment_raw = wp_unslash( $_POST['investment'] ?? '' );
-        $returns_raw    = wp_unslash( $_POST['returns'] ?? '' );
+		$investment_raw = wp_unslash( $_POST['investment'] ?? '' );
+		$returns_raw    = wp_unslash( $_POST['returns'] ?? '' );
 
-        if ( ! is_numeric( $investment_raw ) || ! is_numeric( $returns_raw ) ) {
-            wp_send_json_error( __( 'Invalid values provided.', 'rtbcb' ), 400 );
-        }
+		if ( ! is_numeric( $investment_raw ) || ! is_numeric( $returns_raw ) ) {
+			wp_send_json_error( __( 'Invalid values provided.', 'rtbcb' ), 400 );
+		}
 
-        $investment = floatval( $investment_raw );
-        $returns    = floatval( $returns_raw );
+		$investment = floatval( $investment_raw );
+		$returns    = floatval( $returns_raw );
 
-        if ( $investment <= 0 || $returns <= 0 ) {
-            wp_send_json_error( __( 'Invalid values provided.', 'rtbcb' ), 400 );
-        }
+		if ( $investment <= 0 || $returns <= 0 ) {
+			wp_send_json_error( __( 'Invalid values provided.', 'rtbcb' ), 400 );
+		}
 
-        $roi = 0;
-        if ( $investment > 0 ) {
-            $roi = ( ( $returns - $investment ) / $investment ) * 100;
-        }
+		$roi = 0;
+		if ( $investment > 0 ) {
+			$roi = ( ( $returns - $investment ) / $investment ) * 100;
+		}
 
-        wp_send_json_success(
-            [
-                'roi' => round( $roi, 2 ),
-            ]
-        );
-    }
+		wp_send_json_success(
+			[
+				'roi' => round( $roi, 2 ),
+			]
+		);
+	}
 
 		/**
 		* Output debug information for report generation.
@@ -2576,38 +2576,38 @@ RTBCB_Main::instance();
 
 // Helper functions for use in templates and other plugins
 if ( ! function_exists( 'rtbcb_get_leads_count' ) ) {
-    /**
-     * Get total number of leads.
-     *
-     * @return int
-     */
-    function rtbcb_get_leads_count() {
-        $stats = RTBCB_Leads::get_cached_statistics();
-        return intval( $stats['total_leads'] ?? 0 );
-    }
+	/**
+	 * Get total number of leads.
+	 *
+	 * @return int
+	 */
+	function rtbcb_get_leads_count() {
+		$stats = RTBCB_Leads::get_cached_statistics();
+		return intval( $stats['total_leads'] ?? 0 );
+	}
 }
 
 if ( ! function_exists( 'rtbcb_get_average_roi' ) ) {
-    /**
-     * Get average ROI across all leads.
-     *
-     * @return float
-     */
-    function rtbcb_get_average_roi() {
-        $stats = RTBCB_Leads::get_cached_statistics();
-        return floatval( $stats['average_roi']['avg_base'] ?? 0 );
-    }
+	/**
+	 * Get average ROI across all leads.
+	 *
+	 * @return float
+	 */
+	function rtbcb_get_average_roi() {
+		$stats = RTBCB_Leads::get_cached_statistics();
+		return floatval( $stats['average_roi']['avg_base'] ?? 0 );
+	}
 }
 
 if ( ! function_exists( 'rtbcb_is_configured' ) ) {
-    /**
-     * Check if plugin is properly configured.
-     *
-     * @return bool
-     */
-    function rtbcb_is_configured() {
-        return ! empty( get_option( 'rtbcb_openai_api_key' ) );
-    }
+	/**
+	 * Check if plugin is properly configured.
+	 *
+	 * @return bool
+	 */
+	function rtbcb_is_configured() {
+		return ! empty( get_option( 'rtbcb_openai_api_key' ) );
+	}
 }
 
 
@@ -2619,260 +2619,260 @@ add_action( 'wp_ajax_rtbcb_clear_current_company', 'rtbcb_ajax_clear_current_com
 add_action( 'wp_ajax_rtbcb_company_overview_simple', 'rtbcb_handle_company_overview_simple' );
 
 /**
- * Simple AJAX handler to test company overview generation.
- *
- * @return void
- */
+	* Simple AJAX handler to test company overview generation.
+	*
+	* @return void
+	*/
 function rtbcb_handle_company_overview_simple() {
-    if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_company_overview' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
-        return;
-    }
+	if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_company_overview' ) ) {
+		wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
+		return;
+	}
 
-    $company_name = isset( $_POST['company_name'] ) ? sanitize_text_field( wp_unslash( $_POST['company_name'] ) ) : '';
+	$company_name = isset( $_POST['company_name'] ) ? sanitize_text_field( wp_unslash( $_POST['company_name'] ) ) : '';
 
-    if ( empty( $company_name ) ) {
-        wp_send_json_error( [ 'message' => __( 'Company name required', 'rtbcb' ) ] );
-        return;
-    }
+	if ( empty( $company_name ) ) {
+		wp_send_json_error( [ 'message' => __( 'Company name required', 'rtbcb' ) ] );
+		return;
+	}
 
-    wp_send_json_success(
-        [
-            'message'         => sprintf( __( 'Processing started for %s', 'rtbcb' ), $company_name ),
-            'status'          => 'processing',
-            'simple_analysis' => rtbcb_get_simple_company_info( $company_name ),
-        ]
-    );
+	wp_send_json_success(
+		[
+			'message'         => sprintf( __( 'Processing started for %s', 'rtbcb' ), $company_name ),
+			'status'          => 'processing',
+			'simple_analysis' => rtbcb_get_simple_company_info( $company_name ),
+		]
+	);
 }
 
 /**
- * Provide simple placeholder analysis for testing connections.
- *
- * @param string $company_name Company name.
- * @return array
- */
+	* Provide simple placeholder analysis for testing connections.
+	*
+	* @param string $company_name Company name.
+	* @return array
+	*/
 function rtbcb_get_simple_company_info( $company_name ) {
-    return [
-        'analysis'        => sprintf( __( 'Analysis requested for %s. This is a placeholder response to test the connection without LLM calls.', 'rtbcb' ), $company_name ),
-        'recommendations' => [
-            __( 'Implement treasury management system', 'rtbcb' ),
-            __( 'Automate cash forecasting', 'rtbcb' ),
-            __( 'Improve bank connectivity', 'rtbcb' ),
-        ],
-        'references'      => [
-            esc_url_raw( 'https://www.afponline.org' ),
-            esc_url_raw( 'https://www.treasury.gov' ),
-        ],
-        'generated_at'    => current_time( 'Y-m-d H:i:s' ),
-    ];
+	return [
+		'analysis'        => sprintf( __( 'Analysis requested for %s. This is a placeholder response to test the connection without LLM calls.', 'rtbcb' ), $company_name ),
+		'recommendations' => [
+			__( 'Implement treasury management system', 'rtbcb' ),
+			__( 'Automate cash forecasting', 'rtbcb' ),
+			__( 'Improve bank connectivity', 'rtbcb' ),
+		],
+		'references'      => [
+			esc_url_raw( 'https://www.afponline.org' ),
+			esc_url_raw( 'https://www.treasury.gov' ),
+		],
+		'generated_at'    => current_time( 'Y-m-d H:i:s' ),
+	];
 }
 
 /**
- * AJAX handler for generating company overview.
- *
- * @return void
- */
+	* AJAX handler for generating company overview.
+	*
+	* @return void
+	*/
 function rtbcb_ajax_generate_company_overview() {
-    if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_company_overview' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
-        return;
-    }
+	if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_company_overview' ) ) {
+		wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
+		return;
+	}
 
-    if ( ! current_user_can( 'manage_options' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        return;
-    }
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+		return;
+	}
 
-    $company_name = isset( $_POST['company_name'] ) ? sanitize_text_field( wp_unslash( $_POST['company_name'] ) ) : '';
-    $company_size = isset( $_POST['company_size'] ) ? sanitize_text_field( wp_unslash( $_POST['company_size'] ) ) : '';
-    $industry     = isset( $_POST['industry'] ) ? sanitize_text_field( wp_unslash( $_POST['industry'] ) ) : '';
+	$company_name = isset( $_POST['company_name'] ) ? sanitize_text_field( wp_unslash( $_POST['company_name'] ) ) : '';
+	$company_size = isset( $_POST['company_size'] ) ? sanitize_text_field( wp_unslash( $_POST['company_size'] ) ) : '';
+	$industry     = isset( $_POST['industry'] ) ? sanitize_text_field( wp_unslash( $_POST['industry'] ) ) : '';
 
-    if ( empty( $company_name ) ) {
-        wp_send_json_error( [ 'message' => __( 'Company name is required.', 'rtbcb' ) ] );
-        return;
-    }
+	if ( empty( $company_name ) ) {
+		wp_send_json_error( [ 'message' => __( 'Company name is required.', 'rtbcb' ) ] );
+		return;
+	}
 
-    // Increase timeout for comprehensive analysis
-    ini_set( 'max_execution_time', 300 ); // 5 minutes
-    wp_raise_memory_limit( '512M' ); // Increase memory limit if needed
+	// Increase timeout for comprehensive analysis
+	ini_set( 'max_execution_time', 300 ); // 5 minutes
+	wp_raise_memory_limit( '512M' ); // Increase memory limit if needed
 
-    $start_time = microtime( true );
+	$start_time = microtime( true );
 
-    try {
-        $overview = rtbcb_test_generate_company_overview( $company_name );
+	try {
+		$overview = rtbcb_test_generate_company_overview( $company_name );
 
-        if ( is_wp_error( $overview ) ) {
-            wp_send_json_error( [
-                'message' => sanitize_text_field( $overview->get_error_message() ),
-            ] );
-            return;
-        }
+		if ( is_wp_error( $overview ) ) {
+			wp_send_json_error( [
+				'message' => sanitize_text_field( $overview->get_error_message() ),
+			] );
+			return;
+		}
 
-        $analysis        = $overview['analysis'] ?? '';
-        $recommendations = array_map( 'sanitize_text_field', $overview['recommendations'] ?? [] );
-        $references      = array_map( 'esc_url_raw', $overview['references'] ?? [] );
+		$analysis        = $overview['analysis'] ?? '';
+		$recommendations = array_map( 'sanitize_text_field', $overview['recommendations'] ?? [] );
+		$references      = array_map( 'esc_url_raw', $overview['references'] ?? [] );
 
-        $word_count   = str_word_count( wp_strip_all_tags( $analysis ) );
-        $elapsed_time = microtime( true ) - $start_time;
-        $timestamp    = current_time( 'mysql' );
+		$word_count   = str_word_count( wp_strip_all_tags( $analysis ) );
+		$elapsed_time = microtime( true ) - $start_time;
+		$timestamp    = current_time( 'mysql' );
 
-        $company_data = [
-            'name'            => $company_name,
-            'summary'         => sanitize_textarea_field( wp_strip_all_tags( $analysis ) ),
-            'size'            => $company_size,
-            'industry'        => $industry,
-            'recommendations' => $recommendations,
-            'references'      => $references,
-            'word_count'      => intval( $word_count ),
-            'generated_at'    => $timestamp,
-        ];
+		$company_data = [
+			'name'            => $company_name,
+			'summary'         => sanitize_textarea_field( wp_strip_all_tags( $analysis ) ),
+			'size'            => $company_size,
+			'industry'        => $industry,
+			'recommendations' => $recommendations,
+			'references'      => $references,
+			'word_count'      => intval( $word_count ),
+			'generated_at'    => $timestamp,
+		];
 
-        update_option( 'rtbcb_current_company', $company_data );
+		update_option( 'rtbcb_current_company', $company_data );
 
-        wp_send_json_success(
-            [
-                'overview'        => wp_kses_post( $analysis ),
-                'company_name'    => $company_name,
-                'recommendations' => $recommendations,
-                'references'      => $references,
-                'word_count'      => intval( $word_count ),
-                'elapsed_time'    => round( $elapsed_time, 2 ),
-                'generated_at'    => $timestamp,
-            ]
-        );
-    } catch ( Exception $e ) {
-        error_log( 'RTBCB Company Overview Error: ' . $e->getMessage() );
-        wp_send_json_error(
-            [
-                'message' => __( 'An error occurred while generating the overview. Please try again.', 'rtbcb' ),
-            ]
-        );
-    }
+		wp_send_json_success(
+			[
+				'overview'        => wp_kses_post( $analysis ),
+				'company_name'    => $company_name,
+				'recommendations' => $recommendations,
+				'references'      => $references,
+				'word_count'      => intval( $word_count ),
+				'elapsed_time'    => round( $elapsed_time, 2 ),
+				'generated_at'    => $timestamp,
+			]
+		);
+	} catch ( Exception $e ) {
+		error_log( 'RTBCB Company Overview Error: ' . $e->getMessage() );
+		wp_send_json_error(
+			[
+				'message' => __( 'An error occurred while generating the overview. Please try again.', 'rtbcb' ),
+			]
+		);
+	}
 }
 
 /**
- * AJAX handler to clear current company data.
- *
- * @return void
- */
+	* AJAX handler to clear current company data.
+	*
+	* @return void
+	*/
 function rtbcb_ajax_clear_current_company() {
-    if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_company_overview' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
-        return;
-    }
+	if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_company_overview' ) ) {
+		wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
+		return;
+	}
 
-    if ( ! current_user_can( 'manage_options' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        return;
-    }
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+		return;
+	}
 
-    rtbcb_clear_current_company();
+	rtbcb_clear_current_company();
 
-    wp_send_json_success();
+	wp_send_json_success();
 }
 
 /**
- * AJAX handler for generating Real Treasury platform overview.
- *
- * @return void
- */
+	* AJAX handler for generating Real Treasury platform overview.
+	*
+	* @return void
+	*/
 function rtbcb_ajax_generate_real_treasury_overview() {
-    if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_real_treasury_overview' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
-        return;
-    }
+	if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_real_treasury_overview' ) ) {
+		wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
+		return;
+	}
 
-    if ( ! current_user_can( 'manage_options' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        return;
-    }
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+		return;
+	}
 
-    $company = rtbcb_get_current_company();
-    if ( empty( $company ) ) {
-        wp_send_json_error( [ 'message' => __( 'No company data found. Please run the company overview first.', 'rtbcb' ) ] );
-        return;
-    }
+	$company = rtbcb_get_current_company();
+	if ( empty( $company ) ) {
+		wp_send_json_error( [ 'message' => __( 'No company data found. Please run the company overview first.', 'rtbcb' ) ] );
+		return;
+	}
 
-    $include_portal = isset( $_POST['include_portal'] ) ? rest_sanitize_boolean( wp_unslash( $_POST['include_portal'] ) ) : false;
-    $categories     = [];
-    if ( isset( $_POST['vendor_categories'] ) ) {
-        $categories = array_filter( array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['vendor_categories'] ) ) );
-    }
+	$include_portal = isset( $_POST['include_portal'] ) ? rest_sanitize_boolean( wp_unslash( $_POST['include_portal'] ) ) : false;
+	$categories     = [];
+	if ( isset( $_POST['vendor_categories'] ) ) {
+		$categories = array_filter( array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['vendor_categories'] ) ) );
+	}
 
-    $start_time = microtime( true );
+	$start_time = microtime( true );
 
-    try {
-        $overview = rtbcb_test_generate_real_treasury_overview( $include_portal, $categories );
+	try {
+		$overview = rtbcb_test_generate_real_treasury_overview( $include_portal, $categories );
 
-        if ( is_wp_error( $overview ) ) {
-            wp_send_json_error( [ 'message' => sanitize_text_field( $overview->get_error_message() ) ] );
-            return;
-        }
+		if ( is_wp_error( $overview ) ) {
+			wp_send_json_error( [ 'message' => sanitize_text_field( $overview->get_error_message() ) ] );
+			return;
+		}
 
-        $word_count   = str_word_count( wp_strip_all_tags( $overview ) );
-        $elapsed_time = microtime( true ) - $start_time;
-        $timestamp    = current_time( 'mysql' );
+		$word_count   = str_word_count( wp_strip_all_tags( $overview ) );
+		$elapsed_time = microtime( true ) - $start_time;
+		$timestamp    = current_time( 'mysql' );
 
-        wp_send_json_success(
-            [
-                'overview'       => wp_kses_post( $overview ),
-                'include_portal' => $include_portal,
-                'categories'     => $categories,
-                'word_count'     => intval( $word_count ),
-                'elapsed_time'   => round( $elapsed_time, 2 ),
-                'generated_at'   => $timestamp,
-            ]
-        );
-    } catch ( Exception $e ) {
-        error_log( 'RTBCB Real Treasury Overview Error: ' . $e->getMessage() );
-        wp_send_json_error(
-            [
-                'message' => __( 'An error occurred while generating the overview. Please try again.', 'rtbcb' ),
-            ]
-        );
-    }
+		wp_send_json_success(
+			[
+				'overview'       => wp_kses_post( $overview ),
+				'include_portal' => $include_portal,
+				'categories'     => $categories,
+				'word_count'     => intval( $word_count ),
+				'elapsed_time'   => round( $elapsed_time, 2 ),
+				'generated_at'   => $timestamp,
+			]
+		);
+	} catch ( Exception $e ) {
+		error_log( 'RTBCB Real Treasury Overview Error: ' . $e->getMessage() );
+		wp_send_json_error(
+			[
+				'message' => __( 'An error occurred while generating the overview. Please try again.', 'rtbcb' ),
+			]
+		);
+	}
 }
 
 /**
- * AJAX handler for generating category recommendation.
- *
- * @return void
- */
+	* AJAX handler for generating category recommendation.
+	*
+	* @return void
+	*/
 function rtbcb_ajax_generate_category_recommendation() {
-    if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_category_recommendation' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
-        return;
-    }
+	if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rtbcb_test_category_recommendation' ) ) {
+		wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
+		return;
+	}
 
-    if ( ! current_user_can( 'manage_options' ) ) {
-        wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
-        return;
-    }
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'rtbcb' ) ] );
+		return;
+	}
 
-    $company = rtbcb_get_current_company();
-    if ( empty( $company ) ) {
-        wp_send_json_error( [ 'message' => __( 'No company data found. Please run the company overview first.', 'rtbcb' ) ] );
-        return;
-    }
+	$company = rtbcb_get_current_company();
+	if ( empty( $company ) ) {
+		wp_send_json_error( [ 'message' => __( 'No company data found. Please run the company overview first.', 'rtbcb' ) ] );
+		return;
+	}
 
-    $extra_requirements = isset( $_POST['extra_requirements'] ) ? sanitize_textarea_field( wp_unslash( $_POST['extra_requirements'] ) ) : '';
+	$extra_requirements = isset( $_POST['extra_requirements'] ) ? sanitize_textarea_field( wp_unslash( $_POST['extra_requirements'] ) ) : '';
 
-    $analysis = [
-        'company_overview'    => sanitize_textarea_field( get_option( 'rtbcb_company_overview', '' ) ),
-        'industry_insights'   => sanitize_textarea_field( get_option( 'rtbcb_industry_insights', '' ) ),
-        'maturity_model'      => sanitize_textarea_field( get_option( 'rtbcb_maturity_model', '' ) ),
-        'rag_market_analysis' => get_option( 'rtbcb_rag_market_analysis', [] ),
-        'value_proposition'   => sanitize_textarea_field( get_option( 'rtbcb_value_proposition', '' ) ),
-        'treasury_challenges' => sanitize_textarea_field( get_option( 'rtbcb_treasury_challenges', '' ) ),
-        'extra_requirements'  => $extra_requirements,
-    ];
+	$analysis = [
+		'company_overview'    => sanitize_textarea_field( get_option( 'rtbcb_company_overview', '' ) ),
+		'industry_insights'   => sanitize_textarea_field( get_option( 'rtbcb_industry_insights', '' ) ),
+		'maturity_model'      => sanitize_textarea_field( get_option( 'rtbcb_maturity_model', '' ) ),
+		'rag_market_analysis' => get_option( 'rtbcb_rag_market_analysis', [] ),
+		'value_proposition'   => sanitize_textarea_field( get_option( 'rtbcb_value_proposition', '' ) ),
+		'treasury_challenges' => sanitize_textarea_field( get_option( 'rtbcb_treasury_challenges', '' ) ),
+		'extra_requirements'  => $extra_requirements,
+	];
 
-    try {
-        $recommendation = rtbcb_test_generate_category_recommendation( $analysis );
-        wp_send_json_success( $recommendation );
-    } catch ( Exception $e ) {
-        wp_send_json_error( [ 'message' => __( 'An error occurred while generating the recommendation.', 'rtbcb' ) ] );
-    }
+	try {
+		$recommendation = rtbcb_test_generate_category_recommendation( $analysis );
+		wp_send_json_success( $recommendation );
+	} catch ( Exception $e ) {
+		wp_send_json_error( [ 'message' => __( 'An error occurred while generating the recommendation.', 'rtbcb' ) ] );
+	}
 }
 
 // Enqueue admin scripts for company overview page.
@@ -2881,109 +2881,109 @@ add_action( 'admin_enqueue_scripts', 'rtbcb_enqueue_real_treasury_overview_scrip
 add_action( 'admin_enqueue_scripts', 'rtbcb_enqueue_recommended_category_scripts' );
 
 /**
- * Enqueue admin scripts for company overview page.
- *
- * @param string $hook Current admin page hook.
- * @return void
- */
+	* Enqueue admin scripts for company overview page.
+	*
+	* @param string $hook Current admin page hook.
+	* @return void
+	*/
 function rtbcb_enqueue_company_overview_scripts( $hook ) {
-    $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
-    if ( strpos( $hook, 'rtbcb' ) !== false && ( strpos( $hook, 'company-overview' ) !== false || 'rtbcb-test-dashboard' === $page ) ) {
-        wp_enqueue_script(
-            'rtbcb-test-utils',
-            plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
-            [ 'jquery' ],
-            '1.0.0',
-            true
-        );
-        wp_enqueue_script(
-            'rtbcb-company-overview',
-            plugin_dir_url( __FILE__ ) . 'admin/js/company-overview.js',
-            [ 'jquery', 'rtbcb-test-utils' ],
-            '1.0.0',
-            true
-        );
+	$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+	if ( strpos( $hook, 'rtbcb' ) !== false && ( strpos( $hook, 'company-overview' ) !== false || 'rtbcb-test-dashboard' === $page ) ) {
+		wp_enqueue_script(
+			'rtbcb-test-utils',
+			plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
+			[ 'jquery' ],
+			'1.0.0',
+			true
+		);
+		wp_enqueue_script(
+			'rtbcb-company-overview',
+			plugin_dir_url( __FILE__ ) . 'admin/js/company-overview.js',
+			[ 'jquery', 'rtbcb-test-utils' ],
+			'1.0.0',
+			true
+		);
 
-        wp_localize_script(
-            'rtbcb-company-overview',
-            'rtbcb_ajax',
-            [
-                'ajax_url' => admin_url( 'admin-ajax.php' ),
-                'nonce'    => wp_create_nonce( 'rtbcb_test_company_overview' ),
-                'timeout'  => rtbcb_get_api_timeout() * 1000,
-            ]
-        );
-    }
+		wp_localize_script(
+			'rtbcb-company-overview',
+			'rtbcb_ajax',
+			[
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'rtbcb_test_company_overview' ),
+				'timeout'  => rtbcb_get_api_timeout() * 1000,
+			]
+		);
+	}
 }
 
 /**
- * Enqueue admin scripts for real treasury overview page.
- *
- * @param string $hook Current admin page hook.
- * @return void
- */
+	* Enqueue admin scripts for real treasury overview page.
+	*
+	* @param string $hook Current admin page hook.
+	* @return void
+	*/
 function rtbcb_enqueue_real_treasury_overview_scripts( $hook ) {
-    $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
-    if ( strpos( $hook, 'rtbcb' ) !== false && ( strpos( $hook, 'real-treasury-overview' ) !== false || 'rtbcb-test-dashboard' === $page ) ) {
-        wp_enqueue_script(
-            'rtbcb-test-utils',
-            plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
-            [ 'jquery' ],
-            '1.0.0',
-            true
-        );
-        wp_enqueue_script(
-            'rtbcb-real-treasury-overview',
-            plugin_dir_url( __FILE__ ) . 'admin/js/real-treasury-overview.js',
-            [ 'jquery', 'rtbcb-test-utils' ],
-            '1.0.0',
-            true
-        );
+	$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+	if ( strpos( $hook, 'rtbcb' ) !== false && ( strpos( $hook, 'real-treasury-overview' ) !== false || 'rtbcb-test-dashboard' === $page ) ) {
+		wp_enqueue_script(
+			'rtbcb-test-utils',
+			plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
+			[ 'jquery' ],
+			'1.0.0',
+			true
+		);
+		wp_enqueue_script(
+			'rtbcb-real-treasury-overview',
+			plugin_dir_url( __FILE__ ) . 'admin/js/real-treasury-overview.js',
+			[ 'jquery', 'rtbcb-test-utils' ],
+			'1.0.0',
+			true
+		);
 
-        wp_localize_script(
-            'rtbcb-real-treasury-overview',
-            'rtbcb_ajax',
-            [
-                'ajax_url' => admin_url( 'admin-ajax.php' ),
-                'nonce'    => wp_create_nonce( 'rtbcb_test_real_treasury_overview' ),
-            ]
-        );
-    }
+		wp_localize_script(
+			'rtbcb-real-treasury-overview',
+			'rtbcb_ajax',
+			[
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'rtbcb_test_real_treasury_overview' ),
+			]
+		);
+	}
 }
 
 /**
- * Enqueue admin scripts for category recommendation page.
- *
- * @param string $hook Current admin page hook.
- * @return void
- */
+	* Enqueue admin scripts for category recommendation page.
+	*
+	* @param string $hook Current admin page hook.
+	* @return void
+	*/
 function rtbcb_enqueue_recommended_category_scripts( $hook ) {
-    $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+	$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
 
-    if ( false !== strpos( $page, 'recommended-category' ) || 'rtbcb-test-dashboard' === $page ) {
-        wp_enqueue_script(
-            'rtbcb-test-utils',
-            plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
-            [ 'jquery' ],
-            '1.0.0',
-            true
-        );
-        wp_enqueue_script(
-            'rtbcb-recommended-category',
-            plugin_dir_url( __FILE__ ) . 'admin/js/recommended-category.js',
-            [ 'jquery', 'rtbcb-test-utils' ],
-            '1.0.0',
-            true
-        );
+	if ( false !== strpos( $page, 'recommended-category' ) || 'rtbcb-test-dashboard' === $page ) {
+		wp_enqueue_script(
+			'rtbcb-test-utils',
+			plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
+			[ 'jquery' ],
+			'1.0.0',
+			true
+		);
+		wp_enqueue_script(
+			'rtbcb-recommended-category',
+			plugin_dir_url( __FILE__ ) . 'admin/js/recommended-category.js',
+			[ 'jquery', 'rtbcb-test-utils' ],
+			'1.0.0',
+			true
+		);
 
-        wp_localize_script(
-            'rtbcb-recommended-category',
-            'rtbcb_ajax',
-            [
-                'ajax_url' => admin_url( 'admin-ajax.php' ),
-                'nonce'    => wp_create_nonce( 'rtbcb_test_category_recommendation' ),
-            ]
-        );
-    }
+		wp_localize_script(
+			'rtbcb-recommended-category',
+			'rtbcb_ajax',
+			[
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'rtbcb_test_category_recommendation' ),
+			]
+		);
+	}
 }
 

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -2,10 +2,10 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Enhanced template for the business case form.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Enhanced template for the business case form.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 // Default values for template arguments
 $style   = $style ?? 'default';
@@ -18,436 +18,436 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 
 <!-- Trigger Button -->
 <div class="rtbcb-trigger-container">
-    <button type="button" class="rtbcb-trigger-btn" onclick="openBusinessCaseModal()">
-        <span class="rtbcb-trigger-icon">📊</span>
-        <span class="rtbcb-trigger-text"><?php esc_html_e( 'Build Your Business Case', 'rtbcb' ); ?></span>
-        <span class="rtbcb-trigger-subtitle"><?php esc_html_e( 'Generate ROI analysis in minutes', 'rtbcb' ); ?></span>
-    </button>
+	<button type="button" class="rtbcb-trigger-btn" onclick="openBusinessCaseModal()">
+		<span class="rtbcb-trigger-icon">📊</span>
+		<span class="rtbcb-trigger-text"><?php esc_html_e( 'Build Your Business Case', 'rtbcb' ); ?></span>
+		<span class="rtbcb-trigger-subtitle"><?php esc_html_e( 'Generate ROI analysis in minutes', 'rtbcb' ); ?></span>
+	</button>
 </div>
 
 <!-- Modal Overlay -->
 <div class="rtbcb-modal-overlay" id="rtbcbModalOverlay">
-    <div class="rtbcb-modal-container rtbcb-modal">
-        <!-- Modal Header -->
-        <div class="rtbcb-modal-header">
-            <button type="button" class="rtbcb-modal-close" onclick="closeBusinessCaseModal()">&times;</button>
-            <h2 class="rtbcb-modal-title"><?php echo esc_html( $title ); ?></h2>
-            <p class="rtbcb-modal-subtitle"><?php echo esc_html( $subtitle ); ?></p>
-        </div>
+	<div class="rtbcb-modal-container rtbcb-modal">
+		<!-- Modal Header -->
+		<div class="rtbcb-modal-header">
+			<button type="button" class="rtbcb-modal-close" onclick="closeBusinessCaseModal()">&times;</button>
+			<h2 class="rtbcb-modal-title"><?php echo esc_html( $title ); ?></h2>
+			<p class="rtbcb-modal-subtitle"><?php echo esc_html( $subtitle ); ?></p>
+		</div>
 
-        <!-- Modal Body -->
-        <div class="rtbcb-modal-body">
-            <div class="rtbcb-form-container">
-                <form id="rtbcbForm" class="rtbcb-form rtbcb-wizard" method="post" novalidate>
+		<!-- Modal Body -->
+		<div class="rtbcb-modal-body">
+			<div class="rtbcb-form-container">
+				<form id="rtbcbForm" class="rtbcb-form rtbcb-wizard" method="post" novalidate>
 
-                    <!-- Progress Indicator -->
-                    <div class="rtbcb-wizard-progress">
-                        <div class="rtbcb-progress-line"></div>
-                        <div class="rtbcb-progress-steps">
-                            <div class="rtbcb-progress-step active" data-step="1">
-                                <div class="rtbcb-progress-number">1</div>
-                                <div class="rtbcb-progress-label"><?php esc_html_e( 'Company', 'rtbcb' ); ?></div>
-                            </div>
-                            <div class="rtbcb-progress-step" data-step="2">
-                                <div class="rtbcb-progress-number">2</div>
-                                <div class="rtbcb-progress-label"><?php esc_html_e( 'Operations', 'rtbcb' ); ?></div>
-                            </div>
-                            <div class="rtbcb-progress-step" data-step="3">
-                                <div class="rtbcb-progress-number">3</div>
-                                <div class="rtbcb-progress-label"><?php esc_html_e( 'Challenges', 'rtbcb' ); ?></div>
-                            </div>
-                            <div class="rtbcb-progress-step" data-step="4">
-                                <div class="rtbcb-progress-number">4</div>
-                                <div class="rtbcb-progress-label"><?php esc_html_e( 'Strategy', 'rtbcb' ); ?></div>
-                            </div>
-                            <div class="rtbcb-progress-step" data-step="5">
-                                <div class="rtbcb-progress-number">5</div>
-                                <div class="rtbcb-progress-label"><?php esc_html_e( 'Contact', 'rtbcb' ); ?></div>
-                            </div>
-                        </div>
-                    </div>
+					<!-- Progress Indicator -->
+					<div class="rtbcb-wizard-progress">
+						<div class="rtbcb-progress-line"></div>
+						<div class="rtbcb-progress-steps">
+							<div class="rtbcb-progress-step active" data-step="1">
+								<div class="rtbcb-progress-number">1</div>
+								<div class="rtbcb-progress-label"><?php esc_html_e( 'Company', 'rtbcb' ); ?></div>
+							</div>
+							<div class="rtbcb-progress-step" data-step="2">
+								<div class="rtbcb-progress-number">2</div>
+								<div class="rtbcb-progress-label"><?php esc_html_e( 'Operations', 'rtbcb' ); ?></div>
+							</div>
+							<div class="rtbcb-progress-step" data-step="3">
+								<div class="rtbcb-progress-number">3</div>
+								<div class="rtbcb-progress-label"><?php esc_html_e( 'Challenges', 'rtbcb' ); ?></div>
+							</div>
+							<div class="rtbcb-progress-step" data-step="4">
+								<div class="rtbcb-progress-number">4</div>
+								<div class="rtbcb-progress-label"><?php esc_html_e( 'Strategy', 'rtbcb' ); ?></div>
+							</div>
+							<div class="rtbcb-progress-step" data-step="5">
+								<div class="rtbcb-progress-number">5</div>
+								<div class="rtbcb-progress-label"><?php esc_html_e( 'Contact', 'rtbcb' ); ?></div>
+							</div>
+						</div>
+					</div>
 
-                    <!-- Steps Container -->
-                    <div class="rtbcb-wizard-steps">
-            <!-- Step 1: Company Profile - UPDATED -->
-            <div class="rtbcb-wizard-step active" data-step="1">
-                <div class="rtbcb-step-header">
-                    <h3><?php esc_html_e( 'Tell us about your company', 'rtbcb' ); ?></h3>
-                    <p><?php esc_html_e( 'This helps us provide relevant recommendations for your organization.', 'rtbcb' ); ?></p>
-                </div>
+					<!-- Steps Container -->
+					<div class="rtbcb-wizard-steps">
+			<!-- Step 1: Company Profile - UPDATED -->
+			<div class="rtbcb-wizard-step active" data-step="1">
+				<div class="rtbcb-step-header">
+					<h3><?php esc_html_e( 'Tell us about your company', 'rtbcb' ); ?></h3>
+					<p><?php esc_html_e( 'This helps us provide relevant recommendations for your organization.', 'rtbcb' ); ?></p>
+				</div>
 
-                <div class="rtbcb-step-content">
-                    <!-- NEW: Company Name Field -->
-                    <div class="rtbcb-field rtbcb-field-required">
-                        <label for="company_name">
-                            <?php esc_html_e( 'Company Name', 'rtbcb' ); ?>
-                        </label>
-                        <input type="text" name="company_name" id="company_name" 
-                               placeholder="<?php esc_attr_e( 'Enter your company name', 'rtbcb' ); ?>" 
-                               required 
-                               maxlength="100" />
-                        <div class="rtbcb-field-help">
-                            <?php esc_html_e( 'This will be used to personalize your business case report', 'rtbcb' ); ?>
-                        </div>
-                    </div>
+				<div class="rtbcb-step-content">
+					<!-- NEW: Company Name Field -->
+					<div class="rtbcb-field rtbcb-field-required">
+						<label for="company_name">
+							<?php esc_html_e( 'Company Name', 'rtbcb' ); ?>
+						</label>
+						<input type="text" name="company_name" id="company_name" 
+							   placeholder="<?php esc_attr_e( 'Enter your company name', 'rtbcb' ); ?>" 
+							   required 
+							   maxlength="100" />
+						<div class="rtbcb-field-help">
+							<?php esc_html_e( 'This will be used to personalize your business case report', 'rtbcb' ); ?>
+						</div>
+					</div>
 
-                    <div class="rtbcb-field rtbcb-field-required">
-                        <label for="company_size">
-                            <?php esc_html_e( 'Company Size (Annual Revenue)', 'rtbcb' ); ?>
-                        </label>
-                        <select name="company_size" id="company_size" required>
-                            <option value=""><?php esc_html_e( 'Select your company size...', 'rtbcb' ); ?></option>
-                            <option value="&lt;$50M"><?php esc_html_e( 'Small Business (&lt;$50M)', 'rtbcb' ); ?></option>
-                            <option value="$50M-$500M"><?php esc_html_e( 'Mid-Market ($50M-$500M)', 'rtbcb' ); ?></option>
-                            <option value="$500M-$2B"><?php esc_html_e( 'Large Enterprise ($500M-$2B)', 'rtbcb' ); ?></option>
-                            <option value="&gt;$2B"><?php esc_html_e( 'Fortune 500 (&gt;$2B)', 'rtbcb' ); ?></option>
-                        </select>
-                    </div>
+					<div class="rtbcb-field rtbcb-field-required">
+						<label for="company_size">
+							<?php esc_html_e( 'Company Size (Annual Revenue)', 'rtbcb' ); ?>
+						</label>
+						<select name="company_size" id="company_size" required>
+							<option value=""><?php esc_html_e( 'Select your company size...', 'rtbcb' ); ?></option>
+							<option value="&lt;$50M"><?php esc_html_e( 'Small Business (&lt;$50M)', 'rtbcb' ); ?></option>
+							<option value="$50M-$500M"><?php esc_html_e( 'Mid-Market ($50M-$500M)', 'rtbcb' ); ?></option>
+							<option value="$500M-$2B"><?php esc_html_e( 'Large Enterprise ($500M-$2B)', 'rtbcb' ); ?></option>
+							<option value="&gt;$2B"><?php esc_html_e( 'Fortune 500 (&gt;$2B)', 'rtbcb' ); ?></option>
+						</select>
+					</div>
 
-                    <div class="rtbcb-field rtbcb-field-required">
-                        <label for="industry">
-                            <?php esc_html_e( 'Industry', 'rtbcb' ); ?>
-                        </label>
-                        <select name="industry" id="industry" required>
-                            <option value=""><?php esc_html_e( 'Select your industry...', 'rtbcb' ); ?></option>
-                            <option value="manufacturing"><?php esc_html_e( 'Manufacturing', 'rtbcb' ); ?></option>
-                            <option value="retail"><?php esc_html_e( 'Retail & E-commerce', 'rtbcb' ); ?></option>
-                            <option value="healthcare"><?php esc_html_e( 'Healthcare', 'rtbcb' ); ?></option>
-                            <option value="technology"><?php esc_html_e( 'Technology', 'rtbcb' ); ?></option>
-                            <option value="financial_services"><?php esc_html_e( 'Financial Services', 'rtbcb' ); ?></option>
-                            <option value="energy"><?php esc_html_e( 'Energy & Utilities', 'rtbcb' ); ?></option>
-                            <option value="real_estate"><?php esc_html_e( 'Real Estate', 'rtbcb' ); ?></option>
-                            <option value="professional_services"><?php esc_html_e( 'Professional Services', 'rtbcb' ); ?></option>
-                            <option value="transportation"><?php esc_html_e( 'Transportation & Logistics', 'rtbcb' ); ?></option>
-                            <option value="education"><?php esc_html_e( 'Education', 'rtbcb' ); ?></option>
-                            <option value="government"><?php esc_html_e( 'Government', 'rtbcb' ); ?></option>
-                            <option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
-                        </select>
-                    </div>
+					<div class="rtbcb-field rtbcb-field-required">
+						<label for="industry">
+							<?php esc_html_e( 'Industry', 'rtbcb' ); ?>
+						</label>
+						<select name="industry" id="industry" required>
+							<option value=""><?php esc_html_e( 'Select your industry...', 'rtbcb' ); ?></option>
+							<option value="manufacturing"><?php esc_html_e( 'Manufacturing', 'rtbcb' ); ?></option>
+							<option value="retail"><?php esc_html_e( 'Retail & E-commerce', 'rtbcb' ); ?></option>
+							<option value="healthcare"><?php esc_html_e( 'Healthcare', 'rtbcb' ); ?></option>
+							<option value="technology"><?php esc_html_e( 'Technology', 'rtbcb' ); ?></option>
+							<option value="financial_services"><?php esc_html_e( 'Financial Services', 'rtbcb' ); ?></option>
+							<option value="energy"><?php esc_html_e( 'Energy & Utilities', 'rtbcb' ); ?></option>
+							<option value="real_estate"><?php esc_html_e( 'Real Estate', 'rtbcb' ); ?></option>
+							<option value="professional_services"><?php esc_html_e( 'Professional Services', 'rtbcb' ); ?></option>
+							<option value="transportation"><?php esc_html_e( 'Transportation & Logistics', 'rtbcb' ); ?></option>
+							<option value="education"><?php esc_html_e( 'Education', 'rtbcb' ); ?></option>
+							<option value="government"><?php esc_html_e( 'Government', 'rtbcb' ); ?></option>
+							<option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
+						</select>
+					</div>
 
-                    <!-- Optional: Add current position field for more personalization -->
-                    <div class="rtbcb-field">
-                        <label for="job_title"><?php esc_html_e( 'Your Role (Optional)', 'rtbcb' ); ?></label>
-                        <select name="job_title" id="job_title">
-                            <option value=""><?php esc_html_e( 'Select your role...', 'rtbcb' ); ?></option>
-                            <option value="cfo"><?php esc_html_e( 'CFO', 'rtbcb' ); ?></option>
-                            <option value="treasurer"><?php esc_html_e( 'Treasurer', 'rtbcb' ); ?></option>
-                            <option value="finance_director"><?php esc_html_e( 'Finance Director', 'rtbcb' ); ?></option>
-                            <option value="finance_manager"><?php esc_html_e( 'Finance Manager', 'rtbcb' ); ?></option>
-                            <option value="treasury_analyst"><?php esc_html_e( 'Treasury Analyst', 'rtbcb' ); ?></option>
-                            <option value="controller"><?php esc_html_e( 'Controller', 'rtbcb' ); ?></option>
-                            <option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
-                        </select>
-                        <div class="rtbcb-field-help">
-                            <?php esc_html_e( 'Helps us tailor recommendations to your perspective', 'rtbcb' ); ?>
-                        </div>
-                    </div>
-                </div>
-            </div>
+					<!-- Optional: Add current position field for more personalization -->
+					<div class="rtbcb-field">
+						<label for="job_title"><?php esc_html_e( 'Your Role (Optional)', 'rtbcb' ); ?></label>
+						<select name="job_title" id="job_title">
+							<option value=""><?php esc_html_e( 'Select your role...', 'rtbcb' ); ?></option>
+							<option value="cfo"><?php esc_html_e( 'CFO', 'rtbcb' ); ?></option>
+							<option value="treasurer"><?php esc_html_e( 'Treasurer', 'rtbcb' ); ?></option>
+							<option value="finance_director"><?php esc_html_e( 'Finance Director', 'rtbcb' ); ?></option>
+							<option value="finance_manager"><?php esc_html_e( 'Finance Manager', 'rtbcb' ); ?></option>
+							<option value="treasury_analyst"><?php esc_html_e( 'Treasury Analyst', 'rtbcb' ); ?></option>
+							<option value="controller"><?php esc_html_e( 'Controller', 'rtbcb' ); ?></option>
+							<option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
+						</select>
+						<div class="rtbcb-field-help">
+							<?php esc_html_e( 'Helps us tailor recommendations to your perspective', 'rtbcb' ); ?>
+						</div>
+					</div>
+				</div>
+			</div>
 
-            <!-- Step 2: Treasury Operations -->
-            <div class="rtbcb-wizard-step" data-step="2">
-                <div class="rtbcb-step-header">
-                    <h3><?php esc_html_e( 'Your current treasury operations', 'rtbcb' ); ?></h3>
-                      <p><?php esc_html_e( 'Help us understand your current workload and banking relationships.', 'rtbcb' ); ?></p>
-                </div>
-                
-                <div class="rtbcb-step-content">
-                    <div class="rtbcb-field rtbcb-field-required">
-                        <label for="hours_reconciliation">
-                            <?php esc_html_e( 'Weekly Hours: Bank Reconciliation', 'rtbcb' ); ?>
-                        </label>
-                        <input type="number" name="hours_reconciliation" id="hours_reconciliation"
-                               min="0" max="168" step="0.5" placeholder="0" required inputmode="decimal" />
-                        <div class="rtbcb-field-help">
-                            <?php esc_html_e( 'Total weekly hours spent on bank reconciliation tasks', 'rtbcb' ); ?>
-                        </div>
-                    </div>
+			<!-- Step 2: Treasury Operations -->
+			<div class="rtbcb-wizard-step" data-step="2">
+				<div class="rtbcb-step-header">
+					<h3><?php esc_html_e( 'Your current treasury operations', 'rtbcb' ); ?></h3>
+					  <p><?php esc_html_e( 'Help us understand your current workload and banking relationships.', 'rtbcb' ); ?></p>
+				</div>
+				
+				<div class="rtbcb-step-content">
+					<div class="rtbcb-field rtbcb-field-required">
+						<label for="hours_reconciliation">
+							<?php esc_html_e( 'Weekly Hours: Bank Reconciliation', 'rtbcb' ); ?>
+						</label>
+						<input type="number" name="hours_reconciliation" id="hours_reconciliation"
+							   min="0" max="168" step="0.5" placeholder="0" required inputmode="decimal" />
+						<div class="rtbcb-field-help">
+							<?php esc_html_e( 'Total weekly hours spent on bank reconciliation tasks', 'rtbcb' ); ?>
+						</div>
+					</div>
 
-                    <div class="rtbcb-field rtbcb-field-required">
-                        <label for="hours_cash_positioning">
-                            <?php esc_html_e( 'Weekly Hours: Cash Positioning', 'rtbcb' ); ?>
-                        </label>
-                        <input type="number" name="hours_cash_positioning" id="hours_cash_positioning"
-                               min="0" max="168" step="0.5" placeholder="0" required inputmode="decimal" />
-                        <div class="rtbcb-field-help">
-                            <?php esc_html_e( 'Time spent on cash visibility, forecasting, and positioning', 'rtbcb' ); ?>
-                        </div>
-                    </div>
+					<div class="rtbcb-field rtbcb-field-required">
+						<label for="hours_cash_positioning">
+							<?php esc_html_e( 'Weekly Hours: Cash Positioning', 'rtbcb' ); ?>
+						</label>
+						<input type="number" name="hours_cash_positioning" id="hours_cash_positioning"
+							   min="0" max="168" step="0.5" placeholder="0" required inputmode="decimal" />
+						<div class="rtbcb-field-help">
+							<?php esc_html_e( 'Time spent on cash visibility, forecasting, and positioning', 'rtbcb' ); ?>
+						</div>
+					</div>
 
-                    <div class="rtbcb-field rtbcb-field-required">
-                        <label for="num_banks">
-                            <?php esc_html_e( 'Number of Banking Relationships', 'rtbcb' ); ?>
-                        </label>
-                        <input type="number" name="num_banks" id="num_banks"
-                               min="1" max="50" placeholder="0" required inputmode="decimal" />
-                        <div class="rtbcb-field-help">
-                            <?php esc_html_e( 'Total number of banks where your company maintains accounts', 'rtbcb' ); ?>
-                        </div>
-                    </div>
+					<div class="rtbcb-field rtbcb-field-required">
+						<label for="num_banks">
+							<?php esc_html_e( 'Number of Banking Relationships', 'rtbcb' ); ?>
+						</label>
+						<input type="number" name="num_banks" id="num_banks"
+							   min="1" max="50" placeholder="0" required inputmode="decimal" />
+						<div class="rtbcb-field-help">
+							<?php esc_html_e( 'Total number of banks where your company maintains accounts', 'rtbcb' ); ?>
+						</div>
+					</div>
 
-                    <div class="rtbcb-field rtbcb-field-required">
-                        <label for="ftes">
-                            <?php esc_html_e( 'Treasury Team Size (FTEs)', 'rtbcb' ); ?>
-                        </label>
-                        <input type="number" name="ftes" id="ftes"
-                               min="0.5" max="100" step="0.5" placeholder="0" required inputmode="decimal" />
-                        <div class="rtbcb-field-help">
-                            <?php esc_html_e( 'Full-time equivalent employees dedicated to treasury functions', 'rtbcb' ); ?>
-                        </div>
-                    </div>
-                </div>
-            </div>
+					<div class="rtbcb-field rtbcb-field-required">
+						<label for="ftes">
+							<?php esc_html_e( 'Treasury Team Size (FTEs)', 'rtbcb' ); ?>
+						</label>
+						<input type="number" name="ftes" id="ftes"
+							   min="0.5" max="100" step="0.5" placeholder="0" required inputmode="decimal" />
+						<div class="rtbcb-field-help">
+							<?php esc_html_e( 'Full-time equivalent employees dedicated to treasury functions', 'rtbcb' ); ?>
+						</div>
+					</div>
+				</div>
+			</div>
 
-            <!-- Step 3: Treasury Challenges -->
-            <div class="rtbcb-wizard-step" data-step="3">
-                <div class="rtbcb-step-header">
-                    <h3><?php esc_html_e( 'What are your biggest challenges?', 'rtbcb' ); ?></h3>
-                    <p><?php esc_html_e( 'Select the pain points that best describe your current treasury challenges.', 'rtbcb' ); ?></p>
-                </div>
-                
-                <div class="rtbcb-step-content">
-                    <div class="rtbcb-pain-points-grid">
-                        <div class="rtbcb-pain-point-card">
-                            <label class="rtbcb-pain-point-label">
-                                <input type="checkbox" name="pain_points[]" value="manual_processes" />
-                                <div class="rtbcb-pain-point-content">
-                                    <div class="rtbcb-pain-point-icon">⚙️</div>
-                                    <div class="rtbcb-pain-point-title"><?php esc_html_e( 'Manual Processes', 'rtbcb' ); ?></div>
-                                    <div class="rtbcb-pain-point-description">
-                                        <?php esc_html_e( 'Time-consuming manual data entry and reconciliation', 'rtbcb' ); ?>
-                                    </div>
-                                </div>
-                            </label>
-                        </div>
+			<!-- Step 3: Treasury Challenges -->
+			<div class="rtbcb-wizard-step" data-step="3">
+				<div class="rtbcb-step-header">
+					<h3><?php esc_html_e( 'What are your biggest challenges?', 'rtbcb' ); ?></h3>
+					<p><?php esc_html_e( 'Select the pain points that best describe your current treasury challenges.', 'rtbcb' ); ?></p>
+				</div>
+				
+				<div class="rtbcb-step-content">
+					<div class="rtbcb-pain-points-grid">
+						<div class="rtbcb-pain-point-card">
+							<label class="rtbcb-pain-point-label">
+								<input type="checkbox" name="pain_points[]" value="manual_processes" />
+								<div class="rtbcb-pain-point-content">
+									<div class="rtbcb-pain-point-icon">⚙️</div>
+									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Manual Processes', 'rtbcb' ); ?></div>
+									<div class="rtbcb-pain-point-description">
+										<?php esc_html_e( 'Time-consuming manual data entry and reconciliation', 'rtbcb' ); ?>
+									</div>
+								</div>
+							</label>
+						</div>
 
-                        <div class="rtbcb-pain-point-card">
-                            <label class="rtbcb-pain-point-label">
-                                <input type="checkbox" name="pain_points[]" value="poor_visibility" />
-                                <div class="rtbcb-pain-point-content">
-                                    <div class="rtbcb-pain-point-icon">👁️</div>
-                                    <div class="rtbcb-pain-point-title"><?php esc_html_e( 'Poor Cash Visibility', 'rtbcb' ); ?></div>
-                                    <div class="rtbcb-pain-point-description">
-                                        <?php esc_html_e( 'Lack of real-time visibility into cash positions', 'rtbcb' ); ?>
-                                    </div>
-                                </div>
-                            </label>
-                        </div>
+						<div class="rtbcb-pain-point-card">
+							<label class="rtbcb-pain-point-label">
+								<input type="checkbox" name="pain_points[]" value="poor_visibility" />
+								<div class="rtbcb-pain-point-content">
+									<div class="rtbcb-pain-point-icon">👁️</div>
+									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Poor Cash Visibility', 'rtbcb' ); ?></div>
+									<div class="rtbcb-pain-point-description">
+										<?php esc_html_e( 'Lack of real-time visibility into cash positions', 'rtbcb' ); ?>
+									</div>
+								</div>
+							</label>
+						</div>
 
-                        <div class="rtbcb-pain-point-card">
-                            <label class="rtbcb-pain-point-label">
-                                <input type="checkbox" name="pain_points[]" value="forecast_accuracy" />
-                                <div class="rtbcb-pain-point-content">
-                                    <div class="rtbcb-pain-point-icon">📊</div>
-                                    <div class="rtbcb-pain-point-title"><?php esc_html_e( 'Forecast Accuracy', 'rtbcb' ); ?></div>
-                                    <div class="rtbcb-pain-point-description">
-                                        <?php esc_html_e( 'Inaccurate cash forecasting and planning', 'rtbcb' ); ?>
-                                    </div>
-                                </div>
-                            </label>
-                        </div>
+						<div class="rtbcb-pain-point-card">
+							<label class="rtbcb-pain-point-label">
+								<input type="checkbox" name="pain_points[]" value="forecast_accuracy" />
+								<div class="rtbcb-pain-point-content">
+									<div class="rtbcb-pain-point-icon">📊</div>
+									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Forecast Accuracy', 'rtbcb' ); ?></div>
+									<div class="rtbcb-pain-point-description">
+										<?php esc_html_e( 'Inaccurate cash forecasting and planning', 'rtbcb' ); ?>
+									</div>
+								</div>
+							</label>
+						</div>
 
-                        <div class="rtbcb-pain-point-card">
-                            <label class="rtbcb-pain-point-label">
-                                <input type="checkbox" name="pain_points[]" value="compliance_risk" />
-                                <div class="rtbcb-pain-point-content">
-                                    <div class="rtbcb-pain-point-icon">🛡️</div>
-                                    <div class="rtbcb-pain-point-title"><?php esc_html_e( 'Compliance & Risk', 'rtbcb' ); ?></div>
-                                    <div class="rtbcb-pain-point-description">
-                                        <?php esc_html_e( 'Regulatory compliance and risk management concerns', 'rtbcb' ); ?>
-                                    </div>
-                                </div>
-                            </label>
-                        </div>
+						<div class="rtbcb-pain-point-card">
+							<label class="rtbcb-pain-point-label">
+								<input type="checkbox" name="pain_points[]" value="compliance_risk" />
+								<div class="rtbcb-pain-point-content">
+									<div class="rtbcb-pain-point-icon">🛡️</div>
+									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Compliance & Risk', 'rtbcb' ); ?></div>
+									<div class="rtbcb-pain-point-description">
+										<?php esc_html_e( 'Regulatory compliance and risk management concerns', 'rtbcb' ); ?>
+									</div>
+								</div>
+							</label>
+						</div>
 
-                        <div class="rtbcb-pain-point-card">
-                            <label class="rtbcb-pain-point-label">
-                                <input type="checkbox" name="pain_points[]" value="bank_fees" />
-                                <div class="rtbcb-pain-point-content">
-                                    <div class="rtbcb-pain-point-icon">💰</div>
-                                    <div class="rtbcb-pain-point-title"><?php esc_html_e( 'High Bank Fees', 'rtbcb' ); ?></div>
-                                    <div class="rtbcb-pain-point-description">
-                                        <?php esc_html_e( 'Excessive banking fees and suboptimal cash positioning', 'rtbcb' ); ?>
-                                    </div>
-                                </div>
-                            </label>
-                        </div>
+						<div class="rtbcb-pain-point-card">
+							<label class="rtbcb-pain-point-label">
+								<input type="checkbox" name="pain_points[]" value="bank_fees" />
+								<div class="rtbcb-pain-point-content">
+									<div class="rtbcb-pain-point-icon">💰</div>
+									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'High Bank Fees', 'rtbcb' ); ?></div>
+									<div class="rtbcb-pain-point-description">
+										<?php esc_html_e( 'Excessive banking fees and suboptimal cash positioning', 'rtbcb' ); ?>
+									</div>
+								</div>
+							</label>
+						</div>
 
-                        <div class="rtbcb-pain-point-card">
-                            <label class="rtbcb-pain-point-label">
-                                <input type="checkbox" name="pain_points[]" value="integration_issues" />
-                                <div class="rtbcb-pain-point-content">
-                                    <div class="rtbcb-pain-point-icon">🔗</div>
-                                    <div class="rtbcb-pain-point-title"><?php esc_html_e( 'System Integration', 'rtbcb' ); ?></div>
-                                    <div class="rtbcb-pain-point-description">
-                                        <?php esc_html_e( 'Disconnected systems and data silos', 'rtbcb' ); ?>
-                                    </div>
-                                </div>
-                            </label>
-                        </div>
-                    </div>
-                    
-                    <div class="rtbcb-pain-points-validation">
-                        <div class="rtbcb-validation-message" style="display: none;">
-                            <?php esc_html_e( 'Please select at least one challenge that applies to your organization.', 'rtbcb' ); ?>
-                        </div>
-                    </div>
-                </div>
-            </div>
+						<div class="rtbcb-pain-point-card">
+							<label class="rtbcb-pain-point-label">
+								<input type="checkbox" name="pain_points[]" value="integration_issues" />
+								<div class="rtbcb-pain-point-content">
+									<div class="rtbcb-pain-point-icon">🔗</div>
+									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'System Integration', 'rtbcb' ); ?></div>
+									<div class="rtbcb-pain-point-description">
+										<?php esc_html_e( 'Disconnected systems and data silos', 'rtbcb' ); ?>
+									</div>
+								</div>
+							</label>
+						</div>
+					</div>
+					
+					<div class="rtbcb-pain-points-validation">
+						<div class="rtbcb-validation-message" style="display: none;">
+							<?php esc_html_e( 'Please select at least one challenge that applies to your organization.', 'rtbcb' ); ?>
+						</div>
+					</div>
+				</div>
+			</div>
 
-            <!-- Step 4: Strategic Context -->
-            <div class="rtbcb-wizard-step" data-step="4">
-                <div class="rtbcb-step-header">
-                    <h3><?php esc_html_e( 'Strategic context for your initiative', 'rtbcb' ); ?></h3>
-                    <p><?php esc_html_e( 'Help us understand the goals and constraints for your project.', 'rtbcb' ); ?></p>
-                </div>
+			<!-- Step 4: Strategic Context -->
+			<div class="rtbcb-wizard-step" data-step="4">
+				<div class="rtbcb-step-header">
+					<h3><?php esc_html_e( 'Strategic context for your initiative', 'rtbcb' ); ?></h3>
+					<p><?php esc_html_e( 'Help us understand the goals and constraints for your project.', 'rtbcb' ); ?></p>
+				</div>
 
-                <div class="rtbcb-step-content">
-                    <div class="rtbcb-field">
-                        <label for="current_tech"><?php esc_html_e( 'Current Treasury Technology', 'rtbcb' ); ?></label>
-                        <input type="text" name="current_tech" id="current_tech" />
-                    </div>
+				<div class="rtbcb-step-content">
+					<div class="rtbcb-field">
+						<label for="current_tech"><?php esc_html_e( 'Current Treasury Technology', 'rtbcb' ); ?></label>
+						<input type="text" name="current_tech" id="current_tech" />
+					</div>
 
-                    <div class="rtbcb-field rtbcb-field-required">
-                        <label for="business_objective">
-                            <?php esc_html_e( 'Primary Business Objective', 'rtbcb' ); ?>
-                        </label>
-                        <select name="business_objective" id="business_objective" required>
-                            <option value=""><?php esc_html_e( 'Select an objective...', 'rtbcb' ); ?></option>
-                            <option value="cost_reduction"><?php esc_html_e( 'Cost reduction', 'rtbcb' ); ?></option>
-                            <option value="risk_management"><?php esc_html_e( 'Risk management', 'rtbcb' ); ?></option>
-                            <option value="growth_support"><?php esc_html_e( 'Growth support', 'rtbcb' ); ?></option>
-                            <option value="compliance"><?php esc_html_e( 'Compliance', 'rtbcb' ); ?></option>
-                        </select>
-                    </div>
+					<div class="rtbcb-field rtbcb-field-required">
+						<label for="business_objective">
+							<?php esc_html_e( 'Primary Business Objective', 'rtbcb' ); ?>
+						</label>
+						<select name="business_objective" id="business_objective" required>
+							<option value=""><?php esc_html_e( 'Select an objective...', 'rtbcb' ); ?></option>
+							<option value="cost_reduction"><?php esc_html_e( 'Cost reduction', 'rtbcb' ); ?></option>
+							<option value="risk_management"><?php esc_html_e( 'Risk management', 'rtbcb' ); ?></option>
+							<option value="growth_support"><?php esc_html_e( 'Growth support', 'rtbcb' ); ?></option>
+							<option value="compliance"><?php esc_html_e( 'Compliance', 'rtbcb' ); ?></option>
+						</select>
+					</div>
 
-                    <div class="rtbcb-field rtbcb-field-required">
-                        <label for="implementation_timeline">
-                            <?php esc_html_e( 'Implementation Timeline', 'rtbcb' ); ?>
-                        </label>
-                        <select name="implementation_timeline" id="implementation_timeline" required>
-                            <option value=""><?php esc_html_e( 'Select a timeline...', 'rtbcb' ); ?></option>
-                            <option value="3-6"><?php esc_html_e( '3-6 months', 'rtbcb' ); ?></option>
-                            <option value="6-12"><?php esc_html_e( '6-12 months', 'rtbcb' ); ?></option>
-                            <option value="12+"><?php esc_html_e( '12+ months', 'rtbcb' ); ?></option>
-                        </select>
-                    </div>
+					<div class="rtbcb-field rtbcb-field-required">
+						<label for="implementation_timeline">
+							<?php esc_html_e( 'Implementation Timeline', 'rtbcb' ); ?>
+						</label>
+						<select name="implementation_timeline" id="implementation_timeline" required>
+							<option value=""><?php esc_html_e( 'Select a timeline...', 'rtbcb' ); ?></option>
+							<option value="3-6"><?php esc_html_e( '3-6 months', 'rtbcb' ); ?></option>
+							<option value="6-12"><?php esc_html_e( '6-12 months', 'rtbcb' ); ?></option>
+							<option value="12+"><?php esc_html_e( '12+ months', 'rtbcb' ); ?></option>
+						</select>
+					</div>
 
-                    <div class="rtbcb-field">
-                        <label for="decision_makers"><?php esc_html_e( 'Decision Makers', 'rtbcb' ); ?></label>
-                        <select name="decision_makers[]" id="decision_makers" multiple>
-                            <option value="cfo"><?php esc_html_e( 'CFO', 'rtbcb' ); ?></option>
-                            <option value="treasurer"><?php esc_html_e( 'Treasurer', 'rtbcb' ); ?></option>
-                            <option value="finance_team"><?php esc_html_e( 'Finance Team', 'rtbcb' ); ?></option>
-                            <option value="it"><?php esc_html_e( 'IT', 'rtbcb' ); ?></option>
-                        </select>
-                    </div>
+					<div class="rtbcb-field">
+						<label for="decision_makers"><?php esc_html_e( 'Decision Makers', 'rtbcb' ); ?></label>
+						<select name="decision_makers[]" id="decision_makers" multiple>
+							<option value="cfo"><?php esc_html_e( 'CFO', 'rtbcb' ); ?></option>
+							<option value="treasurer"><?php esc_html_e( 'Treasurer', 'rtbcb' ); ?></option>
+							<option value="finance_team"><?php esc_html_e( 'Finance Team', 'rtbcb' ); ?></option>
+							<option value="it"><?php esc_html_e( 'IT', 'rtbcb' ); ?></option>
+						</select>
+					</div>
 
-                    <div class="rtbcb-field rtbcb-field-required">
-                        <label for="budget_range">
-                            <?php esc_html_e( 'Budget Range', 'rtbcb' ); ?>
-                        </label>
-                        <select name="budget_range" id="budget_range" required>
-                            <option value=""><?php esc_html_e( 'Select a range...', 'rtbcb' ); ?></option>
-                            <option value="50-100"><?php esc_html_e( '$50K-$100K', 'rtbcb' ); ?></option>
-                            <option value="100-250"><?php esc_html_e( '$100K-$250K', 'rtbcb' ); ?></option>
-                            <option value="250-500"><?php esc_html_e( '$250K-$500K', 'rtbcb' ); ?></option>
-                            <option value="500+"><?php esc_html_e( '$500K+', 'rtbcb' ); ?></option>
-                        </select>
-                    </div>
-                </div>
-            </div>
+					<div class="rtbcb-field rtbcb-field-required">
+						<label for="budget_range">
+							<?php esc_html_e( 'Budget Range', 'rtbcb' ); ?>
+						</label>
+						<select name="budget_range" id="budget_range" required>
+							<option value=""><?php esc_html_e( 'Select a range...', 'rtbcb' ); ?></option>
+							<option value="50-100"><?php esc_html_e( '$50K-$100K', 'rtbcb' ); ?></option>
+							<option value="100-250"><?php esc_html_e( '$100K-$250K', 'rtbcb' ); ?></option>
+							<option value="250-500"><?php esc_html_e( '$250K-$500K', 'rtbcb' ); ?></option>
+							<option value="500+"><?php esc_html_e( '$500K+', 'rtbcb' ); ?></option>
+						</select>
+					</div>
+				</div>
+			</div>
 
-            <!-- Step 5: Contact Information -->
-            <div class="rtbcb-wizard-step" data-step="5">
-                <div class="rtbcb-step-header">
-                    <h3><?php esc_html_e( 'Get your business case', 'rtbcb' ); ?></h3>
-                    <p><?php esc_html_e( 'Enter your email to receive your personalized ROI analysis and recommendations.', 'rtbcb' ); ?></p>
-                </div>
-                
-                <div class="rtbcb-step-content">
-                    <div class="rtbcb-field rtbcb-field-required">
-                        <label for="email">
-                            <?php esc_html_e( 'Business Email Address', 'rtbcb' ); ?>
-                        </label>
-                        <input type="email" name="email" id="email" 
-                               placeholder="yourname@company.com" required />
-                        <div class="rtbcb-field-help">
-                            <?php esc_html_e( 'We\'ll send your business case report to this email address', 'rtbcb' ); ?>
-                        </div>
-                    </div>
+			<!-- Step 5: Contact Information -->
+			<div class="rtbcb-wizard-step" data-step="5">
+				<div class="rtbcb-step-header">
+					<h3><?php esc_html_e( 'Get your business case', 'rtbcb' ); ?></h3>
+					<p><?php esc_html_e( 'Enter your email to receive your personalized ROI analysis and recommendations.', 'rtbcb' ); ?></p>
+				</div>
+				
+				<div class="rtbcb-step-content">
+					<div class="rtbcb-field rtbcb-field-required">
+						<label for="email">
+							<?php esc_html_e( 'Business Email Address', 'rtbcb' ); ?>
+						</label>
+						<input type="email" name="email" id="email" 
+							   placeholder="yourname@company.com" required />
+						<div class="rtbcb-field-help">
+							<?php esc_html_e( 'We\'ll send your business case report to this email address', 'rtbcb' ); ?>
+						</div>
+					</div>
 
-                    <div class="rtbcb-consent-container">
-                        <div class="rtbcb-field">
-                            <div class="rtbcb-consent-wrapper">
-                                <label class="rtbcb-consent-label">
-                                    <input type="checkbox" name="consent" required />
-                                    <span class="rtbcb-consent-text">
-                                        <?php
-                                        printf(
-                                            wp_kses(
-                                                __( 'I agree to receive my business case report and occasional treasury insights. You can unsubscribe at any time. View our <a href="%s" target="_blank">privacy policy</a>.', 'rtbcb' ),
-                                                [ 'a' => [ 'href' => [], 'target' => [] ] ]
-                                            ),
-                                            '#'
-                                        );
-                                        ?>
-                                    </span>
-                                </label>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="rtbcb-field">
-                        <label>
-                            <input type="checkbox" name="fast_mode" id="fast_mode" value="1" />
-                            <?php esc_html_e( 'Enable fast mode (ROI only)', 'rtbcb' ); ?>
-                        </label>
-                        <div class="rtbcb-field-help">
-                            <?php esc_html_e( 'Skip AI analysis and only calculate ROI.', 'rtbcb' ); ?>
-                        </div>
-                    </div>
+					<div class="rtbcb-consent-container">
+						<div class="rtbcb-field">
+							<div class="rtbcb-consent-wrapper">
+								<label class="rtbcb-consent-label">
+									<input type="checkbox" name="consent" required />
+									<span class="rtbcb-consent-text">
+										<?php
+										printf(
+											wp_kses(
+												__( 'I agree to receive my business case report and occasional treasury insights. You can unsubscribe at any time. View our <a href="%s" target="_blank">privacy policy</a>.', 'rtbcb' ),
+												[ 'a' => [ 'href' => [], 'target' => [] ] ]
+											),
+											'#'
+										);
+										?>
+									</span>
+								</label>
+							</div>
+						</div>
+					</div>
+					<div class="rtbcb-field">
+						<label>
+							<input type="checkbox" name="fast_mode" id="fast_mode" value="1" />
+							<?php esc_html_e( 'Enable fast mode (ROI only)', 'rtbcb' ); ?>
+						</label>
+						<div class="rtbcb-field-help">
+							<?php esc_html_e( 'Skip AI analysis and only calculate ROI.', 'rtbcb' ); ?>
+						</div>
+					</div>
 
-                    <!-- What You'll Receive Preview -->
-                    <div class="rtbcb-preview-container">
-                        <div class="rtbcb-results-preview">
-                            <h4><?php esc_html_e( 'What You\'ll Receive:', 'rtbcb' ); ?></h4>
-                            <ul class="rtbcb-preview-list">
-                                <li>📊 <?php esc_html_e( 'Detailed ROI projections (conservative, base case, optimistic)', 'rtbcb' ); ?></li>
-                                <li>🎯 <?php esc_html_e( 'Personalized solution category recommendation', 'rtbcb' ); ?></li>
-                                <li>📄 <?php esc_html_e( 'Professional PDF report ready for stakeholders', 'rtbcb' ); ?></li>
-                                <li>🗺️ <?php esc_html_e( 'Implementation roadmap and next steps', 'rtbcb' ); ?></li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+					<!-- What You'll Receive Preview -->
+					<div class="rtbcb-preview-container">
+						<div class="rtbcb-results-preview">
+							<h4><?php esc_html_e( 'What You\'ll Receive:', 'rtbcb' ); ?></h4>
+							<ul class="rtbcb-preview-list">
+								<li>📊 <?php esc_html_e( 'Detailed ROI projections (conservative, base case, optimistic)', 'rtbcb' ); ?></li>
+								<li>🎯 <?php esc_html_e( 'Personalized solution category recommendation', 'rtbcb' ); ?></li>
+								<li>📄 <?php esc_html_e( 'Professional PDF report ready for stakeholders', 'rtbcb' ); ?></li>
+								<li>🗺️ <?php esc_html_e( 'Implementation roadmap and next steps', 'rtbcb' ); ?></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
 
-        <!-- Navigation Controls -->
-        <div class="rtbcb-wizard-navigation">
-            <button type="button" class="rtbcb-nav-btn rtbcb-nav-prev" style="display: none;">
-                <span class="rtbcb-nav-icon">←</span>
-                <?php esc_html_e( 'Previous', 'rtbcb' ); ?>
-            </button>
+		<!-- Navigation Controls -->
+		<div class="rtbcb-wizard-navigation">
+			<button type="button" class="rtbcb-nav-btn rtbcb-nav-prev" style="display: none;">
+				<span class="rtbcb-nav-icon">←</span>
+				<?php esc_html_e( 'Previous', 'rtbcb' ); ?>
+			</button>
 
-            <div class="rtbcb-nav-spacer"></div>
+			<div class="rtbcb-nav-spacer"></div>
 
-            <button type="button" class="rtbcb-nav-btn rtbcb-nav-next">
-                <?php esc_html_e( 'Next', 'rtbcb' ); ?>
-                <span class="rtbcb-nav-icon">→</span>
-            </button>
+			<button type="button" class="rtbcb-nav-btn rtbcb-nav-next">
+				<?php esc_html_e( 'Next', 'rtbcb' ); ?>
+				<span class="rtbcb-nav-icon">→</span>
+			</button>
 
-            <?php wp_nonce_field( 'rtbcb_generate', 'rtbcb_nonce' ); ?>
+			<?php wp_nonce_field( 'rtbcb_generate', 'rtbcb_nonce' ); ?>
 
-            <button type="submit" id="rtbcb-submit-button" class="rtbcb-nav-btn rtbcb-nav-submit" style="display: none;">
-                <span class="rtbcb-nav-icon">🚀</span>
-                <?php esc_html_e( 'Generate Business Case', 'rtbcb' ); ?>
-            </button>
+			<button type="submit" id="rtbcb-submit-button" class="rtbcb-nav-btn rtbcb-nav-submit" style="display: none;">
+				<span class="rtbcb-nav-icon">🚀</span>
+				<?php esc_html_e( 'Generate Business Case', 'rtbcb' ); ?>
+			</button>
 
-        </div>
-                </form>
-            <div id="rtbcbSuccessMessage" class="rtbcb-success-message" style="display:none"></div>
-            </div>
+		</div>
+				</form>
+			<div id="rtbcbSuccessMessage" class="rtbcb-success-message" style="display:none"></div>
+			</div>
 <div id="rtbcb-progress-container" class="rtbcb-progress-overlay" style="display: none;">
 <div class="rtbcb-progress-content">
 <div class="rtbcb-progress-spinner"></div>
@@ -458,43 +458,43 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 </div>
 </div>
 </div>
-        </div>
-    </div>
+		</div>
+	</div>
 </div>
 
 <!-- Results Section (separate from modal) -->
 <div id="rtbcbResults" class="rtbcb-results" style="display: none;">
-    <!-- Results will be populated by JavaScript -->
+	<!-- Results will be populated by JavaScript -->
 </div>
 
 <!-- Category Information Modal (Hidden by default) -->
 <div id="rtbcb-category-modal" class="rtbcb-modal" style="display: none;">
-    <div class="rtbcb-modal-content">
-        <div class="rtbcb-modal-header">
-            <h3><?php esc_html_e( 'Treasury Solution Categories', 'rtbcb' ); ?></h3>
-            <button type="button" class="rtbcb-modal-close">&times;</button>
-        </div>
-        <div class="rtbcb-modal-body">
-            <?php foreach ( $categories as $key => $category ) : ?>
-                <div class="rtbcb-category-info">
-                    <h4><?php echo esc_html( $category['name'] ); ?></h4>
-                    <p><?php echo esc_html( $category['description'] ); ?></p>
-                    <div class="rtbcb-category-features">
-                        <strong><?php esc_html_e( 'Key Features:', 'rtbcb' ); ?></strong>
-                        <ul>
-                            <?php foreach ( array_slice( $category['features'], 0, 3 ) as $feature ) : ?>
-                                <li><?php echo esc_html( $feature ); ?></li>
-                            <?php endforeach; ?>
-                        </ul>
-                    </div>
-                    <div class="rtbcb-category-ideal">
-                        <strong><?php esc_html_e( 'Ideal for:', 'rtbcb' ); ?></strong>
-                        <?php echo esc_html( $category['ideal_for'] ); ?>
-                    </div>
-                </div>
-            <?php endforeach; ?>
-        </div>
-    </div>
+	<div class="rtbcb-modal-content">
+		<div class="rtbcb-modal-header">
+			<h3><?php esc_html_e( 'Treasury Solution Categories', 'rtbcb' ); ?></h3>
+			<button type="button" class="rtbcb-modal-close">&times;</button>
+		</div>
+		<div class="rtbcb-modal-body">
+			<?php foreach ( $categories as $key => $category ) : ?>
+				<div class="rtbcb-category-info">
+					<h4><?php echo esc_html( $category['name'] ); ?></h4>
+					<p><?php echo esc_html( $category['description'] ); ?></p>
+					<div class="rtbcb-category-features">
+						<strong><?php esc_html_e( 'Key Features:', 'rtbcb' ); ?></strong>
+						<ul>
+							<?php foreach ( array_slice( $category['features'], 0, 3 ) as $feature ) : ?>
+								<li><?php echo esc_html( $feature ); ?></li>
+							<?php endforeach; ?>
+						</ul>
+					</div>
+					<div class="rtbcb-category-ideal">
+						<strong><?php esc_html_e( 'Ideal for:', 'rtbcb' ); ?></strong>
+						<?php echo esc_html( $category['ideal_for'] ); ?>
+					</div>
+				</div>
+			<?php endforeach; ?>
+		</div>
+	</div>
 </div>
 
 

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -65,17 +65,17 @@ $processing_time = $metadata['processing_time'] ?? 0;
 						<span class="rtbcb-meta-label"><?php echo esc_html__( 'Processing Time', 'rtbcb' ); ?></span>
 						<span class="rtbcb-meta-value"><?php echo esc_html( round( $processing_time, 1 ) ); ?>s</span>
 					</div>
-	                                    <div class="rtbcb-meta-item">
-	                                            <span class="rtbcb-meta-icon">📊</span>
-	                                            <span class="rtbcb-meta-label"><?php echo esc_html__( 'Analysis Type', 'rtbcb' ); ?></span>
-	                                            <span class="rtbcb-meta-value"><?php echo esc_html( ucfirst( $analysis_type ) ); ?></span>
-	                                    </div>
-	                                    <div class="rtbcb-meta-item">
-	                                            <span class="rtbcb-meta-icon">🏷️</span>
-	                                            <span class="rtbcb-meta-label"><?php echo esc_html__( 'Version', 'rtbcb' ); ?></span>
-                                                <span class="rtbcb-meta-value"><?php echo esc_html( defined( 'RTBCB_VERSION' ) ? RTBCB_VERSION : 'dev' ); ?></span>
-                                        </div>
-                                </div>
+										<div class="rtbcb-meta-item">
+												<span class="rtbcb-meta-icon">📊</span>
+												<span class="rtbcb-meta-label"><?php echo esc_html__( 'Analysis Type', 'rtbcb' ); ?></span>
+												<span class="rtbcb-meta-value"><?php echo esc_html( ucfirst( $analysis_type ) ); ?></span>
+										</div>
+										<div class="rtbcb-meta-item">
+												<span class="rtbcb-meta-icon">🏷️</span>
+												<span class="rtbcb-meta-label"><?php echo esc_html__( 'Version', 'rtbcb' ); ?></span>
+												<span class="rtbcb-meta-value"><?php echo esc_html( defined( 'RTBCB_VERSION' ) ? RTBCB_VERSION : 'dev' ); ?></span>
+										</div>
+								</div>
 			</div>
 
 			<!-- Key Metrics Dashboard -->
@@ -205,27 +205,27 @@ $processing_time = $metadata['processing_time'] ?? 0;
 		</div>
 		
 		<div id="financial-content" class="rtbcb-section-content">
-                <!-- ROI Scenarios Chart -->
-                <?php if ( $enable_charts ) : ?>
-                <div class="rtbcb-roi-chart-container">
-                        <h3><?php echo esc_html__( 'ROI Scenario Analysis', 'rtbcb' ); ?></h3>
-                        <canvas id="rtbcb-roi-chart" width="800" height="400"></canvas>
-                        <div class="rtbcb-chart-legend">
-                                <div class="rtbcb-legend-item">
-                                        <span class="rtbcb-legend-color conservative"></span>
-                                        <span><?php echo esc_html__( 'Conservative Scenario', 'rtbcb' ); ?></span>
-                                </div>
-                                <div class="rtbcb-legend-item">
-                                        <span class="rtbcb-legend-color base"></span>
-                                        <span><?php echo esc_html__( 'Base Case', 'rtbcb' ); ?></span>
-                                </div>
-                                <div class="rtbcb-legend-item">
-                                        <span class="rtbcb-legend-color optimistic"></span>
-                                        <span><?php echo esc_html__( 'Optimistic Scenario', 'rtbcb' ); ?></span>
-                                </div>
-                        </div>
-                </div>
-                <?php endif; ?>
+				<!-- ROI Scenarios Chart -->
+				<?php if ( $enable_charts ) : ?>
+				<div class="rtbcb-roi-chart-container">
+						<h3><?php echo esc_html__( 'ROI Scenario Analysis', 'rtbcb' ); ?></h3>
+						<canvas id="rtbcb-roi-chart" width="800" height="400"></canvas>
+						<div class="rtbcb-chart-legend">
+								<div class="rtbcb-legend-item">
+										<span class="rtbcb-legend-color conservative"></span>
+										<span><?php echo esc_html__( 'Conservative Scenario', 'rtbcb' ); ?></span>
+								</div>
+								<div class="rtbcb-legend-item">
+										<span class="rtbcb-legend-color base"></span>
+										<span><?php echo esc_html__( 'Base Case', 'rtbcb' ); ?></span>
+								</div>
+								<div class="rtbcb-legend-item">
+										<span class="rtbcb-legend-color optimistic"></span>
+										<span><?php echo esc_html__( 'Optimistic Scenario', 'rtbcb' ); ?></span>
+								</div>
+						</div>
+				</div>
+				<?php endif; ?>
 
 			<!-- ROI Breakdown -->
 			<div class="rtbcb-roi-breakdown-enhanced">
@@ -409,8 +409,8 @@ $processing_time = $metadata['processing_time'] ?? 0;
 <?php endif; ?>
 
 	<!-- Supporting Context Section -->
-	    <?php if ( 'basic' !== $analysis_type && ! empty( $rag_context ) ) : ?>
-	    <div class="rtbcb-section-enhanced rtbcb-supporting-context">
+		<?php if ( 'basic' !== $analysis_type && ! empty( $rag_context ) ) : ?>
+		<div class="rtbcb-section-enhanced rtbcb-supporting-context">
 		<div class="rtbcb-section-header-enhanced">
 			<h2 class="rtbcb-section-title">
 				<span class="rtbcb-section-icon">📚</span>

--- a/templates/fast-report-template.php
+++ b/templates/fast-report-template.php
@@ -2,10 +2,10 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Fast ROI report template.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Fast ROI report template.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 $company_name = isset( $form_data['company_name'] ) ? sanitize_text_field( $form_data['company_name'] ) : '';
 $roi_low  = isset( $calculations['conservative']['roi_percentage'] ) ? floatval( $calculations['conservative']['roi_percentage'] ) : 0;

--- a/templates/report-template.php
+++ b/templates/report-template.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Template for generated business case report.
- *
- * @package RealTreasuryBusinessCaseBuilder
- *
- * @var array $business_case_data Business case data from the LLM.
- */
+	* Template for generated business case report.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*
+	* @var array $business_case_data Business case data from the LLM.
+	*/
 
 defined( 'ABSPATH' ) || exit;
 
@@ -17,73 +17,73 @@ $rag_context   = $business_case_data['rag_context'] ?? [];
 	<h2><?php echo esc_html__( 'Business Case Report', 'rtbcb' ); ?></h2>
 	<p class="rtbcb-version-tag"><?php printf( esc_html__( 'Version %s', 'rtbcb' ), esc_html( defined( 'RTBCB_VERSION' ) ? RTBCB_VERSION : 'dev' ) ); ?></p>
 	<?php if ( ! empty( $business_case_data['narrative'] ) ) : ?>
-	    <p><?php echo esc_html( $business_case_data['narrative'] ); ?></p>
+		<p><?php echo esc_html( $business_case_data['narrative'] ); ?></p>
 	<?php endif; ?>
 
 	<?php if ( ! empty( $business_case_data['risks'] ) ) : ?>
-	    <h3><?php echo esc_html__( 'Risks', 'rtbcb' ); ?></h3>
-	    <ul>
-	        <?php foreach ( (array) $business_case_data['risks'] as $risk ) : ?>
-	            <li><?php echo esc_html( $risk ); ?></li>
-	        <?php endforeach; ?>
-	    </ul>
+		<h3><?php echo esc_html__( 'Risks', 'rtbcb' ); ?></h3>
+		<ul>
+			<?php foreach ( (array) $business_case_data['risks'] as $risk ) : ?>
+				<li><?php echo esc_html( $risk ); ?></li>
+			<?php endforeach; ?>
+		</ul>
 	<?php endif; ?>
 
 	<?php if ( ! empty( $business_case_data['assumptions_explained'] ) ) : ?>
-	    <h3><?php echo esc_html__( 'Assumptions', 'rtbcb' ); ?></h3>
-	    <ul>
-	        <?php foreach ( (array) $business_case_data['assumptions_explained'] as $assumption ) : ?>
-	            <li><?php echo esc_html( $assumption ); ?></li>
-	        <?php endforeach; ?>
-	    </ul>
+		<h3><?php echo esc_html__( 'Assumptions', 'rtbcb' ); ?></h3>
+		<ul>
+			<?php foreach ( (array) $business_case_data['assumptions_explained'] as $assumption ) : ?>
+				<li><?php echo esc_html( $assumption ); ?></li>
+			<?php endforeach; ?>
+		</ul>
 	<?php endif; ?>
 
 	<?php if ( ! empty( $business_case_data['citations'] ) ) : ?>
-	    <h3><?php echo esc_html__( 'Citations', 'rtbcb' ); ?></h3>
-	    <ol>
-	        <?php foreach ( (array) $business_case_data['citations'] as $citation ) : ?>
-	            <li>
-	                <?php
-	                if ( is_array( $citation ) && ! empty( $citation['url'] ) ) {
-	                    $url  = esc_url( $citation['url'] );
-	                    $text = ! empty( $citation['text'] ) ? esc_html( $citation['text'] ) : $url;
-	                    echo '<a href="' . $url . '">' . $text . '</a>';
-	                } else {
-	                    echo esc_html( is_array( $citation ) ? wp_json_encode( $citation ) : $citation );
-	                }
-	                ?>
-	            </li>
-	        <?php endforeach; ?>
-	    </ol>
+		<h3><?php echo esc_html__( 'Citations', 'rtbcb' ); ?></h3>
+		<ol>
+			<?php foreach ( (array) $business_case_data['citations'] as $citation ) : ?>
+				<li>
+					<?php
+					if ( is_array( $citation ) && ! empty( $citation['url'] ) ) {
+						$url  = esc_url( $citation['url'] );
+						$text = ! empty( $citation['text'] ) ? esc_html( $citation['text'] ) : $url;
+						echo '<a href="' . $url . '">' . $text . '</a>';
+					} else {
+						echo esc_html( is_array( $citation ) ? wp_json_encode( $citation ) : $citation );
+					}
+					?>
+				</li>
+			<?php endforeach; ?>
+		</ol>
 	<?php endif; ?>
 
 	<?php if ( ! empty( $business_case_data['next_actions'] ) ) : ?>
-	    <h3><?php echo esc_html__( 'Next Actions', 'rtbcb' ); ?></h3>
-	    <ul>
-	        <?php foreach ( (array) $business_case_data['next_actions'] as $action ) : ?>
-	            <li><?php echo esc_html( $action ); ?></li>
-	        <?php endforeach; ?>
-	    </ul>
+		<h3><?php echo esc_html__( 'Next Actions', 'rtbcb' ); ?></h3>
+		<ul>
+			<?php foreach ( (array) $business_case_data['next_actions'] as $action ) : ?>
+				<li><?php echo esc_html( $action ); ?></li>
+			<?php endforeach; ?>
+		</ul>
 	<?php endif; ?>
 
 	<?php if ( isset( $business_case_data['confidence'] ) ) : ?>
-	    <p><?php printf( esc_html__( 'Confidence: %s%%', 'rtbcb' ), esc_html( round( (float) $business_case_data['confidence'] * 100 ) ) ); ?></p>
+		<p><?php printf( esc_html__( 'Confidence: %s%%', 'rtbcb' ), esc_html( round( (float) $business_case_data['confidence'] * 100 ) ) ); ?></p>
 	<?php endif; ?>
 
 	<?php if ( ! empty( $business_case_data['recommended_category'] ) ) : ?>
-	    <p><?php echo esc_html__( 'Recommended Category:', 'rtbcb' ) . ' ' . esc_html( $business_case_data['recommended_category'] ); ?></p>
+		<p><?php echo esc_html__( 'Recommended Category:', 'rtbcb' ) . ' ' . esc_html( $business_case_data['recommended_category'] ); ?></p>
 	<?php endif; ?>
 
 	<?php if ( 'basic' !== $analysis_type ) : ?>
-	    <h3><?php echo esc_html__( 'Context', 'rtbcb' ); ?></h3>
-	    <?php if ( ! empty( $rag_context ) ) : ?>
-	            <ul>
-	                    <?php foreach ( (array) $rag_context as $context_item ) : ?>
-	                            <li><?php echo esc_html( $context_item ); ?></li>
-	                    <?php endforeach; ?>
-	            </ul>
-	    <?php else : ?>
-	            <p><?php echo esc_html__( 'No additional context available.', 'rtbcb' ); ?></p>
-	    <?php endif; ?>
+		<h3><?php echo esc_html__( 'Context', 'rtbcb' ); ?></h3>
+		<?php if ( ! empty( $rag_context ) ) : ?>
+				<ul>
+						<?php foreach ( (array) $rag_context as $context_item ) : ?>
+								<li><?php echo esc_html( $context_item ); ?></li>
+						<?php endforeach; ?>
+				</ul>
+		<?php else : ?>
+				<p><?php echo esc_html__( 'No additional context available.', 'rtbcb' ); ?></p>
+		<?php endif; ?>
 	<?php endif; ?>
 </div>

--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
@@ -2,75 +2,75 @@
 use PHPUnit\Framework\TestCase;
 
 if ( ! class_exists( 'WP_Error' ) ) {
-    class WP_Error {
-        private $code;
-        private $message;
-        private $data;
-        public function __construct( $code = '', $message = '', $data = [] ) {
-            $this->code    = $code;
-            $this->message = $message;
-            $this->data    = $data;
-        }
-        public function get_error_message() {
-            return $this->message;
-        }
-        public function get_error_code() {
-            return $this->code;
-        }
-        public function get_error_data() {
-            return $this->data;
-        }
-    }
+	class WP_Error {
+		private $code;
+		private $message;
+		private $data;
+		public function __construct( $code = '', $message = '', $data = [] ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+		public function get_error_message() {
+			return $this->message;
+		}
+		public function get_error_code() {
+			return $this->code;
+		}
+		public function get_error_data() {
+			return $this->data;
+		}
+	}
 }
 
 if ( ! function_exists( 'is_wp_error' ) ) {
-    function is_wp_error( $thing ) {
-        return $thing instanceof WP_Error;
-    }
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
 }
 
 if ( ! function_exists( 'wp_verify_nonce' ) ) {
-    function wp_verify_nonce( $nonce, $action ) {
-        return true;
-    }
+	function wp_verify_nonce( $nonce, $action ) {
+		return true;
+	}
 }
 
 if ( ! function_exists( 'sanitize_email' ) ) {
-    function sanitize_email( $email ) {
-        return $email;
-    }
+	function sanitize_email( $email ) {
+		return $email;
+	}
 }
 
 if ( ! function_exists( 'sanitize_text_field' ) ) {
-    function sanitize_text_field( $text ) {
-        return $text;
-    }
+	function sanitize_text_field( $text ) {
+		return $text;
+	}
 }
 
 if ( ! function_exists( 'is_email' ) ) {
-    function is_email( $email ) {
-        return filter_var( $email, FILTER_VALIDATE_EMAIL );
-    }
+	function is_email( $email ) {
+		return filter_var( $email, FILTER_VALIDATE_EMAIL );
+	}
 }
 
 if ( ! function_exists( 'wp_get_environment_type' ) ) {
-    function wp_get_environment_type() {
-        return 'production';
-    }
+	function wp_get_environment_type() {
+		return 'production';
+	}
 }
 
 if ( ! function_exists( '__' ) ) {
-    function __( $text, $domain = null ) {
-        return $text;
-    }
+	function __( $text, $domain = null ) {
+		return $text;
+	}
 }
 
 if ( ! function_exists( 'rtbcb_increase_memory_limit' ) ) {
-    function rtbcb_increase_memory_limit() {}
+	function rtbcb_increase_memory_limit() {}
 }
 
 if ( ! function_exists( 'rtbcb_log_memory_usage' ) ) {
-    function rtbcb_log_memory_usage( $stage ) {}
+	function rtbcb_log_memory_usage( $stage ) {}
 }
 
 if ( ! class_exists( 'RTBCB_LLM' ) ) {
@@ -89,111 +89,111 @@ return new WP_Error( 'llm_error', 'LLM failed' );
 }
 
 if ( ! class_exists( 'RTBCB_JSON_Error' ) ) {
-    class RTBCB_JSON_Error extends Exception {
-        public $data;
-        public $status;
-        public function __construct( $data, $status ) {
-            parent::__construct();
-            $this->data   = $data;
-            $this->status = $status;
-        }
-    }
+	class RTBCB_JSON_Error extends Exception {
+		public $data;
+		public $status;
+		public function __construct( $data, $status ) {
+			parent::__construct();
+			$this->data   = $data;
+			$this->status = $status;
+		}
+	}
 }
 
 if ( ! function_exists( 'wp_send_json_error' ) ) {
-    function wp_send_json_error( $data = null, $status_code = null ) {
-        throw new RTBCB_JSON_Error(
-            [
-                'success' => false,
-                'data'    => $data,
-            ],
-            $status_code
-        );
-    }
+	function wp_send_json_error( $data = null, $status_code = null ) {
+		throw new RTBCB_JSON_Error(
+			[
+				'success' => false,
+				'data'    => $data,
+			],
+			$status_code
+		);
+	}
 }
 
 if ( ! class_exists( 'RTBCB_Main' ) ) {
-    class RTBCB_Main {
-        public function ajax_generate_comprehensive_case() {
-            $llm = new RTBCB_LLM();
-            $comprehensive_analysis = $llm->generate_comprehensive_business_case( [], [], [], null );
-            if ( is_wp_error( $comprehensive_analysis ) ) {
-                $error_message  = $comprehensive_analysis->get_error_message();
-                $error_code     = $comprehensive_analysis->get_error_code();
-                $error_data     = $comprehensive_analysis->get_error_data();
-                $status         = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
-                if ( 'llm_http_status' === $error_code ) {
-                    wp_send_json_error( [ 'message' => $error_message, 'error_code' => 'E_LLM_HTTP_STATUS' ], $status );
-                }
-                if ( 'no_api_key' === $error_code ) {
-                    $response_message = __( 'Our AI analysis service is temporarily unavailable. Your submission has been saved and our team will follow up with a personalized business case.', 'rtbcb' );
-                    if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
-                        $response_message = $error_message;
-                    }
-                    wp_send_json_error( [ 'message' => $response_message ], 500 );
-                }
-                $response_message = __( 'Our AI analysis service is temporarily unavailable. Your submission has been saved and our team will follow up with a personalized business case.', 'rtbcb' );
-                if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
-                    $response_message = $error_message;
-                }
-                wp_send_json_error( [ 'message' => $response_message ], 500 );
-            }
-        }
-    }
+	class RTBCB_Main {
+		public function ajax_generate_comprehensive_case() {
+			$llm = new RTBCB_LLM();
+			$comprehensive_analysis = $llm->generate_comprehensive_business_case( [], [], [], null );
+			if ( is_wp_error( $comprehensive_analysis ) ) {
+				$error_message  = $comprehensive_analysis->get_error_message();
+				$error_code     = $comprehensive_analysis->get_error_code();
+				$error_data     = $comprehensive_analysis->get_error_data();
+				$status         = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : 500;
+				if ( 'llm_http_status' === $error_code ) {
+					wp_send_json_error( [ 'message' => $error_message, 'error_code' => 'E_LLM_HTTP_STATUS' ], $status );
+				}
+				if ( 'no_api_key' === $error_code ) {
+					$response_message = __( 'Our AI analysis service is temporarily unavailable. Your submission has been saved and our team will follow up with a personalized business case.', 'rtbcb' );
+					if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+						$response_message = $error_message;
+					}
+					wp_send_json_error( [ 'message' => $response_message ], 500 );
+				}
+				$response_message = __( 'Our AI analysis service is temporarily unavailable. Your submission has been saved and our team will follow up with a personalized business case.', 'rtbcb' );
+				if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+					$response_message = $error_message;
+				}
+				wp_send_json_error( [ 'message' => $response_message ], 500 );
+			}
+		}
+	}
 }
 
 final class RTBCB_AjaxGenerateComprehensiveCaseErrorTest extends TestCase {
-    public function test_ajax_returns_error_json_when_llm_fails() {
-        RTBCB_LLM::$mode = 'generic';
-        $plugin          = new RTBCB_Main();
-        try {
-            $plugin->ajax_generate_comprehensive_case();
-            $this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
-        } catch ( RTBCB_JSON_Error $e ) {
-            $this->assertSame( 500, $e->status );
-            $this->assertSame(
-                [
-                    'success' => false,
-                    'data'    => [ 'message' => 'Our AI analysis service is temporarily unavailable. Your submission has been saved and our team will follow up with a personalized business case.' ],
-                ],
-                $e->data
-            );
-        }
-    }
+	public function test_ajax_returns_error_json_when_llm_fails() {
+		RTBCB_LLM::$mode = 'generic';
+		$plugin          = new RTBCB_Main();
+		try {
+			$plugin->ajax_generate_comprehensive_case();
+			$this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
+		} catch ( RTBCB_JSON_Error $e ) {
+			$this->assertSame( 500, $e->status );
+			$this->assertSame(
+				[
+					'success' => false,
+					'data'    => [ 'message' => 'Our AI analysis service is temporarily unavailable. Your submission has been saved and our team will follow up with a personalized business case.' ],
+				],
+				$e->data
+			);
+		}
+	}
 
-    public function test_ajax_returns_api_key_error_when_missing() {
-        RTBCB_LLM::$mode = 'no_api_key';
-        $plugin          = new RTBCB_Main();
-        try {
-            $plugin->ajax_generate_comprehensive_case();
-            $this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
-        } catch ( RTBCB_JSON_Error $e ) {
-            $this->assertSame( 500, $e->status );
-            $this->assertSame(
-                [
-                    'success' => false,
-                    'data'    => [ 'message' => 'Our AI analysis service is temporarily unavailable. Your submission has been saved and our team will follow up with a personalized business case.' ],
-                ],
-                $e->data
-            );
-        }
-    }
+	public function test_ajax_returns_api_key_error_when_missing() {
+		RTBCB_LLM::$mode = 'no_api_key';
+		$plugin          = new RTBCB_Main();
+		try {
+			$plugin->ajax_generate_comprehensive_case();
+			$this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
+		} catch ( RTBCB_JSON_Error $e ) {
+			$this->assertSame( 500, $e->status );
+			$this->assertSame(
+				[
+					'success' => false,
+					'data'    => [ 'message' => 'Our AI analysis service is temporarily unavailable. Your submission has been saved and our team will follow up with a personalized business case.' ],
+				],
+				$e->data
+			);
+		}
+	}
 
-    public function test_ajax_returns_http_status_error() {
-        RTBCB_LLM::$mode = 'http_status';
-        $plugin          = new RTBCB_Main();
-        try {
-            $plugin->ajax_generate_comprehensive_case();
-            $this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
-        } catch ( RTBCB_JSON_Error $e ) {
-            $this->assertSame( 418, $e->status );
-            $this->assertSame(
-                [
-                    'success' => false,
-                    'data'    => [ 'message' => 'Teapot', 'error_code' => 'E_LLM_HTTP_STATUS' ],
-                ],
-                $e->data
-            );
-        }
-    }
+	public function test_ajax_returns_http_status_error() {
+		RTBCB_LLM::$mode = 'http_status';
+		$plugin          = new RTBCB_Main();
+		try {
+			$plugin->ajax_generate_comprehensive_case();
+			$this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
+		} catch ( RTBCB_JSON_Error $e ) {
+			$this->assertSame( 418, $e->status );
+			$this->assertSame(
+				[
+					'success' => false,
+					'data'    => [ 'message' => 'Teapot', 'error_code' => 'E_LLM_HTTP_STATUS' ],
+				],
+				$e->data
+			);
+		}
+	}
 }

--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
@@ -2,54 +2,54 @@
 use PHPUnit\Framework\TestCase;
 
 if ( ! class_exists( 'WP_Error' ) ) {
-    class WP_Error {
-        private $code;
-        private $message;
-        private $data;
-        public function __construct( $code = '', $message = '', $data = [] ) {
-            $this->code    = $code;
-            $this->message = $message;
-            $this->data    = $data;
-        }
-        public function get_error_message() {
-            return $this->message;
-        }
-        public function get_error_code() {
-            return $this->code;
-        }
-        public function get_error_data() {
-            return $this->data;
-        }
-    }
+	class WP_Error {
+		private $code;
+		private $message;
+		private $data;
+		public function __construct( $code = '', $message = '', $data = [] ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+		public function get_error_message() {
+			return $this->message;
+		}
+		public function get_error_code() {
+			return $this->code;
+		}
+		public function get_error_data() {
+			return $this->data;
+		}
+	}
 }
 
 if ( ! function_exists( 'is_wp_error' ) ) {
-    function is_wp_error( $thing ) {
-        return $thing instanceof WP_Error;
-    }
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
 }
 
 if ( ! function_exists( '__' ) ) {
-    function __( $text, $domain = null ) {
-        return $text;
-    }
+	function __( $text, $domain = null ) {
+		return $text;
+	}
 }
 
 if ( ! function_exists( 'wp_get_environment_type' ) ) {
-    function wp_get_environment_type() {
-        return 'production';
-    }
+	function wp_get_environment_type() {
+		return 'production';
+	}
 }
 
 if ( ! function_exists( 'rtbcb_log_error' ) ) {
-    function rtbcb_log_error( $message, $context = null ) {}
+	function rtbcb_log_error( $message, $context = null ) {}
 }
 
 if ( ! function_exists( 'rtbcb_is_openai_configuration_error' ) ) {
-    function rtbcb_is_openai_configuration_error( $e ) {
-        $message = strtolower( $e->getMessage() );
-        return false !== strpos( $message, 'api key' ) || false !== strpos( $message, 'model' );
-    }
+	function rtbcb_is_openai_configuration_error( $e ) {
+		$message = strtolower( $e->getMessage() );
+		return false !== strpos( $message, 'api key' ) || false !== strpos( $message, 'model' );
+	}
 }
 
 if ( ! class_exists( 'RTBCB_LLM' ) ) {
@@ -68,90 +68,90 @@ return [];
 }
 
 if ( ! class_exists( 'RTBCB_JSON_Error' ) ) {
-    class RTBCB_JSON_Error extends Exception {
-        public $data;
-        public $status;
-        public function __construct( $data, $status ) {
-            parent::__construct();
-            $this->data   = $data;
-            $this->status = $status;
-        }
-    }
+	class RTBCB_JSON_Error extends Exception {
+		public $data;
+		public $status;
+		public function __construct( $data, $status ) {
+			parent::__construct();
+			$this->data   = $data;
+			$this->status = $status;
+		}
+	}
 }
 
 if ( ! function_exists( 'wp_send_json_error' ) ) {
-    function wp_send_json_error( $data = null, $status_code = null ) {
-        throw new RTBCB_JSON_Error(
-            [
-                'success' => false,
-                'data'    => $data,
-            ],
-            $status_code
-        );
-    }
+	function wp_send_json_error( $data = null, $status_code = null ) {
+		throw new RTBCB_JSON_Error(
+			[
+				'success' => false,
+				'data'    => $data,
+			],
+			$status_code
+		);
+	}
 }
 
 if ( ! class_exists( 'RTBCB_Main_Fatal' ) ) {
-    class RTBCB_Main_Fatal {
-        public function ajax_generate_comprehensive_case() {
-            $llm = new RTBCB_LLM();
-            try {
-                $llm->generate_comprehensive_business_case( [], [], [], null );
-            } catch ( Error $e ) {
-                $error_code    = 'E_LLM_FATAL';
-                $error_message = $e->getMessage();
+	class RTBCB_Main_Fatal {
+		public function ajax_generate_comprehensive_case() {
+			$llm = new RTBCB_LLM();
+			try {
+				$llm->generate_comprehensive_business_case( [], [], [], null );
+			} catch ( Error $e ) {
+				$error_code    = 'E_LLM_FATAL';
+				$error_message = $e->getMessage();
 
-                rtbcb_log_error( $error_code . ': ' . $error_message, $e->getTraceAsString() );
+				rtbcb_log_error( $error_code . ': ' . $error_message, $e->getTraceAsString() );
 
-                if ( rtbcb_is_openai_configuration_error( $e ) ) {
-                    $guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
-                    $response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
-                } else {
-                    $response_message = __( 'Internal error. Please try again later.', 'rtbcb' );
-                }
+				if ( rtbcb_is_openai_configuration_error( $e ) ) {
+					$guidance        = __( 'Check the OpenAI API key setting in plugin options.', 'rtbcb' );
+					$response_message = __( 'Our AI analysis service is temporarily unavailable.', 'rtbcb' ) . ' ' . $guidance;
+				} else {
+					$response_message = __( 'Internal error. Please try again later.', 'rtbcb' );
+				}
 
-                wp_send_json_error(
-                    [
-                        'message'    => $response_message,
-                        'error_code' => $error_code,
-                    ],
-                    500
-                );
-            }
-        }
-    }
+				wp_send_json_error(
+					[
+						'message'    => $response_message,
+						'error_code' => $error_code,
+					],
+					500
+				);
+			}
+		}
+	}
 }
 
 final class RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest extends TestCase {
-    public function test_ajax_returns_guidance_when_configuration_error() {
-        RTBCB_LLM::$mode = 'fatal_config';
-        $plugin          = new RTBCB_Main_Fatal();
-        try {
-            $plugin->ajax_generate_comprehensive_case();
-            $this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
-        } catch ( RTBCB_JSON_Error $e ) {
-            $this->assertSame( 500, $e->status );
-            $this->assertSame( 'E_LLM_FATAL', $e->data['data']['error_code'] );
-            $this->assertSame(
-                'Our AI analysis service is temporarily unavailable. Check the OpenAI API key setting in plugin options.',
-                $e->data['data']['message']
-            );
-        }
-    }
+	public function test_ajax_returns_guidance_when_configuration_error() {
+		RTBCB_LLM::$mode = 'fatal_config';
+		$plugin          = new RTBCB_Main_Fatal();
+		try {
+			$plugin->ajax_generate_comprehensive_case();
+			$this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
+		} catch ( RTBCB_JSON_Error $e ) {
+			$this->assertSame( 500, $e->status );
+			$this->assertSame( 'E_LLM_FATAL', $e->data['data']['error_code'] );
+			$this->assertSame(
+				'Our AI analysis service is temporarily unavailable. Check the OpenAI API key setting in plugin options.',
+				$e->data['data']['message']
+			);
+		}
+	}
 
-    public function test_ajax_returns_generic_message_when_internal_error() {
-        RTBCB_LLM::$mode = 'fatal_internal';
-        $plugin          = new RTBCB_Main_Fatal();
-        try {
-            $plugin->ajax_generate_comprehensive_case();
-            $this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
-        } catch ( RTBCB_JSON_Error $e ) {
-            $this->assertSame( 500, $e->status );
-            $this->assertSame( 'E_LLM_FATAL', $e->data['data']['error_code'] );
-            $this->assertSame(
-                'Internal error. Please try again later.',
-                $e->data['data']['message']
-            );
-        }
-    }
+	public function test_ajax_returns_generic_message_when_internal_error() {
+		RTBCB_LLM::$mode = 'fatal_internal';
+		$plugin          = new RTBCB_Main_Fatal();
+		try {
+			$plugin->ajax_generate_comprehensive_case();
+			$this->fail( 'Expected RTBCB_JSON_Error was not thrown.' );
+		} catch ( RTBCB_JSON_Error $e ) {
+			$this->assertSame( 500, $e->status );
+			$this->assertSame( 'E_LLM_FATAL', $e->data['data']['error_code'] );
+			$this->assertSame(
+				'Internal error. Please try again later.',
+				$e->data['data']['message']
+			);
+		}
+	}
 }

--- a/tests/api-tester-gpt5-mini.test.php
+++ b/tests/api-tester-gpt5-mini.test.php
@@ -6,11 +6,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 defined( 'ABSPATH' ) || exit;
 
 if ( ! function_exists( 'add_filter' ) ) {
-    function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
+	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
 }
 
 if ( ! defined( 'RTBCB_DIR' ) ) {
-    define( 'RTBCB_DIR', __DIR__ . '/../' );
+	define( 'RTBCB_DIR', __DIR__ . '/../' );
 }
 
 require_once __DIR__ . '/../inc/config.php';
@@ -18,117 +18,117 @@ require_once __DIR__ . '/../inc/class-rtbcb-api-tester.php';
 require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
 
 if ( ! function_exists( 'get_option' ) ) {
-    function get_option( $name, $default = '' ) {
-        if ( 'rtbcb_mini_model' === $name ) {
-            return 'gpt-5-mini';
-        }
-        if ( 'rtbcb_advanced_model' === $name ) {
-            return 'gpt-5-mini';
-        }
-        if ( 'rtbcb_gpt5_config' === $name ) {
-            return [];
-        }
-        if ( 'rtbcb_gpt5_max_output_tokens' === $name ) {
-            return 25000;
-        }
-        if ( 'rtbcb_gpt5_min_output_tokens' === $name ) {
-            return 5000;
-        }
-        return $default;
-    }
+	function get_option( $name, $default = '' ) {
+		if ( 'rtbcb_mini_model' === $name ) {
+			return 'gpt-5-mini';
+		}
+		if ( 'rtbcb_advanced_model' === $name ) {
+			return 'gpt-5-mini';
+		}
+		if ( 'rtbcb_gpt5_config' === $name ) {
+			return [];
+		}
+		if ( 'rtbcb_gpt5_max_output_tokens' === $name ) {
+			return 25000;
+		}
+		if ( 'rtbcb_gpt5_min_output_tokens' === $name ) {
+			return 5000;
+		}
+		return $default;
+	}
 }
 
 if ( ! function_exists( '__' ) ) {
-    function __( $text, $domain = null ) {
-        return $text;
-    }
+	function __( $text, $domain = null ) {
+		return $text;
+	}
 }
 
 if ( ! function_exists( 'wp_json_encode' ) ) {
-    function wp_json_encode( $data ) {
-        return json_encode( $data );
-    }
+	function wp_json_encode( $data ) {
+		return json_encode( $data );
+	}
 }
 
 if ( ! function_exists( 'sanitize_text_field' ) ) {
-    function sanitize_text_field( $text ) {
-        $text = is_scalar( $text ) ? (string) $text : '';
-        $text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
-        return trim( $text );
-    }
+	function sanitize_text_field( $text ) {
+		$text = is_scalar( $text ) ? (string) $text : '';
+		$text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
+		return trim( $text );
+	}
 }
 
 if ( ! function_exists( 'sanitize_key' ) ) {
-    function sanitize_key( $key ) {
-        $key = strtolower( $key );
-        return preg_replace( '/[^a-z0-9_]/', '', $key );
-    }
+	function sanitize_key( $key ) {
+		$key = strtolower( $key );
+		return preg_replace( '/[^a-z0-9_]/', '', $key );
+	}
 }
 
 if ( ! class_exists( 'WP_Error' ) ) {
-    class WP_Error {}
+	class WP_Error {}
 }
 
 if ( ! function_exists( 'is_wp_error' ) ) {
-    function is_wp_error( $thing ) {
-        return $thing instanceof WP_Error;
-    }
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
 }
 
 $mock_response = [
-    'body' => json_encode( [
-        'status' => 'completed',
-        'output' => [
-            [
-                'id'      => 'reasoning',
-                'type'    => 'reasoning',
-                'content' => [
-                    [
-                        'type' => 'reasoning',
-                        'text' => 'thinking',
-                    ],
-                ],
-            ],
-            [
-                'id'      => 'message',
-                'type'    => 'message',
-                'content' => [
-                    [
-                        'type' => 'output_text',
-                        'text' => 'This is a meaningful response message.',
-                    ],
-                ],
-            ],
-        ],
-    ] ),
+	'body' => json_encode( [
+		'status' => 'completed',
+		'output' => [
+			[
+				'id'      => 'reasoning',
+				'type'    => 'reasoning',
+				'content' => [
+					[
+						'type' => 'reasoning',
+						'text' => 'thinking',
+					],
+				],
+			],
+			[
+				'id'      => 'message',
+				'type'    => 'message',
+				'content' => [
+					[
+						'type' => 'output_text',
+						'text' => 'This is a meaningful response message.',
+					],
+				],
+			],
+		],
+	] ),
 ];
 
 $captured_args = [];
 
 if ( ! function_exists( 'wp_remote_post' ) ) {
-    function wp_remote_post( $url, $args ) {
-        global $mock_response, $captured_args;
-        $captured_args = $args;
-        return $mock_response;
-    }
+	function wp_remote_post( $url, $args ) {
+		global $mock_response, $captured_args;
+		$captured_args = $args;
+		return $mock_response;
+	}
 }
 
 if ( ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
-    function wp_remote_retrieve_response_code( $response ) {
-        return 200;
-    }
+	function wp_remote_retrieve_response_code( $response ) {
+		return 200;
+	}
 }
 
 if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
-    function wp_remote_retrieve_body( $response ) {
-        return $response['body'] ?? '';
-    }
+	function wp_remote_retrieve_body( $response ) {
+		return $response['body'] ?? '';
+	}
 }
 
 if ( ! function_exists( 'rtbcb_model_supports_temperature' ) ) {
-    function rtbcb_model_supports_temperature( $model ) {
-        return true;
-    }
+	function rtbcb_model_supports_temperature( $model ) {
+		return true;
+	}
 }
 
 $method = new ReflectionMethod( RTBCB_API_Tester::class, 'test_completion' );
@@ -137,30 +137,30 @@ $result = $method->invoke( null, 'test-key' );
 
 $sent = json_decode( $captured_args['body'] ?? '{}', true );
 if ( 25000 !== ( $sent['max_output_tokens'] ?? 0 ) ) {
-    echo "API tester did not respect configured max tokens\n";
-    exit( 1 );
+	echo "API tester did not respect configured max tokens\n";
+	exit( 1 );
 }
 
 if ( ! $result['success'] ) {
-    echo "API tester did not report success\n";
-    exit( 1 );
+	echo "API tester did not report success\n";
+	exit( 1 );
 }
 
 if ( 'This is a meaningful response message.' !== ( $result['response'] ?? '' ) ) {
-    echo "API tester failed to extract text\n";
-    exit( 1 );
+	echo "API tester failed to extract text\n";
+	exit( 1 );
 }
 
 $combined = ( $result['message'] ?? '' ) . ' ' . ( $result['details'] ?? '' );
 if ( false !== strpos( $combined, 'max_output_tokens' ) ) {
-    echo "API tester flagged max_output_tokens\n";
-    exit( 1 );
+	echo "API tester flagged max_output_tokens\n";
+	exit( 1 );
 }
 
 $parsed = rtbcb_parse_gpt5_response( $mock_response );
 if ( 'This is a meaningful response message.' !== ( $parsed['output_text'] ?? '' ) ) {
-    echo "Failed to extract message text\n";
-    exit( 1 );
+	echo "Failed to extract message text\n";
+	exit( 1 );
 }
 
 echo "api-tester-gpt5-mini.test.php passed\n";

--- a/tests/background-job.test.php
+++ b/tests/background-job.test.php
@@ -5,155 +5,155 @@ if ( ! defined( 'ABSPATH' ) ) {
 defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'WP_Error' ) ) {
-    class WP_Error {
-        private $code;
-        private $message;
-        private $data;
-        public function __construct( $code = '', $message = '', $data = [] ) {
-            $this->code    = $code;
-            $this->message = $message;
-            $this->data    = $data;
-        }
-        public function get_error_message() {
-            return $this->message;
-        }
-        public function get_error_code() {
-            return $this->code;
-        }
-        public function get_error_data() {
-            return $this->data;
-        }
-    }
+	class WP_Error {
+		private $code;
+		private $message;
+		private $data;
+		public function __construct( $code = '', $message = '', $data = [] ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+		public function get_error_message() {
+			return $this->message;
+		}
+		public function get_error_code() {
+			return $this->code;
+		}
+		public function get_error_data() {
+			return $this->data;
+		}
+	}
 }
 
 if ( ! function_exists( 'is_wp_error' ) ) {
-    function is_wp_error( $thing ) {
-        return $thing instanceof WP_Error;
-    }
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
 }
 
 if ( ! function_exists( 'set_transient' ) ) {
-    function set_transient( $name, $value, $expiration ) {
-        global $transients, $transient_log;
-        $transients[ $name ]     = $value;
-        $transient_log[ $name ][] = $value;
-        return true;
-    }
+	function set_transient( $name, $value, $expiration ) {
+		global $transients, $transient_log;
+		$transients[ $name ]     = $value;
+		$transient_log[ $name ][] = $value;
+		return true;
+	}
 }
 
 if ( ! function_exists( 'get_transient' ) ) {
-    function get_transient( $name ) {
-        global $transients;
-        return $transients[ $name ] ?? false;
-    }
+	function get_transient( $name ) {
+		global $transients;
+		return $transients[ $name ] ?? false;
+	}
 }
 
 if ( ! function_exists( 'delete_transient' ) ) {
-    function delete_transient( $name ) {
-        global $transients;
-        unset( $transients[ $name ] );
-    }
+	function delete_transient( $name ) {
+		global $transients;
+		unset( $transients[ $name ] );
+	}
 }
 
 global $sent_report_email;
 $sent_report_email = [];
 if ( ! function_exists( 'rtbcb_send_report_email' ) ) {
-    function rtbcb_send_report_email( $form_data, $path ) {
-        global $sent_report_email;
-        $sent_report_email = [
-            'form_data' => $form_data,
-            'path'      => $path,
-        ];
-    }
+	function rtbcb_send_report_email( $form_data, $path ) {
+		global $sent_report_email;
+		$sent_report_email = [
+			'form_data' => $form_data,
+			'path'      => $path,
+		];
+	}
 }
 
 if ( ! function_exists( 'wp_schedule_single_event' ) ) {
-    function wp_schedule_single_event( $timestamp, $hook, $args ) {
-        global $scheduled_events;
-        $scheduled_events[] = [
-            'timestamp' => $timestamp,
-            'hook'      => $hook,
-            'args'      => $args,
-        ];
-    }
+	function wp_schedule_single_event( $timestamp, $hook, $args ) {
+		global $scheduled_events;
+		$scheduled_events[] = [
+			'timestamp' => $timestamp,
+			'hook'      => $hook,
+			'args'      => $args,
+		];
+	}
 }
 
 if ( ! function_exists( 'spawn_cron' ) ) {
-    function spawn_cron() {
-        global $spawned_cron;
-        $spawned_cron = true;
-    }
+	function spawn_cron() {
+		global $spawned_cron;
+		$spawned_cron = true;
+	}
 }
 
 if ( ! function_exists( 'wp_doing_cron' ) ) {
-    function wp_doing_cron() {
-        return false;
-    }
+	function wp_doing_cron() {
+		return false;
+	}
 }
 
 global $wp_actions;
 $wp_actions = [];
 
 if ( ! function_exists( 'add_action' ) ) {
-    function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
-        global $wp_actions;
-        $wp_actions[ $hook ][] = [
-            'callback'      => $callback,
-            'accepted_args' => $accepted_args,
-        ];
-    }
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		global $wp_actions;
+		$wp_actions[ $hook ][] = [
+			'callback'      => $callback,
+			'accepted_args' => $accepted_args,
+		];
+	}
 }
 
 if ( ! function_exists( 'do_action' ) ) {
-    function do_action( $hook, ...$args ) {
-        global $wp_actions;
-        if ( isset( $wp_actions[ $hook ] ) ) {
-            foreach ( $wp_actions[ $hook ] as $action ) {
-                call_user_func_array( $action['callback'], array_slice( $args, 0, $action['accepted_args'] ) );
-            }
-        }
-    }
+	function do_action( $hook, ...$args ) {
+		global $wp_actions;
+		if ( isset( $wp_actions[ $hook ] ) ) {
+			foreach ( $wp_actions[ $hook ] as $action ) {
+				call_user_func_array( $action['callback'], array_slice( $args, 0, $action['accepted_args'] ) );
+			}
+		}
+	}
 }
 
 if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
-    define( 'HOUR_IN_SECONDS', 3600 );
+	define( 'HOUR_IN_SECONDS', 3600 );
 }
 if ( ! defined( 'DAY_IN_SECONDS' ) ) {
-    define( 'DAY_IN_SECONDS', 86400 );
+	define( 'DAY_IN_SECONDS', 86400 );
 }
 
 if ( ! class_exists( 'RTBCB_Ajax' ) ) {
-    class RTBCB_Ajax {
-        public static $mode = 'success';
-        public static function process_basic_roi_step( $user_inputs ) {
-            return [ 'financial_analysis' => [] ];
-        }
-        public static function process_comprehensive_case( $user_inputs, $job_id ) {
-            do_action( 'rtbcb_workflow_step_completed', 'ai_enrichment' );
-            RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enriched_profile' => [] ] );
-            do_action( 'rtbcb_workflow_step_completed', 'enhanced_roi_calculation' );
-            RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enhanced_roi' => [] ] );
-            do_action( 'rtbcb_workflow_step_completed', 'intelligent_recommendations' );
-            RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'category' => 'cat' ] );
-            do_action( 'rtbcb_workflow_step_completed', 'hybrid_rag_analysis' );
-            RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'analysis' => [] ] );
-            do_action( 'rtbcb_workflow_step_completed', 'data_structuring' );
-            RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'report_data' => [] ] );
-            if ( 'error' === self::$mode ) {
-                return new WP_Error( 'failed', 'Processing failed.' );
-            }
-            return [ 'result' => 'ok' ];
-        }
-    }
+	class RTBCB_Ajax {
+		public static $mode = 'success';
+		public static function process_basic_roi_step( $user_inputs ) {
+			return [ 'financial_analysis' => [] ];
+		}
+		public static function process_comprehensive_case( $user_inputs, $job_id ) {
+			do_action( 'rtbcb_workflow_step_completed', 'ai_enrichment' );
+			RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enriched_profile' => [] ] );
+			do_action( 'rtbcb_workflow_step_completed', 'enhanced_roi_calculation' );
+			RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'enhanced_roi' => [] ] );
+			do_action( 'rtbcb_workflow_step_completed', 'intelligent_recommendations' );
+			RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'category' => 'cat' ] );
+			do_action( 'rtbcb_workflow_step_completed', 'hybrid_rag_analysis' );
+			RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'analysis' => [] ] );
+			do_action( 'rtbcb_workflow_step_completed', 'data_structuring' );
+			RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'report_data' => [] ] );
+			if ( 'error' === self::$mode ) {
+				return new WP_Error( 'failed', 'Processing failed.' );
+			}
+			return [ 'result' => 'ok' ];
+		}
+	}
 }
 
 require_once __DIR__ . '/../inc/class-rtbcb-background-job.php';
 
 function assert_true( $condition, $message ) {
-    if ( ! $condition ) {
-        echo $message . "\n";
-        exit( 1 );
-    }
+	if ( ! $condition ) {
+		echo $message . "\n";
+		exit( 1 );
+	}
 }
 
 // Successful job flow.

--- a/tests/cosine-similarity-search.test.php
+++ b/tests/cosine-similarity-search.test.php
@@ -2,67 +2,67 @@
 require_once __DIR__ . '/../inc/class-rtbcb-rag.php';
 
 if ( ! defined( 'ARRAY_A' ) ) {
-    define( 'ARRAY_A', 'ARRAY_A' );
+	define( 'ARRAY_A', 'ARRAY_A' );
 }
 
 if ( ! function_exists( 'maybe_unserialize' ) ) {
-    function maybe_unserialize( $data ) {
-        return $data;
-    }
+	function maybe_unserialize( $data ) {
+		return $data;
+	}
 }
 
 class WPDB_Stub {
-    public $prefix = '';
-    public $last_query = '';
+	public $prefix = '';
+	public $last_query = '';
 
-    public function prepare( $query, ...$args ) {
-        $this->last_query = vsprintf( $query, $args );
-        return $this->last_query;
-    }
+	public function prepare( $query, ...$args ) {
+		$this->last_query = vsprintf( $query, $args );
+		return $this->last_query;
+	}
 
-    public function get_var( $sql ) {
-        $this->last_query = $sql;
-        return 'rtbcb_rag_index';
-    }
+	public function get_var( $sql ) {
+		$this->last_query = $sql;
+		return 'rtbcb_rag_index';
+	}
 
-    public function get_results( $sql, $output ) {
-        $this->last_query = $sql;
-        return [
-            [ 'type' => 'vendor', 'ref_id' => '1', 'embedding' => [ 1, 0 ], 'metadata' => [] ],
-            [ 'type' => 'vendor', 'ref_id' => '2', 'embedding' => [ 0.8, 0.2 ], 'metadata' => [] ],
-            [ 'type' => 'vendor', 'ref_id' => '3', 'embedding' => [ 0, 1 ], 'metadata' => [] ],
-        ];
-    }
+	public function get_results( $sql, $output ) {
+		$this->last_query = $sql;
+		return [
+			[ 'type' => 'vendor', 'ref_id' => '1', 'embedding' => [ 1, 0 ], 'metadata' => [] ],
+			[ 'type' => 'vendor', 'ref_id' => '2', 'embedding' => [ 0.8, 0.2 ], 'metadata' => [] ],
+			[ 'type' => 'vendor', 'ref_id' => '3', 'embedding' => [ 0, 1 ], 'metadata' => [] ],
+		];
+	}
 }
 
 global $wpdb;
 $wpdb = new WPDB_Stub();
 
 class RTBCB_RAG_Test extends RTBCB_RAG {
-    public function __construct() {}
-    public function run_search( $query_embedding, $top_k ) {
-        $method = new ReflectionMethod( RTBCB_RAG::class, 'cosine_similarity_search' );
-        $method->setAccessible( true );
-        return $method->invoke( $this, $query_embedding, $top_k );
-    }
+	public function __construct() {}
+	public function run_search( $query_embedding, $top_k ) {
+		$method = new ReflectionMethod( RTBCB_RAG::class, 'cosine_similarity_search' );
+		$method->setAccessible( true );
+		return $method->invoke( $this, $query_embedding, $top_k );
+	}
 }
 
 $rag     = new RTBCB_RAG_Test();
 $results = $rag->run_search( [ 1, 0 ], 2 );
 
 if ( 2 !== count( $results ) ) {
-    echo "Expected 2 results, got " . count( $results ) . "\n";
-    exit( 1 );
+	echo "Expected 2 results, got " . count( $results ) . "\n";
+	exit( 1 );
 }
 
 if ( $results[0]['score'] < $results[1]['score'] ) {
-    echo "Results are not sorted by score\n";
-    exit( 1 );
+	echo "Results are not sorted by score\n";
+	exit( 1 );
 }
 
 if ( false === stripos( $wpdb->last_query, 'limit' ) ) {
-    echo "LIMIT clause missing from query\n";
-    exit( 1 );
+	echo "LIMIT clause missing from query\n";
+	exit( 1 );
 }
 
 echo "cosine-similarity-search.test.php passed\n";

--- a/tests/edge-cases.test.php
+++ b/tests/edge-cases.test.php
@@ -161,8 +161,8 @@ require_once __DIR__ . '/../inc/class-rtbcb-router.php';
 
 final class RTBCB_EdgeCasesTest extends TestCase {
 /**
- * @dataProvider edge_case_provider
- */
+	* @dataProvider edge_case_provider
+	*/
 public function test_handle_form_submission( $post_data, $expected_success ) {
 global $last_response;
 $last_response = null;

--- a/tests/email-and-pdf.test.php
+++ b/tests/email-and-pdf.test.php
@@ -8,13 +8,13 @@ defined( 'ABSPATH' ) || exit;
 
 if ( ! function_exists( 'sanitize_email' ) ) {
 	function sanitize_email( $email ) {
-	    return filter_var( $email, FILTER_SANITIZE_EMAIL );
+		return filter_var( $email, FILTER_SANITIZE_EMAIL );
 	}
 }
 
 if ( ! function_exists( '__' ) ) {
 	function __( $text, $domain = null ) {
-	    return $text;
+		return $text;
 	}
 }
 
@@ -27,9 +27,9 @@ $sent_mail = [];
 function rtbcb_mock_mail( $to, $subject, $message, $headers = [], $attachments = [] ) {
 	global $sent_mail;
 	$sent_mail = [
-	    'to'          => $to,
-	    'subject'     => $subject,
-	    'attachments' => $attachments,
+		'to'          => $to,
+		'subject'     => $subject,
+		'attachments' => $attachments,
 	];
 	return true;
 }

--- a/tests/filters-override.test.php
+++ b/tests/filters-override.test.php
@@ -2,35 +2,35 @@
 require_once __DIR__ . '/../inc/class-rtbcb-calculator.php';
 
 if ( ! function_exists( 'add_filter' ) ) {
-    $GLOBALS['rtbcb_filters'] = [];
+	$GLOBALS['rtbcb_filters'] = [];
 
-    function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
-        $GLOBALS['rtbcb_filters'][ $tag ] = $function_to_add;
-    }
+	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['rtbcb_filters'][ $tag ] = $function_to_add;
+	}
 
-    function apply_filters( $tag, $value ) {
-        $args = func_get_args();
-        $tag  = array_shift( $args );
-        $value = array_shift( $args );
+	function apply_filters( $tag, $value ) {
+		$args = func_get_args();
+		$tag  = array_shift( $args );
+		$value = array_shift( $args );
 
-        if ( isset( $GLOBALS['rtbcb_filters'][ $tag ] ) ) {
-            $value = call_user_func_array( $GLOBALS['rtbcb_filters'][ $tag ], array_merge( [ $value ], $args ) );
-        }
+		if ( isset( $GLOBALS['rtbcb_filters'][ $tag ] ) ) {
+			$value = call_user_func_array( $GLOBALS['rtbcb_filters'][ $tag ], array_merge( [ $value ], $args ) );
+		}
 
-        return $value;
-    }
+		return $value;
+	}
 }
 
 $inputs = [
-    'hours_reconciliation' => 10,
-    'hours_cash_positioning' => 0,
-    'num_banks' => 1,
-    'company_size' => '$50M-$500M',
+	'hours_reconciliation' => 10,
+	'hours_cash_positioning' => 0,
+	'num_banks' => 1,
+	'company_size' => '$50M-$500M',
 ];
 
 $settings = [
-    'labor_cost_per_hour' => 100,
-    'bank_fee_baseline' => 15000,
+	'labor_cost_per_hour' => 100,
+	'bank_fee_baseline' => 15000,
 ];
 
 $category = [ 'roi_range' => [ 0, 1000000 ] ];
@@ -38,13 +38,13 @@ $scenario = 'base';
 $industry_mult = 1.0;
 
 add_filter( 'rtbcb_roi_multipliers', function ( $multipliers, $inputs, $settings, $category, $scenario_type, $industry ) {
-    $multipliers['base'] = 2.0;
-    return $multipliers;
+	$multipliers['base'] = 2.0;
+	return $multipliers;
 }, 10, 6 );
 
 add_filter( 'rtbcb_error_cost_map', function ( $cost_map ) {
-    $cost_map['$50M-$500M'] = 1000000;
-    return $cost_map;
+	$cost_map['$50M-$500M'] = 1000000;
+	return $cost_map;
 }, 10, 4 );
 
 $method = new ReflectionMethod( RTBCB_Calculator::class, 'calculate_scenario' );
@@ -52,13 +52,13 @@ $method->setAccessible( true );
 $result = $method->invoke( null, $inputs, $settings, $category, $scenario, $industry_mult );
 
 if ( abs( $result['assumptions']['efficiency_improvement'] - 0.60 ) > 0.0001 ) {
-    echo "Multiplier filter did not apply\n";
-    exit( 1 );
+	echo "Multiplier filter did not apply\n";
+	exit( 1 );
 }
 
 if ( 500000 !== (int) $result['error_reduction'] ) {
-    echo "Error cost map filter did not apply\n";
-    exit( 1 );
+	echo "Error cost map filter did not apply\n";
+	exit( 1 );
 }
 
 echo "filters-override.test.php passed\n";

--- a/tests/generate-business-analysis.test.php
+++ b/tests/generate-business-analysis.test.php
@@ -2,55 +2,55 @@
 use PHPUnit\Framework\TestCase;
 
 if ( ! class_exists( 'WP_Error' ) ) {
-    class WP_Error {
-        private $code;
-        private $message;
-        private $data;
-        public function __construct( $code = '', $message = '', $data = [] ) {
-            $this->code    = $code;
-            $this->message = $message;
-            $this->data    = $data;
-        }
-        public function get_error_message() {
-            return $this->message;
-        }
-        public function get_error_code() {
-            return $this->code;
-        }
-        public function get_error_data() {
-            return $this->data;
-        }
-    }
+	class WP_Error {
+		private $code;
+		private $message;
+		private $data;
+		public function __construct( $code = '', $message = '', $data = [] ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+		public function get_error_message() {
+			return $this->message;
+		}
+		public function get_error_code() {
+			return $this->code;
+		}
+		public function get_error_data() {
+			return $this->data;
+		}
+	}
 }
 
 if ( ! function_exists( 'is_wp_error' ) ) {
-    function is_wp_error( $thing ) {
-        return $thing instanceof WP_Error;
-    }
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
 }
 
 if ( ! function_exists( '__' ) ) {
-    function __( $text, $domain = null ) {
-        return $text;
-    }
+	function __( $text, $domain = null ) {
+		return $text;
+	}
 }
 
 if ( ! function_exists( 'rtbcb_log_error' ) ) {
-    function rtbcb_log_error( $context, $message ) {}
+	function rtbcb_log_error( $context, $message ) {}
 }
 
 $GLOBALS['rtbcb_has_key'] = true;
 $GLOBALS['rtbcb_timeout'] = 100;
 if ( ! function_exists( 'rtbcb_has_openai_api_key' ) ) {
-    function rtbcb_has_openai_api_key() {
-        return $GLOBALS['rtbcb_has_key'];
-    }
+	function rtbcb_has_openai_api_key() {
+		return $GLOBALS['rtbcb_has_key'];
+	}
 }
 
 if ( ! function_exists( 'rtbcb_get_api_timeout' ) ) {
-    function rtbcb_get_api_timeout() {
-        return $GLOBALS['rtbcb_timeout'];
-    }
+	function rtbcb_get_api_timeout() {
+		return $GLOBALS['rtbcb_timeout'];
+	}
 }
 
 if ( ! class_exists( 'RTBCB_LLM' ) ) {
@@ -149,67 +149,67 @@ return [ 'fallback' => true ];
 }
 
 final class Generate_Business_Analysis_Test extends TestCase {
-    private $plugin;
+	private $plugin;
 
-    protected function setUp(): void {
-        $this->plugin = new RTBCB_Main();
-    }
+	protected function setUp(): void {
+		$this->plugin = new RTBCB_Main();
+	}
 
-    private function invoke_generate_business_analysis() {
-        $reflection = new ReflectionClass( $this->plugin );
-        $method     = $reflection->getMethod( 'generate_business_analysis' );
-        $method->setAccessible( true );
-        return $method->invoke( $this->plugin, [], [], [] );
-    }
+	private function invoke_generate_business_analysis() {
+		$reflection = new ReflectionClass( $this->plugin );
+		$method     = $reflection->getMethod( 'generate_business_analysis' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->plugin, [], [], [] );
+	}
 
-    public function test_llm_called_when_api_key_exists() {
-        $GLOBALS['rtbcb_has_key'] = true;
-        $GLOBALS['rtbcb_timeout'] = 100;
-        RTBCB_LLM::$called        = false;
-        $this->plugin->fallback_called = false;
+	public function test_llm_called_when_api_key_exists() {
+		$GLOBALS['rtbcb_has_key'] = true;
+		$GLOBALS['rtbcb_timeout'] = 100;
+		RTBCB_LLM::$called        = false;
+		$this->plugin->fallback_called = false;
 
-        $this->invoke_generate_business_analysis();
+		$this->invoke_generate_business_analysis();
 
-        $this->assertTrue( RTBCB_LLM::$called, 'LLM should be called when API key exists.' );
-        $this->assertFalse( $this->plugin->fallback_called, 'Fallback should not be called when API key exists.' );
-    }
+		$this->assertTrue( RTBCB_LLM::$called, 'LLM should be called when API key exists.' );
+		$this->assertFalse( $this->plugin->fallback_called, 'Fallback should not be called when API key exists.' );
+	}
 
-    public function test_fallback_called_when_no_api_key() {
-        $GLOBALS['rtbcb_has_key'] = false;
-        $GLOBALS['rtbcb_timeout'] = 100;
-        RTBCB_LLM::$called        = false;
-        $this->plugin->fallback_called = false;
+	public function test_fallback_called_when_no_api_key() {
+		$GLOBALS['rtbcb_has_key'] = false;
+		$GLOBALS['rtbcb_timeout'] = 100;
+		RTBCB_LLM::$called        = false;
+		$this->plugin->fallback_called = false;
 
-        $this->invoke_generate_business_analysis();
+		$this->invoke_generate_business_analysis();
 
-        $this->assertFalse( RTBCB_LLM::$called, 'LLM should not be called without API key.' );
-        $this->assertTrue( $this->plugin->fallback_called, 'Fallback should be called when no API key.' );
-    }
+		$this->assertFalse( RTBCB_LLM::$called, 'LLM should not be called without API key.' );
+		$this->assertTrue( $this->plugin->fallback_called, 'Fallback should be called when no API key.' );
+	}
 
-    public function test_llm_skipped_when_timeout_low() {
-        $GLOBALS['rtbcb_has_key'] = true;
-        $GLOBALS['rtbcb_timeout'] = 3;
-        RTBCB_LLM::$called        = false;
-        $this->plugin->fallback_called = false;
+	public function test_llm_skipped_when_timeout_low() {
+		$GLOBALS['rtbcb_has_key'] = true;
+		$GLOBALS['rtbcb_timeout'] = 3;
+		RTBCB_LLM::$called        = false;
+		$this->plugin->fallback_called = false;
 
-        $this->invoke_generate_business_analysis();
+		$this->invoke_generate_business_analysis();
 
-        $this->assertFalse( RTBCB_LLM::$called, 'LLM should be skipped when timeout low.' );
-        $this->assertTrue( $this->plugin->fallback_called, 'Fallback should run when timeout low.' );
-    }
+		$this->assertFalse( RTBCB_LLM::$called, 'LLM should be skipped when timeout low.' );
+		$this->assertTrue( $this->plugin->fallback_called, 'Fallback should run when timeout low.' );
+	}
 
-    public function test_partial_return_when_time_runs_out_after_llm() {
-        $GLOBALS['rtbcb_has_key'] = true;
-        $GLOBALS['rtbcb_timeout'] = 6;
-        RTBCB_LLM::$sleep         = 5000000; // 5 seconds
-        RTBCB_LLM::$called        = false;
-        $this->plugin->fallback_called = false;
+	public function test_partial_return_when_time_runs_out_after_llm() {
+		$GLOBALS['rtbcb_has_key'] = true;
+		$GLOBALS['rtbcb_timeout'] = 6;
+		RTBCB_LLM::$sleep         = 5000000; // 5 seconds
+		RTBCB_LLM::$called        = false;
+		$this->plugin->fallback_called = false;
 
-        $result = $this->invoke_generate_business_analysis();
+		$result = $this->invoke_generate_business_analysis();
 
-        $this->assertTrue( RTBCB_LLM::$called, 'LLM should be called when time permits.' );
-        $this->assertArrayHasKey( 'analysis', $result );
-        $this->assertArrayHasKey( 'partial', $result['analysis'], 'Partial result expected when time runs out.' );
-    }
+		$this->assertTrue( RTBCB_LLM::$called, 'LLM should be called when time permits.' );
+		$this->assertArrayHasKey( 'analysis', $result );
+		$this->assertArrayHasKey( 'partial', $result['analysis'], 'Partial result expected when time runs out.' );
+	}
 }
 

--- a/tests/helpers/capture-call-openai-body.php
+++ b/tests/helpers/capture-call-openai-body.php
@@ -15,13 +15,13 @@ $capabilities = include __DIR__ . '/../../inc/model-capabilities.php';
 $unsupported  = $capabilities['temperature']['unsupported'] ?? [];
 
 $body = [
-    'model'             => $model,
-    'input'             => 'test prompt',
-    'max_output_tokens' => 256,
+	'model'             => $model,
+	'input'             => 'test prompt',
+	'max_output_tokens' => 256,
 ];
 
 if ( ! in_array( $model, $unsupported, true ) ) {
-    $body['temperature'] = 0.7;
+	$body['temperature'] = 0.7;
 }
 
 echo json_encode( $body );

--- a/tests/job-status.test.php
+++ b/tests/job-status.test.php
@@ -6,90 +6,90 @@ if ( ! defined( 'ABSPATH' ) ) {
 defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'WP_Error' ) ) {
-    class WP_Error {
-        private $code;
-        private $message;
-        public function __construct( $code = '', $message = '' ) {
-            $this->code    = $code;
-            $this->message = $message;
-        }
-        public function get_error_message() {
-            return $this->message;
-        }
-    }
+	class WP_Error {
+		private $code;
+		private $message;
+		public function __construct( $code = '', $message = '' ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+		public function get_error_message() {
+			return $this->message;
+		}
+	}
 }
 
 if ( ! function_exists( 'is_wp_error' ) ) {
-    function is_wp_error( $thing ) {
-        return $thing instanceof WP_Error;
-    }
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
 }
 
 if ( ! function_exists( 'sanitize_text_field' ) ) {
-    function sanitize_text_field( $text ) {
-        return is_string( $text ) ? trim( $text ) : '';
-    }
+	function sanitize_text_field( $text ) {
+		return is_string( $text ) ? trim( $text ) : '';
+	}
 }
 
 if ( ! function_exists( 'wp_unslash' ) ) {
-    function wp_unslash( $value ) {
-        return $value;
-    }
+	function wp_unslash( $value ) {
+		return $value;
+	}
 }
 
 if ( ! function_exists( 'check_ajax_referer' ) ) {
-    function check_ajax_referer( $action, $query_arg = false, $die = true ) {
-        return true;
-    }
+	function check_ajax_referer( $action, $query_arg = false, $die = true ) {
+		return true;
+	}
 }
 
 class RTBCB_JSON_Response extends Exception {
-    public $data;
-    public function __construct( $data ) {
-        parent::__construct();
-        $this->data = $data;
-    }
+	public $data;
+	public function __construct( $data ) {
+		parent::__construct();
+		$this->data = $data;
+	}
 }
 
 if ( ! function_exists( 'wp_send_json_success' ) ) {
-    function wp_send_json_success( $data = null ) {
-        throw new RTBCB_JSON_Response(
-            [
-                'success' => true,
-                'data'    => $data,
-            ]
-        );
-    }
+	function wp_send_json_success( $data = null ) {
+		throw new RTBCB_JSON_Response(
+			[
+				'success' => true,
+				'data'    => $data,
+			]
+		);
+	}
 }
 
 class RTBCB_Background_Job {
-    public static $data = [];
-    public static function get_status( $job_id ) {
-        return self::$data[ $job_id ] ?? new WP_Error( 'not_found', 'Job not found.' );
-    }
+	public static $data = [];
+	public static function get_status( $job_id ) {
+		return self::$data[ $job_id ] ?? new WP_Error( 'not_found', 'Job not found.' );
+	}
 }
 
 require_once __DIR__ . '/../inc/class-rtbcb-ajax.php';
 
 function assert_same( $expected, $actual, $message ) {
-    if ( $expected !== $actual ) {
-        echo $message . "\n";
-        exit( 1 );
-    }
+	if ( $expected !== $actual ) {
+		echo $message . "\n";
+		exit( 1 );
+	}
 }
 
 $_GET['rtbcb_nonce'] = 'nonce';
 $_GET['job_id']      = 'job1';
 RTBCB_Background_Job::$data['job1'] = [
-    'state'   => 'processing',
-    'step'    => 'enrich',
-    'message' => 'Working',
-    'percent' => 50,
+	'state'   => 'processing',
+	'step'    => 'enrich',
+	'message' => 'Working',
+	'percent' => 50,
 ];
 try {
-    RTBCB_Ajax::get_job_status();
+	RTBCB_Ajax::get_job_status();
 } catch ( RTBCB_JSON_Response $e ) {
-    $data = $e->data;
+	$data = $e->data;
 }
 assert_same( true, $data['success'], 'Expected success true' );
 assert_same( 'processing', $data['data']['status'], 'Processing status mismatch' );
@@ -99,13 +99,13 @@ assert_same( 50.0, $data['data']['percent'], 'Percent mismatch' );
 
 $_GET['job_id'] = 'job2';
 RTBCB_Background_Job::$data['job2'] = [
-    'state'  => 'completed',
-    'result' => [ 'report_data' => [ 'foo' => 'bar' ], 'lead_id' => 5 ],
+	'state'  => 'completed',
+	'result' => [ 'report_data' => [ 'foo' => 'bar' ], 'lead_id' => 5 ],
 ];
 try {
-    RTBCB_Ajax::get_job_status();
+	RTBCB_Ajax::get_job_status();
 } catch ( RTBCB_JSON_Response $e ) {
-    $data = $e->data;
+	$data = $e->data;
 }
 assert_same( 'completed', $data['data']['status'], 'Completed status mismatch' );
 assert_same( [ 'foo' => 'bar' ], $data['data']['report_data'], 'Report data missing' );
@@ -113,21 +113,21 @@ assert_same( 5, $data['data']['lead_id'], 'Lead ID mismatch' );
 
 $_GET['job_id'] = 'job3';
 RTBCB_Background_Job::$data['job3'] = [
-    'state'        => 'completed',
-    'download_url' => 'http://example.com/report.pdf',
+	'state'        => 'completed',
+	'download_url' => 'http://example.com/report.pdf',
 ];
 try {
-    RTBCB_Ajax::get_job_status();
+	RTBCB_Ajax::get_job_status();
 } catch ( RTBCB_JSON_Response $e ) {
-    $data = $e->data;
+	$data = $e->data;
 }
 assert_same( 'http://example.com/report.pdf', $data['data']['download_url'], 'Download URL mismatch' );
 
 $_GET['job_id'] = 'missing';
 try {
-    RTBCB_Ajax::get_job_status();
+	RTBCB_Ajax::get_job_status();
 } catch ( RTBCB_JSON_Response $e ) {
-    $data = $e->data;
+	$data = $e->data;
 }
 assert_same( 'error', $data['data']['status'], 'Missing job not error' );
 assert_same( 'Job not found.', $data['data']['message'], 'Missing job message mismatch' );

--- a/tests/json-output-lint.php
+++ b/tests/json-output-lint.php
@@ -1,49 +1,49 @@
 <?php
 /**
- * Lints PHP files that output JSON to prevent stray output.
- *
- * @package RealTreasuryBusinessCaseBuilder
- */
+	* Lints PHP files that output JSON to prevent stray output.
+	*
+	* @package RealTreasuryBusinessCaseBuilder
+	*/
 
 function rtbcb_lint_json_output() {
-    $directory = dirname(__DIR__);
-    $iterator  = new RecursiveIteratorIterator(
-        new RecursiveDirectoryIterator($directory)
-    );
-    $errors = [];
+	$directory = dirname(__DIR__);
+	$iterator  = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator($directory)
+	);
+	$errors = [];
 
-    foreach ($iterator as $file) {
-        if ($file->isDir()) {
-            continue;
-        }
+	foreach ($iterator as $file) {
+		if ($file->isDir()) {
+			continue;
+		}
 
-        if ('.php' !== substr($file->getFilename(), -4)) {
-            continue;
-        }
+		if ('.php' !== substr($file->getFilename(), -4)) {
+			continue;
+		}
 
-        if (false !== strpos($file->getPathname(), '/vendor/')) {
-            continue;
-        }
+		if (false !== strpos($file->getPathname(), '/vendor/')) {
+			continue;
+		}
 
-        $contents = file_get_contents($file->getPathname());
+		$contents = file_get_contents($file->getPathname());
 
-        if (preg_match('/wp_send_json|json_encode/', $contents)) {
-            if (0 !== strpos($contents, '<?php')) {
-                $errors[] = $file->getPathname() . ' does not start with <?php';
-            }
+		if (preg_match('/wp_send_json|json_encode/', $contents)) {
+			if (0 !== strpos($contents, '<?php')) {
+				$errors[] = $file->getPathname() . ' does not start with <?php';
+			}
 
-            if (preg_match('/\?>\s*$/', $contents)) {
-                $errors[] = $file->getPathname() . ' ends with a closing ?> tag';
-            }
-        }
-    }
+			if (preg_match('/\?>\s*$/', $contents)) {
+				$errors[] = $file->getPathname() . ' ends with a closing ?> tag';
+			}
+		}
+	}
 
-    if (!empty($errors)) {
-        echo implode(PHP_EOL, $errors) . PHP_EOL;
-        exit(1);
-    }
+	if (!empty($errors)) {
+		echo implode(PHP_EOL, $errors) . PHP_EOL;
+		exit(1);
+	}
 
-    echo "JSON output lint passed." . PHP_EOL;
+	echo "JSON output lint passed." . PHP_EOL;
 }
 
 rtbcb_lint_json_output();

--- a/tests/lead-storage.test.php
+++ b/tests/lead-storage.test.php
@@ -76,10 +76,10 @@ return $default;
 }
 
 class WPDB_Memory {
-    public $prefix = '';
-    public $insert_id = 0;
-    public $last_error = '';
-    private $dbh;
+	public $prefix = '';
+	public $insert_id = 0;
+	public $last_error = '';
+	private $dbh;
 
 public function __construct() {
 $this->dbh = new SQLite3( ':memory:' );
@@ -132,14 +132,14 @@ $fmt  = $format[ $i ];
 $val  = $data[ $col ];
 $vals[] = '%s' === $fmt ? "'" . str_replace( "'", "''", $val ) . "'" : $val;
 }
-        $sql = "INSERT INTO $table (" . implode( ',', $cols ) . ") VALUES (" . implode( ',', $vals ) . ")";
-        $ok  = $this->dbh->exec( $sql );
-        if ( $ok ) {
-            $this->insert_id = $this->dbh->lastInsertRowID();
-            return 1;
-        }
-        $this->last_error = $this->dbh->lastErrorMsg();
-        return false;
+		$sql = "INSERT INTO $table (" . implode( ',', $cols ) . ") VALUES (" . implode( ',', $vals ) . ")";
+		$ok  = $this->dbh->exec( $sql );
+		if ( $ok ) {
+			$this->insert_id = $this->dbh->lastInsertRowID();
+			return 1;
+		}
+		$this->last_error = $this->dbh->lastErrorMsg();
+		return false;
 }
 
 public function update( $table, $data, $where, $format, $where_format ) {
@@ -153,11 +153,11 @@ $where_val = current( $where );
 $where_fmt = $where_format[0];
 $where_sql = '%s' === $where_fmt ? "'" . str_replace( "'", "''", $where_val ) . "'" : $where_val;
 $sql       = "UPDATE $table SET " . implode( ', ', $sets ) . " WHERE $where_col = $where_sql";
-        $ok = $this->dbh->exec( $sql );
-        if ( ! $ok ) {
-            $this->last_error = $this->dbh->lastErrorMsg();
-        }
-        return $ok;
+		$ok = $this->dbh->exec( $sql );
+		if ( ! $ok ) {
+			$this->last_error = $this->dbh->lastErrorMsg();
+		}
+		return $ok;
 }
 
 public function last_error() {

--- a/tests/mini-model-dynamic.test.php
+++ b/tests/mini-model-dynamic.test.php
@@ -2,34 +2,34 @@
 require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
 
 if ( ! function_exists( 'get_option' ) ) {
-    function get_option( $name, $default = '' ) {
-        if ( 'rtbcb_openai_api_key' === $name ) {
-            return 'test-key';
-        }
-        if ( 'rtbcb_mini_model' === $name ) {
-            return 'dynamic-mini';
-        }
-        return $default;
-    }
+	function get_option( $name, $default = '' ) {
+		if ( 'rtbcb_openai_api_key' === $name ) {
+			return 'test-key';
+		}
+		if ( 'rtbcb_mini_model' === $name ) {
+			return 'dynamic-mini';
+		}
+		return $default;
+	}
 }
 
 if ( ! function_exists( 'sanitize_text_field' ) ) {
-    function sanitize_text_field( $text ) {
-        return $text;
-    }
+	function sanitize_text_field( $text ) {
+		return $text;
+	}
 }
 
 if ( ! function_exists( 'sanitize_key' ) ) {
-    function sanitize_key( $key ) {
-        $key = strtolower( $key );
-        return preg_replace( '/[^a-z0-9_]/', '', $key );
-    }
+	function sanitize_key( $key ) {
+		$key = strtolower( $key );
+		return preg_replace( '/[^a-z0-9_]/', '', $key );
+	}
 }
 
 if ( ! function_exists( '__' ) ) {
-    function __( $text, $domain = null ) {
-        return $text;
-    }
+	function __( $text, $domain = null ) {
+		return $text;
+	}
 }
 
 $llm    = new RTBCB_LLM();
@@ -38,8 +38,8 @@ $method->setAccessible( true );
 $model = $method->invoke( $llm, 'mini' );
 
 if ( 'dynamic-mini' !== $model ) {
-    echo "Mini model did not use configuration\n";
-    exit( 1 );
+	echo "Mini model did not use configuration\n";
+	exit( 1 );
 }
 
 echo "mini-model-dynamic.test.php passed\n";

--- a/tests/openai-api-key-validation.test.php
+++ b/tests/openai-api-key-validation.test.php
@@ -3,35 +3,35 @@
 define( 'ABSPATH', __DIR__ . '/../' );
 
 if ( ! function_exists( 'add_filter' ) ) {
-    function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
-        // No-op for testing.
-    }
+	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+		// No-op for testing.
+	}
 }
 
 require_once __DIR__ . '/../inc/helpers.php';
 
 $valid_keys = [
-    'sk-' . str_repeat( 'A', 20 ) . '_' . str_repeat( 'B', 27 ),
-    'sk-' . str_repeat( 'A', 20 ) . ':' . str_repeat( 'B', 27 ),
+	'sk-' . str_repeat( 'A', 20 ) . '_' . str_repeat( 'B', 27 ),
+	'sk-' . str_repeat( 'A', 20 ) . ':' . str_repeat( 'B', 27 ),
 ];
 
 foreach ( $valid_keys as $key ) {
-    if ( ! rtbcb_is_valid_openai_api_key( $key ) ) {
-        echo "Valid key failed: {$key}\n";
-        exit( 1 );
-    }
+	if ( ! rtbcb_is_valid_openai_api_key( $key ) ) {
+		echo "Valid key failed: {$key}\n";
+		exit( 1 );
+	}
 }
 
 $invalid_keys = [
-    'sk-' . str_repeat( 'A', 47 ),
-    'sk-' . str_repeat( 'A', 20 ) . '+' . str_repeat( 'B', 27 ),
+	'sk-' . str_repeat( 'A', 47 ),
+	'sk-' . str_repeat( 'A', 20 ) . '+' . str_repeat( 'B', 27 ),
 ];
 
 foreach ( $invalid_keys as $key ) {
-    if ( rtbcb_is_valid_openai_api_key( $key ) ) {
-        echo "Invalid key passed: {$key}\n";
-        exit( 1 );
-    }
+	if ( rtbcb_is_valid_openai_api_key( $key ) ) {
+		echo "Invalid key passed: {$key}\n";
+		exit( 1 );
+	}
 }
 
 echo "openai-api-key-validation.test.php passed\n";

--- a/tests/parse-comprehensive-response.test.php
+++ b/tests/parse-comprehensive-response.test.php
@@ -2,51 +2,51 @@
 require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
 
 if ( ! class_exists( 'WP_Error' ) ) {
-    class WP_Error {
-        public $errors = [];
-        public function __construct( $code = '', $message = '' ) {
-            $this->errors[ $code ] = [ $message ];
-        }
-    }
+	class WP_Error {
+		public $errors = [];
+		public function __construct( $code = '', $message = '' ) {
+			$this->errors[ $code ] = [ $message ];
+		}
+	}
 }
 
 if ( ! function_exists( '__' ) ) {
-    function __( $text, $domain = null ) {
-        return $text;
-    }
+	function __( $text, $domain = null ) {
+		return $text;
+	}
 }
 
 if ( ! function_exists( 'is_wp_error' ) ) {
-    function is_wp_error( $thing ) {
-        return $thing instanceof WP_Error;
-    }
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
 }
 
 if ( ! function_exists( 'get_option' ) ) {
-    function get_option( $name, $default = '' ) {
-        return $default;
-    }
+	function get_option( $name, $default = '' ) {
+		return $default;
+	}
 }
 
 if ( ! function_exists( 'sanitize_text_field' ) ) {
-    function sanitize_text_field( $text ) {
-        $text = is_scalar( $text ) ? (string) $text : '';
-        $text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
-        return trim( $text );
-    }
+	function sanitize_text_field( $text ) {
+		$text = is_scalar( $text ) ? (string) $text : '';
+		$text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
+		return trim( $text );
+	}
 }
 
 if ( ! function_exists( 'sanitize_key' ) ) {
-    function sanitize_key( $key ) {
-        $key = strtolower( $key );
-        return preg_replace( '/[^a-z0-9_]/', '', $key );
-    }
+	function sanitize_key( $key ) {
+		$key = strtolower( $key );
+		return preg_replace( '/[^a-z0-9_]/', '', $key );
+	}
 }
 
 if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
-    function wp_remote_retrieve_body( $response ) {
-        return $response['body'] ?? '';
-    }
+	function wp_remote_retrieve_body( $response ) {
+		return $response['body'] ?? '';
+	}
 }
 
 $llm    = new RTBCB_LLM();
@@ -54,89 +54,89 @@ $method = new ReflectionMethod( RTBCB_LLM::class, 'parse_comprehensive_response'
 $method->setAccessible( true );
 
 $valid_json = [
-    'executive_summary' => [
-        'strategic_positioning'   => 'pos',
-        'business_case_strength'  => 'Strong',
-        'key_value_drivers'       => [ 'driver' ],
-        'executive_recommendation'=> 'rec',
-        'confidence_level'        => 0.9,
-    ],
-    'operational_analysis' => [
-        'current_state_assessment' => [
-            'efficiency_rating'    => 'Good',
-            'benchmark_comparison' => 'peer',
-            'capacity_utilization' => 'high',
-        ],
-        'process_inefficiencies'  => [],
-        'automation_opportunities'=> [],
-    ],
-    'industry_insights' => [
-        'sector_trends'          => 'trend',
-        'competitive_benchmarks' => 'bench',
-        'regulatory_considerations' => 'reg',
-    ],
-    'technology_recommendations' => [
-        'primary_solution' => [
-            'category'     => 'cat',
-            'rationale'    => 'why',
-            'key_features' => [ 'feature' ],
-        ],
-        'implementation_approach' => [
-            'phase_1'        => 'p1',
-            'phase_2'        => 'p2',
-            'success_metrics'=> [ 'metric' ],
-        ],
-    ],
-    'financial_analysis' => [
-        'investment_breakdown' => [
-            'software_licensing'      => 'cost',
-            'implementation_services' => 'cost',
-            'training_change_management' => 'cost',
-        ],
-        'payback_analysis' => [
-            'payback_months' => 12,
-            'roi_3_year'     => 50,
-            'npv_analysis'   => 'npv',
-        ],
-    ],
-    'risk_mitigation' => [
-        'implementation_risks' => [ 'risk' ],
-        'mitigation_strategies' => [
-            'risk_1_mitigation' => 'mit1',
-            'risk_2_mitigation' => 'mit2',
-        ],
-    ],
-    'next_steps' => [ 'step' ],
+	'executive_summary' => [
+		'strategic_positioning'   => 'pos',
+		'business_case_strength'  => 'Strong',
+		'key_value_drivers'       => [ 'driver' ],
+		'executive_recommendation'=> 'rec',
+		'confidence_level'        => 0.9,
+	],
+	'operational_analysis' => [
+		'current_state_assessment' => [
+			'efficiency_rating'    => 'Good',
+			'benchmark_comparison' => 'peer',
+			'capacity_utilization' => 'high',
+		],
+		'process_inefficiencies'  => [],
+		'automation_opportunities'=> [],
+	],
+	'industry_insights' => [
+		'sector_trends'          => 'trend',
+		'competitive_benchmarks' => 'bench',
+		'regulatory_considerations' => 'reg',
+	],
+	'technology_recommendations' => [
+		'primary_solution' => [
+			'category'     => 'cat',
+			'rationale'    => 'why',
+			'key_features' => [ 'feature' ],
+		],
+		'implementation_approach' => [
+			'phase_1'        => 'p1',
+			'phase_2'        => 'p2',
+			'success_metrics'=> [ 'metric' ],
+		],
+	],
+	'financial_analysis' => [
+		'investment_breakdown' => [
+			'software_licensing'      => 'cost',
+			'implementation_services' => 'cost',
+			'training_change_management' => 'cost',
+		],
+		'payback_analysis' => [
+			'payback_months' => 12,
+			'roi_3_year'     => 50,
+			'npv_analysis'   => 'npv',
+		],
+	],
+	'risk_mitigation' => [
+		'implementation_risks' => [ 'risk' ],
+		'mitigation_strategies' => [
+			'risk_1_mitigation' => 'mit1',
+			'risk_2_mitigation' => 'mit2',
+		],
+	],
+	'next_steps' => [ 'step' ],
 ];
 
 $response = [
-    'body' => json_encode( [
-        'output_text' => json_encode( $valid_json ),
-    ] ),
+	'body' => json_encode( [
+		'output_text' => json_encode( $valid_json ),
+	] ),
 ];
 
 $result = $method->invoke( $llm, $response );
 
 if ( is_wp_error( $result ) ) {
-    echo "Valid response produced WP_Error\n";
-    exit( 1 );
+	echo "Valid response produced WP_Error\n";
+	exit( 1 );
 }
 
 $required = [ 'executive_summary', 'operational_analysis', 'industry_insights', 'technology_recommendations', 'financial_analysis', 'risk_mitigation', 'next_steps' ];
 
 foreach ( $required as $key ) {
-    if ( ! isset( $result[ $key ] ) ) {
-        echo "Missing expected key: {$key}\n";
-        exit( 1 );
-    }
+	if ( ! isset( $result[ $key ] ) ) {
+		echo "Missing expected key: {$key}\n";
+		exit( 1 );
+	}
 }
 
 $bad_response = [ 'body' => 'not json' ];
 $bad_result   = $method->invoke( $llm, $bad_response );
 
 if ( ! is_wp_error( $bad_result ) ) {
-    echo "Invalid response did not return WP_Error\n";
-    exit( 1 );
+	echo "Invalid response did not return WP_Error\n";
+	exit( 1 );
 }
 
 echo "parse-comprehensive-response.test.php passed\n";

--- a/tests/reasoning-first-output.test.php
+++ b/tests/reasoning-first-output.test.php
@@ -2,9 +2,9 @@
 require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
 
 if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
-    function wp_remote_retrieve_body( $response ) {
-        return $response['body'] ?? '';
-    }
+	function wp_remote_retrieve_body( $response ) {
+		return $response['body'] ?? '';
+	}
 }
 
 $log_file   = __DIR__ . '/reasoning-first-output.log';
@@ -12,32 +12,32 @@ $prev_error = ini_get( 'error_log' );
 ini_set( 'error_log', $log_file );
 
 $mock_response = [
-    'body' => json_encode(
-        [
-            'output' => [
-                [
-                    'id'      => 'reasoning',
-                    'type'    => 'reasoning',
-                    'content' => [
-                        [
-                            'type' => 'reasoning',
-                            'text' => 'thinking',
-                        ],
-                    ],
-                ],
-                [
-                    'id'      => 'message',
-                    'type'    => 'message',
-                    'content' => [
-                        [
-                            'type' => 'output_text',
-                            'text' => 'This is a meaningful response message.',
-                        ],
-                    ],
-                ],
-            ],
-        ]
-    ),
+	'body' => json_encode(
+		[
+			'output' => [
+				[
+					'id'      => 'reasoning',
+					'type'    => 'reasoning',
+					'content' => [
+						[
+							'type' => 'reasoning',
+							'text' => 'thinking',
+						],
+					],
+				],
+				[
+					'id'      => 'message',
+					'type'    => 'message',
+					'content' => [
+						[
+							'type' => 'output_text',
+							'text' => 'This is a meaningful response message.',
+						],
+					],
+				],
+			],
+		]
+	),
 ];
 
 $result = rtbcb_parse_gpt5_response( $mock_response );
@@ -46,23 +46,23 @@ ini_set( 'error_log', $prev_error );
 @unlink( $log_file );
 
 if ( empty( $result['output_text'] ) ) {
-    echo "Empty response detected\n";
-    exit( 1 );
+	echo "Empty response detected\n";
+	exit( 1 );
 }
 
 if ( 'This is a meaningful response message.' !== $result['output_text'] ) {
-    echo "Unexpected output_text\n";
-    exit( 1 );
+	echo "Unexpected output_text\n";
+	exit( 1 );
 }
 
 if ( false === strpos( $log, 'Parsed response' ) ) {
-    echo "Missing parsed response log\n";
-    exit( 1 );
+	echo "Missing parsed response log\n";
+	exit( 1 );
 }
 
 if ( false !== strpos( $log, 'Detected trivial response' ) ) {
-    echo "Unexpected trivial response log\n";
-    exit( 1 );
+	echo "Unexpected trivial response log\n";
+	exit( 1 );
 }
 
 echo "reasoning-first-output.test.php passed\n";

--- a/tests/render-comprehensive-template.test.php
+++ b/tests/render-comprehensive-template.test.php
@@ -2,39 +2,39 @@
 require_once __DIR__ . '/../inc/helpers.php';
 
 if ( ! function_exists( '__' ) ) {
-    function __( $text, $domain = null ) {
-        return $text;
-    }
+	function __( $text, $domain = null ) {
+		return $text;
+	}
 }
 if ( ! function_exists( 'esc_html__' ) ) {
-    function esc_html__( $text, $domain = null ) {
-        return $text;
-    }
+	function esc_html__( $text, $domain = null ) {
+		return $text;
+	}
 }
 if ( ! function_exists( 'esc_html' ) ) {
-    function esc_html( $text ) {
-        return $text;
-    }
+	function esc_html( $text ) {
+		return $text;
+	}
 }
 if ( ! function_exists( 'esc_attr' ) ) {
-    function esc_attr( $text ) {
-        return $text;
-    }
+	function esc_attr( $text ) {
+		return $text;
+	}
 }
 if ( ! function_exists( 'current_time' ) ) {
-    function current_time( $type ) {
-        return '2024-01-01';
-    }
+	function current_time( $type ) {
+		return '2024-01-01';
+	}
 }
 
 $business_case_data = [
-    'company_name'      => 'Demo Corp',
-    'executive_summary' => [
-        'strategic_positioning'   => 'Positioned well.',
-        'business_case_strength'  => 'Strong',
-        'key_value_drivers'       => [ 'Efficiency', 'Compliance' ],
-        'executive_recommendation'=> 'Proceed',
-    ],
+	'company_name'      => 'Demo Corp',
+	'executive_summary' => [
+		'strategic_positioning'   => 'Positioned well.',
+		'business_case_strength'  => 'Strong',
+		'key_value_drivers'       => [ 'Efficiency', 'Compliance' ],
+		'executive_recommendation'=> 'Proceed',
+	],
 ];
 
 ob_start();
@@ -42,8 +42,8 @@ include __DIR__ . '/../templates/comprehensive-report-template.php';
 $output = ob_get_clean();
 
 if ( strpos( $output, 'rtbcb-executive-summary' ) === false ) {
-    echo "Executive summary not found\n";
-    exit( 1 );
+	echo "Executive summary not found\n";
+	exit( 1 );
 }
 
 echo "Comprehensive template render test passed.\n";

--- a/tests/scenario-selection.test.php
+++ b/tests/scenario-selection.test.php
@@ -1,18 +1,18 @@
 <?php
 if ( ! function_exists( 'add_filter' ) ) {
-    $GLOBALS['rtbcb_filters'] = [];
-    function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
-        $GLOBALS['rtbcb_filters'][ $tag ] = $function_to_add;
-    }
-    function apply_filters( $tag, $value ) {
-        $args   = func_get_args();
-        $tag    = array_shift( $args );
-        $value  = array_shift( $args );
-        if ( isset( $GLOBALS['rtbcb_filters'][ $tag ] ) ) {
-            $value = call_user_func_array( $GLOBALS['rtbcb_filters'][ $tag ], array_merge( [ $value ], $args ) );
-        }
-        return $value;
-    }
+	$GLOBALS['rtbcb_filters'] = [];
+	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['rtbcb_filters'][ $tag ] = $function_to_add;
+	}
+	function apply_filters( $tag, $value ) {
+		$args   = func_get_args();
+		$tag    = array_shift( $args );
+		$value  = array_shift( $args );
+		if ( isset( $GLOBALS['rtbcb_filters'][ $tag ] ) ) {
+			$value = call_user_func_array( $GLOBALS['rtbcb_filters'][ $tag ], array_merge( [ $value ], $args ) );
+		}
+		return $value;
+	}
 }
 
 define( 'ABSPATH', __DIR__ );
@@ -20,21 +20,21 @@ require_once __DIR__ . '/../inc/helpers.php';
 
 $received = '';
 add_filter( 'rtbcb_sample_report_inputs', function ( $inputs, $scenario_key ) use ( &$received ) {
-    $received = $scenario_key;
-    if ( 'alt' === $scenario_key ) {
-        $inputs['company_name'] = 'Alternate Inc';
-    }
-    return $inputs;
+	$received = $scenario_key;
+	if ( 'alt' === $scenario_key ) {
+		$inputs['company_name'] = 'Alternate Inc';
+	}
+	return $inputs;
 }, 10, 2 );
 
 $inputs = apply_filters( 'rtbcb_sample_report_inputs', rtbcb_get_sample_inputs(), 'alt' );
 if ( 'alt' !== $received ) {
-    echo "Scenario key not passed to filter\n";
-    exit( 1 );
+	echo "Scenario key not passed to filter\n";
+	exit( 1 );
 }
 if ( 'Alternate Inc' !== $inputs['company_name'] ) {
-    echo "Scenario modification not applied\n";
-    exit( 1 );
+	echo "Scenario modification not applied\n";
+	exit( 1 );
 }
 
 echo "scenario-selection.test.php passed\n";

--- a/tests/validator.test.php
+++ b/tests/validator.test.php
@@ -4,81 +4,81 @@ use PHPUnit\Framework\TestCase;
 define( 'ABSPATH', __DIR__ . '/../' );
 
 if ( ! function_exists( 'add_filter' ) ) {
-    function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
-        // No-op for testing.
-    }
+	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+		// No-op for testing.
+	}
 }
 
 if ( ! function_exists( '__' ) ) {
-    function __( $text, $domain = null ) {
-        return $text;
-    }
+	function __( $text, $domain = null ) {
+		return $text;
+	}
 }
 
 if ( ! function_exists( 'sanitize_text_field' ) ) {
-    function sanitize_text_field( $text ) {
-        return is_string( $text ) ? trim( $text ) : '';
-    }
+	function sanitize_text_field( $text ) {
+		return is_string( $text ) ? trim( $text ) : '';
+	}
 }
 
 if ( ! function_exists( 'sanitize_email' ) ) {
-    function sanitize_email( $email ) {
-        return filter_var( $email, FILTER_SANITIZE_EMAIL );
-    }
+	function sanitize_email( $email ) {
+		return filter_var( $email, FILTER_SANITIZE_EMAIL );
+	}
 }
 
 if ( ! function_exists( 'wp_unslash' ) ) {
-    function wp_unslash( $value ) {
-        return $value;
-    }
+	function wp_unslash( $value ) {
+		return $value;
+	}
 }
 
 require_once __DIR__ . '/../inc/helpers.php';
 require_once __DIR__ . '/../inc/class-rtbcb-validator.php';
 
 final class RTBCB_ValidatorTest extends TestCase {
-    public function test_missing_required_fields() {
-        $validator = new RTBCB_Validator();
+	public function test_missing_required_fields() {
+		$validator = new RTBCB_Validator();
 
-        $result = $validator->validate( [ 'email' => 'user@corp.com', 'company_size' => '100-500' ] );
-        $this->assertSame( 'Company name is required.', $result['error'] );
+		$result = $validator->validate( [ 'email' => 'user@corp.com', 'company_size' => '100-500' ] );
+		$this->assertSame( 'Company name is required.', $result['error'] );
 
-        $result = $validator->validate( [ 'company_name' => 'Acme', 'company_size' => '100-500' ] );
-        $this->assertSame( 'Email is required.', $result['error'] );
+		$result = $validator->validate( [ 'company_name' => 'Acme', 'company_size' => '100-500' ] );
+		$this->assertSame( 'Email is required.', $result['error'] );
 
-        $result = $validator->validate( [ 'company_name' => 'Acme', 'email' => 'user@corp.com' ] );
-        $this->assertSame( 'Company size is required.', $result['error'] );
-    }
+		$result = $validator->validate( [ 'company_name' => 'Acme', 'email' => 'user@corp.com' ] );
+		$this->assertSame( 'Company size is required.', $result['error'] );
+	}
 
-    public function test_email_domain_validation() {
-        $validator = new RTBCB_Validator();
-        $result = $validator->validate( [
-            'company_name' => 'Acme',
-            'email'        => 'user@gmail.com',
-            'company_size' => '100-500',
-        ] );
-        $this->assertSame( 'Please use your business email address.', $result['error'] );
+	public function test_email_domain_validation() {
+		$validator = new RTBCB_Validator();
+		$result = $validator->validate( [
+			'company_name' => 'Acme',
+			'email'        => 'user@gmail.com',
+			'company_size' => '100-500',
+		] );
+		$this->assertSame( 'Please use your business email address.', $result['error'] );
 
-        $this->assertTrue( rtbcb_is_business_email( 'user@company.com' ) );
-        $this->assertFalse( rtbcb_is_business_email( 'user@yahoo.com' ) );
-    }
+		$this->assertTrue( rtbcb_is_business_email( 'user@company.com' ) );
+		$this->assertFalse( rtbcb_is_business_email( 'user@yahoo.com' ) );
+	}
 
-    public function test_field_length_constraints() {
-        $validator = new RTBCB_Validator();
-        $long_name = str_repeat( 'a', 256 );
-        $result = $validator->validate( [
-            'company_name' => $long_name,
-            'email'        => 'user@corp.com',
-            'company_size' => '100-500',
-        ] );
-        $this->assertSame( 'Company Name cannot exceed 255 characters.', $result['error'] );
+	public function test_field_length_constraints() {
+		$validator = new RTBCB_Validator();
+		$long_name = str_repeat( 'a', 256 );
+		$result = $validator->validate( [
+			'company_name' => $long_name,
+			'email'        => 'user@corp.com',
+			'company_size' => '100-500',
+		] );
+		$this->assertSame( 'Company Name cannot exceed 255 characters.', $result['error'] );
 
-        $long_email = str_repeat( 'a', 250 ) . '@example.com';
-        $result = $validator->validate( [
-            'company_name' => 'Acme',
-            'email'        => $long_email,
-            'company_size' => '100-500',
-        ] );
-        $this->assertSame( 'Email cannot exceed 254 characters.', $result['error'] );
-    }
+		$long_email = str_repeat( 'a', 250 ) . '@example.com';
+		$result = $validator->validate( [
+			'company_name' => 'Acme',
+			'email'        => $long_email,
+			'company_size' => '100-500',
+		] );
+		$this->assertSame( 'Email cannot exceed 254 characters.', $result['error'] );
+	}
 }


### PR DESCRIPTION
## Summary
- Replace leading spaces with tabs in PHP sources per WordPress standards
- Apply tab-based indentation across plugin, admin, template, and test files

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found; submission errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b442844a90833181018e506fdd4295