### PR TITLE
Restrict gzip disabling to RTBCB-specific AJAX endpoints

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,7 +7,7 @@ php_value upload_max_filesize 50M
 
 # Disable output compression for RTBCB-specific AJAX endpoints
 <IfModule mod_setenvif.c>
-SetEnvIfExpr "%{REQUEST_URI} =~ m#admin-ajax\\.php$# && %{QUERY_STRING} =~ m#^action=rtbcb_#" no-gzip dont-vary
+SetEnvIfExpr "%{REQUEST_URI} =~ m#admin-ajax\.php$# && %{QUERY_STRING} =~ m#^action=rtbcb_#" no-gzip dont-vary
 </IfModule>
 
 # Ensure proper content type for AJAX


### PR DESCRIPTION
## Summary
- Fix gzip rule to properly match admin-ajax.php requests
- Ensure content-type rule uses correct admin-ajax.php regex

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b49e418a5483318db7d291aa959bc4