### PR TITLE
fix: execute business analysis test suite with phpunit

### DIFF
--- a/tests/lead-storage.test.php
+++ b/tests/lead-storage.test.php
@@ -125,6 +125,14 @@ return null;
 }
 
 public function get_results( $sql, $output = ARRAY_A ) {
+        $result = $this->dbh->query( $sql );
+        if ( $result instanceof SQLite3Result ) {
+                $rows = [];
+                while ( $row = $result->fetchArray( SQLITE3_ASSOC ) ) {
+                        $rows[] = $row;
+                }
+                return $rows;
+        }
         return [];
 }
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -89,9 +89,9 @@ $PHP tests/background-job.test.php
 echo "14b. Running job status tests..."
 $PHP tests/job-status.test.php
 
-# Business analysis generation test
+# Business analysis generation test (PHPUnit)
 echo "14c. Running business analysis generation test..."
-$PHP tests/generate-business-analysis.test.php
+phpunit tests/generate-business-analysis.test.php
 
 # JavaScript tests
 echo "16. Running JavaScript tests..."


### PR DESCRIPTION
## Summary
- run business analysis generation test using phpunit
- allow WPDB_Memory::get_results to return query rows

## Testing
- `php -l tests/lead-storage.test.php`
- `bash tests/run-tests.sh` *(fails: RTBCB_Category_Recommender::recommend_category undefined and rtbcb_clear_report_cache undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68b48ef518348331a57507044253a7c8