### PR TITLE
Normalize PHP indentation to tabs

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -12,8 +12,8 @@ defined( 'ABSPATH' ) || exit;
 	*/
 class RTBCB_Admin {
 	/**
-	 * Constructor.
-	 */
+	* Constructor.
+	*/
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
 		add_action( 'admin_init', [ $this, 'register_settings' ] );
@@ -64,11 +64,11 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Enqueue admin assets.
-	 *
-	 * @param string $hook Page hook.
-	 * @return void
-	 */
+	* Enqueue admin assets.
+	*
+	* @param string $hook Page hook.
+	* @return void
+	*/
 	public function enqueue_admin_assets( $hook ) {
 		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
 		if ( strpos( $hook, 'rtbcb' ) === false && strpos( $page, 'rtbcb' ) === false ) {
@@ -215,10 +215,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Register admin menu and submenus.
-	 *
-	 * @return void
-	 */
+	* Register admin menu and submenus.
+	*
+	* @return void
+	*/
 	public function add_admin_menu() {
 		add_menu_page(
 			__( 'Business Case Builder', 'rtbcb' ),
@@ -305,9 +305,9 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Render enhanced dashboard with statistics.
-	 *
-	 * @return void
+	* Render enhanced dashboard with statistics.
+	*
+	* @return void
 	*/
 	public function render_dashboard() {
 		$stats = RTBCB_Leads::get_cached_statistics();
@@ -317,19 +317,19 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Render settings page.
-	 *
-	 * @return void
-	 */
+	* Render settings page.
+	*
+	* @return void
+	*/
 	public function render_settings() {
 		include RTBCB_DIR . 'admin/settings-page.php';
 	}
 
 	/**
-	 * Render enhanced leads page with filtering and export.
-	 *
-	 * @return void
-	 */
+	* Render enhanced leads page with filtering and export.
+	*
+	* @return void
+	*/
 	public function render_leads() {
 		$page = isset( $_GET['paged'] ) ? intval( wp_unslash( $_GET['paged'] ) ) : 1;
 		$search = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
@@ -369,10 +369,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Render analytics page with charts and insights.
-	 *
-	 * @return void
-	 */
+	* Render analytics page with charts and insights.
+	*
+	* @return void
+	*/
 	public function render_analytics() {
 		$stats = RTBCB_Leads::get_cached_statistics();
 		$monthly_trends = $this->get_monthly_trends();
@@ -381,19 +381,19 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Render calculation info page.
-	 *
-	 * @return void
-	 */
+	* Render calculation info page.
+	*
+	* @return void
+	*/
 	public function render_calculation_info() {
 		include RTBCB_DIR . 'admin/calculations-page.php';
 	}
 
 	/**
-	 * Render test dashboard page.
-	 *
-	 * @return void
-	 */
+	* Render test dashboard page.
+	*
+	* @return void
+	*/
 	public function render_test_dashboard() {
 		$test_results   = get_option( 'rtbcb_test_results', [] );
 		$openai_key     = get_option( 'rtbcb_openai_api_key', '' );
@@ -408,10 +408,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Render API logs page.
-	 *
-	 * @return void
-	 */
+	* Render API logs page.
+	*
+	* @return void
+	*/
 	public function render_api_logs() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
@@ -426,10 +426,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler to save test results from dashboard.
-	 *
-	 * @return void
-	 */
+	* AJAX handler to save test results from dashboard.
+	*
+	* @return void
+	*/
 	public function ajax_save_test_results() {
 		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
 
@@ -488,10 +488,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Register plugin settings.
-	 *
-	 * @return void
-	 */
+	* Register plugin settings.
+	*
+	* @return void
+	*/
 	public function register_settings() {
 		register_setting( 'rtbcb_settings', 'rtbcb_settings', [ 'sanitize_callback' => [ $this, 'sanitize_settings' ] ] );
 		register_setting( 'rtbcb_settings', 'rtbcb_openai_api_key', [ 'sanitize_callback' => 'sanitize_text_field' ] );
@@ -509,11 +509,11 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Sanitize rtbcb_settings option.
-	 *
-	 * @param array $settings Settings array.
-	 * @return array
-	 */
+	* Sanitize rtbcb_settings option.
+	*
+	* @param array $settings Settings array.
+	* @return array
+	*/
 	public function sanitize_settings( $settings ) {
 		$settings = is_array( $settings ) ? $settings : [];
 		$settings['enable_ai_analysis'] = isset( $settings['enable_ai_analysis'] ) ? (bool) $settings['enable_ai_analysis'] : false;
@@ -522,10 +522,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Export leads to CSV.
-	 *
-	 * @return void
-	 */
+	* Export leads to CSV.
+	*
+	* @return void
+	*/
 	public function export_leads_csv() {
 		check_ajax_referer( 'rtbcb_nonce', 'nonce' );
 
@@ -550,10 +550,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Delete a single lead.
-	 *
-	 * @return void
-	 */
+	* Delete a single lead.
+	*
+	* @return void
+	*/
 	public function delete_lead() {
 		check_ajax_referer( 'rtbcb_nonce', 'nonce' );
 
@@ -577,10 +577,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Handle bulk actions on leads.
-	 *
-	 * @return void
-	 */
+	* Handle bulk actions on leads.
+	*
+	* @return void
+	*/
 	public function bulk_action_leads() {
 		check_ajax_referer( 'rtbcb_nonce', 'nonce' );
 
@@ -630,10 +630,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Test the OpenAI API connection.
-	 *
-	 * @return void
-	 */
+	* Test the OpenAI API connection.
+	*
+	* @return void
+	*/
 	public function test_api_connection() {
 		check_ajax_referer( 'rtbcb_nonce', 'nonce' );
 
@@ -676,12 +676,12 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Clear cached OpenAI models when API settings change.
-	 *
-	 * @param string $old_value Old API key.
-	 * @param string $value     New API key.
-	 * @return void
-	 */
+	* Clear cached OpenAI models when API settings change.
+	*
+	* @param string $old_value Old API key.
+	* @param string $value     New API key.
+	* @return void
+	*/
 	public function clear_openai_models_cache( $old_value, $value ) {
 		if ( $old_value !== $value ) {
 			wp_cache_delete( 'rtbcb_openai_models' );
@@ -689,10 +689,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for comprehensive API test.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for comprehensive API test.
+	*
+	* @return void
+	*/
 	public function ajax_test_api() {
 		check_ajax_referer( 'rtbcb_test_api', 'nonce' );
 
@@ -710,10 +710,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for industry commentary testing.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for industry commentary testing.
+	*
+	* @return void
+	*/
 	public function ajax_test_commentary() {
 		check_ajax_referer( 'rtbcb_test_commentary', 'nonce' );
 
@@ -744,14 +744,14 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for company overview testing.
-	 *
-	 * Retrieves the company name from the request, stored options, or the
-	 * currently selected company. Returns an error only if no name can be
-	 * determined.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for company overview testing.
+	*
+	* Retrieves the company name from the request, stored options, or the
+	* currently selected company. Returns an error only if no name can be
+	* determined.
+	*
+	* @return void
+	*/
 	public function ajax_test_company_overview() {
 		check_ajax_referer( 'rtbcb_test_company_overview', 'nonce' );
 
@@ -857,10 +857,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for industry overview testing.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for industry overview testing.
+	*
+	* @return void
+	*/
 	public function ajax_test_industry_overview() {
 		check_ajax_referer( 'rtbcb_test_industry_overview', 'nonce' );
 		$raw_data     = isset( $_POST['company_data'] ) ? wp_unslash( $_POST['company_data'] ) : '';
@@ -895,10 +895,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for maturity model testing.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for maturity model testing.
+	*
+	* @return void
+	*/
 	public function ajax_test_maturity_model() {
 		check_ajax_referer( 'rtbcb_test_maturity_model', 'nonce' );
 
@@ -921,10 +921,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for RAG market analysis testing.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for RAG market analysis testing.
+	*
+	* @return void
+	*/
 	public function ajax_test_rag_market_analysis() {
 		check_ajax_referer( 'rtbcb_test_rag_market_analysis', 'nonce' );
 
@@ -964,10 +964,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for value proposition testing.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for value proposition testing.
+	*
+	* @return void
+	*/
 	public function ajax_test_value_proposition() {
 		check_ajax_referer( 'rtbcb_test_value_proposition', 'nonce' );
 
@@ -989,15 +989,15 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for treasury tech overview testing.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for treasury tech overview testing.
+	*
+	* @return void
+	*/
 	/**
-	 * AJAX handler for real treasury overview testing.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for real treasury overview testing.
+	*
+	* @return void
+	*/
 	public function ajax_test_real_treasury_overview() {
 		check_ajax_referer( 'rtbcb_test_real_treasury_overview', 'nonce' );
 
@@ -1048,10 +1048,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler to retrieve stored company data.
-	 *
-	 * @return void
-	 */
+	* AJAX handler to retrieve stored company data.
+	*
+	* @return void
+	*/
 	public function ajax_get_company_data() {
 		check_ajax_referer( 'rtbcb_test_real_treasury_overview', 'nonce' );
 
@@ -1076,17 +1076,17 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for testing estimated benefits.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for testing estimated benefits.
+	*
+	* @return void
+	*/
 	/**
-	 * AJAX handler to generate estimated benefits.
-	 *
-	 * Stores sanitized results to mark the section complete.
-	 *
-	 * @return void
-	 */
+	* AJAX handler to generate estimated benefits.
+	*
+	* Stores sanitized results to mark the section complete.
+	*
+	* @return void
+	*/
 	public function ajax_test_estimated_benefits() {
 		check_ajax_referer( 'rtbcb_test_estimated_benefits', 'nonce' );
 
@@ -1156,10 +1156,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler to calculate ROI from sample inputs.
-	 *
-	 * @return void
-	 */
+	* AJAX handler to calculate ROI from sample inputs.
+	*
+	* @return void
+	*/
 	public function ajax_test_calculate_roi() {
 		check_ajax_referer( 'rtbcb_test_calculate_roi', 'nonce' );
 
@@ -1188,10 +1188,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for data enrichment testing.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for data enrichment testing.
+	*
+	* @return void
+	*/
 	public function ajax_test_data_enrichment() {
 		check_ajax_referer( 'rtbcb_test_data_enrichment', 'nonce' );
 
@@ -1224,10 +1224,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for data storage testing.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for data storage testing.
+	*
+	* @return void
+	*/
 	public function ajax_test_data_storage() {
 		check_ajax_referer( 'rtbcb_test_data_storage', 'nonce' );
 
@@ -1267,10 +1267,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for report assembly testing.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for report assembly testing.
+	*
+	* @return void
+	*/
 	public function ajax_test_report_assembly() {
 		check_ajax_referer( 'rtbcb_test_report_assembly', 'nonce' );
 
@@ -1299,10 +1299,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for tracking script testing.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for tracking script testing.
+	*
+	* @return void
+	*/
 	public function ajax_test_tracking_script() {
 		check_ajax_referer( 'rtbcb_test_tracking_script', 'nonce' );
 
@@ -1328,10 +1328,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for follow-up email testing.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for follow-up email testing.
+	*
+	* @return void
+	*/
 	public function ajax_test_follow_up_email() {
 		check_ajax_referer( 'rtbcb_test_follow_up_email', 'nonce' );
 
@@ -1368,10 +1368,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Rebuild the RAG index.
-	 *
-	 * @return void
-	 */
+	* Rebuild the RAG index.
+	*
+	* @return void
+	*/
 	public function rebuild_rag_index() {
 		check_ajax_referer( 'rtbcb_nonce', 'nonce' );
 
@@ -1394,10 +1394,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Run integration diagnostics.
-	 *
-	 * @return void
-	 */
+	* Run integration diagnostics.
+	*
+	* @return void
+	*/
 	public function run_integration_tests() {
 		check_ajax_referer( 'rtbcb_nonce', 'nonce' );
 
@@ -1411,10 +1411,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler to set company name for tests.
-	 *
-	 * @return void
-	 */
+	* AJAX handler to set company name for tests.
+	*
+	* @return void
+	*/
 	public function ajax_set_test_company() {
 		check_ajax_referer( 'rtbcb_set_test_company', 'nonce' );
 
@@ -1471,10 +1471,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler to test Portal integration.
-	 *
-	 * @return void
-	 */
+	* AJAX handler to test Portal integration.
+	*
+	* @return void
+	*/
 	public function ajax_test_portal() {
 		check_ajax_referer( 'rtbcb_test_portal', 'nonce' );
 
@@ -1492,10 +1492,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler to test RAG index health.
-	 *
-	 * @return void
-	 */
+	* AJAX handler to test RAG index health.
+	*
+	* @return void
+	*/
 	public function ajax_test_rag() {
 		check_ajax_referer( 'rtbcb_test_rag', 'nonce' );
 
@@ -1525,10 +1525,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Sync portal data to the local site.
-	 *
-	 * @return void
-	 */
+	* Sync portal data to the local site.
+	*
+	* @return void
+	*/
 	public function sync_to_local() {
 		check_ajax_referer( 'rtbcb_sync_local', 'nonce' );
 
@@ -1540,10 +1540,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Get monthly trends data.
-	 *
-	 * @return array Monthly trends.
-	 */
+	* Get monthly trends data.
+	*
+	* @return array Monthly trends.
+	*/
 	private function get_monthly_trends() {
 		global $wpdb;
 		$table_name = $wpdb->prefix . 'rtbcb_leads';
@@ -1553,10 +1553,10 @@ class RTBCB_Admin {
 				DATE_FORMAT(created_at, '%Y-%m') as month,
 				COUNT(*) as leads,
 				AVG(roi_base) as avg_roi
-			 FROM {$table_name}
-			 WHERE created_at >= DATE_SUB(NOW(), INTERVAL 12 MONTH)
-			 GROUP BY DATE_FORMAT(created_at, '%Y-%m')
-			 ORDER BY month",
+			FROM {$table_name}
+			WHERE created_at >= DATE_SUB(NOW(), INTERVAL 12 MONTH)
+			GROUP BY DATE_FORMAT(created_at, '%Y-%m')
+			ORDER BY month",
 			ARRAY_A
 		);
 
@@ -1564,29 +1564,29 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Check if Portal integration is active.
-	 *
-	 * @return bool
-	 */
+	* Check if Portal integration is active.
+	*
+	* @return bool
+	*/
 	private function check_portal_integration() {
 		return (bool) ( has_filter( 'rt_portal_get_vendors' ) || has_filter( 'rt_portal_get_vendor_notes' ) );
 	}
 
 	/**
-	 * Get vendor count from portal.
-	 *
-	 * @return int
-	 */
+	* Get vendor count from portal.
+	*
+	* @return int
+	*/
 	private function get_vendor_count() {
 		$vendors = apply_filters( 'rt_portal_get_vendors', [] );
 		return is_array( $vendors ) ? count( $vendors ) : 0;
 	}
 
 	/**
-	 * Check RAG index health.
-	 *
-	 * @return array Health status.
-	 */
+	* Check RAG index health.
+	*
+	* @return array Health status.
+	*/
 	private function check_rag_health() {
 		global $wpdb;
 		$table_name = $wpdb->prefix . 'rtbcb_rag_index';
@@ -1628,10 +1628,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler to fetch phase completion percentages.
-	 *
-	 * @return void
-	 */
+	* AJAX handler to fetch phase completion percentages.
+	*
+	* @return void
+	*/
 	public function ajax_get_phase_completion() {
 		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
 
@@ -1643,10 +1643,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler to fetch sanitized configuration for a section.
-	 *
-	 * @return void
-	 */
+	* AJAX handler to fetch sanitized configuration for a section.
+	*
+	* @return void
+	*/
 	public function ajax_get_section_config() {
 		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
 
@@ -1672,10 +1672,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler to build test summary HTML.
-	 *
-	 * @return void
-	 */
+	* AJAX handler to build test summary HTML.
+	*
+	* @return void
+	*/
 	public function ajax_get_test_summary_html() {
 		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
 
@@ -1723,11 +1723,11 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Recursively sanitize configuration data.
-	 *
-	 * @param mixed $data Configuration value.
-	 * @return mixed
-	 */
+	* Recursively sanitize configuration data.
+	*
+	* @param mixed $data Configuration value.
+	* @return mixed
+	*/
 	private function sanitize_section_config( $data ) {
 		if ( is_array( $data ) ) {
 			$clean = [];
@@ -1745,10 +1745,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler to generate comprehensive analysis.
-	 *
-	 * @return void
-	 */
+	* AJAX handler to generate comprehensive analysis.
+	*
+	* @return void
+	*/
 	public function ajax_generate_comprehensive_analysis() {
 		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
 		$company_name = isset( $_POST['company_name'] ) ? sanitize_text_field( wp_unslash( $_POST['company_name'] ) ) : '';
@@ -1770,10 +1770,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Get status for a queued comprehensive analysis job.
-	 *
-	 * @return void
-	 */
+	* Get status for a queued comprehensive analysis job.
+	*
+	* @return void
+	*/
 	public function ajax_get_analysis_status() {
 		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
 
@@ -1795,10 +1795,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * Clear stored comprehensive analysis data.
-	 *
-	 * @return void
-	 */
+	* Clear stored comprehensive analysis data.
+	*
+	* @return void
+	*/
 	public function ajax_clear_analysis_data() {
 		check_ajax_referer( 'rtbcb_test_dashboard', 'nonce' );
 
@@ -1821,10 +1821,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for deleting a single log entry.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for deleting a single log entry.
+	*
+	* @return void
+	*/
 	public function ajax_delete_log() {
 		check_ajax_referer( 'rtbcb_api_logs', 'nonce' );
 
@@ -1847,10 +1847,10 @@ class RTBCB_Admin {
 	}
 
 	/**
-	 * AJAX handler for clearing all log entries.
-	 *
-	 * @return void
-	 */
+	* AJAX handler for clearing all log entries.
+	*
+	* @return void
+	*/
 	public function ajax_clear_logs() {
 		check_ajax_referer( 'rtbcb_api_logs', 'nonce' );
 
@@ -1920,10 +1920,10 @@ class RTBCB_Admin {
 		}
 
 		/**
-		 * Retrieve workflow history with lead metadata.
-		 *
-		 * @return array Workflow history entries.
-		 */
+		* Retrieve workflow history with lead metadata.
+		*
+		* @return array Workflow history entries.
+		*/
 		private function get_workflow_history_from_logs() {
 			$history = get_option( 'rtbcb_workflow_history', [] );
 			if ( ! is_array( $history ) ) {
@@ -1964,10 +1964,10 @@ class RTBCB_Admin {
 		}
 
 		/**
-		 * Display notice if PHP max execution time is lower than GPT-5 timeout.
-		 *
-		 * @return void
-		 */
+		* Display notice if PHP max execution time is lower than GPT-5 timeout.
+		*
+		* @return void
+		*/
 		public function maybe_show_timeout_notice() {
 				$php_limit   = (int) ini_get( 'max_execution_time' );
 				$gpt_timeout = (int) get_option( 'rtbcb_gpt5_timeout' );
@@ -1995,10 +1995,10 @@ class RTBCB_Admin {
 
 
 	/**
-	 * Display notice when heavy features are disabled.
-	 *
-	 * @return void
-	 */
+	* Display notice when heavy features are disabled.
+	*
+	* @return void
+	*/
 	public function maybe_show_bypass_notice() {
 		if ( get_option( 'rtbcb_disable_heavy_features', 0 ) ) {
 			echo '<div class="notice notice-warning"><p>' . esc_html__( 'Heavy AI features are temporarily disabled. Remove the rtbcb_disable_heavy_features option to restore full functionality.', 'rtbcb' ) . '</p></div>';

--- a/admin/dashboard-page.php
+++ b/admin/dashboard-page.php
@@ -295,7 +295,7 @@ $avg_roi = intval( $roi_stats['avg_base'] ?? 0 );
 						</div>
 						<div class="rtbcb-category-bar">
 							<div class="rtbcb-category-fill rtbcb-cat-<?php echo esc_attr( $stat['recommended_category'] ); ?>"
-								 style="width: <?php echo esc_attr( $percentage ); ?>%"></div>
+								style="width: <?php echo esc_attr( $percentage ); ?>%"></div>
 						</div>
 						<div class="rtbcb-category-percentage"><?php echo esc_html( number_format( $percentage, 1 ) ); ?>%</div>
 					</div>

--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -8,10 +8,10 @@ defined( 'ABSPATH' ) || exit;
 	*/
 class RTBCB_Ajax {
 	/**
-	 * Generate comprehensive case via AJAX.
-	 *
-	 * @return void
-	 */
+	* Generate comprehensive case via AJAX.
+	*
+	* @return void
+	*/
 		public static function generate_comprehensive_case() {
 				if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
 						wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
@@ -29,10 +29,10 @@ class RTBCB_Ajax {
 		}
 
 		/**
-		 * Stream business analysis chunks via AJAX.
-		 *
-		 * @return void
-		 */
+		* Stream business analysis chunks via AJAX.
+		*
+		* @return void
+		*/
 		public static function stream_analysis() {
 				if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
 						wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
@@ -79,11 +79,11 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 				exit;
 		}
 	/**
-	 * Process the basic ROI calculation step.
-	 *
-	 * @param array $user_inputs User inputs.
-	 * @return array ROI block.
-	 */
+	* Process the basic ROI calculation step.
+	*
+	* @param array $user_inputs User inputs.
+	* @return array ROI block.
+	*/
 	public static function process_basic_roi_step( $user_inputs ) {
 		$roi_scenarios = RTBCB_Calculator::calculate_roi( $user_inputs );
 
@@ -96,16 +96,16 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 
 
 	/**
-	 * Process comprehensive case generation.
-	 *
-	 * @param array $user_inputs User inputs.
-	 * @return array|WP_Error Result data or error.
-	 */
+	* Process comprehensive case generation.
+	*
+	* @param array $user_inputs User inputs.
+	* @return array|WP_Error Result data or error.
+	*/
 		public static function process_comprehensive_case( $user_inputs, $job_id = '' ) {
-			   $request_start    = microtime( true );
-			   $workflow_tracker = new RTBCB_Workflow_Tracker();
-			   $bypass_heavy    = rtbcb_heavy_features_disabled();
-			   $enable_ai        = ! $bypass_heavy && RTBCB_Settings::get_setting( 'enable_ai_analysis', true );
+			$request_start    = microtime( true );
+			$workflow_tracker = new RTBCB_Workflow_Tracker();
+			$bypass_heavy    = rtbcb_heavy_features_disabled();
+			$enable_ai        = ! $bypass_heavy && RTBCB_Settings::get_setting( 'enable_ai_analysis', true );
 
 		add_action(
 			'rtbcb_llm_prompt_sent',
@@ -235,15 +235,15 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 								$final_analysis = self::create_fallback_analysis( $enriched_profile, $roi_scenarios );
 								$workflow_tracker->add_warning( 'hybrid_rag_disabled', __( 'AI analysis disabled.', 'rtbcb' ) );
 						}
-					   $workflow_tracker->complete_step( 'hybrid_rag_analysis', $final_analysis );
-					   if ( $job_id ) {
-							   RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'analysis' => $final_analysis ] );
-					   }
+					$workflow_tracker->complete_step( 'hybrid_rag_analysis', $final_analysis );
+					if ( $job_id ) {
+							RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'analysis' => $final_analysis ] );
+					}
 
-					   $chart_data = self::prepare_chart_data( $roi_scenarios );
+					$chart_data = self::prepare_chart_data( $roi_scenarios );
 
-					   $workflow_tracker->start_step( 'data_structuring' );
-					   $structured_report_data = self::structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $chart_data, $request_start );
+					$workflow_tracker->start_step( 'data_structuring' );
+					$structured_report_data = self::structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $chart_data, $request_start );
 						$workflow_tracker->complete_step( 'data_structuring', $structured_report_data );
 						if ( $job_id ) {
 								RTBCB_Background_Job::update_status( $job_id, 'processing', [ 'report_data' => $structured_report_data ] );
@@ -263,7 +263,7 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 				'report_data'   => $structured_report_data,
 				'workflow_info' => $debug_info,
 				'lead_id'       => $lead_id,
-							   'analysis_type' => rtbcb_get_analysis_type(),
+							'analysis_type' => rtbcb_get_analysis_type(),
 			];
 		} catch ( Exception $e ) {
 			$workflow_tracker->add_error( 'exception', $e->getMessage() );
@@ -280,10 +280,10 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 	}
 
 	/**
-	 * Get background job status.
-	 *
-	 * @return void
-	 */
+	* Get background job status.
+	*
+	* @return void
+	*/
 	public static function get_job_status() {
 		if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
 			wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
@@ -344,9 +344,9 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 		}
 
 		wp_send_json_success( $response );
-	   }
+	}
 
-	   private static function collect_and_validate_user_inputs() {
+	private static function collect_and_validate_user_inputs() {
 		$validator = new RTBCB_Validator();
 		$validated = $validator->validate( $_POST );
 
@@ -355,7 +355,7 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 		}
 
 		return $validated;
-	   }
+	}
 
 	private static function create_fallback_profile( $user_inputs ) {
 		return [
@@ -400,7 +400,7 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 			'metadata' => [
 				'company_name'   => $user_inputs['company_name'],
 				'analysis_date'  => current_time( 'Y-m-d' ),
-							   'analysis_type'  => rtbcb_get_analysis_type(),
+							'analysis_type'  => rtbcb_get_analysis_type(),
 				'confidence_level' => $final_analysis['confidence_level'] ?? 0.85,
 				'processing_time' => microtime( true ) - $request_start,
 			],
@@ -417,13 +417,13 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 				'maturity_assessment' => $enriched_profile['maturity_assessment'] ?? [],
 				'competitive_position'=> $enriched_profile['competitive_position'] ?? [],
 			],
-					   'financial_analysis' => [
-							   'roi_scenarios'        => self::format_roi_scenarios( $roi_scenarios ),
-							   'investment_breakdown' => $final_analysis['financial_analysis']['investment_breakdown'] ?? [],
-							   'payback_analysis'     => $final_analysis['financial_analysis']['payback_analysis'] ?? [],
-							   'sensitivity_analysis' => $roi_scenarios['sensitivity_analysis'] ?? [],
-							   'chart_data'           => $chart_data,
-					   ],
+					'financial_analysis' => [
+							'roi_scenarios'        => self::format_roi_scenarios( $roi_scenarios ),
+							'investment_breakdown' => $final_analysis['financial_analysis']['investment_breakdown'] ?? [],
+							'payback_analysis'     => $final_analysis['financial_analysis']['payback_analysis'] ?? [],
+							'sensitivity_analysis' => $roi_scenarios['sensitivity_analysis'] ?? [],
+							'chart_data'           => $chart_data,
+					],
 			'technology_strategy' => [
 				'recommended_category' => $recommendation['recommended'],
 				'category_details'     => $recommendation['category_info'],
@@ -480,78 +480,78 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 				return null;
 		}
 
-	   /**
+	/**
 		* Prepare chart data for ROI visualization.
 		*
 		* @param array $roi_scenarios ROI scenarios.
 		* @return array Chart.js compatible data structure.
 		*/
-	   private static function prepare_chart_data( $roi_scenarios ) {
-			   return [
-					   'labels'   => [
-							   __( 'Labor Savings', 'rtbcb' ),
-							   __( 'Fee Savings', 'rtbcb' ),
-							   __( 'Error Reduction', 'rtbcb' ),
-							   __( 'Total Benefit', 'rtbcb' ),
-					   ],
-					   'datasets' => [
-							   [
-									   'label'           => __( 'Conservative', 'rtbcb' ),
-									   'data'            => [
-											   $roi_scenarios['conservative']['labor_savings'] ?? 0,
-											   $roi_scenarios['conservative']['fee_savings'] ?? 0,
-											   $roi_scenarios['conservative']['error_reduction'] ?? 0,
-											   $roi_scenarios['conservative']['total_annual_benefit'] ?? 0,
-									   ],
-									   'backgroundColor' => 'rgba(239, 68, 68, 0.8)',
-									   'borderColor'     => 'rgba(239, 68, 68, 1)',
-									   'borderWidth'     => 1,
-							   ],
-							   [
-									   'label'           => __( 'Base Case', 'rtbcb' ),
-									   'data'            => [
-											   $roi_scenarios['base']['labor_savings'] ?? 0,
-											   $roi_scenarios['base']['fee_savings'] ?? 0,
-											   $roi_scenarios['base']['error_reduction'] ?? 0,
-											   $roi_scenarios['base']['total_annual_benefit'] ?? 0,
-									   ],
-									   'backgroundColor' => 'rgba(59, 130, 246, 0.8)',
-									   'borderColor'     => 'rgba(59, 130, 246, 1)',
-									   'borderWidth'     => 1,
-							   ],
-							   [
-									   'label'           => __( 'Optimistic', 'rtbcb' ),
-									   'data'            => [
-											   $roi_scenarios['optimistic']['labor_savings'] ?? 0,
-											   $roi_scenarios['optimistic']['fee_savings'] ?? 0,
-											   $roi_scenarios['optimistic']['error_reduction'] ?? 0,
-											   $roi_scenarios['optimistic']['total_annual_benefit'] ?? 0,
-									   ],
-									   'backgroundColor' => 'rgba(16, 185, 129, 0.8)',
-									   'borderColor'     => 'rgba(16, 185, 129, 1)',
-									   'borderWidth'     => 1,
-							   ],
-					   ],
-			   ];
-	   }
+	private static function prepare_chart_data( $roi_scenarios ) {
+			return [
+					'labels'   => [
+							__( 'Labor Savings', 'rtbcb' ),
+							__( 'Fee Savings', 'rtbcb' ),
+							__( 'Error Reduction', 'rtbcb' ),
+							__( 'Total Benefit', 'rtbcb' ),
+					],
+					'datasets' => [
+							[
+									'label'           => __( 'Conservative', 'rtbcb' ),
+									'data'            => [
+											$roi_scenarios['conservative']['labor_savings'] ?? 0,
+											$roi_scenarios['conservative']['fee_savings'] ?? 0,
+											$roi_scenarios['conservative']['error_reduction'] ?? 0,
+											$roi_scenarios['conservative']['total_annual_benefit'] ?? 0,
+									],
+									'backgroundColor' => 'rgba(239, 68, 68, 0.8)',
+									'borderColor'     => 'rgba(239, 68, 68, 1)',
+									'borderWidth'     => 1,
+							],
+							[
+									'label'           => __( 'Base Case', 'rtbcb' ),
+									'data'            => [
+											$roi_scenarios['base']['labor_savings'] ?? 0,
+											$roi_scenarios['base']['fee_savings'] ?? 0,
+											$roi_scenarios['base']['error_reduction'] ?? 0,
+											$roi_scenarios['base']['total_annual_benefit'] ?? 0,
+									],
+									'backgroundColor' => 'rgba(59, 130, 246, 0.8)',
+									'borderColor'     => 'rgba(59, 130, 246, 1)',
+									'borderWidth'     => 1,
+							],
+							[
+									'label'           => __( 'Optimistic', 'rtbcb' ),
+									'data'            => [
+											$roi_scenarios['optimistic']['labor_savings'] ?? 0,
+											$roi_scenarios['optimistic']['fee_savings'] ?? 0,
+											$roi_scenarios['optimistic']['error_reduction'] ?? 0,
+											$roi_scenarios['optimistic']['total_annual_benefit'] ?? 0,
+									],
+									'backgroundColor' => 'rgba(16, 185, 129, 0.8)',
+									'borderColor'     => 'rgba(16, 185, 129, 1)',
+									'borderWidth'     => 1,
+							],
+					],
+			];
+	}
 
-	   private static function calculate_business_case_strength( $roi_scenarios, $recommendation ) {
-			   $base = $roi_scenarios['base']['total_annual_benefit'] ?? 0;
-			   return $base > 0 ? 'strong' : 'weak';
-	   }
+	private static function calculate_business_case_strength( $roi_scenarios, $recommendation ) {
+			$base = $roi_scenarios['base']['total_annual_benefit'] ?? 0;
+			return $base > 0 ? 'strong' : 'weak';
+	}
 
 	private static function format_roi_scenarios( $roi_scenarios ) {
 		return $roi_scenarios;
 	}
 
 /**
-	 * Store workflow history and associated lead metadata.
-	 *
-	 * @param array     $debug_info  Workflow debug information.
-	 * @param int|null  $lead_id     Lead ID.
-	 * @param string    $lead_email  Lead email address.
-	 * @return void
-	 */
+	* Store workflow history and associated lead metadata.
+	*
+	* @param array     $debug_info  Workflow debug information.
+	* @param int|null  $lead_id     Lead ID.
+	* @param string    $lead_email  Lead email address.
+	* @return void
+	*/
 	private static function store_workflow_history( $debug_info, $lead_id = null, $lead_email = '' ) {
 		$history = get_option( 'rtbcb_workflow_history', [] );
 		if ( ! is_array( $history ) ) {

--- a/inc/class-rtbcb-api-log.php
+++ b/inc/class-rtbcb-api-log.php
@@ -12,17 +12,17 @@ defined( 'ABSPATH' ) || exit;
 	*/
 class RTBCB_API_Log {
 	/**
-	 * Database table name.
-	 *
-	 * @var string
-	 */
+	* Database table name.
+	*
+	* @var string
+	*/
 	private static $table_name;
 
 	/**
-	 * Initialize the table name and create the table.
-	 *
-	 * @return void
-	 */
+	* Initialize the table name and create the table.
+	*
+	* @return void
+	*/
 	public static function init() {
 		global $wpdb;
 
@@ -31,10 +31,10 @@ class RTBCB_API_Log {
 	}
 
 	/**
-	 * Create the API logs table.
-	 *
-	 * @return bool True on success, false on failure.
-	 */
+	* Create the API logs table.
+	*
+	* @return bool True on success, false on failure.
+	*/
 	private static function create_table() {
 		global $wpdb;
 
@@ -111,15 +111,15 @@ class RTBCB_API_Log {
 	}
 
 	/**
-	 * Save a log entry.
-	 *
-	 * @param array  $request      Request data.
-	 * @param array  $response     Response data.
-	 * @param int    $user_id      User ID.
-	 * @param string $user_email   User email.
-	 * @param string $company_name Company name.
-	 * @return void
-	 */
+	* Save a log entry.
+	*
+	* @param array  $request      Request data.
+	* @param array  $response     Response data.
+	* @param int    $user_id      User ID.
+	* @param string $user_email   User email.
+	* @param string $company_name Company name.
+	* @return void
+	*/
 	public static function save_log( $request, $response, $user_id, $user_email = '', $company_name = '' ) {
 		global $wpdb;
 
@@ -158,11 +158,11 @@ class RTBCB_API_Log {
 	}
 
 	/**
-	 * Retrieve recent logs.
-	 *
-	 * @param int $limit Number of logs to retrieve.
-	 * @return array Log rows.
-	 */
+	* Retrieve recent logs.
+	*
+	* @param int $limit Number of logs to retrieve.
+	* @return array Log rows.
+	*/
 	public static function get_logs( $limit = 50 ) {
 		global $wpdb;
 
@@ -181,11 +181,11 @@ class RTBCB_API_Log {
 	}
 
 	/**
-	 * Purge old logs.
-	 *
-	 * @param int $days Number of days to retain.
-	 * @return int Rows deleted.
-	 */
+	* Purge old logs.
+	*
+	* @param int $days Number of days to retain.
+	* @return int Rows deleted.
+	*/
 	public static function purge_logs( $days = 30 ) {
 		global $wpdb;
 
@@ -209,11 +209,11 @@ class RTBCB_API_Log {
 	}
 
 	/**
-	 * Delete a single log entry.
-	 *
-	 * @param int $id Log ID.
-	 * @return int Rows deleted.
-	 */
+	* Delete a single log entry.
+	*
+	* @param int $id Log ID.
+	* @return int Rows deleted.
+	*/
 	public static function delete_log( $id ) {
 		global $wpdb;
 
@@ -230,10 +230,10 @@ class RTBCB_API_Log {
 	}
 
 	/**
-	 * Clear all log entries.
-	 *
-	 * @return int Rows deleted.
-	 */
+	* Clear all log entries.
+	*
+	* @return int Rows deleted.
+	*/
 	public static function clear_logs() {
 		global $wpdb;
 
@@ -245,15 +245,15 @@ class RTBCB_API_Log {
 	}
 
 	/**
-	 * Retrieve logs with pagination support.
-	 *
-	 * @param int $paged    Current page number.
-	 * @param int $per_page Items per page.
-	 * @return array{
-	 *     logs: array,
-	 *     total: int
-	 * }
-	 */
+	* Retrieve logs with pagination support.
+	*
+	* @param int $paged    Current page number.
+	* @param int $per_page Items per page.
+	* @return array{
+	*     logs: array,
+	*     total: int
+	* }
+	*/
 	public static function get_logs_paginated( $paged = 1, $per_page = 20 ) {
 		global $wpdb;
 

--- a/inc/class-rtbcb-api-tester.php
+++ b/inc/class-rtbcb-api-tester.php
@@ -12,11 +12,11 @@ defined( 'ABSPATH' ) || exit;
 	*/
 class RTBCB_API_Tester {
 	/**
-	 * Test OpenAI API connection.
-	 *
-	 * @param string $api_key Optional API key to test.
-	 * @return array Test result.
-	 */
+	* Test OpenAI API connection.
+	*
+	* @param string $api_key Optional API key to test.
+	* @return array Test result.
+	*/
 	public static function test_connection( $api_key = null ) {
 		$api_key = $api_key ?: rtbcb_get_openai_api_key();
 
@@ -40,11 +40,11 @@ class RTBCB_API_Tester {
 	}
 
 	/**
-	 * Test API with a simple completion request.
-	 *
-	 * @param string $api_key API key.
-	 * @return array Test result.
-	 */
+	* Test API with a simple completion request.
+	*
+	* @param string $api_key API key.
+	* @return array Test result.
+	*/
 	private static function test_completion( $api_key ) {
 		$model  = get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) );
 		$config = rtbcb_get_gpt5_config();

--- a/inc/class-rtbcb-background-job.php
+++ b/inc/class-rtbcb-background-job.php
@@ -33,11 +33,11 @@ $current['updated'] = time();
 set_transient( $job_id, $current, HOUR_IN_SECONDS );
 }
 	/**
-	 * Enqueue a case generation job.
-	 *
-	 * @param array $user_inputs Sanitized user inputs.
-	 * @return string Job ID.
-	 */
+	* Enqueue a case generation job.
+	*
+	* @param array $user_inputs Sanitized user inputs.
+	* @return string Job ID.
+	*/
 public static function enqueue( $user_inputs ) {
 $job_id = uniqid( 'rtbcb_job_', true );
 
@@ -58,12 +58,12 @@ self::update_status( $job_id, 'queued' );
 		}
 
 	/**
-	 * Process a queued job.
-	 *
-	 * @param string $job_id      Job identifier.
-	 * @param array  $user_inputs User inputs.
-	 * @return void
-	 */
+	* Process a queued job.
+	*
+	* @param string $job_id      Job identifier.
+	* @param array  $user_inputs User inputs.
+	* @return void
+	*/
 public static function process_job( $job_id, $user_inputs ) {
 self::update_status( $job_id, 'processing' );
 

--- a/inc/class-rtbcb-calculator.php
+++ b/inc/class-rtbcb-calculator.php
@@ -14,12 +14,12 @@ defined( 'ABSPATH' ) || exit;
 	*/
 class RTBCB_Calculator {
 	/**
-	 * Calculate ROI scenarios for given inputs.
-	 *
-	 * @param array $user_inputs User provided inputs.
-	 * @param array $category    Optional category info.
-	 * @return array
-	 */
+	* Calculate ROI scenarios for given inputs.
+	*
+	* @param array $user_inputs User provided inputs.
+	* @param array $category    Optional category info.
+	* @return array
+	*/
 	public static function calculate_roi( $user_inputs, $category = [] ) {
 		$settings      = RTBCB_Settings::get_all();
 		$industry_mult = self::get_industry_benchmark( $user_inputs['industry'] ?? '' );
@@ -33,37 +33,37 @@ class RTBCB_Calculator {
 	}
 
 	/**
-	 * Recalculate ROI scenarios using recommended category info.
-	 *
-	 * @param array $user_inputs User provided inputs.
-	 * @param array $category    Category info from recommender.
-	 * @return array
-	 */
+	* Recalculate ROI scenarios using recommended category info.
+	*
+	* @param array $user_inputs User provided inputs.
+	* @param array $category    Category info from recommender.
+	* @return array
+	*/
 	public static function calculate_category_refined_roi( $user_inputs, $category ) {
 		return self::calculate_roi( $user_inputs, $category );
 	}
 
 	/**
-	 * Calculate ROI for a scenario.
-	 *
-	 * @param array  $inputs        User inputs.
-	 * @param array  $settings      Plugin settings.
-	 * @param array  $category      Recommended category info.
-	 * @param string $scenario_type Scenario type.
-	 * @param float  $industry_mult Industry benchmark multiplier.
-	 * @return array
-	 */
+	* Calculate ROI for a scenario.
+	*
+	* @param array  $inputs        User inputs.
+	* @param array  $settings      Plugin settings.
+	* @param array  $category      Recommended category info.
+	* @param string $scenario_type Scenario type.
+	* @param float  $industry_mult Industry benchmark multiplier.
+	* @return array
+	*/
 	private static function calculate_scenario( $inputs, $settings, $category, $scenario_type, $industry_mult ) {
 		/**
-		 * Filters the scenario multipliers used to adjust ROI calculations.
-		 *
-		 * @param array  $multipliers   Associative array of scenario multipliers.
-		 * @param array  $inputs        User provided inputs.
-		 * @param array  $settings      Plugin settings.
-		 * @param array  $category      Recommended category info.
-		 * @param string $scenario_type Scenario type.
-		 * @param float  $industry_mult Industry benchmark multiplier.
-		 */
+		* Filters the scenario multipliers used to adjust ROI calculations.
+		*
+		* @param array  $multipliers   Associative array of scenario multipliers.
+		* @param array  $inputs        User provided inputs.
+		* @param array  $settings      Plugin settings.
+		* @param array  $category      Recommended category info.
+		* @param string $scenario_type Scenario type.
+		* @param float  $industry_mult Industry benchmark multiplier.
+		*/
 		$multipliers = apply_filters(
 			'rtbcb_roi_multipliers',
 			[
@@ -103,14 +103,14 @@ class RTBCB_Calculator {
 	}
 
 	/**
-	 * Calculate labor cost savings.
-	 *
-	 * @param array $inputs     User inputs.
-	 * @param array $settings   Plugin settings.
-	 * @param float $multiplier Scenario multiplier.
-	 *
-	 * @return float Annual labor savings.
-	 */
+	* Calculate labor cost savings.
+	*
+	* @param array $inputs     User inputs.
+	* @param array $settings   Plugin settings.
+	* @param float $multiplier Scenario multiplier.
+	*
+	* @return float Annual labor savings.
+	*/
 	private static function calculate_labor_savings( $inputs, $settings, $multiplier ) {
 		$hourly_cost = isset( $settings['labor_cost_per_hour'] ) ? floatval( $settings['labor_cost_per_hour'] ) : 100;
 		$weekly_hours = ( isset( $inputs['hours_reconciliation'] ) ? floatval( $inputs['hours_reconciliation'] ) : 0 )
@@ -122,14 +122,14 @@ class RTBCB_Calculator {
 	}
 
 	/**
-	 * Calculate bank fee savings.
-	 *
-	 * @param array $inputs     User inputs.
-	 * @param array $settings   Plugin settings.
-	 * @param float $multiplier Scenario multiplier.
-	 *
-	 * @return float Annual fee savings.
-	 */
+	* Calculate bank fee savings.
+	*
+	* @param array $inputs     User inputs.
+	* @param array $settings   Plugin settings.
+	* @param float $multiplier Scenario multiplier.
+	*
+	* @return float Annual fee savings.
+	*/
 	private static function calculate_fee_savings( $inputs, $settings, $multiplier ) {
 		$num_banks = isset( $inputs['num_banks'] ) ? intval( $inputs['num_banks'] ) : 0;
 		$baseline  = isset( $settings['bank_fee_baseline'] ) ? floatval( $settings['bank_fee_baseline'] ) : 15000;
@@ -139,23 +139,23 @@ class RTBCB_Calculator {
 	}
 
 	/**
-	 * Calculate savings from error reduction.
-	 *
-	 * @param array $inputs     User inputs.
-	 * @param array $settings   Plugin settings.
-	 * @param float $multiplier Scenario multiplier.
-	 *
-	 * @return float Annual error reduction benefit.
-	 */
+	* Calculate savings from error reduction.
+	*
+	* @param array $inputs     User inputs.
+	* @param array $settings   Plugin settings.
+	* @param float $multiplier Scenario multiplier.
+	*
+	* @return float Annual error reduction benefit.
+	*/
 	private static function calculate_error_reduction( $inputs, $settings, $multiplier ) {
 		/**
-		 * Filters the base error cost map used for calculating error reduction savings.
-		 *
-		 * @param array $cost_map   Map of company sizes to base error costs.
-		 * @param array $inputs     User provided inputs.
-		 * @param array $settings   Plugin settings.
-		 * @param float $multiplier Scenario multiplier.
-		 */
+		* Filters the base error cost map used for calculating error reduction savings.
+		*
+		* @param array $cost_map   Map of company sizes to base error costs.
+		* @param array $inputs     User provided inputs.
+		* @param array $settings   Plugin settings.
+		* @param float $multiplier Scenario multiplier.
+		*/
 		$cost_map = apply_filters(
 			'rtbcb_error_cost_map',
 			[
@@ -176,14 +176,14 @@ class RTBCB_Calculator {
 	}
 
 	/**
-	 * Get scenario assumptions.
-	 *
-	 * @param string $scenario_type Scenario key.
-	 * @param float  $multiplier    Scenario multiplier.
-	 * @param float  $industry_mult Industry multiplier.
-	 *
-	 * @return array Assumptions for the scenario.
-	 */
+	* Get scenario assumptions.
+	*
+	* @param string $scenario_type Scenario key.
+	* @param float  $multiplier    Scenario multiplier.
+	* @param float  $industry_mult Industry multiplier.
+	*
+	* @return array Assumptions for the scenario.
+	*/
 	private static function get_scenario_assumptions( $scenario_type, $multiplier, $industry_mult ) {
 		return [
 			'name'                  => ucfirst( $scenario_type ),
@@ -195,11 +195,11 @@ class RTBCB_Calculator {
 	}
 
 	/**
-	 * Retrieve industry benchmark multiplier.
-	 *
-	 * @param string $industry Industry identifier.
-	 * @return float Multiplier.
-	 */
+	* Retrieve industry benchmark multiplier.
+	*
+	* @param string $industry Industry identifier.
+	* @return float Multiplier.
+	*/
 	private static function get_industry_benchmark( $industry ) {
 		$benchmarks = [
 			'manufacturing' => 0.9,

--- a/inc/class-rtbcb-category-recommender.php
+++ b/inc/class-rtbcb-category-recommender.php
@@ -12,10 +12,10 @@ defined( 'ABSPATH' ) || exit;
 	*/
 class RTBCB_Category_Recommender {
 	/**
-	 * Category definitions with descriptions and criteria.
-	 *
-	 * @var array
-	 */
+	* Category definitions with descriptions and criteria.
+	*
+	* @var array
+	*/
 	public const CATEGORIES = [
 		'cash_tools' => [
 			'name'        => 'Cash Management Tools',
@@ -62,11 +62,11 @@ class RTBCB_Category_Recommender {
 	];
 
 	/**
-	 * Recommend the most appropriate category based on user inputs.
-	 *
-	 * @param array $user_inputs User form data.
-	 * @return array Recommendation with scoring details.
-	 */
+	* Recommend the most appropriate category based on user inputs.
+	*
+	* @param array $user_inputs User form data.
+	* @return array Recommendation with scoring details.
+	*/
 	public static function recommend_category( $user_inputs ) {
 		$empty = [
 			'recommended'   => '',
@@ -109,11 +109,11 @@ class RTBCB_Category_Recommender {
 	}
 
 	/**
-	 * Translate category info strings.
-	 *
-	 * @param array $category Category data.
-	 * @return array
-	 */
+	* Translate category info strings.
+	*
+	* @param array $category Category data.
+	* @return array
+	*/
 	private static function translate_category_info( $category ) {
 		$category['name']        = __( $category['name'], 'rtbcb' );
 		$category['description'] = __( $category['description'], 'rtbcb' );
@@ -129,12 +129,12 @@ class RTBCB_Category_Recommender {
 	}
 
 	/**
-	 * Calculate score for a specific category.
-	 *
-	 * @param string $category Category key.
-	 * @param array  $inputs   User inputs.
-	 * @return float Score (0-100).
-	 */
+	* Calculate score for a specific category.
+	*
+	* @param string $category Category key.
+	* @param array  $inputs   User inputs.
+	* @return float Score (0-100).
+	*/
 	private static function calculate_category_score( $category, $inputs ) {
 		$score     = 0;
 		$max_score = 0;
@@ -159,12 +159,12 @@ class RTBCB_Category_Recommender {
 	}
 
 	/**
-	 * Score based on company size.
-	 *
-	 * @param string $category     Category key.
-	 * @param string $company_size Company size.
-	 * @return float Score (0-100).
-	 */
+	* Score based on company size.
+	*
+	* @param string $category     Category key.
+	* @param string $company_size Company size.
+	* @return float Score (0-100).
+	*/
 	private static function score_company_size( $category, $company_size ) {
 		$size_scores = [
 			'cash_tools' => [
@@ -191,12 +191,12 @@ class RTBCB_Category_Recommender {
 	}
 
 	/**
-	 * Score based on operational complexity.
-	 *
-	 * @param string $category Category key.
-	 * @param array  $inputs   User inputs.
-	 * @return float Score (0-100).
-	 */
+	* Score based on operational complexity.
+	*
+	* @param string $category Category key.
+	* @param array  $inputs   User inputs.
+	* @return float Score (0-100).
+	*/
 	private static function score_complexity( $category, $inputs ) {
 		$num_banks   = intval( $inputs['num_banks'] ?? 0 );
 		$ftes        = floatval( $inputs['ftes'] ?? 0 );
@@ -238,12 +238,12 @@ class RTBCB_Category_Recommender {
 	}
 
 	/**
-	 * Score based on pain points alignment.
-	 *
-	 * @param string $category    Category key.
-	 * @param array  $pain_points Selected pain points.
-	 * @return float Score (0-100).
-	 */
+	* Score based on pain points alignment.
+	*
+	* @param string $category    Category key.
+	* @param array  $pain_points Selected pain points.
+	* @return float Score (0-100).
+	*/
 	private static function score_pain_points( $category, $pain_points ) {
 		if ( empty( $pain_points ) ) {
 			return 50;
@@ -290,12 +290,12 @@ class RTBCB_Category_Recommender {
 	}
 
 	/**
-	 * Score based on transaction volume indicators.
-	 *
-	 * @param string $category Category key.
-	 * @param array  $inputs   User inputs.
-	 * @return float Score (0-100).
-	 */
+	* Score based on transaction volume indicators.
+	*
+	* @param string $category Category key.
+	* @param array  $inputs   User inputs.
+	* @return float Score (0-100).
+	*/
 	private static function score_volume( $category, $inputs ) {
 		$num_banks = intval( $inputs['num_banks'] ?? 0 );
 		$ftes      = floatval( $inputs['ftes'] ?? 0 );
@@ -319,11 +319,11 @@ class RTBCB_Category_Recommender {
 	}
 
 	/**
-	 * Calculate confidence level in recommendation.
-	 *
-	 * @param array $scores Category scores.
-	 * @return float Confidence (0-1).
-	 */
+	* Calculate confidence level in recommendation.
+	*
+	* @param array $scores Category scores.
+	* @return float Confidence (0-1).
+	*/
 	private static function calculate_confidence( $scores ) {
 		$score_values = array_values( $scores );
 		$top_score    = $score_values[0];
@@ -336,12 +336,12 @@ class RTBCB_Category_Recommender {
 	}
 
 	/**
-	 * Generate human-readable reasoning for the recommendation.
-	 *
-	 * @param string $recommended Recommended category.
-	 * @param array  $inputs      User inputs.
-	 * @return string Reasoning text.
-	 */
+	* Generate human-readable reasoning for the recommendation.
+	*
+	* @param string $recommended Recommended category.
+	* @param array  $inputs      User inputs.
+	* @return string Reasoning text.
+	*/
 	private static function generate_reasoning( $recommended, $inputs ) {
 		$company_size = $inputs['company_size'] ?? '';
 		$num_banks    = intval( $inputs['num_banks'] ?? 0 );
@@ -417,12 +417,12 @@ class RTBCB_Category_Recommender {
 	}
 
 	/**
-	 * Get alternative recommendations.
-	 *
-	 * @param array  $scores       All category scores.
-	 * @param string $recommended  Primary recommendation.
-	 * @return array Alternative categories.
-	 */
+	* Get alternative recommendations.
+	*
+	* @param array  $scores       All category scores.
+	* @param string $recommended  Primary recommendation.
+	* @return array Alternative categories.
+	*/
 	private static function get_alternatives( $scores, $recommended ) {
 		$alternatives = [];
 
@@ -440,11 +440,11 @@ class RTBCB_Category_Recommender {
 	}
 
 	/**
-	 * Get category information by key.
-	 *
-	 * @param string $category_key Category key.
-	 * @return array|null Category information.
-	 */
+	* Get category information by key.
+	*
+	* @param string $category_key Category key.
+	* @return array|null Category information.
+	*/
 	public static function get_category_info( $category_key ) {
 		if ( ! isset( self::CATEGORIES[ $category_key ] ) ) {
 			return null;
@@ -453,10 +453,10 @@ class RTBCB_Category_Recommender {
 	}
 
 	/**
-	 * Get all available categories.
-	 *
-	 * @return array All categories.
-	 */
+	* Get all available categories.
+	*
+	* @return array All categories.
+	*/
 	public static function get_all_categories() {
 		$translated = [];
 		foreach ( self::CATEGORIES as $key => $category ) {

--- a/inc/class-rtbcb-db.php
+++ b/inc/class-rtbcb-db.php
@@ -12,15 +12,15 @@ defined( 'ABSPATH' ) || exit;
 	*/
 class RTBCB_DB {
 	/**
-	 * Current database version.
-	 */
+	* Current database version.
+	*/
 	const DB_VERSION = '2.0.3';
 
 	/**
-	 * Initialize database and handle upgrades.
-	 *
-	 * @return void
-	 */
+	* Initialize database and handle upgrades.
+	*
+	* @return void
+	*/
 	public static function init() {
 		$current = get_option( 'rtbcb_db_version', '1.0.0' );
 
@@ -39,11 +39,11 @@ class RTBCB_DB {
 	}
 
 	/**
-	 * Perform database upgrades.
-	 *
-	 * @param string $from_version Previous database version.
-	 * @return void
-	 */
+	* Perform database upgrades.
+	*
+	* @param string $from_version Previous database version.
+	* @return void
+	*/
 	private static function upgrade( $from_version ) {
 		// Run table creation/migration for leads.
 		RTBCB_Leads::init();
@@ -73,10 +73,10 @@ class RTBCB_DB {
 	}
 
 	/**
-	 * Create the RAG index table if it does not exist.
-	 *
-	 * @return void
-	 */
+	* Create the RAG index table if it does not exist.
+	*
+	* @return void
+	*/
 	private static function create_rag_table() {
 		global $wpdb;
 
@@ -103,10 +103,10 @@ class RTBCB_DB {
 	}
 
 	/**
-	 * Add embedding_norm index to the RAG table if missing.
-	 *
-	 * @return void
-	 */
+	* Add embedding_norm index to the RAG table if missing.
+	*
+	* @return void
+	*/
 	private static function add_embedding_norm_index() {
 		global $wpdb;
 
@@ -118,10 +118,10 @@ class RTBCB_DB {
 	}
 
 	/**
-	 * Seed sample data into the RAG index when empty.
-	 *
-	 * @return void
-	 */
+	* Seed sample data into the RAG index when empty.
+	*
+	* @return void
+	*/
 	private static function seed_rag_sample_data() {
 		global $wpdb;
 

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -12,24 +12,24 @@ defined( 'ABSPATH' ) || exit;
 	*/
 class RTBCB_Leads {
 	/**
-	 * Database table name.
-	 *
-	 * @var string
-	 */
+	* Database table name.
+	*
+	* @var string
+	*/
 	private static $table_name;
 
 	/**
-	 * Option name for cached statistics.
-	 *
-	 * @var string
-	 */
+	* Option name for cached statistics.
+	*
+	* @var string
+	*/
 	private static $cache_option = 'rtbcb_lead_stats';
 
 	/**
-	 * Create the leads table with improved error handling.
-	 *
-	 * @return bool True on success, false on failure.
-	 */
+	* Create the leads table with improved error handling.
+	*
+	* @return bool True on success, false on failure.
+	*/
 	private static function create_table() {
 		global $wpdb;
 
@@ -139,8 +139,8 @@ class RTBCB_Leads {
 	}
 
 	/**
-	 * Initialize the class with better error handling.
-	 */
+	* Initialize the class with better error handling.
+	*/
 	public static function init() {
 		global $wpdb;
 		self::$table_name = $wpdb->prefix . 'rtbcb_leads';
@@ -160,12 +160,12 @@ class RTBCB_Leads {
 		}
 	}
 	/**
-	 * Add missing indexes to the leads table.
-	 *
-	 * Ensures unique and secondary indexes exist for commonly queried fields.
-	 *
-	 * @return void
-	 */
+	* Add missing indexes to the leads table.
+	*
+	* Ensures unique and secondary indexes exist for commonly queried fields.
+	*
+	* @return void
+	*/
 		public static function add_missing_indexes() {
 				global $wpdb;
 
@@ -188,10 +188,10 @@ class RTBCB_Leads {
 		}
 
 	/**
-	 * Compress existing report_html entries.
-	 *
-	 * @return void
-	 */
+	* Compress existing report_html entries.
+	*
+	* @return void
+	*/
 	public static function compress_existing_report_html() {
 		global $wpdb;
 
@@ -220,11 +220,11 @@ class RTBCB_Leads {
 
 
 	/**
-	 * Save a lead to the database.
-	 *
-	 * @param array $lead_data Lead information.
-	 * @return int|false Lead ID or false on failure.
-	 */
+	* Save a lead to the database.
+	*
+	* @param array $lead_data Lead information.
+	* @return int|false Lead ID or false on failure.
+	*/
 	public static function save_lead( $lead_data ) {
 		global $wpdb;
 
@@ -334,11 +334,11 @@ class RTBCB_Leads {
 	}
 
 	/**
-	 * Get a lead by email address.
-	 *
-	 * @param string $email Email address.
-	 * @return array|null Lead data or null if not found.
-	 */
+	* Get a lead by email address.
+	*
+	* @param string $email Email address.
+	* @return array|null Lead data or null if not found.
+	*/
 	public static function get_lead_by_email( $email ) {
 		global $wpdb;
 
@@ -365,11 +365,11 @@ class RTBCB_Leads {
 	}
 
 	/**
-	 * Get all leads with pagination and filtering.
-	 *
-	 * @param array $args Query arguments.
-	 * @return array Leads data with pagination info.
-	 */
+	* Get all leads with pagination and filtering.
+	*
+	* @param array $args Query arguments.
+	* @return array Leads data with pagination info.
+	*/
 	public static function get_all_leads( $args = [] ) {
 		global $wpdb;
 
@@ -446,10 +446,10 @@ class RTBCB_Leads {
 	}
 
 	/**
-	 * Get lead statistics.
-	 *
-	 * @return array Statistics data.
-	 */
+	* Get lead statistics.
+	*
+	* @return array Statistics data.
+	*/
 	public static function get_statistics() {
 		global $wpdb;
 
@@ -461,8 +461,8 @@ class RTBCB_Leads {
 		// Leads by category
 		$category_stats = $wpdb->get_results(
 			"SELECT recommended_category, COUNT(*) as count FROM " . self::$table_name . "
-			 WHERE recommended_category != ''
-			 GROUP BY recommended_category",
+			WHERE recommended_category != ''
+			GROUP BY recommended_category",
 			ARRAY_A
 		);
 		$stats['by_category'] = $category_stats;
@@ -470,8 +470,8 @@ class RTBCB_Leads {
 		// Leads by company size
 		$size_stats = $wpdb->get_results(
 			"SELECT company_size, COUNT(*) as count FROM " . self::$table_name . "
-			 WHERE company_size != ''
-			 GROUP BY company_size",
+			WHERE company_size != ''
+			GROUP BY company_size",
 			ARRAY_A
 		);
 		$stats['by_company_size'] = $size_stats;
@@ -479,8 +479,8 @@ class RTBCB_Leads {
 		// Average ROI
 		$roi_stats = $wpdb->get_row(
 			"SELECT AVG(roi_low) as avg_low, AVG(roi_base) as avg_base, AVG(roi_high) as avg_high
-			 FROM " . self::$table_name . "
-			 WHERE roi_base > 0",
+			FROM " . self::$table_name . "
+			WHERE roi_base > 0",
 			ARRAY_A
 		);
 		$stats['average_roi'] = $roi_stats;
@@ -488,17 +488,17 @@ class RTBCB_Leads {
 		// Recent activity (last 30 days)
 		$stats['recent_leads'] = $wpdb->get_var(
 			"SELECT COUNT(*) FROM " . self::$table_name . "
-			 WHERE created_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)"
+			WHERE created_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)"
 		);
 
 		return $stats;
 	}
 
 	/**
-	 * Update cached statistics option.
-	 *
-	 * @return array Cached statistics.
-	 */
+	* Update cached statistics option.
+	*
+	* @return array Cached statistics.
+	*/
 	public static function update_cached_statistics() {
 		$stats = self::get_statistics();
 		update_option( self::$cache_option, $stats );
@@ -506,10 +506,10 @@ class RTBCB_Leads {
 	}
 
 	/**
-	 * Retrieve cached statistics.
-	 *
-	 * @return array Cached statistics.
-	 */
+	* Retrieve cached statistics.
+	*
+	* @return array Cached statistics.
+	*/
 	public static function get_cached_statistics() {
 		$stats = get_option( self::$cache_option, [] );
 		if ( empty( $stats ) ) {
@@ -519,11 +519,11 @@ class RTBCB_Leads {
 	}
 
 	/**
-	 * Export leads to CSV.
-	 *
-	 * @param array $args Export arguments.
-	 * @return string CSV content.
-	 */
+	* Export leads to CSV.
+	*
+	* @param array $args Export arguments.
+	* @return string CSV content.
+	*/
 	public static function export_to_csv( $args = [] ) {
 		$leads_data = self::get_all_leads( array_merge( $args, [ 'per_page' => -1 ] ) );
 		$leads = $leads_data['leads'];
@@ -566,10 +566,10 @@ class RTBCB_Leads {
 	}
 
 	/**
-	 * Get client IP address.
-	 *
-	 * @return string IP address.
-	 */
+	* Get client IP address.
+	*
+	* @return string IP address.
+	*/
 	private static function get_client_ip() {
 		$ip_keys = [ 'HTTP_X_FORWARDED_FOR', 'HTTP_X_REAL_IP', 'HTTP_CLIENT_IP', 'REMOTE_ADDR' ];
 

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -15,31 +15,31 @@ class RTBCB_LLM {
 	private $current_inputs = [];
 
 	/**
-	 * GPT-5 configuration settings.
-	 *
-	 * @var array
-	 */
+	* GPT-5 configuration settings.
+	*
+	* @var array
+	*/
 	private $gpt5_config;
 
 	/**
-	 * Last JSON-decoded request body sent to OpenAI.
-	 *
-	 * @var array|null
-	 */
+	* Last JSON-decoded request body sent to OpenAI.
+	*
+	* @var array|null
+	*/
 	protected $last_request;
 
 	/**
-	 * Last response or WP_Error returned from the OpenAI API.
-	 *
-	 * @var array|WP_Error|null
-	 */
+	* Last response or WP_Error returned from the OpenAI API.
+	*
+	* @var array|WP_Error|null
+	*/
 	protected $last_response;
 
 	/**
-	 * Serialized company research from the last request.
-	 *
-	 * @var string|null
-	 */
+	* Serialized company research from the last request.
+	*
+	* @var string|null
+	*/
 	protected $last_company_research;
 
 	public function __construct() {
@@ -64,14 +64,14 @@ class RTBCB_LLM {
 	}
 
 	/**
-	 * Get the configured model for a given tier.
-	 *
-	 * Retrieves the model name from the WordPress options table and falls
-	 * back to the plugin's default if the option is not set.
-	 *
-	 * @param string $tier Model tier identifier.
-	 * @return string Sanitized model name.
-	 */
+	* Get the configured model for a given tier.
+	*
+	* Retrieves the model name from the WordPress options table and falls
+	* back to the plugin's default if the option is not set.
+	*
+	* @param string $tier Model tier identifier.
+	* @return string Sanitized model name.
+	*/
 	private function get_model( $tier ) {
 		$tier    = sanitize_key( $tier );
 		$default = rtbcb_get_default_model( $tier );
@@ -81,29 +81,29 @@ class RTBCB_LLM {
 	}
 
 	/**
-	 * Retrieve the last request body sent to the OpenAI API.
-	 *
-	 * @return array|null Last request body.
-	 */
+	* Retrieve the last request body sent to the OpenAI API.
+	*
+	* @return array|null Last request body.
+	*/
 	public function get_last_request() {
 		return $this->last_request;
 	}
 
 	/**
-	 * Retrieve the last response returned from the OpenAI API.
-	 *
-	 * @return array|WP_Error|null Last response or WP_Error.
-	 */
+	* Retrieve the last response returned from the OpenAI API.
+	*
+	* @return array|WP_Error|null Last response or WP_Error.
+	*/
 	public function get_last_response() {
 		return $this->last_response;
 	}
 
 	/**
-	 * Estimate token usage from a desired word count.
-	 *
-	 * @param int $words Desired word count.
-	 * @return int Estimated token count capped by configuration.
-	 */
+	* Estimate token usage from a desired word count.
+	*
+	* @param int $words Desired word count.
+	* @return int Estimated token count capped by configuration.
+	*/
 	private function estimate_tokens( $words ) {
 		$words       = max( 0, intval( $words ) );
 		$tokens      = (int) ceil( $words * 1.5 );
@@ -115,11 +115,11 @@ class RTBCB_LLM {
 	}
 
 	/**
-	 * Determine token limit for a report type.
-	 *
-	 * @param string $type Report type identifier.
-	 * @return int Estimated token count for the report.
-	 */
+	* Determine token limit for a report type.
+	*
+	* @param string $type Report type identifier.
+	* @return int Estimated token count for the report.
+	*/
 	private function tokens_for_report( $type ) {
 		$targets = [
 			'business_case'             => 600,
@@ -142,19 +142,19 @@ class RTBCB_LLM {
 	}
 
 	/**
-	 * Generate a simplified business case analysis.
-	 *
-	 * Attempts to call the LLM for a brief analysis. If no API key is
-	 * configured or the LLM call fails, a {@see WP_Error} is returned for the
-	 * caller to handle.
-	 *
-	 * @param array       $user_inputs    Sanitized user inputs.
-	 * @param array       $roi_data       ROI calculation data.
-	 * @param array       $context_chunks Optional context strings for the prompt.
-	 * @param string|null $model          LLM model to use.
-	 *
-	 * @return array|WP_Error Simplified analysis array or error object.
-	 */
+	* Generate a simplified business case analysis.
+	*
+	* Attempts to call the LLM for a brief analysis. If no API key is
+	* configured or the LLM call fails, a {@see WP_Error} is returned for the
+	* caller to handle.
+	*
+	* @param array       $user_inputs    Sanitized user inputs.
+	* @param array       $roi_data       ROI calculation data.
+	* @param array       $context_chunks Optional context strings for the prompt.
+	* @param string|null $model          LLM model to use.
+	*
+	* @return array|WP_Error Simplified analysis array or error object.
+	*/
 	public function generate_business_case( $user_inputs, $roi_data, $context_chunks = [], $model = null ) {
 		$inputs = [
 			'company_name'           => sanitize_text_field( $user_inputs['company_name'] ?? '' ),
@@ -232,11 +232,11 @@ class RTBCB_LLM {
 	}
 
 	/**
-	 * Generate short commentary for a given industry.
-	 *
-	 * @param string $industry Industry slug.
-	 * @return string|WP_Error Commentary text or error object.
-	 */
+	* Generate short commentary for a given industry.
+	*
+	* @param string $industry Industry slug.
+	* @return string|WP_Error Commentary text or error object.
+	*/
 	public function generate_industry_commentary( $industry ) {
 		$industry = sanitize_text_field( $industry );
 
@@ -272,11 +272,11 @@ class RTBCB_LLM {
 	}
 
 	/**
-	 * Generate a comprehensive company overview with structured analysis.
-	 *
-	 * @param string $company_name Company name.
-	 * @return array|WP_Error Structured overview array or error object.
-	 */
+	* Generate a comprehensive company overview with structured analysis.
+	*
+	* @param string $company_name Company name.
+	* @return array|WP_Error Structured overview array or error object.
+	*/
 	public function generate_company_overview( $company_name ) {
 		$company_name = sanitize_text_field( $company_name );
 
@@ -297,13 +297,13 @@ Return only valid JSON matching this schema:
 	"recommendations": {"type": "array", "items": {"type": "string"}, "minItems": 1},
 	"references": {"type": "array", "items": {"type": "string", "format": "uri"}},
 	"metrics": {
-	  "type": "object",
-	  "properties": {
+	"type": "object",
+	"properties": {
 		"revenue": {"type": "number"},
 		"staff_count": {"type": "number"},
 		"baseline_efficiency": {"type": "number"}
-	  },
-	  "required": ["revenue", "staff_count", "baseline_efficiency"]
+	},
+	"required": ["revenue", "staff_count", "baseline_efficiency"]
 	}
 	},
 	"required": ["analysis", "recommendations", "references", "metrics"]
@@ -432,12 +432,12 @@ USER,
 	}
 
 	/**
-	 * Generate an industry overview.
-	 *
-	 * @param string $industry     Industry name.
-	 * @param string $company_size Company size description.
-	 * @return string|WP_Error Overview text or error object.
-	 */
+	* Generate an industry overview.
+	*
+	* @param string $industry     Industry name.
+	* @param string $company_size Company size description.
+	* @return string|WP_Error Overview text or error object.
+	*/
 	public function generate_industry_overview( $industry, $company_size ) {
 		$industry     = sanitize_text_field( $industry );
 		$company_size = sanitize_text_field( $company_size );
@@ -479,11 +479,11 @@ USER,
 	}
 
 	/**
-	 * Generate a treasury technology overview.
-	 *
-	 * @param array $company_data Company data including focus areas and complexity.
-	 * @return string|WP_Error Overview text or error object.
-	 */
+	* Generate a treasury technology overview.
+	*
+	* @param array $company_data Company data including focus areas and complexity.
+	* @return string|WP_Error Overview text or error object.
+	*/
 	public function generate_treasury_tech_overview( $company_data ) {
 		$company_data = rtbcb_sanitize_form_data( (array) $company_data );
 		$focus_areas  = array_map( 'sanitize_text_field', (array) ( $company_data['focus_areas'] ?? [] ) );
@@ -529,19 +529,19 @@ USER,
 	}
 
 	/**
-	 * Generate a Real Treasury platform overview.
-	 *
-	 * @param array $company_data {
-	 *     Company context data.
-	 *
-	 *     @type bool   $include_portal Include portal integration details.
-	 *     @type string $company_size   Company size description.
-	 *     @type string $industry       Company industry.
-	 *     @type array  $challenges     List of identified challenges.
-	 *     @type array  $categories     Vendor categories to highlight.
-	 * }
-	 * @return string|WP_Error Overview text or error object.
-	 */
+	* Generate a Real Treasury platform overview.
+	*
+	* @param array $company_data {
+	*     Company context data.
+	*
+	*     @type bool   $include_portal Include portal integration details.
+	*     @type string $company_size   Company size description.
+	*     @type string $industry       Company industry.
+	*     @type array  $challenges     List of identified challenges.
+	*     @type array  $categories     Vendor categories to highlight.
+	* }
+	* @return string|WP_Error Overview text or error object.
+	*/
 	public function generate_real_treasury_overview( $company_data ) {
 		$include_portal = ! empty( $company_data['include_portal'] );
 		$company_size   = sanitize_text_field( $company_data['company_size'] ?? '' );
@@ -595,11 +595,11 @@ USER,
 	}
 
 	/**
-	 * Generate implementation roadmap and success factors for a category.
-	 *
-	 * @param string $category Category key.
-	 * @return array|WP_Error Roadmap and success factor text or error object.
-	 */
+	* Generate implementation roadmap and success factors for a category.
+	*
+	* @param string $category Category key.
+	* @return array|WP_Error Roadmap and success factor text or error object.
+	*/
 	public function generate_category_recommendation( $category ) {
 		$category = sanitize_text_field( $category );
 
@@ -643,14 +643,14 @@ USER,
 	}
 
 	/**
-	 * Generate benefits estimate based on company metrics and category.
-	 *
-	 * @param float  $revenue     Annual revenue.
-	 * @param int    $staff_count Number of staff.
-	 * @param float  $efficiency  Current efficiency percentage.
-	 * @param string $category    Solution category.
-	 * @return array|WP_Error Structured benefits estimate or error object.
-	 */
+	* Generate benefits estimate based on company metrics and category.
+	*
+	* @param float  $revenue     Annual revenue.
+	* @param int    $staff_count Number of staff.
+	* @param float  $efficiency  Current efficiency percentage.
+	* @param string $category    Solution category.
+	* @return array|WP_Error Structured benefits estimate or error object.
+	*/
 	public function generate_benefits_estimate( $revenue, $staff_count, $efficiency, $category ) {
 		$revenue     = floatval( $revenue );
 		$staff_count = intval( $staff_count );
@@ -703,18 +703,18 @@ USER,
 	}
 
 	/**
-	 * Generate comprehensive business case with deep analysis.
-	 *
-	 * Returns a {@see WP_Error} when the API key is missing or when the LLM
-	 * call or response parsing fails.
-	 *
-	 * @param array                     $user_inputs    Sanitized user inputs.
-	 * @param array                     $roi_data       ROI calculation data.
-	 * @param callable|array|Traversable $context_chunks Optional context provider or strings for the prompt.
-	 * @param callable|null             $chunk_callback Optional streaming callback.
-	 *
-	 * @return array|WP_Error Comprehensive analysis array or error object.
-	 */
+	* Generate comprehensive business case with deep analysis.
+	*
+	* Returns a {@see WP_Error} when the API key is missing or when the LLM
+	* call or response parsing fails.
+	*
+	* @param array                     $user_inputs    Sanitized user inputs.
+	* @param array                     $roi_data       ROI calculation data.
+	* @param callable|array|Traversable $context_chunks Optional context provider or strings for the prompt.
+	* @param callable|null             $chunk_callback Optional streaming callback.
+	*
+	* @return array|WP_Error Comprehensive analysis array or error object.
+	*/
 	public function generate_comprehensive_business_case( $user_inputs, $roi_data, $context_chunks = [], $chunk_callback = null ) {
 
 		if ( rtbcb_heavy_features_disabled() ) {
@@ -900,12 +900,12 @@ $batch_prompts['tech'] = [
 	}
 
 	/**
-	 * Parse and validate comprehensive OpenAI response.
-	 *
-	 * @param array $response Raw response from wp_remote_post.
-	 *
-	 * @return array|WP_Error Structured analysis array or error object.
-	 */
+	* Parse and validate comprehensive OpenAI response.
+	*
+	* @param array $response Raw response from wp_remote_post.
+	*
+	* @return array|WP_Error Structured analysis array or error object.
+	*/
 	private function parse_comprehensive_response( $response ) {
 		$parsed_response = rtbcb_parse_gpt5_response( $response, true );
 		$content         = $parsed_response['output_text'];
@@ -1022,11 +1022,11 @@ $batch_prompts['tech'] = [
 	}
 
 	/**
-	 * Conduct company-specific research.
-	 *
-	 * @param array $user_inputs User-provided company details.
-	 * @return array Structured research data.
-	 */
+	* Conduct company-specific research.
+	*
+	* @param array $user_inputs User-provided company details.
+	* @return array Structured research data.
+	*/
 	private function conduct_company_research( $user_inputs ) {
 	$company_name = sanitize_text_field( $user_inputs['company_name'] ?? '' );
 	$industry     = sanitize_text_field( $user_inputs['industry'] ?? '' );
@@ -1052,8 +1052,8 @@ $batch_prompts['tech'] = [
 	}
 
 	/**
-	 * Build detailed company profile
-	 */
+	* Build detailed company profile
+	*/
 	private function build_company_profile( $company_name, $industry, $company_size ) {
 		$size_profiles = [
 			'<$50M' => [
@@ -1096,8 +1096,8 @@ $batch_prompts['tech'] = [
 	}
 
 	/**
-	 * Get industry-specific context
-	 */
+	* Get industry-specific context
+	*/
 	private function get_industry_context( $industry ) {
 		$contexts = [
 			'manufacturing' => [
@@ -1130,19 +1130,19 @@ $batch_prompts['tech'] = [
 	}
 
 	/**
-	 * Analyze the competitive landscape for a given industry.
-	 *
-	 * Provides a list of competitors and brief notes on their strengths. If an
-	 * OpenAI API key is configured, the method will query the language model for
-	 * up-to-date insights; otherwise a basic set of placeholder competitors is
-	 * returned.
-	 *
-	 * @param string $industry Industry name or slug.
-	 * @return array {
-	 *     @type array $competitors List of competitors, each having `name` and
-	 *                              `strength` keys.
-	 * }
-	 */
+	* Analyze the competitive landscape for a given industry.
+	*
+	* Provides a list of competitors and brief notes on their strengths. If an
+	* OpenAI API key is configured, the method will query the language model for
+	* up-to-date insights; otherwise a basic set of placeholder competitors is
+	* returned.
+	*
+	* @param string $industry Industry name or slug.
+	* @return array {
+	*     @type array $competitors List of competitors, each having `name` and
+	*                              `strength` keys.
+	* }
+	*/
 	private function analyze_competitive_context( $industry ) {
 		$industry = sanitize_text_field( $industry );
 
@@ -1221,12 +1221,12 @@ $batch_prompts['tech'] = [
 	}
 
 	/**
-	 * Analyze a company's market position within its industry.
-	 *
-	 * @param string $industry     Industry name.
-	 * @param string $company_size Company size descriptor.
-	 * @return array Structured data including market share, peers, and growth outlook.
-	 */
+	* Analyze a company's market position within its industry.
+	*
+	* @param string $industry     Industry name.
+	* @param string $company_size Company size descriptor.
+	* @return array Structured data including market share, peers, and growth outlook.
+	*/
 	private function analyze_market_position( $industry, $company_size ) {
 		$industry     = sanitize_text_field( $industry );
 		$company_size = sanitize_text_field( $company_size );
@@ -1266,14 +1266,14 @@ $batch_prompts['tech'] = [
 	}
 
 	/**
-	 * Assess treasury maturity based on user inputs.
-	 *
-	 * @param array $user_inputs Sanitized user inputs.
-	 * @return array {
-	 *     @type string $level     Assessed maturity level.
-	 *     @type string $rationale Rationale for the assessment.
-	 * }
-	 */
+	* Assess treasury maturity based on user inputs.
+	*
+	* @param array $user_inputs Sanitized user inputs.
+	* @return array {
+	*     @type string $level     Assessed maturity level.
+	*     @type string $rationale Rationale for the assessment.
+	* }
+	*/
 	private function assess_treasury_maturity( $user_inputs ) {
 		$company_data = [
 			'ftes' => isset( $user_inputs['ftes'] ) ? floatval( $user_inputs['ftes'] ) : 0,
@@ -1311,18 +1311,18 @@ $batch_prompts['tech'] = [
 	}
 
 	/**
-	 * Project growth trajectory based on company size and industry.
-	 *
-	 * @param string $company_size Company size descriptor.
-	 * @param string $industry     Industry name or slug.
-	 * @return array {
-	 *     @type string $size_tier        Tier label derived from company size.
-	 *     @type string $size_outlook     Growth outlook based on company size.
-	 *     @type string $industry_tier    Tier label derived from industry.
-	 *     @type string $industry_outlook Growth outlook based on industry.
-	 *     @type string $summary          Combined sanitized summary.
-	 * }
-	 */
+	* Project growth trajectory based on company size and industry.
+	*
+	* @param string $company_size Company size descriptor.
+	* @param string $industry     Industry name or slug.
+	* @return array {
+	*     @type string $size_tier        Tier label derived from company size.
+	*     @type string $size_outlook     Growth outlook based on company size.
+	*     @type string $industry_tier    Tier label derived from industry.
+	*     @type string $industry_outlook Growth outlook based on industry.
+	*     @type string $summary          Combined sanitized summary.
+	* }
+	*/
 	private function project_growth_path( $company_size, $industry ) {
 		$company_size = sanitize_text_field( $company_size );
 		$industry     = sanitize_key( $industry );
@@ -1354,16 +1354,16 @@ $batch_prompts['tech'] = [
 	}
 
 	/**
-	 * Execute company, industry, and technology research in a single LLM call.
-	 *
-	 * @param array                     $user_inputs    Sanitized user inputs.
-	 * @param callable|array|Traversable $context_chunks Optional context strings.
-	 * @return array|WP_Error {
-	 *     @type array  $company_research  Company research data.
-	 *     @type array  $industry_analysis Industry analysis data.
-	 *     @type string $tech_landscape    Technology landscape summary.
-	 * }
-	 */
+	* Execute company, industry, and technology research in a single LLM call.
+	*
+	* @param array                     $user_inputs    Sanitized user inputs.
+	* @param callable|array|Traversable $context_chunks Optional context strings.
+	* @return array|WP_Error {
+	*     @type array  $company_research  Company research data.
+	*     @type array  $industry_analysis Industry analysis data.
+	*     @type string $tech_landscape    Technology landscape summary.
+	* }
+	*/
 	private function run_batched_research( $user_inputs, $context_chunks ) {
 		if ( empty( $this->api_key ) ) {
 			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
@@ -1380,14 +1380,14 @@ You are a senior treasury technology consultant. Return a single JSON object wit
 {
 	"company_research": {
 	"company_profile": {
-	  "business_stage": string,
-	  "key_characteristics": string,
-	  "treasury_priorities": string,
-	  "common_challenges": string
+	"business_stage": string,
+	"key_characteristics": string,
+	"treasury_priorities": string,
+	"common_challenges": string
 	},
 	"treasury_maturity": {
-	  "level": string,
-	  "rationale": string
+	"level": string,
+	"rationale": string
 	}
 	},
 	"industry_analysis": {
@@ -1462,14 +1462,14 @@ SYSTEM;
 	}
 
 	/**
-	 * Generate multiple research responses in a single OpenAI request.
-	 *
-	 * Each prompt should include `instructions` and `input` keys. The returned
-	 * array preserves the original prompt keys.
-	 *
-	 * @param array $prompts Associative array of prompt data.
-	 * @return array|WP_Error Array of responses or error object.
-	 */
+	* Generate multiple research responses in a single OpenAI request.
+	*
+	* Each prompt should include `instructions` and `input` keys. The returned
+	* array preserves the original prompt keys.
+	*
+	* @param array $prompts Associative array of prompt data.
+	* @return array|WP_Error Array of responses or error object.
+	*/
 	private function generate_research_batch( $prompts ) {
 		if ( empty( $this->api_key ) ) {
 			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
@@ -1557,11 +1557,11 @@ SYSTEM;
 	}
 
 	/**
-	 * Analyze industry context using the LLM.
-	 *
-	 * @param array $user_inputs Sanitized user inputs.
-	 * @return array|WP_Error Industry analysis or error object.
-	 */
+	* Analyze industry context using the LLM.
+	*
+	* @param array $user_inputs Sanitized user inputs.
+	* @return array|WP_Error Industry analysis or error object.
+	*/
 	private function analyze_industry_context( $user_inputs ) {
 		if ( empty( $this->api_key ) ) {
 			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
@@ -1632,12 +1632,12 @@ SYSTEM;
 	}
 
 	/**
-	 * Research treasury technology solutions using the LLM.
-	 *
-	 * @param array $user_inputs    Sanitized user inputs.
-	 * @param array $context_chunks Optional context strings.
-	 * @return string|WP_Error Research summary or error object.
-	 */
+	* Research treasury technology solutions using the LLM.
+	*
+	* @param array $user_inputs    Sanitized user inputs.
+	* @param array $context_chunks Optional context strings.
+	* @return string|WP_Error Research summary or error object.
+	*/
 	private function research_treasury_solutions( $user_inputs, $context_chunks ) {
 		if ( empty( $this->api_key ) ) {
 			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
@@ -1677,12 +1677,12 @@ SYSTEM;
 	}
 
 	/**
-	 * Select the optimal model for comprehensive analysis.
-	 *
-	  * @param array                     $user_inputs    Sanitized user inputs.
-	  * @param callable|array|Traversable $context_chunks Optional context strings.
-	 * @return string Model identifier.
-	 */
+	* Select the optimal model for comprehensive analysis.
+	*
+	* @param array                     $user_inputs    Sanitized user inputs.
+	* @param callable|array|Traversable $context_chunks Optional context strings.
+	* @return string Model identifier.
+	*/
 	private function select_optimal_model( $user_inputs, $context_chunks ) {
 		$model         = $this->get_model( 'advanced' );
 		$context_count = 0;
@@ -1701,8 +1701,8 @@ SYSTEM;
 	}
 
 	/**
-	 * Build comprehensive prompt with research context
-	 */
+	* Build comprehensive prompt with research context
+	*/
 	private function build_comprehensive_prompt( $user_inputs, $roi_data, $company_research, $industry_analysis, $tech_landscape ) {
 		$company_name    = $user_inputs['company_name'] ?? 'the company';
 		$company_profile = $company_research['company_profile'];
@@ -1861,14 +1861,14 @@ SYSTEM;
 	}
 
 	/**
-	 * Enhance parsed analysis with research context.
-	 *
-	 * @param array $analysis          Parsed analysis from LLM.
-	 * @param array  $company_research  Company research data.
-	 * @param array  $industry_analysis Industry analysis data.
-	 * @param string $tech_landscape    Technology landscape summary.
-	 * @return array Enhanced analysis.
-	 */
+	* Enhance parsed analysis with research context.
+	*
+	* @param array $analysis          Parsed analysis from LLM.
+	* @param array  $company_research  Company research data.
+	* @param array  $industry_analysis Industry analysis data.
+	* @param string $tech_landscape    Technology landscape summary.
+	* @return array Enhanced analysis.
+	*/
 	private function enhance_with_research( $analysis, $company_research, $industry_analysis, $tech_landscape ) {
 		$analysis['research'] = [
 			'company'   => $company_research,
@@ -1880,11 +1880,11 @@ return $analysis;
 }
 
 	/**
-	 * PHASE 1: Consolidated Company & Industry Enrichment.
-	 *
-	 * @param array $user_inputs Validated user inputs.
-	 * @return array|WP_Error Enriched company profile or error.
-	 */
+	* PHASE 1: Consolidated Company & Industry Enrichment.
+	*
+	* @param array $user_inputs Validated user inputs.
+	* @return array|WP_Error Enriched company profile or error.
+	*/
 	public function enrich_company_profile( $user_inputs ) {
 
 		if ( rtbcb_heavy_features_disabled() ) {
@@ -1918,10 +1918,10 @@ return $analysis;
 	}
 
 	/**
-	 * Build system prompt for consolidated enrichment.
-	 *
-	 * @return string System prompt.
-	 */
+	* Build system prompt for consolidated enrichment.
+	*
+	* @return string System prompt.
+	*/
 	private function build_enrichment_system_prompt() {
 	return <<<'SYSTEM'
 	You are a senior treasury technology consultant conducting comprehensive company and industry research.
@@ -1934,67 +1934,67 @@ return $analysis;
 
 	```json
 	{
-	  "company_profile": {
+	"company_profile": {
 		"enhanced_description": "string - comprehensive company description",
 		"business_model": "string - primary business model and revenue streams",
 		"market_position": "string - competitive position and market standing",
 		"maturity_level": "basic|developing|strategic|optimized",
 		"financial_indicators": {
-		  "estimated_revenue": "number - best estimate in USD",
-		  "growth_stage": "startup|growth|mature|decline",
-		  "financial_health": "strong|stable|concerning|unknown"
+		"estimated_revenue": "number - best estimate in USD",
+		"growth_stage": "startup|growth|mature|decline",
+		"financial_health": "strong|stable|concerning|unknown"
 		},
 		"treasury_maturity": {
-		  "current_state": "string - assessment of current treasury operations",
-		  "sophistication_level": "manual|semi_automated|automated|strategic",
-		  "key_gaps": ["array of identified gaps"],
-		  "automation_readiness": "low|medium|high"
+		"current_state": "string - assessment of current treasury operations",
+		"sophistication_level": "manual|semi_automated|automated|strategic",
+		"key_gaps": ["array of identified gaps"],
+		"automation_readiness": "low|medium|high"
 		},
 		"strategic_context": {
-		  "primary_challenges": ["array of business challenges"],
-		  "growth_objectives": ["array of growth objectives"],
-		  "competitive_pressures": ["array of competitive factors"],
-		  "regulatory_environment": "string - regulatory considerations"
+		"primary_challenges": ["array of business challenges"],
+		"growth_objectives": ["array of growth objectives"],
+		"competitive_pressures": ["array of competitive factors"],
+		"regulatory_environment": "string - regulatory considerations"
 		}
-	  },
-	  "industry_context": {
+	},
+	"industry_context": {
 		"sector_analysis": {
-		  "market_dynamics": "string - current market conditions",
-		  "growth_trends": "string - industry growth patterns",
-		  "disruption_factors": ["array of disruptive forces"],
-		  "technology_adoption": "laggard|follower|mainstream|leader"
+		"market_dynamics": "string - current market conditions",
+		"growth_trends": "string - industry growth patterns",
+		"disruption_factors": ["array of disruptive forces"],
+		"technology_adoption": "laggard|follower|mainstream|leader"
 		},
 		"benchmarking": {
-		  "typical_treasury_setup": "string - industry norm for treasury operations",
-		  "common_pain_points": ["array of industry-wide challenges"],
-		  "technology_penetration": "low|medium|high",
-		  "investment_patterns": "string - typical technology investment patterns"
+		"typical_treasury_setup": "string - industry norm for treasury operations",
+		"common_pain_points": ["array of industry-wide challenges"],
+		"technology_penetration": "low|medium|high",
+		"investment_patterns": "string - typical technology investment patterns"
 		},
 		"regulatory_landscape": {
-		  "key_regulations": ["array of relevant regulations"],
-		  "compliance_complexity": "low|medium|high|very_high",
-		  "upcoming_changes": ["array of anticipated regulatory changes"]
+		"key_regulations": ["array of relevant regulations"],
+		"compliance_complexity": "low|medium|high|very_high",
+		"upcoming_changes": ["array of anticipated regulatory changes"]
 		}
-	  },
-	  "strategic_insights": {
+	},
+	"strategic_insights": {
 		"technology_readiness": "not_ready|ready|urgent_need",
 		"investment_justification": "weak|moderate|strong|compelling",
 		"implementation_complexity": "low|medium|high|very_high",
 		"expected_benefits": {
-		  "efficiency_gains": "string - expected efficiency improvements",
-		  "risk_reduction": "string - risk mitigation benefits",
-		  "strategic_value": "string - strategic business value",
-		  "competitive_advantage": "string - competitive positioning benefits"
+		"efficiency_gains": "string - expected efficiency improvements",
+		"risk_reduction": "string - risk mitigation benefits",
+		"strategic_value": "string - strategic business value",
+		"competitive_advantage": "string - competitive positioning benefits"
 		},
 		"critical_success_factors": ["array of key success factors"],
 		"potential_obstacles": ["array of implementation challenges"]
-	  },
-	  "enrichment_metadata": {
+	},
+	"enrichment_metadata": {
 		"confidence_level": "number - 0.0 to 1.0",
 		"data_sources": ["array of information sources considered"],
 		"analysis_depth": "surface|moderate|comprehensive",
 		"recommendations_priority": "low|medium|high|urgent"
-	  }
+	}
 	}
 	```
 
@@ -2018,11 +2018,11 @@ return $analysis;
 	}
 
 	/**
-	 * Build user prompt with company data.
-	 *
-	 * @param array $user_inputs User inputs.
-	 * @return string User prompt.
-	 */
+	* Build user prompt with company data.
+	*
+	* @param array $user_inputs User inputs.
+	* @return string User prompt.
+	*/
 	private function build_enrichment_user_prompt( $user_inputs ) {
 	$pain_points_formatted = implode( ', ', $user_inputs['pain_points'] );
 
@@ -2059,14 +2059,14 @@ return $analysis;
 	}
 
 	/**
-	 * PHASE 2: Strategic Analysis Generation.
-	 *
-	 * @param array $enriched_profile Enriched company profile.
-	 * @param array $roi_scenarios    ROI calculations.
-	 * @param array $recommendation   Category recommendation.
-	 * @param array $rag_baseline     RAG search results.
-	 * @return array|WP_Error Strategic analysis or error.
-	 */
+	* PHASE 2: Strategic Analysis Generation.
+	*
+	* @param array $enriched_profile Enriched company profile.
+	* @param array $roi_scenarios    ROI calculations.
+	* @param array $recommendation   Category recommendation.
+	* @param array $rag_baseline     RAG search results.
+	* @return array|WP_Error Strategic analysis or error.
+	*/
 	public function generate_strategic_analysis( $enriched_profile, $roi_scenarios, $recommendation, $rag_baseline ) {
 
 		if ( rtbcb_heavy_features_disabled() ) {
@@ -2105,10 +2105,10 @@ return $analysis;
 	}
 
 	/**
-	 * Build system prompt for strategic analysis.
-	 *
-	 * @return string System prompt.
-	 */
+	* Build system prompt for strategic analysis.
+	*
+	* @return string System prompt.
+	*/
 	private function build_strategic_analysis_system_prompt() {
 	return <<<'SYSTEM'
 	You are a senior treasury technology consultant creating executive-level strategic recommendations.
@@ -2127,79 +2127,79 @@ return $analysis;
 
 	```json
 	{
-	  "executive_summary": {
+	"executive_summary": {
 		"strategic_positioning": "string - 2-3 sentences on strategic position",
 		"business_case_strength": "weak|moderate|strong|compelling",
 		"key_value_drivers": ["array of 3-4 primary value drivers"],
 		"executive_recommendation": "string - clear recommendation with next steps",
 		"confidence_level": "number - 0.7 to 0.95"
-	  },
-	  "operational_analysis": {
+	},
+	"operational_analysis": {
 		"current_state_assessment": {
-		  "efficiency_rating": "poor|fair|good|excellent",
-		  "benchmark_comparison": "string - vs industry peers",
-		  "capacity_utilization": "string - team capacity analysis"
+		"efficiency_rating": "poor|fair|good|excellent",
+		"benchmark_comparison": "string - vs industry peers",
+		"capacity_utilization": "string - team capacity analysis"
 		},
 		"process_improvements": [
-		  {
+		{
 			"process_area": "string - specific process",
 			"current_state": "string - current approach",
 			"improved_state": "string - post-implementation state",
 			"impact_level": "low|medium|high|transformational"
-		  }
+		}
 		],
 		"automation_opportunities": [
-		  {
+		{
 			"opportunity": "string - automation opportunity",
 			"complexity": "low|medium|high",
 			"time_savings": "number - hours per week",
 			"implementation_effort": "low|medium|high"
-		  }
+		}
 		]
-	  },
-	  "financial_analysis": {
+	},
+	"financial_analysis": {
 		"investment_breakdown": {
-		  "software_licensing": "string - cost range and considerations",
-		  "implementation_services": "string - cost range and scope",
-		  "training_change_management": "string - cost range and requirements",
-		  "ongoing_support": "string - annual costs"
+		"software_licensing": "string - cost range and considerations",
+		"implementation_services": "string - cost range and scope",
+		"training_change_management": "string - cost range and requirements",
+		"ongoing_support": "string - annual costs"
 		},
 		"payback_analysis": {
-		  "payback_months": "number - expected payback period",
-		  "roi_3_year": "number - 3 year ROI percentage",
-		  "npv_analysis": "string - net present value assessment",
-		  "sensitivity_factors": ["array of factors affecting ROI"]
+		"payback_months": "number - expected payback period",
+		"roi_3_year": "number - 3 year ROI percentage",
+		"npv_analysis": "string - net present value assessment",
+		"sensitivity_factors": ["array of factors affecting ROI"]
 		}
-	  },
-	  "implementation_roadmap": [
+	},
+	"implementation_roadmap": [
 		{
-		  "phase": "string - phase name",
-		  "duration": "string - time estimate",
-		  "key_activities": ["array of activities"],
-		  "success_criteria": ["array of success metrics"],
-		  "risks": ["array of phase-specific risks"]
+		"phase": "string - phase name",
+		"duration": "string - time estimate",
+		"key_activities": ["array of activities"],
+		"success_criteria": ["array of success metrics"],
+		"risks": ["array of phase-specific risks"]
 		}
-	  ],
-	  "risk_mitigation": {
+	],
+	"risk_mitigation": {
 		"implementation_risks": ["array of key risks"],
 		"mitigation_strategies": {
-		  "change_management": "string - change management approach",
-		  "technical_integration": "string - integration risk mitigation",
-		  "vendor_selection": "string - vendor risk mitigation",
-		  "timeline_management": "string - timeline risk mitigation"
+		"change_management": "string - change management approach",
+		"technical_integration": "string - integration risk mitigation",
+		"vendor_selection": "string - vendor risk mitigation",
+		"timeline_management": "string - timeline risk mitigation"
 		},
 		"success_factors": ["array of critical success factors"]
-	  },
-	  "next_steps": {
+	},
+	"next_steps": {
 		"immediate": ["array of immediate actions (next 30 days)"],
 		"short_term": ["array of short-term milestones (3-6 months)"],
 		"long_term": ["array of long-term objectives (6+ months)"]
-	  },
-	  "vendor_considerations": {
+	},
+	"vendor_considerations": {
 		"evaluation_criteria": ["array of key selection criteria"],
 		"due_diligence_areas": ["array of due diligence focus areas"],
 		"negotiation_priorities": ["array of contract negotiation priorities"]
-	  }
+	}
 	}
 	```
 
@@ -2217,14 +2217,14 @@ return $analysis;
 	}
 
 	/**
-	 * Build user prompt for strategic analysis.
-	 *
-	 * @param array $enriched_profile Enriched company profile.
-	 * @param array $roi_scenarios    ROI scenarios.
-	 * @param array $recommendation   Technology recommendation.
-	 * @param array $rag_baseline     Market research context.
-	 * @return string User prompt.
-	 */
+	* Build user prompt for strategic analysis.
+	*
+	* @param array $enriched_profile Enriched company profile.
+	* @param array $roi_scenarios    ROI scenarios.
+	* @param array $recommendation   Technology recommendation.
+	* @param array $rag_baseline     Market research context.
+	* @return string User prompt.
+	*/
 	private function build_strategic_analysis_user_prompt( $enriched_profile, $roi_scenarios, $recommendation, $rag_baseline ) {
 	$prompt = <<<PROMPT
 	Create a comprehensive strategic analysis and executive recommendations based on the following research and analysis:
@@ -2268,12 +2268,12 @@ return $analysis;
 	}
 
 	/**
-	 * Validate and structure enrichment data.
-	 *
-	 * @param array $enriched_data Enriched data from LLM.
-	 * @param array $user_inputs   User inputs.
-	 * @return array Structured enrichment data.
-	 */
+	* Validate and structure enrichment data.
+	*
+	* @param array $enriched_data Enriched data from LLM.
+	* @param array $user_inputs   User inputs.
+	* @return array Structured enrichment data.
+	*/
 	private function validate_and_structure_enrichment( $enriched_data, $user_inputs ) {
 	$structured = [
 	'company_profile'    => $this->validate_company_profile( $enriched_data['company_profile'] ?? [], $user_inputs ),
@@ -2286,18 +2286,18 @@ return $analysis;
 	}
 
 	/**
-	 * Validate company profile data.
-	 *
-	 * @param array $profile     Profile data.
-	 * @param array $user_inputs User inputs.
-	 * @return array Validated profile data.
-	 */
+	* Validate company profile data.
+	*
+	* @param array $profile     Profile data.
+	* @param array $user_inputs User inputs.
+	* @return array Validated profile data.
+	*/
 	private function validate_company_profile( $profile, $user_inputs ) {
 	return [
 	'name'                => $user_inputs['company_name'],
-	   'enhanced_description' => wp_kses_post( $profile['enhanced_description'] ?? '' ),
-	   'business_model'      => wp_kses_post( $profile['business_model'] ?? '' ),
-	   'market_position'     => wp_kses_post( $profile['market_position'] ?? '' ),
+	'enhanced_description' => wp_kses_post( $profile['enhanced_description'] ?? '' ),
+	'business_model'      => wp_kses_post( $profile['business_model'] ?? '' ),
+	'market_position'     => wp_kses_post( $profile['market_position'] ?? '' ),
 	'maturity_level'      => in_array( $profile['maturity_level'] ?? '', [ 'basic', 'developing', 'strategic', 'optimized' ], true )
 	? $profile['maturity_level']
 	: 'basic',
@@ -2307,7 +2307,7 @@ return $analysis;
 	'financial_health'  => sanitize_text_field( $profile['financial_indicators']['financial_health'] ?? 'unknown' ),
 	],
 	'treasury_maturity'   => [
-	   'current_state'        => wp_kses_post( $profile['treasury_maturity']['current_state'] ?? '' ),
+	'current_state'        => wp_kses_post( $profile['treasury_maturity']['current_state'] ?? '' ),
 	'sophistication_level' => sanitize_text_field( $profile['treasury_maturity']['sophistication_level'] ?? 'manual' ),
 	'key_gaps'            => array_map( 'sanitize_text_field', $profile['treasury_maturity']['key_gaps'] ?? [] ),
 	'automation_readiness' => sanitize_text_field( $profile['treasury_maturity']['automation_readiness'] ?? 'medium' ),
@@ -2316,18 +2316,18 @@ return $analysis;
 	'primary_challenges'   => array_map( 'sanitize_text_field', $profile['strategic_context']['primary_challenges'] ?? [] ),
 	'growth_objectives'    => array_map( 'sanitize_text_field', $profile['strategic_context']['growth_objectives'] ?? [] ),
 	'competitive_pressures' => array_map( 'sanitize_text_field', $profile['strategic_context']['competitive_pressures'] ?? [] ),
-	   'regulatory_environment' => wp_kses_post( $profile['strategic_context']['regulatory_environment'] ?? '' ),
+	'regulatory_environment' => wp_kses_post( $profile['strategic_context']['regulatory_environment'] ?? '' ),
 	],
 	];
 	}
 
 	/**
-	 * Safe JSON encoding with error handling.
-	 *
-	 * @param mixed $data   Data to encode.
-	 * @param bool  $pretty Pretty print JSON.
-	 * @return string JSON representation.
-	 */
+	* Safe JSON encoding with error handling.
+	*
+	* @param mixed $data   Data to encode.
+	* @param bool  $pretty Pretty print JSON.
+	* @return string JSON representation.
+	*/
 	private function json_encode_safe( $data, $pretty = true ) {
 	$flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
 	if ( $pretty ) {
@@ -2339,24 +2339,24 @@ return $analysis;
 	}
 
 	/**
-	 * Validate industry context data.
-	 *
-	 * @param array $context Context data.
-	 * @return array Validated context.
-	 */
+	* Validate industry context data.
+	*
+	* @param array $context Context data.
+	* @return array Validated context.
+	*/
 	private function validate_industry_context( $context ) {
 	return [
 	'sector_analysis'    => [
-	   'market_dynamics'   => wp_kses_post( $context['sector_analysis']['market_dynamics'] ?? '' ),
-	   'growth_trends'     => wp_kses_post( $context['sector_analysis']['growth_trends'] ?? '' ),
+	'market_dynamics'   => wp_kses_post( $context['sector_analysis']['market_dynamics'] ?? '' ),
+	'growth_trends'     => wp_kses_post( $context['sector_analysis']['growth_trends'] ?? '' ),
 	'disruption_factors' => array_map( 'sanitize_text_field', $context['sector_analysis']['disruption_factors'] ?? [] ),
 	'technology_adoption' => sanitize_text_field( $context['sector_analysis']['technology_adoption'] ?? 'follower' ),
 	],
 	'benchmarking'       => [
-	   'typical_treasury_setup' => wp_kses_post( $context['benchmarking']['typical_treasury_setup'] ?? '' ),
+	'typical_treasury_setup' => wp_kses_post( $context['benchmarking']['typical_treasury_setup'] ?? '' ),
 	'common_pain_points'     => array_map( 'sanitize_text_field', $context['benchmarking']['common_pain_points'] ?? [] ),
 	'technology_penetration' => sanitize_text_field( $context['benchmarking']['technology_penetration'] ?? 'medium' ),
-	   'investment_patterns'    => wp_kses_post( $context['benchmarking']['investment_patterns'] ?? '' ),
+	'investment_patterns'    => wp_kses_post( $context['benchmarking']['investment_patterns'] ?? '' ),
 	],
 	'regulatory_landscape' => [
 	'key_regulations'      => array_map( 'sanitize_text_field', $context['regulatory_landscape']['key_regulations'] ?? [] ),
@@ -2367,21 +2367,21 @@ return $analysis;
 	}
 
 	/**
-	 * Validate strategic insights data.
-	 *
-	 * @param array $insights Insights data.
-	 * @return array Validated insights.
-	 */
+	* Validate strategic insights data.
+	*
+	* @param array $insights Insights data.
+	* @return array Validated insights.
+	*/
 	private function validate_strategic_insights( $insights ) {
 	return [
 	'technology_readiness'     => sanitize_text_field( $insights['technology_readiness'] ?? 'not_ready' ),
 	'investment_justification' => sanitize_text_field( $insights['investment_justification'] ?? 'weak' ),
 	'implementation_complexity' => sanitize_text_field( $insights['implementation_complexity'] ?? 'medium' ),
 	'expected_benefits'        => [
-	   'efficiency_gains'     => wp_kses_post( $insights['expected_benefits']['efficiency_gains'] ?? '' ),
-	   'risk_reduction'       => wp_kses_post( $insights['expected_benefits']['risk_reduction'] ?? '' ),
-	   'strategic_value'      => wp_kses_post( $insights['expected_benefits']['strategic_value'] ?? '' ),
-	   'competitive_advantage' => wp_kses_post( $insights['expected_benefits']['competitive_advantage'] ?? '' ),
+	'efficiency_gains'     => wp_kses_post( $insights['expected_benefits']['efficiency_gains'] ?? '' ),
+	'risk_reduction'       => wp_kses_post( $insights['expected_benefits']['risk_reduction'] ?? '' ),
+	'strategic_value'      => wp_kses_post( $insights['expected_benefits']['strategic_value'] ?? '' ),
+	'competitive_advantage' => wp_kses_post( $insights['expected_benefits']['competitive_advantage'] ?? '' ),
 	],
 	'critical_success_factors' => array_map( 'sanitize_text_field', $insights['critical_success_factors'] ?? [] ),
 	'potential_obstacles'      => array_map( 'sanitize_text_field', $insights['potential_obstacles'] ?? [] ),
@@ -2389,11 +2389,11 @@ return $analysis;
 	}
 
 	/**
-	 * Validate enrichment metadata.
-	 *
-	 * @param array $metadata Metadata.
-	 * @return array Validated metadata.
-	 */
+	* Validate enrichment metadata.
+	*
+	* @param array $metadata Metadata.
+	* @return array Validated metadata.
+	*/
 	private function validate_enrichment_metadata( $metadata ) {
 	$confidence = isset( $metadata['confidence_level'] ) ? floatval( $metadata['confidence_level'] ) : 0;
 	$confidence = max( 0, min( 1, $confidence ) );
@@ -2407,11 +2407,11 @@ return $analysis;
 	}
 
 	/**
-	 * Validate and structure strategic analysis data.
-	 *
-	 * @param array $analysis_data Raw analysis data.
-	 * @return array Structured analysis.
-	 */
+	* Validate and structure strategic analysis data.
+	*
+	* @param array $analysis_data Raw analysis data.
+	* @return array Structured analysis.
+	*/
 	private function validate_and_structure_analysis( $analysis_data ) {
 	$analysis = [
 	'executive_summary' => [
@@ -2499,19 +2499,19 @@ return $analysis;
 	}
 
 	/**
-	 * Call OpenAI with retry logic.
-	 *
-	 * Uses exponential backoff with jitter between retries. Each subsequent
-	 * attempt slightly reduces the maximum output tokens and increases the
-	 * timeout to improve the chances of success.
-	 *
-	 * @param string       $model             Model name.
-	 * @param array|string $prompt            Prompt for the model.
-	 * @param int|null     $max_output_tokens Maximum output tokens.
-	 * @param int|null     $max_retries       Number of retries.
-	 * @param callable|null $chunk_handler     Optional streaming handler.
-	 * @return array|WP_Error Response array or error.
-	 */
+	* Call OpenAI with retry logic.
+	*
+	* Uses exponential backoff with jitter between retries. Each subsequent
+	* attempt slightly reduces the maximum output tokens and increases the
+	* timeout to improve the chances of success.
+	*
+	* @param string       $model             Model name.
+	* @param array|string $prompt            Prompt for the model.
+	* @param int|null     $max_output_tokens Maximum output tokens.
+	* @param int|null     $max_retries       Number of retries.
+	* @param callable|null $chunk_handler     Optional streaming handler.
+	* @return array|WP_Error Response array or error.
+	*/
 	private function call_openai_with_retry( $model, $prompt, $max_output_tokens = null, $max_retries = null, $chunk_handler = null ) {
 		$raw_key   = $model . '|' . wp_json_encode( $prompt );
 		$cache_key = 'rtbcb_llm_' . md5( $raw_key );
@@ -2538,7 +2538,7 @@ return $analysis;
 		}
 
 		$max_retries     = $max_retries ?? intval( $this->gpt5_config['max_retries'] );
-	   $base_timeout    = intval( $this->gpt5_config['timeout'] ?? 300 );
+	$base_timeout    = intval( $this->gpt5_config['timeout'] ?? 300 );
 		$current_timeout = $base_timeout;
 		$current_tokens  = $max_output_tokens;
 		$max_retry_time  = max( $base_timeout, intval( $this->gpt5_config['max_retry_time'] ?? $base_timeout ) );
@@ -2608,16 +2608,16 @@ return $analysis;
 	}
 
 	/**
-	 * Build instructions and input for the Responses API.
-	 *
-	 * @param array       $history       Array of conversation items.
-	 * @param string|null $system_prompt Optional system prompt.
-	 *
-	 * @return array {
-	 *     @type string $instructions System prompt for the model.
-	 *     @type string $input        User prompt for the model.
-	 * }
-	 */
+	* Build instructions and input for the Responses API.
+	*
+	* @param array       $history       Array of conversation items.
+	* @param string|null $system_prompt Optional system prompt.
+	*
+	* @return array {
+	*     @type string $instructions System prompt for the model.
+	*     @type string $input        User prompt for the model.
+	* }
+	*/
 	private function build_context_for_responses( $history, $system_prompt = null ) {
 		$default_system = 'You are a senior treasury technology consultant. Provide detailed, research-driven analysis in the exact JSON format requested. Do not include any text outside the JSON structure.';
 
@@ -2642,14 +2642,14 @@ return $analysis;
 	}
 
 	/**
-	 * Call the OpenAI Responses API.
-	 *
-	 * @param string       $model             Model name.
-	 * @param array|string $prompt            Prompt array or string.
-	 * @param int|null     $max_output_tokens Maximum output tokens.
-	 * @param callable|null $chunk_handler    Optional streaming handler.
-	 * @return array|WP_Error HTTP response array or WP_Error on failure.
-	 */
+	* Call the OpenAI Responses API.
+	*
+	* @param string       $model             Model name.
+	* @param array|string $prompt            Prompt array or string.
+	* @param int|null     $max_output_tokens Maximum output tokens.
+	* @param callable|null $chunk_handler    Optional streaming handler.
+	* @return array|WP_Error HTTP response array or WP_Error on failure.
+	*/
 	private function call_openai( $model, $prompt, $max_output_tokens = null, $chunk_handler = null ) {
 		if ( empty( $this->api_key ) ) {
 			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
@@ -2827,11 +2827,11 @@ return $analysis;
 	}
 
 	/**
-	 * Determine appropriate reasoning effort based on task complexity.
-	 *
-	 * @param array|string $prompt Prompt data or text.
-	 * @return string Reasoning effort level.
-	 */
+	* Determine appropriate reasoning effort based on task complexity.
+	*
+	* @param array|string $prompt Prompt data or text.
+	* @return string Reasoning effort level.
+	*/
 	private function get_reasoning_effort_for_task( $prompt ) {
 		$prompt_text = is_array( $prompt )
 			? ( $prompt['input'] ?? '' ) . ' ' . ( $prompt['instructions'] ?? '' )
@@ -2858,11 +2858,11 @@ return $analysis;
 	}
 
 	/**
-	 * Determine appropriate verbosity based on output requirements.
-	 *
-	 * @param array|string $prompt Prompt data or text.
-	 * @return string Verbosity level.
-	 */
+	* Determine appropriate verbosity based on output requirements.
+	*
+	* @param array|string $prompt Prompt data or text.
+	* @return string Verbosity level.
+	*/
 	private function get_verbosity_for_task( $prompt ) {
 		$prompt_text = is_array( $prompt )
 			? ( $prompt['input'] ?? '' ) . ' ' . ( $prompt['instructions'] ?? '' )
@@ -2882,12 +2882,12 @@ return $analysis;
 	}
 
 	/**
-	 * Log details about a GPT-5 API call.
-	 *
-	 * @param array|string $context  Context or instructions sent to the model.
-	 * @param array        $response Decoded response array or HTTP response array.
-	 * @param string|null  $error    Optional error message.
-	 */
+	* Log details about a GPT-5 API call.
+	*
+	* @param array|string $context  Context or instructions sent to the model.
+	* @param array        $response Decoded response array or HTTP response array.
+	* @param string|null  $error    Optional error message.
+	*/
 	private function log_gpt5_call( $context, $response, $error = null ) {
 		$context_serialized = is_array( $context ) ? wp_json_encode( $context ) : (string) $context;
 		$context_size       = strlen( $context_serialized );
@@ -2924,11 +2924,11 @@ return $analysis;
 	}
 
 	/**
-	 * Extract content and decoded data from an OpenAI response.
-	 *
-	 * @param array $response HTTP response array.
-	 * @return array {string, array} Content string and decoded array.
-	 */
+	* Extract content and decoded data from an OpenAI response.
+	*
+	* @param array $response HTTP response array.
+	* @return array {string, array} Content string and decoded array.
+	*/
 	private function extract_openai_output( $response ) {
 		$body    = wp_remote_retrieve_body( $response );
 		$decoded = json_decode( $body, true );

--- a/inc/class-rtbcb-logger.php
+++ b/inc/class-rtbcb-logger.php
@@ -8,16 +8,16 @@ defined( 'ABSPATH' ) || exit;
 	*/
 
 /**
-		 * Structured logging for API interactions.
-		 */
+		* Structured logging for API interactions.
+		*/
 		class RTBCB_Logger {
 			/**
-			 * Send a structured log record.
-			 *
-			 * @param string $event   Event name.
-			 * @param array  $context Context data.
-			 * @return void
-			 */
+			* Send a structured log record.
+			*
+			* @param string $event   Event name.
+			* @param array  $context Context data.
+			* @return void
+			*/
 	public static function log( $event, $context = [] ) {
 		$record = [
 			'timestamp' => gmdate( 'c' ),
@@ -41,12 +41,12 @@ defined( 'ABSPATH' ) || exit;
 	}
 
 	/**
-	 * Log request details on shutdown.
-	 *
-	 * @param float $start_time Request start time.
-	 * @param array $payload    Sanitized request payload.
-	 * @return void
-	 */
+	* Log request details on shutdown.
+	*
+	* @param float $start_time Request start time.
+	* @param array $payload    Sanitized request payload.
+	* @return void
+	*/
 	public static function log_shutdown( $start_time, $payload ) {
 		$duration = ( microtime( true ) - $start_time ) * 1000;
 		$code     = http_response_code();
@@ -70,10 +70,10 @@ defined( 'ABSPATH' ) || exit;
 	}
 
 	/**
-	 * Increment timeout counter and trigger alert if threshold exceeded.
-	 *
-	 * @return void
-	 */
+	* Increment timeout counter and trigger alert if threshold exceeded.
+	*
+	* @return void
+	*/
 	public static function record_timeout() {
 		$count = (int) get_transient( 'rtbcb_timeout_count' );
 		$count++;
@@ -86,11 +86,11 @@ defined( 'ABSPATH' ) || exit;
 	}
 
 	/**
-	 * Send timeout alert email.
-	 *
-	 * @param int $count Timeout count.
-	 * @return void
-	 */
+	* Send timeout alert email.
+	*
+	* @param int $count Timeout count.
+	* @return void
+	*/
 	private static function send_timeout_alert( $count ) {
 		$admin_email = get_option( 'admin_email' );
 		$subject     = __( 'Business Case Builder timeout alert', 'rtbcb' );

--- a/inc/class-rtbcb-maturity-model.php
+++ b/inc/class-rtbcb-maturity-model.php
@@ -12,11 +12,11 @@ defined( 'ABSPATH' ) || exit;
 	*/
 class RTBCB_Maturity_Model {
 	/**
-	 * Assess maturity level using full-time equivalents.
-	 *
-	 * @param array $company_data Company data inputs.
-	 * @return array Assessment results.
-	 */
+	* Assess maturity level using full-time equivalents.
+	*
+	* @param array $company_data Company data inputs.
+	* @return array Assessment results.
+	*/
 	public function assess( $company_data ) {
 		$level = __( 'Basic', 'rtbcb' );
 		$ftes  = isset( $company_data['ftes'] ) ? floatval( $company_data['ftes'] ) : 1.0;
@@ -39,17 +39,17 @@ class RTBCB_Maturity_Model {
 	}
 
 	/**
-	 * Assess treasury maturity from user inputs.
-	 *
-	 * Sanitizes provided data and derives a maturity level
-	 * with explanatory rationale.
-	 *
-	 * @param array $user_inputs User-provided data.
-	 * @return array {
-	 *     @type string $level     Maturity level.
-	 *     @type string $rationale Explanation for the level.
-	 * }
-	 */
+	* Assess treasury maturity from user inputs.
+	*
+	* Sanitizes provided data and derives a maturity level
+	* with explanatory rationale.
+	*
+	* @param array $user_inputs User-provided data.
+	* @return array {
+	*     @type string $level     Maturity level.
+	*     @type string $rationale Explanation for the level.
+	* }
+	*/
 	private function assess_treasury_maturity( $user_inputs ) {
 		$sanitized = [];
 

--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -12,19 +12,19 @@ defined( 'ABSPATH' ) || exit;
 	*/
 class RTBCB_RAG {
 	/**
-	 * Constructor.
-	 */
+	* Constructor.
+	*/
 	public function __construct() {
 		RTBCB_DB::init();
 	}
 
 	/**
-	 * Rebuild the RAG index from portal data.
-	 *
-	 * Optionally invalidates cached search results.
-	 *
-	 * @return void
-	 */
+	* Rebuild the RAG index from portal data.
+	*
+	* Optionally invalidates cached search results.
+	*
+	* @return void
+	*/
 	public function rebuild_index() {
 		// Ensure the index table exists.
 		RTBCB_DB::init();
@@ -67,15 +67,15 @@ class RTBCB_RAG {
 	}
 
 	/**
-	 * Search the index for similar content.
-	 *
-	 * Caches results using the WordPress object cache.
-	 *
-	 * @param string $query Query string.
-	 * @param int    $top_k Number of results.
-	 *
-	 * @return array Matching rows.
-	 */
+	* Search the index for similar content.
+	*
+	* Caches results using the WordPress object cache.
+	*
+	* @param string $query Query string.
+	* @param int    $top_k Number of results.
+	*
+	* @return array Matching rows.
+	*/
 	public function search_similar( $query, $top_k = 3 ) {
 
 		if ( rtbcb_heavy_features_disabled() ) {
@@ -102,17 +102,17 @@ class RTBCB_RAG {
 	}
 
 	/**
-	 * Retrieve context metadata for a query.
-	 *
-	 * Calls {@see search_similar()} and returns only the metadata portion of
-	 * the results. If embeddings cannot be generated, an empty array is
-	 * returned.
-	 *
-	 * @param string $query Query string.
-	 * @param int    $top_k Number of results to retrieve.
-	 *
-	 * @return array List of metadata arrays.
-	 */
+	* Retrieve context metadata for a query.
+	*
+	* Calls {@see search_similar()} and returns only the metadata portion of
+	* the results. If embeddings cannot be generated, an empty array is
+	* returned.
+	*
+	* @param string $query Query string.
+	* @param int    $top_k Number of results to retrieve.
+	*
+	* @return array List of metadata arrays.
+	*/
 	public function get_context( $query, $top_k = 3 ) {
 
 		if ( rtbcb_heavy_features_disabled() ) {
@@ -136,12 +136,12 @@ class RTBCB_RAG {
 	}
 
 	/**
-	 * Index a vendor record.
-	 *
-	 * @param array $vendor Vendor data.
-	 *
-	 * @return void
-	 */
+	* Index a vendor record.
+	*
+	* @param array $vendor Vendor data.
+	*
+	* @return void
+	*/
 	private function index_vendor( $vendor ) {
 		global $wpdb;
 		$table_name = $wpdb->prefix . 'rtbcb_rag_index';
@@ -171,12 +171,12 @@ class RTBCB_RAG {
 	}
 
 	/**
-	 * Index a note record.
-	 *
-	 * @param array $note Note data.
-	 *
-	 * @return void
-	 */
+	* Index a note record.
+	*
+	* @param array $note Note data.
+	*
+	* @return void
+	*/
 	private function index_note( $note ) {
 		global $wpdb;
 		$table_name = $wpdb->prefix . 'rtbcb_rag_index';
@@ -200,12 +200,12 @@ class RTBCB_RAG {
 	}
 
 	/**
-	 * Retrieve embedding vector for text.
-	 *
-	 * @param string $text Text to embed.
-	 *
-	 * @return array Embedding vector.
-	 */
+	* Retrieve embedding vector for text.
+	*
+	* @param string $text Text to embed.
+	*
+	* @return array Embedding vector.
+	*/
 	private function get_embedding( $text ) {
 		$api_key = get_option( 'rtbcb_openai_api_key' );
 		$model   = get_option( 'rtbcb_embedding_model', 'text-embedding-3-small' );
@@ -241,13 +241,13 @@ $response = rtbcb_wp_remote_post_with_retry( $endpoint, $args );
 	}
 
 	/**
-	 * Search embeddings using cosine similarity.
-	 *
-	 * @param array $query_embedding Query embedding.
-	 * @param int   $top_k           Number of results.
-	 *
-	 * @return array
-	 */
+	* Search embeddings using cosine similarity.
+	*
+	* @param array $query_embedding Query embedding.
+	* @param int   $top_k           Number of results.
+	*
+	* @return array
+	*/
 	private function cosine_similarity_search( $query_embedding, $top_k ) {
 		global $wpdb;
 		$table_name = $wpdb->prefix . 'rtbcb_rag_index';
@@ -301,12 +301,12 @@ $response = rtbcb_wp_remote_post_with_retry( $endpoint, $args );
 	}
 
 	/**
-	 * Calculate the Euclidean norm of an embedding vector.
-	 *
-	 * @param array $embedding Embedding vector.
-	 *
-	 * @return float Vector norm.
-	 */
+	* Calculate the Euclidean norm of an embedding vector.
+	*
+	* @param array $embedding Embedding vector.
+	*
+	* @return float Vector norm.
+	*/
 	private function calculate_embedding_norm( $embedding ) {
 		$norm = 0;
 		foreach ( $embedding as $value ) {
@@ -316,13 +316,13 @@ $response = rtbcb_wp_remote_post_with_retry( $endpoint, $args );
 	}
 
 	/**
-	 * Calculate cosine similarity between two vectors.
-	 *
-	 * @param array $a Vector A.
-	 * @param array $b Vector B.
-	 *
-	 * @return float Similarity score.
-	 */
+	* Calculate cosine similarity between two vectors.
+	*
+	* @param array $a Vector A.
+	* @param array $b Vector B.
+	*
+	* @return float Similarity score.
+	*/
 	private function cosine_similarity( $a, $b ) {
 		$dot = 0;
 		$norm_a = 0;

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -14,12 +14,12 @@ require_once __DIR__ . '/helpers.php';
 	*/
 class RTBCB_Router {
 	/**
-	 * Handle form submission and generate the business case.
-	 *
-	 * @param string $report_type Optional report type (fast, basic or comprehensive).
-	 *
-	 * @return void
-	 */
+	* Handle form submission and generate the business case.
+	*
+	* @param string $report_type Optional report type (fast, basic or comprehensive).
+	*
+	* @return void
+	*/
 	public function handle_form_submission( $report_type = 'basic' ) {
 		// Nonce verification.
 		if (
@@ -194,13 +194,13 @@ class RTBCB_Router {
 		}
 	}
 	/**
-	 * Route to the appropriate LLM model.
-	 *
-	 * @param array $inputs User inputs.
-	 * @param array $chunks Context chunks.
-	 *
-	 * @return string|WP_Error Model name or error if no model configured.
-	 */
+	* Route to the appropriate LLM model.
+	*
+	* @param array $inputs User inputs.
+	* @param array $chunks Context chunks.
+	*
+	* @return string|WP_Error Model name or error if no model configured.
+	*/
 	public function route_model( $inputs, $chunks ) {
 		$complexity = $this->calculate_complexity( $inputs, $chunks );
 		$category   = RTBCB_Category_Recommender::recommend_category( $inputs )['recommended'];
@@ -237,13 +237,13 @@ class RTBCB_Router {
 	}
 
 	/**
-	 * Calculate complexity score for model routing.
-	 *
-	 * @param array $inputs User inputs.
-	 * @param array $chunks Context chunks.
-	 *
-	 * @return float Complexity score between 0 and 1.
-	 */
+	* Calculate complexity score for model routing.
+	*
+	* @param array $inputs User inputs.
+	* @param array $chunks Context chunks.
+	*
+	* @return float Complexity score between 0 and 1.
+	*/
 	private function calculate_complexity( $inputs, $chunks ) {
 		$score = 0;
 
@@ -259,12 +259,12 @@ class RTBCB_Router {
 	}
 
 	/**
-	 * Generate report HTML.
-	 *
-	 * @param array $business_case_data Business case data.
-	 *
-	 * @return string Report HTML.
-	 */
+	* Generate report HTML.
+	*
+	* @param array $business_case_data Business case data.
+	*
+	* @return string Report HTML.
+	*/
 	public function get_report_html( $business_case_data ) {
 		$template_path = RTBCB_DIR . 'templates/report-template.php';
 
@@ -295,13 +295,13 @@ class RTBCB_Router {
 	}
 
 	/**
-	 * Generate fast mode report HTML.
-	 *
-	 * @param array $form_data   Form data.
-	 * @param array $calculations ROI calculations.
-	 *
-	 * @return string Report HTML.
-	 */
+	* Generate fast mode report HTML.
+	*
+	* @param array $form_data   Form data.
+	* @param array $calculations ROI calculations.
+	*
+	* @return string Report HTML.
+	*/
 	public function get_fast_report_html( $form_data, $calculations ) {
 		$template_path = RTBCB_DIR . 'templates/fast-report-template.php';
 
@@ -336,7 +336,7 @@ class RTBCB_Router {
 			return $this->get_report_html( $business_case_data );
 		}
 
-	   $business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
+	$business_case_data = is_array( $business_case_data ) ? $business_case_data : [];
 
 	$report_data = $business_case_data['report_data'] ?? null;
 	$hash_source = $report_data ?: $business_case_data;
@@ -345,23 +345,23 @@ class RTBCB_Router {
 	$cache_key  = md5( $template_path . ':' . $data_hash . ':' . $version );
 
 	$cached_html = wp_cache_get( $cache_key, 'rtbcb_reports' );
-	   if ( false !== $cached_html ) {
-		   return $cached_html;
-	   }
+	if ( false !== $cached_html ) {
+		return $cached_html;
+	}
 
-	   if ( null === $report_data ) {
-		   // Transform data structure for comprehensive template.
-		   $report_data = $this->transform_data_for_template( $business_case_data );
-	   }
+	if ( null === $report_data ) {
+		// Transform data structure for comprehensive template.
+		$report_data = $this->transform_data_for_template( $business_case_data );
+	}
 
-	   ob_start();
-	   include $template_path;
-	   $html = ob_get_clean();
-	   $html = wp_kses( $html, rtbcb_get_report_allowed_html() );
+	ob_start();
+	include $template_path;
+	$html = ob_get_clean();
+	$html = wp_kses( $html, rtbcb_get_report_allowed_html() );
 
-	   wp_cache_set( $cache_key, $html, 'rtbcb_reports', HOUR_IN_SECONDS );
+	wp_cache_set( $cache_key, $html, 'rtbcb_reports', HOUR_IN_SECONDS );
 
-	   return $html;
+	return $html;
 	}
 
 	/**
@@ -372,104 +372,104 @@ class RTBCB_Router {
 	* @return array
 	*/
 	private function transform_data_for_template( $business_case_data ) {
-	   $defaults = [
-		   'company_name'           => '',
-		   'base_roi'               => 0,
-		   'roi_base'               => 0,
-		   'recommended_category'   => '',
-		   'category_info'          => [],
-		   'executive_summary'      => '',
-		   'narrative'              => '',
-		   'executive_recommendation' => '',
-		   'recommendation'         => '',
-		   'payback_months'         => 'N/A',
-		   'sensitivity_analysis'   => [],
-		   'company_analysis'       => '',
-		   'maturity_level'         => 'intermediate',
-		   'current_state_analysis' => '',
-		   'market_analysis'        => '',
-		   'tech_adoption_level'    => 'medium',
-		   'operational_analysis'   => [],
-		   'risks'                  => [],
-		   'confidence'             => 0.85,
-		   'processing_time'        => 0,
-	   ];
-	   $business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
+	$defaults = [
+		'company_name'           => '',
+		'base_roi'               => 0,
+		'roi_base'               => 0,
+		'recommended_category'   => '',
+		'category_info'          => [],
+		'executive_summary'      => '',
+		'narrative'              => '',
+		'executive_recommendation' => '',
+		'recommendation'         => '',
+		'payback_months'         => 'N/A',
+		'sensitivity_analysis'   => [],
+		'company_analysis'       => '',
+		'maturity_level'         => 'intermediate',
+		'current_state_analysis' => '',
+		'market_analysis'        => '',
+		'tech_adoption_level'    => 'medium',
+		'operational_analysis'   => [],
+		'risks'                  => [],
+		'confidence'             => 0.85,
+		'processing_time'        => 0,
+	];
+	$business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
 
-	   // Get current company data.
-	   $company      = rtbcb_get_current_company();
-	   $company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
+	// Get current company data.
+	$company      = rtbcb_get_current_company();
+	$company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
 
-	   // Derive recommended category and details from recommendation if not provided.
-	   $recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
-	   $category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
+	// Derive recommended category and details from recommendation if not provided.
+	$recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
+	$category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
 
-	   // Prepare operational and risk data with fallbacks.
-	   $operational_analysis = array_map( 'sanitize_text_field', (array) $business_case_data['operational_analysis'] );
-	   if ( empty( $operational_analysis ) ) {
-		   $operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
-	   }
+	// Prepare operational and risk data with fallbacks.
+	$operational_analysis = array_map( 'sanitize_text_field', (array) $business_case_data['operational_analysis'] );
+	if ( empty( $operational_analysis ) ) {
+		$operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
+	}
 
-	   $implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
-	   if ( empty( $implementation_risks ) ) {
-		   $implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
-	   }
+	$implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
+	if ( empty( $implementation_risks ) ) {
+		$implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
+	}
 
-	   // Create structured data format expected by template.
-	   $report_data = [
-		   'metadata'           => [
-			   'company_name'     => $company_name,
-			   'analysis_date'    => current_time( 'Y-m-d' ),
-			   'analysis_type'    => rtbcb_get_analysis_type(),
-			   'confidence_level' => floatval( $business_case_data['confidence'] ),
-			   'processing_time'  => intval( $business_case_data['processing_time'] ),
-		   ],
-		   'executive_summary'  => [
-			   'strategic_positioning'    => wp_kses_post( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
-			   'key_value_drivers'       => $this->extract_value_drivers( $business_case_data ),
-			   'executive_recommendation' => wp_kses_post( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
-			   'business_case_strength'  => $this->determine_business_case_strength( $business_case_data ),
-		   ],
-		   'financial_analysis' => [
-			   'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
-			   'payback_analysis'   => [
-				   'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
-			   ],
-			   'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
-		   ],
-		   'company_intelligence' => [
-			   'enriched_profile' => [
-				   'enhanced_description' => wp_kses_post( $business_case_data['company_analysis'] ),
-				   'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
-				   'treasury_maturity'    => [
-					   'current_state' => wp_kses_post( $business_case_data['current_state_analysis'] ),
-				   ],
-			   ],
-			   'industry_context' => [
-				   'sector_analysis' => [
-					   'market_dynamics' => wp_kses_post( $business_case_data['market_analysis'] ),
-				   ],
-				   'benchmarking'   => [
-					   'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
-				   ],
-			   ],
-		   ],
-		   'technology_strategy' => [
-			   'recommended_category' => $recommended_category,
-			   'category_details'     => $category_details,
-		   ],
-		   'operational_insights' => $operational_analysis,
-		   'risk_analysis'        => [
-			   'implementation_risks' => $implementation_risks,
-		   ],
-		   'action_plan'          => [
-			   'immediate_steps'      => $this->extract_immediate_steps( $business_case_data ),
-			   'short_term_milestones'=> $this->extract_short_term_steps( $business_case_data ),
-			   'long_term_objectives' => $this->extract_long_term_steps( $business_case_data ),
-		   ],
-	   ];
+	// Create structured data format expected by template.
+	$report_data = [
+		'metadata'           => [
+			'company_name'     => $company_name,
+			'analysis_date'    => current_time( 'Y-m-d' ),
+			'analysis_type'    => rtbcb_get_analysis_type(),
+			'confidence_level' => floatval( $business_case_data['confidence'] ),
+			'processing_time'  => intval( $business_case_data['processing_time'] ),
+		],
+		'executive_summary'  => [
+			'strategic_positioning'    => wp_kses_post( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
+			'key_value_drivers'       => $this->extract_value_drivers( $business_case_data ),
+			'executive_recommendation' => wp_kses_post( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
+			'business_case_strength'  => $this->determine_business_case_strength( $business_case_data ),
+		],
+		'financial_analysis' => [
+			'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
+			'payback_analysis'   => [
+				'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
+			],
+			'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
+		],
+		'company_intelligence' => [
+			'enriched_profile' => [
+				'enhanced_description' => wp_kses_post( $business_case_data['company_analysis'] ),
+				'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
+				'treasury_maturity'    => [
+					'current_state' => wp_kses_post( $business_case_data['current_state_analysis'] ),
+				],
+			],
+			'industry_context' => [
+				'sector_analysis' => [
+					'market_dynamics' => wp_kses_post( $business_case_data['market_analysis'] ),
+				],
+				'benchmarking'   => [
+					'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
+				],
+			],
+		],
+		'technology_strategy' => [
+			'recommended_category' => $recommended_category,
+			'category_details'     => $category_details,
+		],
+		'operational_insights' => $operational_analysis,
+		'risk_analysis'        => [
+			'implementation_risks' => $implementation_risks,
+		],
+		'action_plan'          => [
+			'immediate_steps'      => $this->extract_immediate_steps( $business_case_data ),
+			'short_term_milestones'=> $this->extract_short_term_steps( $business_case_data ),
+			'long_term_objectives' => $this->extract_long_term_steps( $business_case_data ),
+		],
+	];
 
-	   return $report_data;
+	return $report_data;
 	}
 
 	/**
@@ -480,24 +480,24 @@ class RTBCB_Router {
 	* @return array
 	*/
 	private function extract_value_drivers( $data ) {
-	   $drivers = [];
+	$drivers = [];
 
-	   // Extract from various possible sources.
-	   if ( ! empty( $data['value_drivers'] ) ) {
-		   $drivers = (array) $data['value_drivers'];
-	   } elseif ( ! empty( $data['key_benefits'] ) ) {
-		   $drivers = (array) $data['key_benefits'];
-	   } else {
-		   // Default value drivers.
-		   $drivers = [
-			   __( 'Automated cash management processes', 'rtbcb' ),
-			   __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
-			   __( 'Reduced operational risk and errors', 'rtbcb' ),
-			   __( 'Improved regulatory compliance', 'rtbcb' ),
-		   ];
-	   }
+	// Extract from various possible sources.
+	if ( ! empty( $data['value_drivers'] ) ) {
+		$drivers = (array) $data['value_drivers'];
+	} elseif ( ! empty( $data['key_benefits'] ) ) {
+		$drivers = (array) $data['key_benefits'];
+	} else {
+		// Default value drivers.
+		$drivers = [
+			__( 'Automated cash management processes', 'rtbcb' ),
+			__( 'Enhanced financial visibility and reporting', 'rtbcb' ),
+			__( 'Reduced operational risk and errors', 'rtbcb' ),
+			__( 'Improved regulatory compliance', 'rtbcb' ),
+		];
+	}
 
-	   return array_slice( $drivers, 0, 4 );
+	return array_slice( $drivers, 0, 4 );
 	}
 
 	/**
@@ -508,36 +508,36 @@ class RTBCB_Router {
 	* @return array
 	*/
 	private function format_roi_scenarios( $data ) {
-	   // Try to get ROI data from various possible locations.
-	   if ( ! empty( $data['scenarios'] ) ) {
-		   return $data['scenarios'];
-	   }
+	// Try to get ROI data from various possible locations.
+	if ( ! empty( $data['scenarios'] ) ) {
+		return $data['scenarios'];
+	}
 
-	   if ( ! empty( $data['roi_scenarios'] ) ) {
-		   return $data['roi_scenarios'];
-	   }
+	if ( ! empty( $data['roi_scenarios'] ) ) {
+		return $data['roi_scenarios'];
+	}
 
-	   // Fallback to default structure.
-	   return [
-		   'conservative' => [
-			   'total_annual_benefit' => $data['roi_low'] ?? 0,
-			   'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
-			   'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
-			   'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
-		   ],
-		   'base' => [
-			   'total_annual_benefit' => $data['roi_base'] ?? 0,
-			   'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
-			   'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
-			   'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
-		   ],
-		   'optimistic' => [
-			   'total_annual_benefit' => $data['roi_high'] ?? 0,
-			   'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
-			   'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
-			   'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
-		   ],
-	   ];
+	// Fallback to default structure.
+	return [
+		'conservative' => [
+			'total_annual_benefit' => $data['roi_low'] ?? 0,
+			'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
+			'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
+			'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
+		],
+		'base' => [
+			'total_annual_benefit' => $data['roi_base'] ?? 0,
+			'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
+			'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
+			'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
+		],
+		'optimistic' => [
+			'total_annual_benefit' => $data['roi_high'] ?? 0,
+			'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
+			'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
+			'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
+		],
+	];
 	}
 
 	/**
@@ -548,17 +548,17 @@ class RTBCB_Router {
 	* @return string
 	*/
 	private function determine_business_case_strength( $data ) {
-	   $base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
+	$base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
 
-	   if ( $base_roi > 500000 ) {
-		   return 'Compelling';
-	   } elseif ( $base_roi > 200000 ) {
-		   return 'Strong';
-	   } elseif ( $base_roi > 50000 ) {
-		   return 'Moderate';
-	   } else {
-		   return 'Developing';
-	   }
+	if ( $base_roi > 500000 ) {
+		return 'Compelling';
+	} elseif ( $base_roi > 200000 ) {
+		return 'Strong';
+	} elseif ( $base_roi > 50000 ) {
+		return 'Moderate';
+	} else {
+		return 'Developing';
+	}
 	}
 
 	/**
@@ -569,16 +569,16 @@ class RTBCB_Router {
 	* @return array
 	*/
 	private function extract_immediate_steps( $data ) {
-	   if ( ! empty( $data['next_actions'] ) ) {
-		   $all_actions = (array) $data['next_actions'];
-		   return array_slice( $all_actions, 0, 3 );
-	   }
+	if ( ! empty( $data['next_actions'] ) ) {
+		$all_actions = (array) $data['next_actions'];
+		return array_slice( $all_actions, 0, 3 );
+	}
 
-	   return [
-		   __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
-		   __( 'Form project steering committee', 'rtbcb' ),
-		   __( 'Conduct detailed requirements gathering', 'rtbcb' ),
-	   ];
+	return [
+		__( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
+		__( 'Form project steering committee', 'rtbcb' ),
+		__( 'Conduct detailed requirements gathering', 'rtbcb' ),
+	];
 	}
 
 	/**
@@ -589,17 +589,17 @@ class RTBCB_Router {
 	* @return array
 	*/
 	private function extract_short_term_steps( $data ) {
-	   if ( ! empty( $data['implementation_steps'] ) ) {
-		   $steps = (array) $data['implementation_steps'];
-		   return array_slice( $steps, 0, 4 );
-	   }
+	if ( ! empty( $data['implementation_steps'] ) ) {
+		$steps = (array) $data['implementation_steps'];
+		return array_slice( $steps, 0, 4 );
+	}
 
-	   return [
-		   __( 'Issue RFP to qualified vendors', 'rtbcb' ),
-		   __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
-		   __( 'Negotiate contracts and terms', 'rtbcb' ),
-		   __( 'Begin system implementation planning', 'rtbcb' ),
-	   ];
+	return [
+		__( 'Issue RFP to qualified vendors', 'rtbcb' ),
+		__( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
+		__( 'Negotiate contracts and terms', 'rtbcb' ),
+		__( 'Begin system implementation planning', 'rtbcb' ),
+	];
 	}
 
 	/**
@@ -610,12 +610,12 @@ class RTBCB_Router {
 	* @return array
 	*/
 	private function extract_long_term_steps( $data ) {
-	   return [
-		   __( 'Complete system implementation and testing', 'rtbcb' ),
-		   __( 'Conduct user training and change management', 'rtbcb' ),
-		   __( 'Measure and optimize system performance', 'rtbcb' ),
-		   __( 'Expand functionality and integration capabilities', 'rtbcb' ),
-	   ];
+	return [
+		__( 'Complete system implementation and testing', 'rtbcb' ),
+		__( 'Conduct user training and change management', 'rtbcb' ),
+		__( 'Measure and optimize system performance', 'rtbcb' ),
+		__( 'Expand functionality and integration capabilities', 'rtbcb' ),
+	];
 	}
 }
 

--- a/inc/class-rtbcb-settings.php
+++ b/inc/class-rtbcb-settings.php
@@ -12,10 +12,10 @@ defined( 'ABSPATH' ) || exit;
 	*/
 class RTBCB_Settings {
 	/**
-	 * Default settings.
-	 *
-	 * @var array
-	 */
+	* Default settings.
+	*
+	* @var array
+	*/
 	const DEFAULTS = [
 		'labor_cost_per_hour'       => 100,
 		'efficiency_ranges'         => [
@@ -31,22 +31,22 @@ class RTBCB_Settings {
 	];
 
 	/**
-	 * Retrieve a setting value.
-	 *
-	 * @param string $key     Setting key.
-	 * @param mixed  $default Default value.
-	 * @return mixed
-	 */
+	* Retrieve a setting value.
+	*
+	* @param string $key     Setting key.
+	* @param mixed  $default Default value.
+	* @return mixed
+	*/
 	public static function get_setting( $key, $default = null ) {
 		$settings = get_option( 'rtbcb_settings', self::DEFAULTS );
 		return $settings[ $key ] ?? $default;
 	}
 
 	/**
-	 * Retrieve all settings.
-	 *
-	 * @return array
-	 */
+	* Retrieve all settings.
+	*
+	* @return array
+	*/
 	public static function get_all() {
 		return get_option( 'rtbcb_settings', self::DEFAULTS );
 	}

--- a/inc/class-rtbcb-tests.php
+++ b/inc/class-rtbcb-tests.php
@@ -12,10 +12,10 @@ defined( 'ABSPATH' ) || exit;
 	*/
 class RTBCB_Tests {
 	/**
-	 * Run all integration tests.
-	 *
-	 * @return array
-	 */
+	* Run all integration tests.
+	*
+	* @return array
+	*/
 	public static function run_integration_tests() {
 		$results = [];
 
@@ -28,10 +28,10 @@ class RTBCB_Tests {
 	}
 
 	/**
-	 * Verify portal integration hooks return data.
-	 *
-	 * @return array Test result.
-	 */
+	* Verify portal integration hooks return data.
+	*
+	* @return array Test result.
+	*/
 	private static function test_portal_integration() {
 		$vendors = apply_filters( 'rt_portal_get_vendors', [] );
 
@@ -49,10 +49,10 @@ class RTBCB_Tests {
 	}
 
 	/**
-	 * Ensure ROI calculator static method is available.
-	 *
-	 * @return array Test result.
-	 */
+	* Ensure ROI calculator static method is available.
+	*
+	* @return array Test result.
+	*/
 	private static function test_roi_calculations() {
 		if ( ! class_exists( 'RTBCB_Calculator' ) || ! is_callable( [ 'RTBCB_Calculator', 'calculate_roi' ] ) ) {
 			return [
@@ -68,10 +68,10 @@ class RTBCB_Tests {
 	}
 
 	/**
-	 * Check LLM integration readiness.
-	 *
-	 * @return array Test result.
-	 */
+	* Check LLM integration readiness.
+	*
+	* @return array Test result.
+	*/
 	private static function test_llm_integration() {
 		if ( ! class_exists( 'RTBCB_LLM' ) ) {
 			return [
@@ -121,10 +121,10 @@ class RTBCB_Tests {
 	}
 
 	/**
-	 * Verify RAG index search runs.
-	 *
-	 * @return array Test result.
-	 */
+	* Verify RAG index search runs.
+	*
+	* @return array Test result.
+	*/
 	private static function test_rag_index() {
 		if ( ! class_exists( 'RTBCB_RAG' ) ) {
 			return [

--- a/inc/class-rtbcb-validator.php
+++ b/inc/class-rtbcb-validator.php
@@ -12,11 +12,11 @@ defined( 'ABSPATH' ) || exit;
 	*/
 class RTBCB_Validator {
 	/**
-	 * Validate and sanitize form data.
-	 *
-	 * @param array $data Raw form data.
-	 * @return array Sanitized data or array with 'error' key.
-	 */
+	* Validate and sanitize form data.
+	*
+	* @param array $data Raw form data.
+	* @return array Sanitized data or array with 'error' key.
+	*/
 	public function validate( array $data ): array {
 		$sanitized = rtbcb_sanitize_form_data( wp_unslash( $data ) );
 
@@ -38,23 +38,23 @@ class RTBCB_Validator {
 			}
 		}
 
-	   $numeric_fields = [
-			   'hours_reconciliation',
-			   'hours_cash_positioning',
-			   'num_banks',
-			   'ftes',
-	   ];
+	$numeric_fields = [
+			'hours_reconciliation',
+			'hours_cash_positioning',
+			'num_banks',
+			'ftes',
+	];
 
-	   foreach ( $numeric_fields as $field ) {
-			   if ( isset( $data[ $field ] ) && '' !== $data[ $field ] && ! is_numeric( $data[ $field ] ) ) {
-					   return [
-							   'error' => sprintf(
-									   __( '%s must be a numeric value.', 'rtbcb' ),
-									   ucwords( str_replace( '_', ' ', $field ) )
-							   ),
-					   ];
-			   }
-	   }
+	foreach ( $numeric_fields as $field ) {
+			if ( isset( $data[ $field ] ) && '' !== $data[ $field ] && ! is_numeric( $data[ $field ] ) ) {
+					return [
+							'error' => sprintf(
+									__( '%s must be a numeric value.', 'rtbcb' ),
+									ucwords( str_replace( '_', ' ', $field ) )
+							),
+					];
+			}
+	}
 
 		if ( ! rtbcb_is_business_email( $sanitized['email'] ) ) {
 			return [

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -18,10 +18,10 @@ function rtbcb_get_api_timeout() {
 	$timeout = rtbcb_sanitize_api_timeout( $timeout );
 
 	/**
-	 * Filter the API request timeout.
-	 *
-	 * @param int $timeout Timeout in seconds.
-	 */
+	* Filter the API request timeout.
+	*
+	* @param int $timeout Timeout in seconds.
+	*/
 	if ( function_exists( 'apply_filters' ) ) {
 		return (int) apply_filters( 'rtbcb_api_timeout', $timeout );
 	}
@@ -884,11 +884,11 @@ function rtbcb_is_simple_case( $user_inputs ) {
 		$is_simple = ( $num_banks <= $max_banks && $ftes <= $max_ftes && $hours <= $max_hours );
 
 		/**
-		 * Filter whether a case is simple enough for synchronous execution.
-		 *
-		 * @param bool  $is_simple   Whether case is considered simple.
-		 * @param array $user_inputs User input data.
-		 */
+		* Filter whether a case is simple enough for synchronous execution.
+		*
+		* @param bool  $is_simple   Whether case is considered simple.
+		* @param array $user_inputs User input data.
+		*/
 		return (bool) apply_filters( 'rtbcb_is_simple_case', $is_simple, $user_inputs );
 }
 
@@ -1329,8 +1329,8 @@ function rtbcb_test_generate_executive_summary() {
 	$company = rtbcb_get_current_company();
 	$roi     = get_option( 'rtbcb_roi_results', [] );
 
-	   $llm    = new RTBCB_LLM();
-	   $result = $llm->generate_comprehensive_business_case( $company, $roi, [], null );
+	$llm    = new RTBCB_LLM();
+	$result = $llm->generate_comprehensive_business_case( $company, $roi, [], null );
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
@@ -1687,8 +1687,8 @@ function rtbcb_handle_comprehensive_analysis( $company_name, $job_id ) {
 		$rag_context = array_map( 'sanitize_text_field', $vendor_list );
 	}
 
-	   $llm      = new RTBCB_LLM();
-	   $analysis = $llm->generate_comprehensive_business_case( [ 'company_name' => $company_name ], [], $rag_context, null );
+	$llm      = new RTBCB_LLM();
+	$analysis = $llm->generate_comprehensive_business_case( [ 'company_name' => $company_name ], [], $rag_context, null );
 
 	if ( is_wp_error( $analysis ) ) {
 		update_option(
@@ -1833,13 +1833,13 @@ function rtbcb_set_research_cache( $company, $industry, $type, $data, $ttl = 0 )
 	}
 
 	/**
-	 * Filter the research cache TTL.
-	 *
-	 * @param int $ttl Cache duration in seconds.
-	 * @param string $type Cache segment identifier.
-	 * @param string $company Sanitized company name.
-	 * @param string $industry Sanitized industry.
-	 */
+	* Filter the research cache TTL.
+	*
+	* @param int $ttl Cache duration in seconds.
+	* @param string $type Cache segment identifier.
+	* @param string $company Sanitized company name.
+	* @param string $industry Sanitized industry.
+	*/
 	$ttl = apply_filters( 'rtbcb_research_cache_ttl', $ttl, $type, $company, $industry );
 
 	set_transient( $key, $data, $ttl );

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -27,31 +27,31 @@ if ( ! defined( 'RTBCB_DEBUG' ) ) {
 	*/
 class RTBCB_Main {
 	/**
-	 * Singleton instance.
-	 *
-	 * @var RTBCB_Main|null
-	 */
+	* Singleton instance.
+	*
+	* @var RTBCB_Main|null
+	*/
 	private static $instance = null;
 
 	/**
-	 * Plugin data.
-	 *
-	 * @var array
-	 */
+	* Plugin data.
+	*
+	* @var array
+	*/
 	private $plugin_data = [];
 
 	/**
-	 * Request start time.
-	 *
-	 * @var float
-	 */
+	* Request start time.
+	*
+	* @var float
+	*/
 	private $request_start_time = 0.0;
 
 	/**
-	 * Get plugin instance.
-	 *
-	 * @return RTBCB_Main
-	 */
+	* Get plugin instance.
+	*
+	* @return RTBCB_Main
+	*/
 	public static function instance() {
 		if ( null === self::$instance ) {
 			self::$instance = new self();
@@ -61,8 +61,8 @@ class RTBCB_Main {
 	}
 
 	/**
-	 * Constructor.
-	 */
+	* Constructor.
+	*/
 	private function __construct() {
 		$this->plugin_data = get_file_data( RTBCB_FILE, [
 			'Name'        => 'Plugin Name',
@@ -78,10 +78,10 @@ class RTBCB_Main {
 	}
 
 	/**
-	 * Initialize hooks.
-	 *
-	 * @return void
-	 */
+	* Initialize hooks.
+	*
+	* @return void
+	*/
 	private function init_hooks() {
 		register_activation_hook( RTBCB_FILE, [ $this, 'activate' ] );
 		register_deactivation_hook( RTBCB_FILE, [ $this, 'deactivate' ] );
@@ -126,10 +126,10 @@ class RTBCB_Main {
 	}
 
 	/**
-	 * Initialize debug-related hooks.
-	 *
-	 * @return void
-	 */
+	* Initialize debug-related hooks.
+	*
+	* @return void
+	*/
 				private function init_hooks_debug() {
 					add_action( 'wp_ajax_rtbcb_debug_test', [ $this, 'debug_ajax_handler' ] );
 					add_action( 'wp_ajax_rtbcb_simple_test', [ $this, 'ajax_generate_case_simple' ] );
@@ -137,10 +137,10 @@ class RTBCB_Main {
 				}
 
 	/**
-	 * Include required files.
-	 *
-	 * @return void
-	 */
+	* Include required files.
+	*
+	* @return void
+	*/
 	private function includes() {
 		// Core classes
 		require_once RTBCB_DIR . 'inc/helpers.php';
@@ -172,10 +172,10 @@ class RTBCB_Main {
 	}
 
 	/**
-	 * Plugin initialization.
-	 *
-	 * @return void
-	 */
+	* Plugin initialization.
+	*
+	* @return void
+	*/
 	public function init() {
 		// Load text domain
 		load_plugin_textdomain( 'rtbcb', false, dirname( plugin_basename( RTBCB_FILE ) ) . '/languages' );
@@ -186,10 +186,10 @@ class RTBCB_Main {
 	}
 
 	/**
-	 * Initialize components after plugins are loaded.
-	 *
-	 * @return void
-	 */
+	* Initialize components after plugins are loaded.
+	*
+	* @return void
+	*/
 	public function plugins_loaded() {
 		// Check compatibility
 		if ( ! $this->check_compatibility() ) {
@@ -207,10 +207,10 @@ class RTBCB_Main {
 	}
 
 	/**
-	 * Check plugin compatibility.
-	 *
-	 * @return bool
-	 */
+	* Check plugin compatibility.
+	*
+	* @return bool
+	*/
 	private function check_compatibility() {
 		// Check PHP version
 		if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
@@ -273,10 +273,10 @@ class RTBCB_Main {
 	}
 
 	/**
-	 * Initialize database tables.
-	 *
-	 * @return void
-	 */
+	* Initialize database tables.
+	*
+	* @return void
+	*/
 	private function init_database() {
 		// Initialize database and tables
 		RTBCB_DB::init();
@@ -288,10 +288,10 @@ class RTBCB_Main {
 	}
 
 	/**
-	 * Setup user capabilities.
-	 *
-	 * @return void
-	 */
+	* Setup user capabilities.
+	*
+	* @return void
+	*/
 	private function setup_capabilities() {
 		$admin = get_role( 'administrator' );
 		if ( $admin ) {
@@ -302,10 +302,10 @@ class RTBCB_Main {
 	}
 
 	/**
-	 * Setup cron jobs for maintenance tasks.
-	 *
-	 * @return void
-	 */
+	* Setup cron jobs for maintenance tasks.
+	*
+	* @return void
+	*/
 	private function setup_cron_jobs() {
 		// Schedule RAG index rebuilds
 		if ( ! wp_next_scheduled( 'rtbcb_rebuild_rag_index' ) ) {
@@ -337,10 +337,10 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 }
 
 	/**
-	 * Handle version upgrades.
-	 *
-	 * @return void
-	 */
+	* Handle version upgrades.
+	*
+	* @return void
+	*/
 	private function maybe_upgrade() {
 		$current_version = get_option( 'rtbcb_version', '1.0.0' );
 
@@ -351,11 +351,11 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 	}
 
 	/**
-	 * Upgrade plugin data and settings.
-	 *
-	 * @param string $from_version Previous version.
-	 * @return void
-	 */
+	* Upgrade plugin data and settings.
+	*
+	* @param string $from_version Previous version.
+	* @return void
+	*/
 	private function upgrade_plugin( $from_version ) {
 		// Upgrade from 1.x to 2.x
 		if ( version_compare( $from_version, '2.0.0', '<' ) ) {
@@ -386,10 +386,10 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 	}
 
 	/**
-	 * Migrate v1 settings to v2 format.
-	 *
-	 * @return void
-	 */
+	* Migrate v1 settings to v2 format.
+	*
+	* @return void
+	*/
 	private function migrate_v1_settings() {
 		// Migration logic for old settings format
 		$old_settings = get_option( 'rtbcb_old_settings', [] );
@@ -406,10 +406,10 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 	}
 
 	/**
-	 * Set default options for new installation.
-	 *
-	 * @return void
-	 */
+	* Set default options for new installation.
+	*
+	* @return void
+	*/
 	private function set_default_options() {
 		$defaults = [
 			'rtbcb_mini_model'         => rtbcb_get_default_model( 'mini' ),
@@ -429,10 +429,10 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 	}
 
 	/**
-	 * Enqueue frontend assets with enhanced report support.
-	 *
-	 * @return void
-	 */
+	* Enqueue frontend assets with enhanced report support.
+	*
+	* @return void
+	*/
 	public function enqueue_assets() {
 		if ( ! $this->should_load_assets() ) {
 			return;
@@ -523,8 +523,8 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 	}
 
 	/**
-	 * Localize scripts with proper configuration data.
-	 */
+	* Localize scripts with proper configuration data.
+	*/
 	private function localize_scripts() {
 		// Wizard configuration
 		wp_localize_script(
@@ -585,10 +585,10 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 	}
 
 	/**
-	 * Check if assets should be loaded on current page.
-	 *
-	 * @return bool
-	 */
+	* Check if assets should be loaded on current page.
+	*
+	* @return bool
+	*/
 	private function should_load_assets() {
 		// Always load on admin pages for this plugin.
 		if ( is_admin() ) {
@@ -618,12 +618,12 @@ add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
 		return false;
 	}
 
-			   /**
+			/**
 				* Determine if comprehensive template should be used.
 				*
 				* @return bool
 				*/
-			   private function should_use_comprehensive_template() {
+			private function should_use_comprehensive_template() {
 $comprehensive_enabled = get_option( 'rtbcb_comprehensive_analysis', true );
 
 $template_path  = RTBCB_DIR . 'templates/comprehensive-report-template.php';
@@ -649,11 +649,11 @@ return $use_comprehensive;
 }
 
 	/**
-	 * Shortcode handler.
-	 *
-	 * @param array $atts Shortcode attributes.
-	 * @return string
-	 */
+	* Shortcode handler.
+	*
+	* @param array $atts Shortcode attributes.
+	* @return string
+	*/
 	public function shortcode_handler( $atts = [] ) {
 		// Parse attributes
 		$atts = shortcode_atts( [
@@ -679,12 +679,12 @@ return $use_comprehensive;
 	}
 
 	/**
-	 * Load a template file with arguments.
-	 *
-	 * @param string $template Template name.
-	 * @param array  $args     Template arguments.
-	 * @return void
-	 */
+	* Load a template file with arguments.
+	*
+	* @param string $template Template name.
+	* @param array  $args     Template arguments.
+	* @return void
+	*/
 	private function load_template( $template, $args = [] ) {
 		$template_path = RTBCB_DIR . "templates/{$template}.php";
 
@@ -698,10 +698,10 @@ return $use_comprehensive;
 	}
 
 	/**
-	 * Handle portal data changes.
-	 *
-	 * @return void
-	 */
+	* Handle portal data changes.
+	*
+	* @return void
+	*/
 	public function handle_portal_data_change() {
 		// Rebuild RAG index when portal data changes
 		if ( class_exists( 'RTBCB_RAG' ) ) {
@@ -713,10 +713,10 @@ return $use_comprehensive;
 	}
 
 	/**
-	 * Scheduled RAG index rebuild.
-	 *
-	 * @return void
-	 */
+	* Scheduled RAG index rebuild.
+	*
+	* @return void
+	*/
 	public function scheduled_rag_rebuild() {
 		if ( ! class_exists( 'RTBCB_RAG' ) ) {
 			return;
@@ -732,10 +732,10 @@ return $use_comprehensive;
 	}
 
 	/**
-	 * Scheduled data cleanup.
-	 *
-	 * @return void
-	 */
+	* Scheduled data cleanup.
+	*
+	* @return void
+	*/
 	public function scheduled_data_cleanup() {
 		global $wpdb;
 
@@ -776,8 +776,8 @@ return $use_comprehensive;
 
 
 		/**
-		 * Enhanced AJAX handler for comprehensive case generation.
-		 */
+		* Enhanced AJAX handler for comprehensive case generation.
+		*/
 		public function ajax_generate_comprehensive_case_enhanced() {
 			// Security and setup.
 			if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
@@ -823,30 +823,30 @@ return $use_comprehensive;
 										return;
 								}
 
-							   $recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
-							   $scenarios      = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $recommendation['category_info'] );
+							$recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );
+							$scenarios      = RTBCB_Calculator::calculate_category_refined_roi( $user_inputs, $recommendation['category_info'] );
 
-							   // Generate business case analysis with lazy RAG loading.
-							   $analysis_data          = $this->generate_business_analysis( $user_inputs, $scenarios, $recommendation );
-							   $comprehensive_analysis = $analysis_data['analysis'];
-							   $rag_context            = $analysis_data['rag_context'];
+							// Generate business case analysis with lazy RAG loading.
+							$analysis_data          = $this->generate_business_analysis( $user_inputs, $scenarios, $recommendation );
+							$comprehensive_analysis = $analysis_data['analysis'];
+							$rag_context            = $analysis_data['rag_context'];
 
-							   if ( is_wp_error( $comprehensive_analysis ) ) {
-									   wp_send_json_error( [ 'message' => $comprehensive_analysis->get_error_message() ], 500 );
-									   return;
-							   }
+							if ( is_wp_error( $comprehensive_analysis ) ) {
+									wp_send_json_error( [ 'message' => $comprehensive_analysis->get_error_message() ], 500 );
+									return;
+							}
 
-							   // Merge all data for report generation.
-							   $report_data = array_merge(
-									   $comprehensive_analysis,
-									   [
-											   'company_name'    => $user_inputs['company_name'],
-											   'scenarios'       => $scenarios,
-											   'recommendation'  => $recommendation,
-											   'rag_context'     => $rag_context,
-											   'processing_time' => microtime( true ) - $_SERVER['REQUEST_TIME_FLOAT'],
-									   ]
-							   );
+							// Merge all data for report generation.
+							$report_data = array_merge(
+									$comprehensive_analysis,
+									[
+											'company_name'    => $user_inputs['company_name'],
+											'scenarios'       => $scenarios,
+											'recommendation'  => $recommendation,
+											'rag_context'     => $rag_context,
+											'processing_time' => microtime( true ) - $_SERVER['REQUEST_TIME_FLOAT'],
+									]
+							);
 
 				// Generate HTML report using our fixed method.
 				$report_html = $this->get_comprehensive_report_html( $report_data );
@@ -889,8 +889,8 @@ return $use_comprehensive;
 		}
 
 	/**
-	 * Collect and validate user inputs from POST data.
-	 */
+	* Collect and validate user inputs from POST data.
+	*/
 	private function collect_and_validate_inputs() {
 	// Get company data
 	$company      = rtbcb_get_current_company();
@@ -958,8 +958,8 @@ return $use_comprehensive;
 	}
 
 	/**
-	 * Get RAG context for enhanced analysis.
-	 */
+	* Get RAG context for enhanced analysis.
+	*/
 	private function get_rag_context( $user_inputs, $recommendation ) {
 	if ( ! class_exists( 'RTBCB_RAG' ) ) {
 	return [];
@@ -1002,7 +1002,7 @@ return $use_comprehensive;
 	}
 	}
 
-	   /**
+	/**
 		* Generate comprehensive business analysis using LLM.
 		*
 		* @param array $user_inputs    Sanitized user inputs.
@@ -1014,96 +1014,96 @@ return $use_comprehensive;
 		*     @type array          $rag_context Context chunks used for RAG.
 		* }
 		*/
-	   private function generate_business_analysis( $user_inputs, $scenarios, $recommendation, $chunk_callback = null ) {
-		   $start_time = microtime( true );
-		   $timeout    = absint( rtbcb_get_api_timeout() );
+	private function generate_business_analysis( $user_inputs, $scenarios, $recommendation, $chunk_callback = null ) {
+		$start_time = microtime( true );
+		$timeout    = absint( rtbcb_get_api_timeout() );
 
-		   $time_remaining = static function() use ( $start_time, $timeout ) {
-			   return $timeout - ( microtime( true ) - $start_time );
-		   };
+		$time_remaining = static function() use ( $start_time, $timeout ) {
+			return $timeout - ( microtime( true ) - $start_time );
+		};
 
-		   if ( ! class_exists( 'RTBCB_LLM' ) ) {
-			   return [
-				   'analysis'    => new WP_Error( 'llm_unavailable', __( 'AI analysis service unavailable.', 'rtbcb' ) ),
-				   'rag_context' => [],
-			   ];
-		   }
+		if ( ! class_exists( 'RTBCB_LLM' ) ) {
+			return [
+				'analysis'    => new WP_Error( 'llm_unavailable', __( 'AI analysis service unavailable.', 'rtbcb' ) ),
+				'rag_context' => [],
+			];
+		}
 
-		   if ( ! rtbcb_has_openai_api_key() ) {
-			   return [
-				   'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
-				   'rag_context' => [],
-			   ];
-		   }
+		if ( ! rtbcb_has_openai_api_key() ) {
+			return [
+				'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
+				'rag_context' => [],
+			];
+		}
 
-		   if ( $time_remaining() < 5 ) {
-			   return [
-				   'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
-				   'rag_context' => [],
-			   ];
-		   }
+		if ( $time_remaining() < 5 ) {
+			return [
+				'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
+				'rag_context' => [],
+			];
+		}
 
-		   $rag_context = [];
-		   $rag_used    = false;
+		$rag_context = [];
+		$rag_used    = false;
 
-		   $rag_loader = function() use ( $user_inputs, $recommendation, &$rag_context, &$rag_used, $time_remaining ) {
-			   $rag_used = true;
-			   if ( $time_remaining() < 10 ) {
-				   $rag_context = [];
-			   } else {
-				   $rag_context = $this->get_rag_context( $user_inputs, $recommendation );
-			   }
-			   return $rag_context;
-		   };
+		$rag_loader = function() use ( $user_inputs, $recommendation, &$rag_context, &$rag_used, $time_remaining ) {
+			$rag_used = true;
+			if ( $time_remaining() < 10 ) {
+				$rag_context = [];
+			} else {
+				$rag_context = $this->get_rag_context( $user_inputs, $recommendation );
+			}
+			return $rag_context;
+		};
 
-		   try {
-			   $llm    = new RTBCB_LLM();
-			   $result = $llm->generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_loader, $chunk_callback );
+		try {
+			$llm    = new RTBCB_LLM();
+			$result = $llm->generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_loader, $chunk_callback );
 
-			   if ( is_wp_error( $result ) ) {
-				   return [
-					   'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
-					   'rag_context' => [],
-				   ];
-			   }
+			if ( is_wp_error( $result ) ) {
+				return [
+					'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
+					'rag_context' => [],
+				];
+			}
 
-			   if ( $time_remaining() < 2 ) {
-				   return [
-					   'analysis'    => [
-						   'executive_summary' => $result['executive_summary'] ?? '',
-						   'partial'          => true,
-					   ],
-					   'rag_context' => $rag_used ? $rag_context : [],
-				   ];
-			   }
+			if ( $time_remaining() < 2 ) {
+				return [
+					'analysis'    => [
+						'executive_summary' => $result['executive_summary'] ?? '',
+						'partial'          => true,
+					],
+					'rag_context' => $rag_used ? $rag_context : [],
+				];
+			}
 
-			   $required_keys = [ 'executive_summary', 'financial_analysis', 'industry_analysis', 'implementation_roadmap', 'risk_mitigation', 'next_steps' ];
-			   $missing_keys  = array_diff( $required_keys, array_keys( $result ) );
+			$required_keys = [ 'executive_summary', 'financial_analysis', 'industry_analysis', 'implementation_roadmap', 'risk_mitigation', 'next_steps' ];
+			$missing_keys  = array_diff( $required_keys, array_keys( $result ) );
 
-			   if ( ! empty( $missing_keys ) ) {
-				   rtbcb_log_error( 'LLM missing required sections', [ 'missing' => $missing_keys ] );
-				   return [
-					   'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
-					   'rag_context' => [],
-				   ];
-			   }
+			if ( ! empty( $missing_keys ) ) {
+				rtbcb_log_error( 'LLM missing required sections', [ 'missing' => $missing_keys ] );
+				return [
+					'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
+					'rag_context' => [],
+				];
+			}
 
-			   return [
-				   'analysis'    => $result,
-				   'rag_context' => $rag_used ? $rag_context : [],
-			   ];
-		   } catch ( Exception $e ) {
-			   rtbcb_log_error( 'LLM analysis failed', $e->getMessage() );
-			   return [
-				   'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
-				   'rag_context' => [],
-			   ];
-		   }
-	   }
+			return [
+				'analysis'    => $result,
+				'rag_context' => $rag_used ? $rag_context : [],
+			];
+		} catch ( Exception $e ) {
+			rtbcb_log_error( 'LLM analysis failed', $e->getMessage() );
+			return [
+				'analysis'    => $this->generate_fallback_analysis( $user_inputs, $scenarios ),
+				'rag_context' => [],
+			];
+		}
+	}
 
 	/**
-	 * Generate fallback analysis when LLM is unavailable.
-	 */
+	* Generate fallback analysis when LLM is unavailable.
+	*/
 	private function generate_fallback_analysis( $user_inputs, $scenarios ) {
 	$company_name = $user_inputs['company_name'];
 	$base_roi     = $scenarios['base']['total_annual_benefit'] ?? 0;
@@ -1134,16 +1134,16 @@ return $use_comprehensive;
 		__( 'Evaluate treasury technology vendors', 'rtbcb' ),
 		__( 'Develop implementation roadmap and timeline', 'rtbcb' ),
 		],
-	   'company_name'      => $company_name,
-	   'base_roi'          => $base_roi,
+	'company_name'      => $company_name,
+	'base_roi'          => $base_roi,
 		'confidence'        => 0.75,
 		'enhanced_fallback' => true,
 		];
 	}
 
 	/**
-	 * Save lead data to database.
-	 */
+	* Save lead data to database.
+	*/
 	private function save_lead_data( $user_inputs, $scenarios, $recommendation, $report_html ) {
 	if ( ! class_exists( 'RTBCB_Leads' ) ) {
 	return null;
@@ -1175,8 +1175,8 @@ return $use_comprehensive;
 	}
 
 	/**
-	 * Format scenarios for JSON response.
-	 */
+	* Format scenarios for JSON response.
+	*/
 	private function format_scenarios_for_response( $scenarios ) {
 		$map       = [
 			'low'  => 'conservative',
@@ -1210,8 +1210,8 @@ return $use_comprehensive;
 
 
 		/**
-	 * Debug wrapper for comprehensive case generation AJAX handler.
-	 */
+	* Debug wrapper for comprehensive case generation AJAX handler.
+	*/
 	public function ajax_generate_comprehensive_case_debug() {
 		error_log( 'RTBCB: Enter ajax_generate_comprehensive_case_debug' );
 
@@ -1273,8 +1273,8 @@ return $use_comprehensive;
 
 
 	/**
-	 * Enhanced AJAX handler with memory management
-	 */
+	* Enhanced AJAX handler with memory management
+	*/
 	public function ajax_generate_comprehensive_case_legacy() {
 		$request_start   = microtime( true );
 		$request_payload = rtbcb_recursive_sanitize_text_field( wp_unslash( $_POST ) );
@@ -1968,175 +1968,175 @@ return $use_comprehensive;
 	* @return array
 	*/
 	private function transform_data_for_template( $business_case_data ) {
-	   $defaults = [
-		   'company_name'           => '',
-		   'base_roi'               => 0,
-		   'roi_base'               => 0,
-		   'recommended_category'   => '',
-		   'category_info'          => [],
-		   'executive_summary'      => '',
-		   'narrative'              => '',
-		   'executive_recommendation' => '',
-		   'recommendation'         => '',
-		   'payback_months'         => 'N/A',
-		   'sensitivity_analysis'   => [],
-		   'company_analysis'       => '',
-		   'maturity_level'         => 'intermediate',
-		   'current_state_analysis' => '',
-		   'market_analysis'        => '',
-		   'tech_adoption_level'    => 'medium',
-		   'operational_analysis'   => [],
-		   'risks'                  => [],
-		   'confidence'             => 0.85,
-		   'processing_time'        => 0,
-	   ];
-	   $business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
+	$defaults = [
+		'company_name'           => '',
+		'base_roi'               => 0,
+		'roi_base'               => 0,
+		'recommended_category'   => '',
+		'category_info'          => [],
+		'executive_summary'      => '',
+		'narrative'              => '',
+		'executive_recommendation' => '',
+		'recommendation'         => '',
+		'payback_months'         => 'N/A',
+		'sensitivity_analysis'   => [],
+		'company_analysis'       => '',
+		'maturity_level'         => 'intermediate',
+		'current_state_analysis' => '',
+		'market_analysis'        => '',
+		'tech_adoption_level'    => 'medium',
+		'operational_analysis'   => [],
+		'risks'                  => [],
+		'confidence'             => 0.85,
+		'processing_time'        => 0,
+	];
+	$business_case_data = wp_parse_args( (array) $business_case_data, $defaults );
 
-	   // Get current company data.
-	   $company      = rtbcb_get_current_company();
-	   $company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
-	   $base_roi     = floatval( $business_case_data['base_roi'] ?: $business_case_data['roi_base'] );
-	   $business_case_data['roi_base'] = $base_roi;
+	// Get current company data.
+	$company      = rtbcb_get_current_company();
+	$company_name = sanitize_text_field( $business_case_data['company_name'] ?: ( $company['name'] ?? __( 'Your Company', 'rtbcb' ) ) );
+	$base_roi     = floatval( $business_case_data['base_roi'] ?: $business_case_data['roi_base'] );
+	$business_case_data['roi_base'] = $base_roi;
 
-	   // Derive recommended category and details from recommendation if not provided.
-	   $recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
-	   $category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
+	// Derive recommended category and details from recommendation if not provided.
+	$recommended_category = sanitize_text_field( $business_case_data['recommended_category'] ?: ( $business_case_data['recommendation']['recommended'] ?? 'treasury_management_system' ) );
+	$category_details     = $business_case_data['category_info'] ?: ( $business_case_data['recommendation']['category_info'] ?? [] );
 
-	   // Prepare operational and risk data with fallbacks.
-	   $operational_analysis = array_map( 'sanitize_text_field', (array) $business_case_data['operational_analysis'] );
-	   if ( empty( $operational_analysis ) ) {
-		   $operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
-	   }
+	// Prepare operational and risk data with fallbacks.
+	$operational_analysis = array_map( 'sanitize_text_field', (array) $business_case_data['operational_analysis'] );
+	if ( empty( $operational_analysis ) ) {
+		$operational_analysis = [ __( 'No data provided', 'rtbcb' ) ];
+	}
 
-	   $implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
-	   if ( empty( $implementation_risks ) ) {
-		   $implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
-	   }
+	$implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
+	if ( empty( $implementation_risks ) ) {
+		$implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
+	}
 
-	   // Create structured data format expected by template.
-	   $report_data = [
-		   'metadata'           => [
-			   'company_name'     => $company_name,
-			   'analysis_date'    => current_time( 'Y-m-d' ),
-			   'analysis_type'    => rtbcb_get_analysis_type(),
-			   'confidence_level' => floatval( $business_case_data['confidence'] ),
-			   'processing_time'  => intval( $business_case_data['processing_time'] ),
-		   ],
-		   'executive_summary'  => [
-			   'strategic_positioning'    => wp_kses_post( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
-			   'key_value_drivers'       => $this->extract_value_drivers( $business_case_data ),
-			   'executive_recommendation' => wp_kses_post( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
-			   'business_case_strength'  => $this->determine_business_case_strength( $business_case_data ),
-		   ],
-		   'financial_analysis' => [
-			   'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
-			   'payback_analysis'   => [
-				   'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
-			   ],
-			   'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
-		   ],
-		   'company_intelligence' => [
-			   'enriched_profile' => [
-				   'enhanced_description' => wp_kses_post( $business_case_data['company_analysis'] ),
-				   'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
-				   'treasury_maturity'    => [
-					   'current_state' => wp_kses_post( $business_case_data['current_state_analysis'] ),
-				   ],
-			   ],
-			   'industry_context' => [
-				   'sector_analysis' => [
-					   'market_dynamics' => wp_kses_post( $business_case_data['market_analysis'] ),
-				   ],
-				   'benchmarking'   => [
-					   'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
-				   ],
-			   ],
-		   ],
-		   'technology_strategy' => [
-			   'recommended_category' => $recommended_category,
-			   'category_details'     => $category_details,
-		   ],
-		   'operational_insights' => $operational_analysis,
-		   'risk_analysis'        => [
-			   'implementation_risks' => $implementation_risks,
-		   ],
-		   'action_plan'          => [
-			   'immediate_steps'      => $this->extract_immediate_steps( $business_case_data ),
-			   'short_term_milestones'=> $this->extract_short_term_steps( $business_case_data ),
-			   'long_term_objectives' => $this->extract_long_term_steps( $business_case_data ),
-		   ],
-	   ];
+	// Create structured data format expected by template.
+	$report_data = [
+		'metadata'           => [
+			'company_name'     => $company_name,
+			'analysis_date'    => current_time( 'Y-m-d' ),
+			'analysis_type'    => rtbcb_get_analysis_type(),
+			'confidence_level' => floatval( $business_case_data['confidence'] ),
+			'processing_time'  => intval( $business_case_data['processing_time'] ),
+		],
+		'executive_summary'  => [
+			'strategic_positioning'    => wp_kses_post( $business_case_data['executive_summary'] ?: $business_case_data['narrative'] ),
+			'key_value_drivers'       => $this->extract_value_drivers( $business_case_data ),
+			'executive_recommendation' => wp_kses_post( $business_case_data['executive_recommendation'] ?: $business_case_data['recommendation'] ),
+			'business_case_strength'  => $this->determine_business_case_strength( $business_case_data ),
+		],
+		'financial_analysis' => [
+			'roi_scenarios'      => $this->format_roi_scenarios( $business_case_data ),
+			'payback_analysis'   => [
+				'payback_months' => sanitize_text_field( $business_case_data['payback_months'] ),
+			],
+			'sensitivity_analysis' => $business_case_data['sensitivity_analysis'],
+		],
+		'company_intelligence' => [
+			'enriched_profile' => [
+				'enhanced_description' => wp_kses_post( $business_case_data['company_analysis'] ),
+				'maturity_level'       => sanitize_text_field( $business_case_data['maturity_level'] ),
+				'treasury_maturity'    => [
+					'current_state' => wp_kses_post( $business_case_data['current_state_analysis'] ),
+				],
+			],
+			'industry_context' => [
+				'sector_analysis' => [
+					'market_dynamics' => wp_kses_post( $business_case_data['market_analysis'] ),
+				],
+				'benchmarking'   => [
+					'technology_penetration' => sanitize_text_field( $business_case_data['tech_adoption_level'] ),
+				],
+			],
+		],
+		'technology_strategy' => [
+			'recommended_category' => $recommended_category,
+			'category_details'     => $category_details,
+		],
+		'operational_insights' => $operational_analysis,
+		'risk_analysis'        => [
+			'implementation_risks' => $implementation_risks,
+		],
+		'action_plan'          => [
+			'immediate_steps'      => $this->extract_immediate_steps( $business_case_data ),
+			'short_term_milestones'=> $this->extract_short_term_steps( $business_case_data ),
+			'long_term_objectives' => $this->extract_long_term_steps( $business_case_data ),
+		],
+	];
 
-	   $required_sections = [
-		   'metadata',
-		   'executive_summary',
-		   'financial_analysis',
-		   'company_intelligence',
-		   'technology_strategy',
-		   'operational_insights',
-		   'risk_analysis',
-		   'action_plan',
-	   ];
+	$required_sections = [
+		'metadata',
+		'executive_summary',
+		'financial_analysis',
+		'company_intelligence',
+		'technology_strategy',
+		'operational_insights',
+		'risk_analysis',
+		'action_plan',
+	];
 
-	   $section_defaults = [
-		   'metadata'           => [
-			   'company_name'     => '',
-			   'analysis_date'    => '',
-			   'analysis_type'    => '',
-			   'confidence_level' => 0,
-			   'processing_time'  => 0,
-		   ],
-		   'executive_summary'  => [
-			   'strategic_positioning'    => '',
-			   'key_value_drivers'       => [],
-			   'executive_recommendation' => '',
-			   'business_case_strength'  => '',
-		   ],
-		   'financial_analysis' => [
-			   'roi_scenarios'      => [],
-			   'payback_analysis'   => [ 'payback_months' => '' ],
-			   'sensitivity_analysis' => [],
-		   ],
-		   'company_intelligence' => [],
-		   'technology_strategy'  => [],
-		   'operational_insights' => [],
-		   'risk_analysis'        => [ 'implementation_risks' => [] ],
-		   'action_plan'          => [
-			   'immediate_steps'       => [],
-			   'short_term_milestones' => [],
-			   'long_term_objectives'  => [],
-		   ],
-	   ];
+	$section_defaults = [
+		'metadata'           => [
+			'company_name'     => '',
+			'analysis_date'    => '',
+			'analysis_type'    => '',
+			'confidence_level' => 0,
+			'processing_time'  => 0,
+		],
+		'executive_summary'  => [
+			'strategic_positioning'    => '',
+			'key_value_drivers'       => [],
+			'executive_recommendation' => '',
+			'business_case_strength'  => '',
+		],
+		'financial_analysis' => [
+			'roi_scenarios'      => [],
+			'payback_analysis'   => [ 'payback_months' => '' ],
+			'sensitivity_analysis' => [],
+		],
+		'company_intelligence' => [],
+		'technology_strategy'  => [],
+		'operational_insights' => [],
+		'risk_analysis'        => [ 'implementation_risks' => [] ],
+		'action_plan'          => [
+			'immediate_steps'       => [],
+			'short_term_milestones' => [],
+			'long_term_objectives'  => [],
+		],
+	];
 
-	   $missing_sections = [];
+	$missing_sections = [];
 
-	   foreach ( $required_sections as $section ) {
-		   if ( empty( $report_data[ $section ] ) ) {
-			   $missing_sections[] = $section;
-			   rtbcb_log_error(
-				   'Missing report data section',
-				   [
-					   'section' => $section,
-				   ]
-			   );
-			   $report_data[ $section ] = $section_defaults[ $section ];
-		   }
-	   }
+	foreach ( $required_sections as $section ) {
+		if ( empty( $report_data[ $section ] ) ) {
+			$missing_sections[] = $section;
+			rtbcb_log_error(
+				'Missing report data section',
+				[
+					'section' => $section,
+				]
+			);
+			$report_data[ $section ] = $section_defaults[ $section ];
+		}
+	}
 
-	   $report_data['status'] = [
-		   'valid'        => empty( $missing_sections ),
-		   'missing_keys' => $missing_sections,
-	   ];
+	$report_data['status'] = [
+		'valid'        => empty( $missing_sections ),
+		'missing_keys' => $missing_sections,
+	];
 
-	   if ( ! empty( $missing_sections ) ) {
-		   return new WP_Error(
-			   'rtbcb_missing_report_sections',
-			   __( 'Missing required report sections.', 'rtbcb' ),
-			   $report_data
-		   );
-	   }
+	if ( ! empty( $missing_sections ) ) {
+		return new WP_Error(
+			'rtbcb_missing_report_sections',
+			__( 'Missing required report sections.', 'rtbcb' ),
+			$report_data
+		);
+	}
 
-	   return $report_data;
+	return $report_data;
 	}
 
 	/**
@@ -2147,24 +2147,24 @@ return $use_comprehensive;
 	* @return array
 	*/
 	private function extract_value_drivers( $data ) {
-	   $drivers = [];
+	$drivers = [];
 
-	   // Extract from various possible sources.
-	   if ( ! empty( $data['value_drivers'] ) ) {
-		   $drivers = (array) $data['value_drivers'];
-	   } elseif ( ! empty( $data['key_benefits'] ) ) {
-		   $drivers = (array) $data['key_benefits'];
-	   } else {
-		   // Default value drivers.
-		   $drivers = [
-			   __( 'Automated cash management processes', 'rtbcb' ),
-			   __( 'Enhanced financial visibility and reporting', 'rtbcb' ),
-			   __( 'Reduced operational risk and errors', 'rtbcb' ),
-			   __( 'Improved regulatory compliance', 'rtbcb' ),
-		   ];
-	   }
+	// Extract from various possible sources.
+	if ( ! empty( $data['value_drivers'] ) ) {
+		$drivers = (array) $data['value_drivers'];
+	} elseif ( ! empty( $data['key_benefits'] ) ) {
+		$drivers = (array) $data['key_benefits'];
+	} else {
+		// Default value drivers.
+		$drivers = [
+			__( 'Automated cash management processes', 'rtbcb' ),
+			__( 'Enhanced financial visibility and reporting', 'rtbcb' ),
+			__( 'Reduced operational risk and errors', 'rtbcb' ),
+			__( 'Improved regulatory compliance', 'rtbcb' ),
+		];
+	}
 
-	   return array_slice( $drivers, 0, 4 );
+	return array_slice( $drivers, 0, 4 );
 	}
 
 	/**
@@ -2175,36 +2175,36 @@ return $use_comprehensive;
 	* @return array
 	*/
 	private function format_roi_scenarios( $data ) {
-	   // Try to get ROI data from various possible locations.
-	   if ( ! empty( $data['scenarios'] ) ) {
-		   return $data['scenarios'];
-	   }
+	// Try to get ROI data from various possible locations.
+	if ( ! empty( $data['scenarios'] ) ) {
+		return $data['scenarios'];
+	}
 
-	   if ( ! empty( $data['roi_scenarios'] ) ) {
-		   return $data['roi_scenarios'];
-	   }
+	if ( ! empty( $data['roi_scenarios'] ) ) {
+		return $data['roi_scenarios'];
+	}
 
-	   // Fallback to default structure.
-	   return [
-		   'conservative' => [
-			   'total_annual_benefit' => $data['roi_low'] ?? 0,
-			   'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
-			   'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
-			   'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
-		   ],
-		   'base' => [
-			   'total_annual_benefit' => $data['roi_base'] ?? 0,
-			   'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
-			   'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
-			   'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
-		   ],
-		   'optimistic' => [
-			   'total_annual_benefit' => $data['roi_high'] ?? 0,
-			   'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
-			   'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
-			   'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
-		   ],
-	   ];
+	// Fallback to default structure.
+	return [
+		'conservative' => [
+			'total_annual_benefit' => $data['roi_low'] ?? 0,
+			'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
+			'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
+			'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
+		],
+		'base' => [
+			'total_annual_benefit' => $data['roi_base'] ?? 0,
+			'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
+			'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
+			'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
+		],
+		'optimistic' => [
+			'total_annual_benefit' => $data['roi_high'] ?? 0,
+			'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
+			'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
+			'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
+		],
+	];
 	}
 
 	/**
@@ -2215,17 +2215,17 @@ return $use_comprehensive;
 	* @return string
 	*/
 	private function determine_business_case_strength( $data ) {
-	   $base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
+	$base_roi = $data['roi_base'] ?? $data['scenarios']['base']['total_annual_benefit'] ?? 0;
 
-	   if ( $base_roi > 500000 ) {
-		   return 'Compelling';
-	   } elseif ( $base_roi > 200000 ) {
-		   return 'Strong';
-	   } elseif ( $base_roi > 50000 ) {
-		   return 'Moderate';
-	   } else {
-		   return 'Developing';
-	   }
+	if ( $base_roi > 500000 ) {
+		return 'Compelling';
+	} elseif ( $base_roi > 200000 ) {
+		return 'Strong';
+	} elseif ( $base_roi > 50000 ) {
+		return 'Moderate';
+	} else {
+		return 'Developing';
+	}
 	}
 
 	/**
@@ -2236,16 +2236,16 @@ return $use_comprehensive;
 	* @return array
 	*/
 	private function extract_immediate_steps( $data ) {
-	   if ( ! empty( $data['next_actions'] ) ) {
-		   $all_actions = (array) $data['next_actions'];
-		   return array_slice( $all_actions, 0, 3 );
-	   }
+	if ( ! empty( $data['next_actions'] ) ) {
+		$all_actions = (array) $data['next_actions'];
+		return array_slice( $all_actions, 0, 3 );
+	}
 
-	   return [
-		   __( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
-		   __( 'Form project steering committee', 'rtbcb' ),
-		   __( 'Conduct detailed requirements gathering', 'rtbcb' ),
-	   ];
+	return [
+		__( 'Secure executive sponsorship and budget approval', 'rtbcb' ),
+		__( 'Form project steering committee', 'rtbcb' ),
+		__( 'Conduct detailed requirements gathering', 'rtbcb' ),
+	];
 	}
 
 	/**
@@ -2256,17 +2256,17 @@ return $use_comprehensive;
 	* @return array
 	*/
 	private function extract_short_term_steps( $data ) {
-	   if ( ! empty( $data['implementation_steps'] ) ) {
-		   $steps = (array) $data['implementation_steps'];
-		   return array_slice( $steps, 0, 4 );
-	   }
+	if ( ! empty( $data['implementation_steps'] ) ) {
+		$steps = (array) $data['implementation_steps'];
+		return array_slice( $steps, 0, 4 );
+	}
 
-	   return [
-		   __( 'Issue RFP to qualified vendors', 'rtbcb' ),
-		   __( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
-		   __( 'Negotiate contracts and terms', 'rtbcb' ),
-		   __( 'Begin system implementation planning', 'rtbcb' ),
-	   ];
+	return [
+		__( 'Issue RFP to qualified vendors', 'rtbcb' ),
+		__( 'Conduct vendor demonstrations and evaluations', 'rtbcb' ),
+		__( 'Negotiate contracts and terms', 'rtbcb' ),
+		__( 'Begin system implementation planning', 'rtbcb' ),
+	];
 	}
 
 	/**
@@ -2277,12 +2277,12 @@ return $use_comprehensive;
 	* @return array
 	*/
 	private function extract_long_term_steps( $data ) {
-	   return [
-		   __( 'Complete system implementation and testing', 'rtbcb' ),
-		   __( 'Conduct user training and change management', 'rtbcb' ),
-		   __( 'Measure and optimize system performance', 'rtbcb' ),
-		   __( 'Expand functionality and integration capabilities', 'rtbcb' ),
-	   ];
+	return [
+		__( 'Complete system implementation and testing', 'rtbcb' ),
+		__( 'Conduct user training and change management', 'rtbcb' ),
+		__( 'Measure and optimize system performance', 'rtbcb' ),
+		__( 'Expand functionality and integration capabilities', 'rtbcb' ),
+	];
 	}
 
 	public function admin_notices() {
@@ -2317,11 +2317,11 @@ return $use_comprehensive;
 	}
 
 	/**
-	 * Add plugin action links.
-	 *
-	 * @param array $links Existing links.
-	 * @return array Modified links.
-	 */
+	* Add plugin action links.
+	*
+	* @param array $links Existing links.
+	* @return array Modified links.
+	*/
 	public function plugin_action_links( $links ) {
 		$custom_links = [
 			'settings' => sprintf(
@@ -2340,10 +2340,10 @@ return $use_comprehensive;
 	}
 
 	/**
-	 * Plugin activation.
-	 *
-	 * @return void
-	 */
+	* Plugin activation.
+	*
+	* @return void
+	*/
 	public function activate() {
 		// Create database tables
 		$this->init_database();
@@ -2367,10 +2367,10 @@ return $use_comprehensive;
 	}
 
 	/**
-	 * Plugin deactivation.
-	 *
-	 * @return void
-	 */
+	* Plugin deactivation.
+	*
+	* @return void
+	*/
 	public function deactivate() {
 		// Clear scheduled events
 		wp_clear_scheduled_hook( 'rtbcb_rebuild_rag_index' );
@@ -2384,10 +2384,10 @@ return $use_comprehensive;
 	}
 
 	/**
-	 * Plugin uninstall.
-	 *
-	 * @return void
-	 */
+	* Plugin uninstall.
+	*
+	* @return void
+	*/
 	public static function uninstall() {
 		global $wpdb;
 
@@ -2455,11 +2455,11 @@ return $use_comprehensive;
 	}
 
 	/**
-	 * Get plugin data.
-	 *
-	 * @param string $key Data key.
-	 * @return mixed
-	 */
+	* Get plugin data.
+	*
+	* @param string $key Data key.
+	* @return mixed
+	*/
 	public function get_plugin_data( $key = null ) {
 		if ( $key ) {
 			return $this->plugin_data[ $key ] ?? null;
@@ -2468,10 +2468,10 @@ return $use_comprehensive;
 	}
 
 	/**
-	 * Handle debug diagnostics via AJAX.
-	 *
-	 * @return void
-	 */
+	* Handle debug diagnostics via AJAX.
+	*
+	* @return void
+	*/
 	public function debug_ajax_handler() {
 		$nonce       = isset( $_POST['rtbcb_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ) : '';
 		$nonce_valid = wp_verify_nonce( $nonce, 'rtbcb_debug' );
@@ -2497,10 +2497,10 @@ return $use_comprehensive;
 	}
 
 	/**
-	 * Handle simplified ROI test via AJAX.
-	 *
-	 * @return void
-	 */
+	* Handle simplified ROI test via AJAX.
+	*
+	* @return void
+	*/
 	public function ajax_generate_case_simple() {
 		if ( ! check_ajax_referer( 'rtbcb_simple', 'rtbcb_nonce', false ) ) {
 			wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
@@ -2577,10 +2577,10 @@ RTBCB_Main::instance();
 // Helper functions for use in templates and other plugins
 if ( ! function_exists( 'rtbcb_get_leads_count' ) ) {
 	/**
-	 * Get total number of leads.
-	 *
-	 * @return int
-	 */
+	* Get total number of leads.
+	*
+	* @return int
+	*/
 	function rtbcb_get_leads_count() {
 		$stats = RTBCB_Leads::get_cached_statistics();
 		return intval( $stats['total_leads'] ?? 0 );
@@ -2589,10 +2589,10 @@ if ( ! function_exists( 'rtbcb_get_leads_count' ) ) {
 
 if ( ! function_exists( 'rtbcb_get_average_roi' ) ) {
 	/**
-	 * Get average ROI across all leads.
-	 *
-	 * @return float
-	 */
+	* Get average ROI across all leads.
+	*
+	* @return float
+	*/
 	function rtbcb_get_average_roi() {
 		$stats = RTBCB_Leads::get_cached_statistics();
 		return floatval( $stats['average_roi']['avg_base'] ?? 0 );
@@ -2601,10 +2601,10 @@ if ( ! function_exists( 'rtbcb_get_average_roi' ) ) {
 
 if ( ! function_exists( 'rtbcb_is_configured' ) ) {
 	/**
-	 * Check if plugin is properly configured.
-	 *
-	 * @return bool
-	 */
+	* Check if plugin is properly configured.
+	*
+	* @return bool
+	*/
 	function rtbcb_is_configured() {
 		return ! empty( get_option( 'rtbcb_openai_api_key' ) );
 	}

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -83,9 +83,9 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 							<?php esc_html_e( 'Company Name', 'rtbcb' ); ?>
 						</label>
 						<input type="text" name="company_name" id="company_name"
-							   placeholder="<?php esc_attr_e( 'Enter your company name', 'rtbcb' ); ?>"
-							   required
-							   maxlength="100" />
+							placeholder="<?php esc_attr_e( 'Enter your company name', 'rtbcb' ); ?>"
+							required
+							maxlength="100" />
 						<div class="rtbcb-field-help">
 							<?php esc_html_e( 'This will be used to personalize your business case report', 'rtbcb' ); ?>
 						</div>
@@ -149,7 +149,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 			<div class="rtbcb-wizard-step" data-step="2">
 				<div class="rtbcb-step-header">
 					<h3><?php esc_html_e( 'Your current treasury operations', 'rtbcb' ); ?></h3>
-					  <p><?php esc_html_e( 'Help us understand your current workload and banking relationships.', 'rtbcb' ); ?></p>
+					<p><?php esc_html_e( 'Help us understand your current workload and banking relationships.', 'rtbcb' ); ?></p>
 				</div>
 
 				<div class="rtbcb-step-content">
@@ -158,7 +158,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 							<?php esc_html_e( 'Weekly Hours: Bank Reconciliation', 'rtbcb' ); ?>
 						</label>
 						<input type="number" name="hours_reconciliation" id="hours_reconciliation"
-							   min="0" max="168" step="0.5" placeholder="0" required inputmode="decimal" />
+							min="0" max="168" step="0.5" placeholder="0" required inputmode="decimal" />
 						<div class="rtbcb-field-help">
 							<?php esc_html_e( 'Total weekly hours spent on bank reconciliation tasks', 'rtbcb' ); ?>
 						</div>
@@ -169,7 +169,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 							<?php esc_html_e( 'Weekly Hours: Cash Positioning', 'rtbcb' ); ?>
 						</label>
 						<input type="number" name="hours_cash_positioning" id="hours_cash_positioning"
-							   min="0" max="168" step="0.5" placeholder="0" required inputmode="decimal" />
+							min="0" max="168" step="0.5" placeholder="0" required inputmode="decimal" />
 						<div class="rtbcb-field-help">
 							<?php esc_html_e( 'Time spent on cash visibility, forecasting, and positioning', 'rtbcb' ); ?>
 						</div>
@@ -180,7 +180,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 							<?php esc_html_e( 'Number of Banking Relationships', 'rtbcb' ); ?>
 						</label>
 						<input type="number" name="num_banks" id="num_banks"
-							   min="1" max="50" placeholder="0" required inputmode="decimal" />
+							min="1" max="50" placeholder="0" required inputmode="decimal" />
 						<div class="rtbcb-field-help">
 							<?php esc_html_e( 'Total number of banks where your company maintains accounts', 'rtbcb' ); ?>
 						</div>
@@ -191,7 +191,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 							<?php esc_html_e( 'Treasury Team Size (FTEs)', 'rtbcb' ); ?>
 						</label>
 						<input type="number" name="ftes" id="ftes"
-							   min="0.5" max="100" step="0.5" placeholder="0" required inputmode="decimal" />
+							min="0.5" max="100" step="0.5" placeholder="0" required inputmode="decimal" />
 						<div class="rtbcb-field-help">
 							<?php esc_html_e( 'Full-time equivalent employees dedicated to treasury functions', 'rtbcb' ); ?>
 						</div>
@@ -371,7 +371,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 							<?php esc_html_e( 'Business Email Address', 'rtbcb' ); ?>
 						</label>
 						<input type="email" name="email" id="email"
-							   placeholder="yourname@company.com" required />
+							placeholder="yourname@company.com" required />
 						<div class="rtbcb-field-help">
 							<?php esc_html_e( 'We\'ll send your business case report to this email address', 'rtbcb' ); ?>
 						</div>


### PR DESCRIPTION
## Summary
- use tabs instead of spaces for PHP indentation across plugin files
- normalize admin, inc, and template files to conform to WP coding standards

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `phpcs --standard=WordPress` *(fails: command not found)*
- `bash tests/run-tests.sh` *(fails: missing WordPress functions, phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4744b927c83318cb455000b04232c