### PR TITLE
Add ABSPATH guards to admin and template files

### DIFF
--- a/admin/analytics-page.php
+++ b/admin/analytics-page.php
@@ -1,10 +1,9 @@
 <?php
-/**
-	* Analytics admin page for Real Treasury Business Case Builder plugin.
-	*/
-
-// Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Analytics admin page for Real Treasury Business Case Builder plugin.
+ */
 
 $categories = RTBCB_Category_Recommender::get_all_categories();
 $total_leads = $stats['total_leads'] ?? 0;

--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -1,11 +1,12 @@
 <?php
-/**
-	* API logs admin page.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * API logs admin page.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+
 ?>
 <div class="wrap">
 	<h1><?php echo esc_html__( 'API Logs', 'rtbcb' ); ?></h1>

--- a/admin/calculations-page.php
+++ b/admin/calculations-page.php
@@ -1,12 +1,11 @@
 <?php
-/**
-	* Calculation info admin page for Real Treasury Business Case Builder plugin.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
-// Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Calculation info admin page for Real Treasury Business Case Builder plugin.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 $labor_cost = get_option( 'rtbcb_labor_cost_per_hour', 0 );
 $bank_fee   = get_option( 'rtbcb_bank_fee_baseline', 0 );

--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Enhanced admin functionality for Real Treasury Business Case Builder plugin.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enhanced admin functionality for Real Treasury Business Case Builder plugin.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 /**
 	* Enhanced admin class with full feature integration.

--- a/admin/dashboard-page.php
+++ b/admin/dashboard-page.php
@@ -1,10 +1,9 @@
 <?php
-/**
-	* Enhanced Dashboard admin page for Real Treasury Business Case Builder plugin.
-	*/
-
-// Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enhanced Dashboard admin page for Real Treasury Business Case Builder plugin.
+ */
 
 $total_leads = $stats['total_leads'] ?? 0;
 $recent_leads = $stats['recent_leads'] ?? 0;

--- a/admin/leads-page-enhanced.php
+++ b/admin/leads-page-enhanced.php
@@ -1,10 +1,9 @@
 <?php
-/**
-	* Enhanced Leads admin page for Real Treasury Business Case Builder plugin.
-	*/
-
-// Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enhanced Leads admin page for Real Treasury Business Case Builder plugin.
+ */
 
 $current_page = $leads_data['current_page'] ?? 1;
 $total_pages = $leads_data['total_pages'] ?? 1;

--- a/admin/partials/dashboard-connectivity.php
+++ b/admin/partials/dashboard-connectivity.php
@@ -1,11 +1,12 @@
 <?php
-/**
-	* Dashboard connectivity status and tests.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Dashboard connectivity status and tests.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+
 ?>
 <div class="card">
 	<h2 class="title"><?php esc_html_e( 'Connectivity Tests & Status', 'rtbcb' ); ?></h2>

--- a/admin/partials/dashboard-test-results.php
+++ b/admin/partials/dashboard-test-results.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Dashboard recent test results.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Dashboard recent test results.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 $max_results  = 10;
 $recent_results = [];

--- a/admin/partials/test-company-overview.php
+++ b/admin/partials/test-company-overview.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Partial for Test Company Overview section.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Partial for Test Company Overview section.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-company-overview', false ) ) {
 	echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-data-enrichment.php
+++ b/admin/partials/test-data-enrichment.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Partial for Test Data Enrichment section.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Partial for Test Data Enrichment section.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-data-enrichment', false ) ) {
 	echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-data-storage.php
+++ b/admin/partials/test-data-storage.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Partial for Test Data Storage section.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Partial for Test Data Storage section.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-data-storage', false ) ) {
 	echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-estimated-benefits.php
+++ b/admin/partials/test-estimated-benefits.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Partial for Test Estimated Benefits section.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Partial for Test Estimated Benefits section.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-estimated-benefits', false ) ) {
 	echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-follow-up-email.php
+++ b/admin/partials/test-follow-up-email.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Follow-up email queue test.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Follow-up email queue test.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-follow-up-email', false ) ) {
 	echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-industry-overview.php
+++ b/admin/partials/test-industry-overview.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Partial for Test Industry Overview section.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Partial for Test Industry Overview section.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 $allowed = rtbcb_require_completed_steps( 'rtbcb-test-industry-overview', false );
 if ( ! $allowed ) {

--- a/admin/partials/test-maturity-model.php
+++ b/admin/partials/test-maturity-model.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Partial for Test Maturity Model section.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Partial for Test Maturity Model section.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-maturity-model', false ) ) {
 	echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-rag-market-analysis.php
+++ b/admin/partials/test-rag-market-analysis.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Partial for Test RAG Market Analysis section.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Partial for Test RAG Market Analysis section.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-rag-market-analysis', false ) ) {
 	echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-real-treasury-overview.php
+++ b/admin/partials/test-real-treasury-overview.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Partial for Test Real Treasury Overview section.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Partial for Test Real Treasury Overview section.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-real-treasury-overview', false ) ) {
 	echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-report-assembly.php
+++ b/admin/partials/test-report-assembly.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Report assembly and delivery test section.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Report assembly and delivery test section.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 $allowed = rtbcb_require_completed_steps( 'rtbcb-test-report-assembly', false );
 if ( ! $allowed ) {

--- a/admin/partials/test-roadmap-generator.php
+++ b/admin/partials/test-roadmap-generator.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Partial for Test Roadmap Generator section.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Partial for Test Roadmap Generator section.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-roadmap-generator', false ) ) {
 	echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-roi-calculator.php
+++ b/admin/partials/test-roi-calculator.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Partial for Test ROI Calculator section.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Partial for Test ROI Calculator section.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-roi-calculator', false ) ) {
 	echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-tracking-script.php
+++ b/admin/partials/test-tracking-script.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Tracking script injection test.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Tracking script injection test.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-tracking-script', false ) ) {
 	echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/partials/test-value-proposition.php
+++ b/admin/partials/test-value-proposition.php
@@ -1,11 +1,11 @@
 <?php
-/**
-	* Partial for Test Value Proposition section.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Partial for Test Value Proposition section.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 
 if ( ! rtbcb_require_completed_steps( 'rtbcb-test-value-proposition', false ) ) {
 	echo '<div class="notice notice-warning inline"><p>' .

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -1,10 +1,9 @@
 <?php
-/**
-	* Settings admin page for Real Treasury Business Case Builder plugin.
-	*/
-
-// Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Settings admin page for Real Treasury Business Case Builder plugin.
+ */
 
 $api_key         = function_exists( 'get_option' ) ? get_option( 'rtbcb_openai_api_key', '' ) : '';
 $mini_model      = function_exists( 'get_option' ) ? get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) ) : rtbcb_get_default_model( 'mini' );

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -1,10 +1,11 @@
 <?php
-/**
-	* Test Dashboard admin page.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Test Dashboard admin page.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
 $company_data   = get_option( 'rtbcb_company_data', [] );
 $company_name   = isset( $company_data['name'] ) ? sanitize_text_field( $company_data['name'] ) : '';
 $test_results  = get_option( 'rtbcb_test_results', [] );

--- a/admin/workflow-visualizer-page.php
+++ b/admin/workflow-visualizer-page.php
@@ -1,11 +1,12 @@
 <?php
-/**
-	* Workflow Visualizer admin page.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Workflow Visualizer admin page.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+
 ?>
 <div class="wrap rtbcb-workflow-visualizer">
 <h1><?php echo esc_html__( 'Treasury Report Workflow Visualizer', 'rtbcb' ); ?></h1>

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -1,19 +1,19 @@
 <?php
-/**
-* Enhanced Comprehensive Report Template
-*
-* This template now handles structured data from the refactored workflow
-* and generates a modern dashboard-style interface with:
-* - Interactive charts and metrics
-* - Collapsible sections
-* - Enhanced visual design
-* - Mobile-responsive layout
-*
-* @package RealTreasuryBusinessCaseBuilder
-* @var array $report_data Structured report data from the new workflow
-*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enhanced Comprehensive Report Template
+ *
+ * This template now handles structured data from the refactored workflow
+ * and generates a modern dashboard-style interface with:
+ * - Interactive charts and metrics
+ * - Collapsible sections
+ * - Enhanced visual design
+ * - Mobile-responsive layout
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ * @var array $report_data Structured report data from the new workflow
+ */
 
 // Extract structured data sections
 $metadata             = $report_data['metadata'] ?? [];

--- a/templates/report-template.php
+++ b/templates/report-template.php
@@ -1,13 +1,13 @@
 <?php
-/**
-	* Template for generated business case report.
-	*
-	* @package RealTreasuryBusinessCaseBuilder
-	*
-	* @var array $business_case_data Business case data from the LLM.
-	*/
-
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Template for generated business case report.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ *
+ * @var array $business_case_data Business case data from the LLM.
+ */
 
 $metadata      = $business_case_data['metadata'] ?? [];
 $analysis_type = $metadata['analysis_type'] ?? 'basic';


### PR DESCRIPTION
## Summary
- ensure every PHP file under `admin/` and `templates/` starts with `defined( 'ABSPATH' ) || exit;`
- move the guard to the top of files and remove redundant direct-access comments

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(missing phpunit in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c461edc08331b3bfc0c3734f9acf