### PR TITLE
Handle Jetpack requests early

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -87,6 +87,10 @@ class RTBCB_Main {
 	* @return bool
 	*/
 	private function is_jetpack_request() {
+		if ( function_exists( 'wp_doing_cron' ) && wp_doing_cron() ) {
+			return false;
+		}
+
 		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
 			return true;
 		}
@@ -2600,7 +2604,10 @@ if ( ! class_exists( 'Real_Treasury_BCB' ) ) {
 }
 
 // Initialize the plugin
-RTBCB_Main::instance();
+if ( ! defined( 'RTBCB_NO_BOOTSTRAP' ) ) {
+	RTBCB_Main::instance();
+}
+
 
 // Helper functions for use in templates and other plugins
 if ( ! function_exists( 'rtbcb_get_leads_count' ) ) {

--- a/tests/jetpack-cron.test.php
+++ b/tests/jetpack-cron.test.php
@@ -1,0 +1,52 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'plugin_dir_url' ) ) {
+	function plugin_dir_url( $file ) {
+		return '';
+	}
+}
+
+if ( ! function_exists( 'plugin_dir_path' ) ) {
+	function plugin_dir_path( $file ) {
+		return __DIR__ . '/../';
+	}
+}
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+	function wp_unslash( $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'wp_doing_cron' ) ) {
+	function wp_doing_cron() {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+	}
+}
+
+$_SERVER['HTTP_X_JETPACK_SIGNATURE'] = 'sig';
+
+define( 'RTBCB_NO_BOOTSTRAP', true );
+require_once __DIR__ . '/../real-treasury-business-case-builder.php';
+
+$reflection = new ReflectionClass( 'RTBCB_Main' );
+$method      = $reflection->getMethod( 'is_jetpack_request' );
+$method->setAccessible( true );
+$instance = $reflection->newInstanceWithoutConstructor();
+$result   = $method->invoke( $instance );
+
+if ( $result ) {
+	echo "Jetpack cron incorrectly detected\n";
+	exit( 1 );
+}
+
+echo "jetpack-cron.test.php passed\n";

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -123,6 +123,9 @@ php tests/project-growth-path.test.php
 echo "18b. Running company research cache test..."
 php tests/company-research-cache.test.php
 
+echo "18c. Running Jetpack cron test..."
+php tests/jetpack-cron.test.php
+
 echo "19. Running validator tests..."
 phpunit -c phpunit.xml
 


### PR DESCRIPTION
## Summary
- Allow Jetpack-driven cron requests to bootstrap normally
- Guard plugin bootstrap with `RTBCB_NO_BOOTSTRAP` constant for tests
- Add regression test for Jetpack cron and hook into test runner

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4996f572883319196ad362dc43c53