### PR TITLE
Handle report HTML encoding and improve tests

### DIFF
--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -202,21 +202,26 @@ class RTBCB_Leads {
 			ARRAY_A
 		);
 
-               foreach ( $leads as $lead ) {
-                       $decoded = base64_decode( $lead['report_html'], true );
-                       if ( $decoded && false !== @gzuncompress( $decoded ) ) {
-                               continue;
-                       }
+		foreach ( $leads as $lead ) {
+			$decoded = base64_decode( $lead['report_html'], true );
+			if ( false !== $decoded && false !== @gzuncompress( $decoded ) ) {
+				continue;
+			}
 
-                       $compressed = base64_encode( gzcompress( $lead['report_html'] ) );
-                       $wpdb->update(
-                               self::$table_name,
-                               [ 'report_html' => $compressed ],
-                               [ 'id' => $lead['id'] ],
-                               [ '%s' ],
-                               [ '%d' ]
-                       );
-               }
+			if ( false !== @gzuncompress( $lead['report_html'] ) ) {
+				$compressed = base64_encode( $lead['report_html'] );
+			} else {
+				$compressed = base64_encode( gzcompress( $lead['report_html'] ) );
+			}
+
+			$wpdb->update(
+				self::$table_name,
+				[ 'report_html' => $compressed ],
+				[ 'id' => $lead['id'] ],
+				[ '%s' ],
+				[ '%d' ]
+			);
+		}
 	}
 
 


### PR DESCRIPTION
## Summary
- Detect and base64-encode existing gz-compressed `report_html` values during migration to avoid corrupting historic leads

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b49e6c34fc833199a9513019447df0