### PR TITLE
Guard add_action usage in helper

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1968,4 +1968,6 @@ function rtbcb_enable_persistent_connection() {
 	$wpdb->db_connect();
 }
 
-add_action( 'plugins_loaded', 'rtbcb_enable_persistent_connection', 1 );
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'plugins_loaded', 'rtbcb_enable_persistent_connection', 1 );
+}


### PR DESCRIPTION
## Summary
- guard persistent connection hook with function_exists check to avoid undefined function errors when WordPress is absent

## Testing
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*
- `php tests/api-tester-gpt5-mini.test.php`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b492c33bd083319e363b0a37069a81