### PR TITLE
Use RTBCB_Ajax handler for generate case AJAX requests

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -135,9 +135,9 @@ class RTBCB_Main {
 		// Plugin action links
 		add_filter( 'plugin_action_links_' . plugin_basename( RTBCB_FILE ), [ $this, 'plugin_action_links' ] );
 
-		// AJAX handlers - Use the enhanced version
-		add_action( 'wp_ajax_rtbcb_generate_case', [ $this, 'ajax_generate_comprehensive_case_enhanced' ] );
-		add_action( 'wp_ajax_nopriv_rtbcb_generate_case', [ $this, 'ajax_generate_comprehensive_case_enhanced' ] );
+		// AJAX handler for comprehensive case generation
+		add_action( 'wp_ajax_rtbcb_generate_case', [ 'RTBCB_Ajax', 'generate_comprehensive_case' ] );
+		add_action( 'wp_ajax_nopriv_rtbcb_generate_case', [ 'RTBCB_Ajax', 'generate_comprehensive_case' ] );
 
 		// Job status handlers
 		add_action( 'wp_ajax_rtbcb_job_status', [ 'RTBCB_Ajax', 'get_job_status' ] );


### PR DESCRIPTION
## Summary
- ensure only `RTBCB_Ajax::generate_comprehensive_case` handles `rtbcb_generate_case` AJAX action

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: vendor/bin/phpunit: No such file or directory; SyntaxError: await is only valid in async functions)*

------
https://chatgpt.com/codex/tasks/task_e_68b5af5df24c833180bc41d5395ffb1a