### PR TITLE
Add WordPress helper stubs

### DIFF
--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -1,65 +1,79 @@
 <?php
 defined( 'ABSPATH' ) || exit;
 if ( ! function_exists( 'add_filter' ) ) {
-    function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
+	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
 }
 if ( ! function_exists( 'apply_filters' ) ) {
-    function apply_filters( $tag, $value ) {
-        return $value;
-    }
+	function apply_filters( $tag, $value ) {
+		return $value;
+	}
 }
 if ( ! function_exists( 'add_action' ) ) {
-    function add_action( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
+	function add_action( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
 }
 if ( ! function_exists( 'do_action' ) ) {
-    function do_action( $tag, ...$args ) {}
+	function do_action( $tag, ...$args ) {}
 }
 if ( ! function_exists( 'get_option' ) ) {
-    function get_option( $option, $default = false ) {
-        return $default;
-    }
+	function get_option( $option, $default = false ) {
+		return $default;
+	}
 }
 if ( ! function_exists( 'update_option' ) ) {
-    function update_option( $option, $value ) {
-        return true;
-    }
+	function update_option( $option, $value ) {
+		return true;
+	}
 }
 if ( ! function_exists( 'sanitize_text_field' ) ) {
-    function sanitize_text_field( $text ) {
-        return is_string( $text ) ? trim( $text ) : '';
-    }
+	function sanitize_text_field( $text ) {
+		return is_string( $text ) ? trim( $text ) : '';
+	}
 }
 if ( ! function_exists( 'sanitize_email' ) ) {
-    function sanitize_email( $email ) {
-        return filter_var( $email, FILTER_SANITIZE_EMAIL );
-    }
+	function sanitize_email( $email ) {
+		return filter_var( $email, FILTER_SANITIZE_EMAIL );
+	}
 }
 if ( ! function_exists( 'wp_unslash' ) ) {
-    function wp_unslash( $value ) {
-        return $value;
-    }
+	function wp_unslash( $value ) {
+		return $value;
+	}
 }
-
+if ( ! function_exists( 'wp_trim_words' ) ) {
+	function wp_trim_words( $text, $num_words = 55, $more = null ) {
+		$words = preg_split( '/[\s]+/', strip_tags( $text ) );
+		if ( count( $words ) > $num_words ) {
+			$words = array_slice( $words, 0, $num_words );
+			$text  = implode( ' ', $words ) . ( $more ? $more : '...' );
+		}
+		return $text;
+	}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data ) {
+		return json_encode( $data );
+	}
+}
 if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
-    class RTBCB_Category_Recommender {
-        /**
-         * Recommend a category based on inputs.
-         *
-         * @param array $inputs Input values.
-         * @return array Recommended category.
-         */
-        public static function recommend_category( $inputs ) {
-            return self::suggest_category( $inputs );
-        }
-
-        /**
-         * Suggest a category for backward compatibility.
-         *
-         * @param array $inputs Input values.
-         * @return array Recommended category.
-         */
-        public static function suggest_category( $inputs ) {
-            return [ 'recommended' => 'general' ];
-        }
-    }
+	class RTBCB_Category_Recommender {
+		/**
+		 * Recommend a category based on inputs.
+		 *
+		 * @param array $inputs Input values.
+		 * @return array Recommended category.
+		 */
+		public static function recommend_category( $inputs ) {
+			return self::suggest_category( $inputs );
+		}
+		/**
+		 * Suggest a category for backward compatibility.
+		 *
+		 * @param array $inputs Input values.
+		 * @return array Recommended category.
+		 */
+		public static function suggest_category( $inputs ) {
+			return [ 'recommended' => 'general' ];
+		}
+	}
 }
+


### PR DESCRIPTION
## Summary
- add `wp_trim_words` and `wp_json_encode` helper stubs for tests
- ensure stubs follow WordPress coding conventions

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b492c33bd083319e363b0a37069a81