### PR TITLE
Restrict gzip disabling to RTBCB-specific AJAX endpoints

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,9 +5,9 @@ php_value max_input_time 600
 php_value post_max_size 50M
 php_value upload_max_filesize 50M
 
-# Disable output compression for AJAX
-<IfModule mod_env.c>
-SetEnvIf Request_URI "admin-ajax\.php\?action=rtbcb_" no-gzip dont-vary
+# Disable output compression for RTBCB-specific AJAX endpoints
+<IfModule mod_setenvif.c>
+SetEnvIfExpr "%{REQUEST_URI} =~ m#admin-ajax\\.php$# && %{QUERY_STRING} =~ m#^action=rtbcb_#" no-gzip dont-vary
 </IfModule>
 
 # Ensure proper content type for AJAX


### PR DESCRIPTION
## Summary
- Fix `.htaccess` no-gzip rule to match `admin-ajax.php` requests with `rtbcb_` actions

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b498480d1c833197396523d6dacd07