### PR TITLE
Add shared JSDOM test environment and integrate across JS tests

### DIFF
--- a/tests/poll-job-partial-fields.test.js
+++ b/tests/poll-job-partial-fields.test.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const fs = require('fs');
 const vm = require('vm');
 require('./jsdom-setup');
 


### PR DESCRIPTION
## Summary
- remove duplicate `fs` import in `poll-job-partial-fields.test.js`

## Testing
- `npx --yes jest tests/poll-job-partial-fields.test.js --config '{"testEnvironment":"node"}'`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4916433d883318edf73b5dbcb8b9f