### PR TITLE
Add WordPress test stubs and DOM shim setup

### DIFF
--- a/tests/company-research-cache.test.php
+++ b/tests/company-research-cache.test.php
@@ -4,6 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 defined( 'ABSPATH' ) || exit;
+require_once __DIR__ . '/wp-stubs.php';
 
 ini_set( 'error_log', '/dev/null' );
 

--- a/tests/edge-cases.test.php
+++ b/tests/edge-cases.test.php
@@ -5,6 +5,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 defined( 'ABSPATH' ) || exit;
 
+require_once __DIR__ . '/wp-stubs.php';
+
 use PHPUnit\Framework\TestCase;
 
 // Stub WordPress functions.
@@ -14,19 +16,7 @@ return true;
 }
 }
 
-if ( ! function_exists( 'sanitize_text_field' ) ) {
-function sanitize_text_field( $text ) {
-$text = is_scalar( $text ) ? (string) $text : '';
-$text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
-return trim( $text );
-}
-}
 
-if ( ! function_exists( 'wp_unslash' ) ) {
-function wp_unslash( $value ) {
-return $value;
-}
-}
 
 if ( ! function_exists( '__' ) ) {
 function __( $text, $domain = null ) {
@@ -34,11 +24,6 @@ return $text;
 }
 }
 
-if ( ! function_exists( 'sanitize_email' ) ) {
-function sanitize_email( $email ) {
-return filter_var( $email, FILTER_SANITIZE_EMAIL );
-}
-}
 
 if ( ! function_exists( 'wp_send_json_success' ) ) {
 function wp_send_json_success( $data, $status = 200 ) {

--- a/tests/jsdom-setup.js
+++ b/tests/jsdom-setup.js
@@ -1,0 +1,20 @@
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+let doc = dom.window.document;
+
+Object.defineProperty(global, 'document', {
+  configurable: true,
+  get() {
+    return doc;
+  },
+  set(v) {
+    doc = Object.setPrototypeOf(v, dom.window.document);
+  }
+});
+
+global.window = dom.window;
+global.HTMLElement = dom.window.HTMLElement;
+global.Node = dom.window.Node;
+global.Event = dom.window.Event;
+global.navigator = dom.window.navigator;

--- a/tests/project-growth-path.test.php
+++ b/tests/project-growth-path.test.php
@@ -4,6 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 defined( 'ABSPATH' ) || exit;
+require_once __DIR__ . '/wp-stubs.php';
 
 if ( ! function_exists( 'add_filter' ) ) {
 	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -9,6 +9,7 @@ export RTBCB_TEST_MODEL="${RTBCB_TEST_MODEL:-gpt-5-mini}"
 
 # Install JS dependencies for headless browser tests
 npm install --no-save --no-package-lock jsdom >/dev/null 2>&1
+export NODE_OPTIONS="--require ./tests/jsdom-setup.js"
 
 # PHP Lint
 echo "1. Running PHP syntax check..."

--- a/tests/validator.test.php
+++ b/tests/validator.test.php
@@ -2,83 +2,60 @@
 use PHPUnit\Framework\TestCase;
 
 define( 'ABSPATH', __DIR__ . '/../' );
-
-if ( ! function_exists( 'add_filter' ) ) {
-	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
-		// No-op for testing.
-	}
-}
+require_once __DIR__ . '/wp-stubs.php';
 
 if ( ! function_exists( '__' ) ) {
-	function __( $text, $domain = null ) {
-		return $text;
-	}
+function __( $text, $domain = null ) {
+return $text;
 }
-
-if ( ! function_exists( 'sanitize_text_field' ) ) {
-	function sanitize_text_field( $text ) {
-		return is_string( $text ) ? trim( $text ) : '';
-	}
-}
-
-if ( ! function_exists( 'sanitize_email' ) ) {
-	function sanitize_email( $email ) {
-		return filter_var( $email, FILTER_SANITIZE_EMAIL );
-	}
-}
-
-if ( ! function_exists( 'wp_unslash' ) ) {
-	function wp_unslash( $value ) {
-		return $value;
-	}
 }
 
 require_once __DIR__ . '/../inc/helpers.php';
 require_once __DIR__ . '/../inc/class-rtbcb-validator.php';
 
 final class RTBCB_ValidatorTest extends TestCase {
-	public function test_missing_required_fields() {
-		$validator = new RTBCB_Validator();
+public function test_missing_required_fields() {
+$validator = new RTBCB_Validator();
 
-		$result = $validator->validate( [ 'email' => 'user@corp.com', 'company_size' => '100-500' ] );
-		$this->assertSame( 'Company name is required.', $result['error'] );
+$result = $validator->validate( [ 'email' => 'user@corp.com', 'company_size' => '100-500' ] );
+$this->assertSame( 'Company name is required.', $result['error'] );
 
-		$result = $validator->validate( [ 'company_name' => 'Acme', 'company_size' => '100-500' ] );
-		$this->assertSame( 'Email is required.', $result['error'] );
+$result = $validator->validate( [ 'company_name' => 'Acme', 'company_size' => '100-500' ] );
+$this->assertSame( 'Email is required.', $result['error'] );
 
-		$result = $validator->validate( [ 'company_name' => 'Acme', 'email' => 'user@corp.com' ] );
-		$this->assertSame( 'Company size is required.', $result['error'] );
-	}
+$result = $validator->validate( [ 'company_name' => 'Acme', 'email' => 'user@corp.com' ] );
+$this->assertSame( 'Company size is required.', $result['error'] );
+}
 
-	public function test_email_domain_validation() {
-		$validator = new RTBCB_Validator();
-		$result = $validator->validate( [
-			'company_name' => 'Acme',
-			'email'        => 'user@gmail.com',
-			'company_size' => '100-500',
-		] );
-		$this->assertSame( 'Please use your business email address.', $result['error'] );
+public function test_email_domain_validation() {
+$validator = new RTBCB_Validator();
+$result = $validator->validate( [
+'company_name' => 'Acme',
+'email'        => 'user@gmail.com',
+'company_size' => '100-500',
+] );
+$this->assertSame( 'Please use your business email address.', $result['error'] );
 
-		$this->assertTrue( rtbcb_is_business_email( 'user@company.com' ) );
-		$this->assertFalse( rtbcb_is_business_email( 'user@yahoo.com' ) );
-	}
+$this->assertTrue( rtbcb_is_business_email( 'user@company.com' ) );
+$this->assertFalse( rtbcb_is_business_email( 'user@yahoo.com' ) );
+}
 
-	public function test_field_length_constraints() {
-		$validator = new RTBCB_Validator();
-		$long_name = str_repeat( 'a', 256 );
-		$result = $validator->validate( [
-			'company_name' => $long_name,
-			'email'        => 'user@corp.com',
-			'company_size' => '100-500',
-		] );
-		$this->assertSame( 'Company Name cannot exceed 255 characters.', $result['error'] );
+public function test_field_length_constraints() {
+$validator = new RTBCB_Validator();
+$long_name = str_repeat( 'a', 256 );
+$result = $validator->validate( [
+'company_name' => $long_name,
+'email'        => 'user@corp.com',
+'company_size' => '100-500',
+] );
+$this->assertSame( 'Company Name cannot exceed 255 characters.', $result['error'] );
 
-		$long_email = str_repeat( 'a', 250 ) . '@example.com';
-		$result = $validator->validate( [
-			'company_name' => 'Acme',
-			'email'        => $long_email,
-			'company_size' => '100-500',
-		] );
-		$this->assertSame( 'Email cannot exceed 254 characters.', $result['error'] );
-	}
+$long_email = str_repeat( 'a', 250 ) . '@example.com';
+$result = $validator->validate( [
+'company_name' => 'Acme',
+'email'        => $long_email,
+'company_size' => '100-500',
+] );
+$this->assertSame( 'Email cannot exceed 254 characters.', $result['error'] );
+}
 }

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -1,0 +1,40 @@
+<?php
+if ( ! function_exists( 'add_filter' ) ) {
+    function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+    function apply_filters( $tag, $value ) {
+        return $value;
+    }
+}
+if ( ! function_exists( 'add_action' ) ) {
+    function add_action( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
+}
+if ( ! function_exists( 'do_action' ) ) {
+    function do_action( $tag, ...$args ) {}
+}
+if ( ! function_exists( 'get_option' ) ) {
+    function get_option( $option, $default = false ) {
+        return $default;
+    }
+}
+if ( ! function_exists( 'update_option' ) ) {
+    function update_option( $option, $value ) {
+        return true;
+    }
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $text ) {
+        return is_string( $text ) ? trim( $text ) : '';
+    }
+}
+if ( ! function_exists( 'sanitize_email' ) ) {
+    function sanitize_email( $email ) {
+        return filter_var( $email, FILTER_SANITIZE_EMAIL );
+    }
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+    function wp_unslash( $value ) {
+        return $value;
+    }
+}


### PR DESCRIPTION
## Summary
- create reusable WordPress function stubs for tests
- load jsdom shim in test runner for DOM APIs
- ensure key PHP tests load stubbed hooks

## Testing
- `bash tests/run-tests.sh` *(fails: TypeError and HTTP errors in Node tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b47dc693ac8331bf929df7650501e6