### PR TITLE
Add shared JSDOM test environment and integrate across JS tests

### DIFF
--- a/tests/export-to-pdf-button.test.js
+++ b/tests/export-to-pdf-button.test.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
+require('./jsdom-setup');
+
 const appended = [];
 const reportContainer = {
     innerHTML: '',

--- a/tests/handle-invalid-server-response.test.js
+++ b/tests/handle-invalid-server-response.test.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
+require('./jsdom-setup');
+
 global.rtbcbAjax = { ajax_url: 'test-url', nonce: 'test-nonce' };
 
 class SimpleFormData {
@@ -56,17 +58,18 @@ const form = {
     closest: () => ({ style: {} })
 };
 
-global.document = {
-    readyState: 'complete',
-    addEventListener: () => {},
-    getElementById: (id) => {
-        if (id === 'rtbcbForm') return form;
-        if (id === 'rtbcbModalOverlay') return {};
-        return null;
-    }
-};
+const formElem = document.createElement('form');
+formElem.id = 'rtbcbForm';
+Object.assign(formElem, form);
+document.body.appendChild(formElem);
 
-global.window = {};
+document.readyState = 'complete';
+const modalOverlay = document.createElement('div');
+modalOverlay.id = 'rtbcbModalOverlay';
+document.body.appendChild(modalOverlay);
+const progressContainer = document.createElement('div');
+progressContainer.id = 'rtbcb-progress-container';
+document.body.appendChild(progressContainer);
 
 const code = fs.readFileSync('public/js/rtbcb-wizard.js', 'utf8');
 vm.runInThisContext(code);

--- a/tests/handle-server-error-display.test.js
+++ b/tests/handle-server-error-display.test.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
+require('./jsdom-setup');
+
 global.rtbcbAjax = { ajax_url: 'test-url', nonce: 'test-nonce' };
 
 class SimpleFormData {
@@ -58,17 +60,18 @@ const form = {
     closest: () => ({ style: {} })
 };
 
-global.document = {
-    readyState: 'complete',
-    addEventListener: () => {},
-    getElementById: (id) => {
-        if (id === 'rtbcbForm') return form;
-        if (id === 'rtbcbModalOverlay') return {};
-        return null;
-    }
-};
+const formElem = document.createElement('form');
+formElem.id = 'rtbcbForm';
+Object.assign(formElem, form);
+document.body.appendChild(formElem);
 
-global.window = {};
+document.readyState = 'complete';
+const modalOverlay = document.createElement('div');
+modalOverlay.id = 'rtbcbModalOverlay';
+document.body.appendChild(modalOverlay);
+const progressContainer = document.createElement('div');
+progressContainer.id = 'rtbcb-progress-container';
+document.body.appendChild(progressContainer);
 
 const code = fs.readFileSync('public/js/rtbcb-wizard.js', 'utf8');
 vm.runInThisContext(code);

--- a/tests/handle-string-error-response.test.js
+++ b/tests/handle-string-error-response.test.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
+require('./jsdom-setup');
+
 global.rtbcbAjax = { ajax_url: 'test-url', nonce: 'test-nonce' };
 
 class SimpleFormData {
@@ -60,17 +62,18 @@ const form = {
     closest: () => ({ style: {} })
 };
 
-global.document = {
-    readyState: 'complete',
-    addEventListener: () => {},
-    getElementById: (id) => {
-        if (id === 'rtbcbForm') return form;
-        if (id === 'rtbcbModalOverlay') return {};
-        return null;
-    }
-};
+const formElem = document.createElement('form');
+formElem.id = 'rtbcbForm';
+Object.assign(formElem, form);
+document.body.appendChild(formElem);
 
-global.window = {};
+document.readyState = 'complete';
+const modalOverlay = document.createElement('div');
+modalOverlay.id = 'rtbcbModalOverlay';
+document.body.appendChild(modalOverlay);
+const progressContainer = document.createElement('div');
+progressContainer.id = 'rtbcb-progress-container';
+document.body.appendChild(progressContainer);
 
 const code = fs.readFileSync('public/js/rtbcb-wizard.js', 'utf8');
 vm.runInThisContext(code);

--- a/tests/handle-submit-error.test.js
+++ b/tests/handle-submit-error.test.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
+require('./jsdom-setup');
+
 global.rtbcbAjax = { ajax_url: 'test-url', nonce: 'test-nonce' };
 
 class SimpleFormData {
@@ -63,17 +65,18 @@ const form = {
     closest: () => ({ style: {} })
 };
 
-global.document = {
-    readyState: 'complete',
-    addEventListener: () => {},
-    getElementById: (id) => {
-        if (id === 'rtbcbForm') return form;
-        if (id === 'rtbcbModalOverlay') return {};
-        return null;
-    }
-};
+const formElem = document.createElement('form');
+formElem.id = 'rtbcbForm';
+Object.assign(formElem, form);
+document.body.appendChild(formElem);
 
-global.window = {};
+document.readyState = 'complete';
+const modalOverlay = document.createElement('div');
+modalOverlay.id = 'rtbcbModalOverlay';
+document.body.appendChild(modalOverlay);
+const progressContainer = document.createElement('div');
+progressContainer.id = 'rtbcb-progress-container';
+document.body.appendChild(progressContainer);
 
 const code = fs.readFileSync('public/js/rtbcb-wizard.js', 'utf8');
 vm.runInThisContext(code);

--- a/tests/handle-submit-no-ajax-url.test.js
+++ b/tests/handle-submit-no-ajax-url.test.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
+require('./jsdom-setup');
+
 global.rtbcbAjax = { ajax_url: '', nonce: 'test-nonce' };
 
 class SimpleFormData {
@@ -53,17 +55,18 @@ const form = {
     closest: () => ({ style: {} })
 };
 
-global.document = {
-    readyState: 'complete',
-    addEventListener: () => {},
-    getElementById: (id) => {
-        if (id === 'rtbcbForm') return form;
-        if (id === 'rtbcbModalOverlay') return {};
-        return null;
-    }
-};
+const formElem = document.createElement('form');
+formElem.id = 'rtbcbForm';
+Object.assign(formElem, form);
+document.body.appendChild(formElem);
 
-global.window = {};
+document.readyState = 'complete';
+const modalOverlay = document.createElement('div');
+modalOverlay.id = 'rtbcbModalOverlay';
+document.body.appendChild(modalOverlay);
+const progressContainer = document.createElement('div');
+progressContainer.id = 'rtbcb-progress-container';
+document.body.appendChild(progressContainer);
 
 const code = fs.readFileSync('public/js/rtbcb-wizard.js', 'utf8');
 vm.runInThisContext(code);

--- a/tests/handle-submit-success.test.js
+++ b/tests/handle-submit-success.test.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
+require('./jsdom-setup');
+
 global.rtbcbAjax = { ajax_url: 'test-url', nonce: 'test-nonce' };
 
 class SimpleFormData {
@@ -69,37 +71,39 @@ const form = {
     closest: () => ({ style: {} })
 };
 
-global.document = {
-    readyState: 'complete',
-    addEventListener: () => {},
-    getElementById: (id) => {
-        if (id === 'rtbcbForm') return form;
-        if (id === 'rtbcbModalOverlay') return {};
-        return null;
-    }
-};
+const formElem = document.createElement('form');
+formElem.id = 'rtbcbForm';
+Object.assign(formElem, form);
+document.body.appendChild(formElem);
 
-global.window = {};
+document.readyState = 'complete';
+const modalOverlay = document.createElement('div');
+modalOverlay.id = 'rtbcbModalOverlay';
+document.body.appendChild(modalOverlay);
+const progressContainer = document.createElement('div');
+progressContainer.id = 'rtbcb-progress-container';
+document.body.appendChild(progressContainer);
 
   const code = fs.readFileSync('public/js/rtbcb-wizard.js', 'utf8');
   vm.runInThisContext(code);
 
   const builder = new BusinessCaseBuilder();
   builder.form = form;
-  let resultsData = null;
   builder.showProgress = () => {};
-  builder.showResults = (data) => { resultsData = data; };
+  builder.showResults = () => {};
   builder.showEnhancedError = () => {};
   builder.pollJob = () => { builder.handleSuccess({ report_html: '<div>Report</div>' }); };
 
-(async () => {
+ (async () => {
     await builder.handleSubmit();
-    assert.strictEqual(resultsData.report_html, '<div>Report</div>');
+    const injected = document.getElementById('rtbcb-results-enhanced');
+    assert.ok(injected);
+    assert.strictEqual(injected.innerHTML, '<div>Report</div>');
     assert.strictEqual(receivedHeaders['Accept'], 'application/json, text/html');
     assert.strictEqual(warnCalled, false);
     console.warn = originalWarn;
     console.log('Success path test passed.');
-})().catch(err => {
+ })().catch(err => {
     console.error(err);
     process.exit(1);
 });

--- a/tests/jsdom-setup.js
+++ b/tests/jsdom-setup.js
@@ -1,20 +1,18 @@
 const { JSDOM } = require('jsdom');
 
 const dom = new JSDOM('<!doctype html><html><body></body></html>');
-let doc = dom.window.document;
-
-Object.defineProperty(global, 'document', {
-  configurable: true,
-  get() {
-    return doc;
-  },
-  set(v) {
-    doc = Object.setPrototypeOf(v, dom.window.document);
-  }
-});
 
 global.window = dom.window;
+global.document = dom.window.document;
 global.HTMLElement = dom.window.HTMLElement;
 global.Node = dom.window.Node;
 global.Event = dom.window.Event;
 global.navigator = dom.window.navigator;
+global.HTMLElement.prototype.scrollIntoView = function() {};
+
+// Expose common DOM helpers on the global object for tests
+global.createElement = (...args) => global.document.createElement(...args);
+global.appendChild = (...args) => global.document.body.appendChild(...args);
+global.getElementById = (...args) => global.document.getElementById(...args);
+global.querySelector = (...args) => global.document.querySelector(...args);
+global.querySelectorAll = (...args) => global.document.querySelectorAll(...args);

--- a/tests/min-output-tokens.test.js
+++ b/tests/min-output-tokens.test.js
@@ -2,6 +2,8 @@ const assert = require('assert');
 const fs = require('fs');
 const vm = require('vm');
 
+require('./jsdom-setup');
+
 async function runTests() {
     const code = fs.readFileSync('public/js/rtbcb-report.js', 'utf8');
     vm.runInThisContext(code);

--- a/tests/poll-job-completed.test.js
+++ b/tests/poll-job-completed.test.js
@@ -1,14 +1,11 @@
 const fs = require('fs');
 const vm = require('vm');
+require('./jsdom-setup');
 
 // Minimal DOM stubs for script execution
 const nodeGlobal = vm.runInThisContext('this');
-nodeGlobal.window = {};
-nodeGlobal.document = {
-    getElementById: () => null,
-    addEventListener: () => null,
-    body: { style: {} },
-};
+nodeGlobal.window = global.window;
+nodeGlobal.document = global.document;
 
 // Load the BusinessCaseBuilder script
 const code = fs.readFileSync('public/js/rtbcb-wizard.js', 'utf8');

--- a/tests/poll-job-partial-fields.test.js
+++ b/tests/poll-job-partial-fields.test.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
+const fs = require('fs');
 const vm = require('vm');
+require('./jsdom-setup');
 
 describe('pollJob partial updates', () => {
 test('renders provisional ROI and category while processing', async () => {
@@ -7,39 +9,21 @@ jest.useFakeTimers();
 
 const nodeGlobal = vm.runInThisContext('this');
 
-const progressStatus = { textContent: '' };
-const roiElem = { textContent: '', style: { display: 'none' } };
-const categoryElem = { textContent: '', style: { display: 'none' } };
+const progressStatus = document.createElement('div');
+progressStatus.id = 'rtbcb-progress-status';
+const roiElem = document.createElement('div');
+roiElem.id = 'rtbcb-partial-basic-roi';
+roiElem.style.display = 'none';
+const categoryElem = document.createElement('div');
+categoryElem.id = 'rtbcb-partial-category';
+categoryElem.style.display = 'none';
+
+document.body.appendChild(progressStatus);
+document.body.appendChild(roiElem);
+document.body.appendChild(categoryElem);
 
 nodeGlobal.window = {};
-nodeGlobal.document = {
-getElementById: (id) => {
-if (id === 'rtbcb-progress-status') {
-return progressStatus;
-}
-if (id === 'rtbcb-partial-basic-roi') {
-return roiElem;
-}
-if (id === 'rtbcb-partial-category') {
-return categoryElem;
-}
-return null;
-},
-addEventListener: () => {},
-createElement: () => {
-const elem = { innerHTML: '' };
-Object.defineProperty(elem, 'textContent', {
-get() {
-return this.innerHTML;
-},
-set(v) {
-this.innerHTML = v;
-}
-});
-return elem;
-},
-body: { style: {} }
-};
+nodeGlobal.document = global.document;
 
 nodeGlobal.rtbcbAjax = { nonce: 'test-nonce' };
 

--- a/tests/poll-job-progress-text.test.js
+++ b/tests/poll-job-progress-text.test.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const vm = require('vm');
+require('./jsdom-setup');
 
 describe('pollJob progress updates', () => {
     test('updates progress text with job status', async () => {
@@ -7,19 +8,13 @@ describe('pollJob progress updates', () => {
 
         const nodeGlobal = vm.runInThisContext('this');
 
-        const progressStatus = { textContent: '' };
+        const progressStatus = document.createElement('div');
+        progressStatus.id = 'rtbcb-progress-status';
+        progressStatus.textContent = '';
+        document.body.appendChild(progressStatus);
 
         nodeGlobal.window = {};
-        nodeGlobal.document = {
-            getElementById: (id) => {
-                if (id === 'rtbcb-progress-status') {
-                    return progressStatus;
-                }
-                return null;
-            },
-            addEventListener: () => {},
-            body: { style: {} }
-        };
+        nodeGlobal.document = global.document;
 
         nodeGlobal.rtbcbAjax = { nonce: 'test-nonce' };
 

--- a/tests/poll-job-show-results.test.js
+++ b/tests/poll-job-show-results.test.js
@@ -1,23 +1,27 @@
 const fs = require('fs');
 const vm = require('vm');
+require('./jsdom-setup');
 
 describe('pollJob completion', () => {
     test('invokes showResults with report data and clears progress', async () => {
         const nodeGlobal = vm.runInThisContext('this');
 
-        const progressContainer = { style: { display: 'block' }, innerHTML: 'loading' };
-        const resultsContainer = { innerHTML: '', style: {}, scrollIntoView: () => {} };
+        const progressContainer = document.createElement('div');
+        progressContainer.id = 'rtbcb-progress-container';
+        progressContainer.style.display = 'block';
+        progressContainer.innerHTML = 'loading';
+
+        const resultsContainer = document.createElement('div');
+        resultsContainer.id = 'rtbcbResults';
+        resultsContainer.innerHTML = '';
+        resultsContainer.style = {};
+        resultsContainer.scrollIntoView = () => {};
+
+        document.body.appendChild(progressContainer);
+        document.body.appendChild(resultsContainer);
 
         nodeGlobal.window = { closeBusinessCaseModal: () => {} };
-        nodeGlobal.document = {
-            getElementById: (id) => {
-                if (id === 'rtbcb-progress-container') return progressContainer;
-                if (id === 'rtbcbResults') return resultsContainer;
-                return null;
-            },
-            addEventListener: () => {},
-            body: { style: {} }
-        };
+        nodeGlobal.document = global.document;
         nodeGlobal.rtbcbAjax = { nonce: 'test-nonce' };
 
         const code = fs.readFileSync('public/js/rtbcb-wizard.js', 'utf8');

--- a/tests/render-results-no-narrative.test.js
+++ b/tests/render-results-no-narrative.test.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
+require('./jsdom-setup');
+
 global.window = {};
 global.document = {
     readyState: 'complete',

--- a/tests/report-interactivity-extended.test.js
+++ b/tests/report-interactivity-extended.test.js
@@ -2,6 +2,8 @@ const assert = require('assert');
 const fs = require('fs');
 const vm = require('vm');
 
+require('./jsdom-setup');
+
 // Test for initializeSectionToggles
 (() => {
     const content = { style: { display: 'none' } };

--- a/tests/report-interactivity.test.js
+++ b/tests/report-interactivity.test.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
+require('./jsdom-setup');
+
 const container = {
     childNodes: [],
     innerHTML: '',

--- a/tests/temperature-model.test.js
+++ b/tests/temperature-model.test.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const vm = require('vm');
 const { execSync } = require('child_process');
 
+require('./jsdom-setup');
+
 async function runTests() {
     const code = fs.readFileSync('public/js/rtbcb-report.js', 'utf8');
     vm.runInThisContext(code);

--- a/tests/wizard-report-flow.test.js
+++ b/tests/wizard-report-flow.test.js
@@ -3,6 +3,8 @@ const vm = require('vm');
 const assert = require('assert');
 const { JSDOM } = require('jsdom');
 
+require('./jsdom-setup');
+
 // Read sample report HTML from template
 const sampleReport = fs.readFileSync('templates/comprehensive-report-template.php', 'utf8');
 


### PR DESCRIPTION
## Summary
- add `tests/jsdom-setup.js` to provide a shared JSDOM window, document and helper APIs
- require the JSDOM setup in DOM‑using JS tests and replace ad-hoc stubs with real JSDOM elements

## Testing
- `bash tests/run-tests.sh` *(PHPUnit missing; JavaScript tests executed with polyfilled DOM)*

------
https://chatgpt.com/codex/tasks/task_e_68b48ad909bc8331b142f261067402ef