### PR TITLE
Guard AJAX headers for Jetpack compatibility

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -45,6 +45,13 @@ class RTBCB_Ajax {
 						return;
 				}
 
+				$action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : '';
+				if ( 'rtbcb_stream_analysis' !== $action ) {
+				// Jetpack also routes requests through admin-ajax.php; avoid sending
+				// streaming headers for unrelated actions.
+				return;
+				}
+
 				nocache_headers();
 				header( 'Content-Type: text/event-stream' );
 				header( 'Cache-Control: no-cache' );
@@ -74,10 +81,10 @@ $method = new ReflectionMethod( RTBCB_Main::class, 'generate_business_analysis' 
 
 				echo 'data: ' . wp_json_encode( [ 'type' => 'final', 'payload' => $result ] ) . "\n\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				if ( function_exists( 'flush' ) ) {
-						flush();
+					flush();
 				}
-				exit;
-		}
+				wp_die();
+                       }
 	/**
 	* Process the basic ROI calculation step.
 	*

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1455,6 +1455,13 @@ function rtbcb_proxy_openai_responses() {
 	$body_array['stream']            = true;
 	$payload                         = wp_json_encode( $body_array );
 
+	$action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : '';
+	if ( 'rtbcb_openai_responses' !== $action ) {
+		// Jetpack also routes requests through admin-ajax.php; avoid sending
+		// streaming headers for unrelated actions.
+		return;
+	}
+
 	nocache_headers();
 	header( 'Content-Type: text/event-stream' );
 	header( 'Cache-Control: no-cache' );
@@ -1490,7 +1497,7 @@ function rtbcb_proxy_openai_responses() {
 		echo 'data: ' . wp_json_encode( [ 'error' => $msg ] ) . "\n\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
-	exit;
+	wp_die();
 }
 
 /**


### PR DESCRIPTION
## Summary
- prevent unrelated AJAX requests from triggering Business Case Builder SSE headers
- add early termination after streamed output

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b496b71c4c83319c9411c43720f140