### PR TITLE
Sanitize leads page filter inputs

### DIFF
--- a/admin/leads-page-enhanced.php
+++ b/admin/leads-page-enhanced.php
@@ -12,6 +12,10 @@ $total_leads = $leads_data['total'] ?? 0;
 $leads = $leads_data['leads'] ?? [];
 $orderby = isset( $orderby ) ? sanitize_key( $orderby ) : 'created_at';
 $order   = isset( $order ) ? sanitize_key( $order ) : 'DESC';
+$search    = isset( $leads_data['search'] ) ? sanitize_text_field( $leads_data['search'] ) : '';
+$category  = isset( $leads_data['category'] ) ? sanitize_text_field( $leads_data['category'] ) : '';
+$date_from = isset( $leads_data['date_from'] ) ? sanitize_text_field( $leads_data['date_from'] ) : '';
+$date_to   = isset( $leads_data['date_to'] ) ? sanitize_text_field( $leads_data['date_to'] ) : '';
 ?>
 
 <div class="wrap rtbcb-admin-page">


### PR DESCRIPTION
## Summary
- Sanitize leads page filter inputs before use

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`
- `phpcs --standard=WordPress admin/leads-page-enhanced.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b596cf48908331b68133d7827b9bdc