### PR TITLE
chore: improve test stubs and scripts

### DIFF
--- a/tests/lead-storage.test.php
+++ b/tests/lead-storage.test.php
@@ -125,7 +125,14 @@ return null;
 }
 
 public function get_results( $sql, $output = ARRAY_A ) {
-        return [];
+	$results = [];
+	$query   = $this->dbh->query( $sql );
+	if ( $query instanceof SQLite3Result ) {
+		while ( $row = $query->fetchArray( SQLITE3_ASSOC ) ) {
+			$results[] = $row;
+		}
+	}
+	return $results;
 }
 
 public function insert( $table, $data, $format ) {

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -91,7 +91,7 @@ $PHP tests/job-status.test.php
 
 # Business analysis generation test
 echo "14c. Running business analysis generation test..."
-$PHP tests/generate-business-analysis.test.php
+phpunit tests/generate-business-analysis.test.php
 
 # JavaScript tests
 echo "16. Running JavaScript tests..."


### PR DESCRIPTION
## Summary
- implement WPDB_Memory::get_results to return query rows
- run generate-business-analysis test via phpunit

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: SQLite3::query syntax error, rtbcb_clear_report_cache undefined, phpunit: command not found)*
- `phpcs --standard=WordPress` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b48f149f5c83318a8f234adf35fef4