### PR TITLE
Restrict gzip disabling to RTBCB-specific AJAX endpoints

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,7 +7,7 @@ php_value upload_max_filesize 50M
 
 # Disable output compression for AJAX
 <IfModule mod_env.c>
-SetEnvIf Request_URI "admin-ajax\.php" no-gzip dont-vary
+SetEnvIf Request_URI "admin-ajax\.php\?action=rtbcb_" no-gzip dont-vary
 </IfModule>
 
 # Ensure proper content type for AJAX


### PR DESCRIPTION
## Summary
- Limit no-gzip rule to RTBCB admin-ajax actions

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*
- `wp cache flush` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b496df03348331907a58e445dbbb06