### PR TITLE
Add stub category recommender to test stubs

### DIFF
--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'ABSPATH' ) || exit;
 if ( ! function_exists( 'add_filter' ) ) {
     function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
 }
@@ -36,5 +37,29 @@ if ( ! function_exists( 'sanitize_email' ) ) {
 if ( ! function_exists( 'wp_unslash' ) ) {
     function wp_unslash( $value ) {
         return $value;
+    }
+}
+
+if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
+    class RTBCB_Category_Recommender {
+        /**
+         * Recommend a category based on inputs.
+         *
+         * @param array $inputs Input values.
+         * @return array Recommended category.
+         */
+        public static function recommend_category( $inputs ) {
+            return self::suggest_category( $inputs );
+        }
+
+        /**
+         * Suggest a category for backward compatibility.
+         *
+         * @param array $inputs Input values.
+         * @return array Recommended category.
+         */
+        public static function suggest_category( $inputs ) {
+            return [ 'recommended' => 'general' ];
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add ABSPATH guard and a stub `RTBCB_Category_Recommender` with `recommend_category` delegating to `suggest_category`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b48fdca99c83319a7b2745ef8e6448