### PR TITLE
Localize admin utility strings

### DIFF
--- a/admin/js/rtbcb-test-utils.js
+++ b/admin/js/rtbcb-test-utils.js
@@ -1,10 +1,12 @@
-(function($){
+ (function($){
     'use strict';
+
+    const { __ } = wp.i18n;
 
     const utils = {
         showLoading(button, text) {
             const original = button.text();
-            button.prop('disabled', true).text(text || original);
+            button.prop('disabled', true).text(text || __( 'Processing...', 'rtbcb' ));
             return original;
         },
         hideLoading(button, original) {
@@ -24,15 +26,18 @@
             const notice = $('<div class="notice notice-success" />');
             notice.append('<div class="rtbcb-result-text" />');
             notice.find('.rtbcb-result-text').text(text);
-            notice.append('<p class="rtbcb-result-meta">Word count: ' + wordCount + ' | Generated: ' + timestamp + ' | Elapsed: ' + elapsed + 's</p>');
+            notice.append('<p class="rtbcb-result-meta">' +
+                __( 'Word count', 'rtbcb' ) + ': ' + wordCount +
+                ' | ' + __( 'Generated', 'rtbcb' ) + ': ' + timestamp +
+                ' | ' + __( 'Elapsed', 'rtbcb' ) + ': ' + elapsed + 's</p>');
             container.html(notice);
             return notice;
         },
         renderError(container, message, retryCallback) {
             const notice = $('<div class="notice notice-error" />');
-            const p = $('<p />').html('<strong>Error:</strong> ' + message + ' ');
+            const p = $('<p />').html('<strong>' + __( 'Error:', 'rtbcb' ) + '</strong> ' + message + ' ');
             if (retryCallback) {
-                const retry = $('<a href="#" class="rtbcb-retry">Retry</a>');
+                const retry = $('<a href="#" class="rtbcb-retry"></a>').text( __( 'Retry', 'rtbcb' ) );
                 retry.on('click', function(e){
                     e.preventDefault();
                     retryCallback();
@@ -57,7 +62,7 @@
             try {
                 const successful = document.execCommand('copy');
                 document.body.removeChild(textarea);
-                return successful ? Promise.resolve() : Promise.reject(new Error('Copy failed'));
+                return successful ? Promise.resolve() : Promise.reject(new Error( __( 'Copy failed', 'rtbcb' ) ));
             } catch (err) {
                 document.body.removeChild(textarea);
                 return Promise.reject(err);

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2980,13 +2980,14 @@ add_action( 'admin_enqueue_scripts', 'rtbcb_enqueue_recommended_category_scripts
 function rtbcb_enqueue_company_overview_scripts( $hook ) {
 	$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
 	if ( strpos( $hook, 'rtbcb' ) !== false && ( strpos( $hook, 'company-overview' ) !== false || 'rtbcb-test-dashboard' === $page ) ) {
-		wp_enqueue_script(
-		'rtbcb-test-utils',
-		plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
-		[ 'jquery' ],
-		'1.0.0',
-		true
-		);
+                wp_enqueue_script(
+                'rtbcb-test-utils',
+                plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
+                [ 'jquery', 'wp-i18n' ],
+                '1.0.0',
+                true
+                );
+                wp_set_script_translations( 'rtbcb-test-utils', 'rtbcb' );
 		wp_enqueue_script(
 		'rtbcb-company-overview',
 		plugin_dir_url( __FILE__ ) . 'admin/js/company-overview.js',
@@ -3016,13 +3017,14 @@ function rtbcb_enqueue_company_overview_scripts( $hook ) {
 function rtbcb_enqueue_real_treasury_overview_scripts( $hook ) {
 	$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
 	if ( strpos( $hook, 'rtbcb' ) !== false && ( strpos( $hook, 'real-treasury-overview' ) !== false || 'rtbcb-test-dashboard' === $page ) ) {
-		wp_enqueue_script(
-		'rtbcb-test-utils',
-		plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
-		[ 'jquery' ],
-		'1.0.0',
-		true
-		);
+                wp_enqueue_script(
+                'rtbcb-test-utils',
+                plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
+                [ 'jquery', 'wp-i18n' ],
+                '1.0.0',
+                true
+                );
+                wp_set_script_translations( 'rtbcb-test-utils', 'rtbcb' );
 		wp_enqueue_script(
 		'rtbcb-real-treasury-overview',
 		plugin_dir_url( __FILE__ ) . 'admin/js/real-treasury-overview.js',
@@ -3052,13 +3054,14 @@ function rtbcb_enqueue_recommended_category_scripts( $hook ) {
 	$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
 
 	if ( false !== strpos( $page, 'recommended-category' ) || 'rtbcb-test-dashboard' === $page ) {
-		wp_enqueue_script(
-		'rtbcb-test-utils',
-		plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
-		[ 'jquery' ],
-		'1.0.0',
-		true
-		);
+                wp_enqueue_script(
+                'rtbcb-test-utils',
+                plugin_dir_url( __FILE__ ) . 'admin/js/rtbcb-test-utils.js',
+                [ 'jquery', 'wp-i18n' ],
+                '1.0.0',
+                true
+                );
+                wp_set_script_translations( 'rtbcb-test-utils', 'rtbcb' );
 		wp_enqueue_script(
 		'rtbcb-recommended-category',
 		plugin_dir_url( __FILE__ ) . 'admin/js/recommended-category.js',


### PR DESCRIPTION
## Summary
- localize admin utility helpers using WordPress `wp.i18n` and `rtbcb` domain
- ensure `rtbcb-test-utils.js` scripts load translation support

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b5c682d9308331be6d7f24a6e964d5