### PR TITLE
Guard report cache clearing

### DIFF
--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -304,7 +304,9 @@ class RTBCB_Leads {
 				}
 
 				self::update_cached_statistics();
-				rtbcb_clear_report_cache();
+				if ( function_exists( 'rtbcb_clear_report_cache' ) ) {
+					rtbcb_clear_report_cache();
+				}
 				return intval( $existing_lead['id'] );
 			} else {
 				// Insert new lead
@@ -321,7 +323,9 @@ class RTBCB_Leads {
 
 				$lead_id = $wpdb->insert_id;
 				self::update_cached_statistics();
-				rtbcb_clear_report_cache();
+				if ( function_exists( 'rtbcb_clear_report_cache' ) ) {
+					rtbcb_clear_report_cache();
+				}
 				return $lead_id;
 			}
 		} catch ( Exception $e ) {


### PR DESCRIPTION
## Summary
- Avoid undefined function errors when clearing report cache in lead storage

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b492c33bd083319e363b0a37069a81