### PR TITLE
Remove admin-ajax JSON content-type override

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -10,7 +10,3 @@ php_value upload_max_filesize 50M
 SetEnvIf Request_URI "admin-ajax\.php" no-gzip dont-vary
 </IfModule>
 
-# Ensure proper content type for AJAX
-<FilesMatch "admin-ajax\.php$">
-Header set Content-Type "application/json; charset=utf-8"
-</FilesMatch>


### PR DESCRIPTION
## Summary
- Stop forcing JSON Content-Type headers for `admin-ajax.php` requests via `.htaccess` so Jetpack and other plugins can negotiate headers normally.
- Rely on WordPress helpers like `wp_send_json()` for plugin-specific AJAX responses.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b496eafc2883319eb451712a7f00b5