### PR TITLE
Ensure ABSPATH guard in PHP tests

### DIFF
--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
 use PHPUnit\Framework\TestCase;
 
 if ( ! class_exists( 'WP_Error' ) ) {

--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
 use PHPUnit\Framework\TestCase;
 
 if ( ! class_exists( 'WP_Error' ) ) {

--- a/tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
+++ b/tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
 use PHPUnit\Framework\TestCase;
 
 if ( ! class_exists( 'WP_Error' ) ) {

--- a/tests/cosine-similarity-search.test.php
+++ b/tests/cosine-similarity-search.test.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
 require_once __DIR__ . '/../inc/class-rtbcb-rag.php';
 
 if ( ! defined( 'ARRAY_A' ) ) {

--- a/tests/filters-override.test.php
+++ b/tests/filters-override.test.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
 require_once __DIR__ . '/../inc/class-rtbcb-calculator.php';
 
 if ( ! function_exists( 'add_filter' ) ) {

--- a/tests/generate-business-analysis.test.php
+++ b/tests/generate-business-analysis.test.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
 use PHPUnit\Framework\TestCase;
 
 if ( ! class_exists( 'WP_Error' ) ) {

--- a/tests/jetpack-compatibility.test.php
+++ b/tests/jetpack-compatibility.test.php
@@ -1,5 +1,8 @@
 <?php
-define( 'ABSPATH', __DIR__ . '/../' );
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
 require_once __DIR__ . '/wp-stubs.php';
 
 if ( ! function_exists( 'plugin_dir_url' ) ) {

--- a/tests/json-output-lint.php
+++ b/tests/json-output-lint.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
 /**
 	* Lints PHP files that output JSON to prevent stray output.
 	*

--- a/tests/mini-model-dynamic.test.php
+++ b/tests/mini-model-dynamic.test.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
 require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
 
 if ( ! function_exists( 'get_option' ) ) {

--- a/tests/openai-api-key-validation.test.php
+++ b/tests/openai-api-key-validation.test.php
@@ -1,6 +1,8 @@
 <?php
-
-define( 'ABSPATH', __DIR__ . '/../' );
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! function_exists( 'add_filter' ) ) {
 	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {

--- a/tests/operational-risks-fallback.test.php
+++ b/tests/operational-risks-fallback.test.php
@@ -1,8 +1,12 @@
 <?php
-if ( ! function_exists( '__' ) ) {
-function __( $text, $domain = null ) {
-return $text;
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
 }
+defined( 'ABSPATH' ) || exit;
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) {
+		return $text;
+	}
 }
 if ( ! class_exists( 'WP_Error' ) ) {
 class WP_Error {
@@ -80,7 +84,6 @@ return [];
 }
 }
 
-define( 'ABSPATH', __DIR__ );
 $plugin_code = file_get_contents( __DIR__ . '/../real-treasury-business-case-builder.php' );
 $plugin_code = preg_replace( '/
 ?\/\/ Initialize the plugin\s*RTBCB_Main::instance\(\);/', '', $plugin_code );

--- a/tests/parse-comprehensive-response.test.php
+++ b/tests/parse-comprehensive-response.test.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
 require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
 
 if ( ! class_exists( 'WP_Error' ) ) {

--- a/tests/parse-gpt5-response-raw-option.test.php
+++ b/tests/parse-gpt5-response-raw-option.test.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
 require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
 
 if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {

--- a/tests/reasoning-first-output.test.php
+++ b/tests/reasoning-first-output.test.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
 require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
 
 if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {

--- a/tests/render-comprehensive-template.test.php
+++ b/tests/render-comprehensive-template.test.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
 require_once __DIR__ . '/../inc/helpers.php';
 
 if ( ! function_exists( '__' ) ) {

--- a/tests/report-error-handling.test.php
+++ b/tests/report-error-handling.test.php
@@ -1,7 +1,10 @@
 <?php
-use PHPUnit\Framework\TestCase;
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
 
-define( 'ABSPATH', __DIR__ . '/../' );
+use PHPUnit\Framework\TestCase;
 
 if ( ! class_exists( 'WP_Error' ) ) {
 class WP_Error {

--- a/tests/report-memory-usage.test.php
+++ b/tests/report-memory-usage.test.php
@@ -1,9 +1,10 @@
 <?php
-if (!defined('ABSPATH')) {
-	define('ABSPATH', __DIR__);
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
 }
-if (!function_exists('__')) {
-	function __($text, $domain = null) {
+defined( 'ABSPATH' ) || exit;
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) {
 		return $text;
 	}
 }
@@ -28,7 +29,7 @@ if (!function_exists('esc_html')) {
 }
 if (!function_exists('esc_attr')) {
 function esc_attr($text) {
-return $text;
+		return $text;
 }
 }
 if (!function_exists('wp_convert_hr_to_bytes')) {

--- a/tests/scenario-selection.test.php
+++ b/tests/scenario-selection.test.php
@@ -1,4 +1,8 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+defined( 'ABSPATH' ) || exit;
 if ( ! function_exists( 'add_filter' ) ) {
 	$GLOBALS['rtbcb_filters'] = [];
 	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
@@ -15,7 +19,6 @@ if ( ! function_exists( 'add_filter' ) ) {
 	}
 }
 
-define( 'ABSPATH', __DIR__ );
 require_once __DIR__ . '/../inc/helpers.php';
 
 $received = '';

--- a/tests/validator.test.php
+++ b/tests/validator.test.php
@@ -1,7 +1,10 @@
 <?php
-use PHPUnit\Framework\TestCase;
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
 
-define( 'ABSPATH', __DIR__ . '/../' );
+use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/wp-stubs.php';
 
 if ( ! function_exists( '__' ) ) {


### PR DESCRIPTION
## Summary
- add `defined( 'ABSPATH' ) || exit;` guard across all PHP test files
- move existing ABSPATH defines to precede guard where necessary

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b596d66688833188da25eb30a3ce65