### PR TITLE
Fix hook registration conflicts and priorities

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -17,9 +17,9 @@ class RTBCB_Admin {
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
 		add_action( 'admin_init', [ $this, 'register_settings' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
-		add_action( 'admin_notices', [ $this, 'maybe_show_timeout_notice' ] );
-		add_action( 'admin_notices', [ $this, 'maybe_show_bypass_notice' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ], 10 );
+		add_action( 'admin_notices', [ $this, 'maybe_show_timeout_notice' ], 10 );
+		add_action( 'admin_notices', [ $this, 'maybe_show_bypass_notice' ], 20 );
 
 		// AJAX handlers
 		add_action( 'wp_ajax_rtbcb_test_connection', [ $this, 'test_api_connection' ] );

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -126,11 +126,11 @@ class RTBCB_Main {
 		// Shortcode
 		add_shortcode( 'rt_business_case_builder', [ $this, 'shortcode_handler' ] );
 
-		// Portal integration hooks
-		add_action( 'rt_portal_data_changed', [ $this, 'handle_portal_data_change' ] );
+               // Portal integration hooks
+               add_action( 'rtbcb_portal_data_changed', [ $this, 'handle_portal_data_change' ] );
 
-		// Admin notices
-		add_action( 'admin_notices', [ $this, 'admin_notices' ] );
+               // Admin notices
+               add_action( 'admin_notices', [ $this, 'admin_notices' ], 10 );
 
 		// Plugin action links
 		add_filter( 'plugin_action_links_' . plugin_basename( RTBCB_FILE ), [ $this, 'plugin_action_links' ] );
@@ -382,9 +382,6 @@ class RTBCB_Main {
                        wp_schedule_event( time(), 'hourly', 'rtbcb_cleanup_jobs' );
                }
 
-               if ( class_exists( 'RTBCB_Background_Job' ) ) {
-                       add_action( 'rtbcb_cleanup_jobs', [ 'RTBCB_Background_Job', 'cleanup' ] );
-               }
 
                // Schedule lead metrics refresh
                if ( ! wp_next_scheduled( 'rtbcb_refresh_lead_metrics' ) ) {
@@ -2968,9 +2965,9 @@ function rtbcb_ajax_generate_category_recommendation() {
 }
 
 // Enqueue admin scripts for company overview page.
-add_action( 'admin_enqueue_scripts', 'rtbcb_enqueue_company_overview_scripts' );
-add_action( 'admin_enqueue_scripts', 'rtbcb_enqueue_real_treasury_overview_scripts' );
-add_action( 'admin_enqueue_scripts', 'rtbcb_enqueue_recommended_category_scripts' );
+add_action( 'admin_enqueue_scripts', 'rtbcb_enqueue_company_overview_scripts', 20 );
+add_action( 'admin_enqueue_scripts', 'rtbcb_enqueue_real_treasury_overview_scripts', 20 );
+add_action( 'admin_enqueue_scripts', 'rtbcb_enqueue_recommended_category_scripts', 20 );
 
 /**
 	* Enqueue admin scripts for company overview page.


### PR DESCRIPTION
## Summary
- Namespace portal data change hook to `rtbcb_portal_data_changed`
- Remove duplicate background job cleanup hook registration
- Add explicit priorities to admin hooks and script enqueues

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bcff4604833185f375adb2fd9fb5