### PR TITLE
Localize remaining user-facing strings

### DIFF
--- a/admin/analytics-page.php
+++ b/admin/analytics-page.php
@@ -118,7 +118,7 @@ $enable_charts = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_setting(
 				<?php foreach ( $size_stats as $stat ) : ?>
 					<div class="rtbcb-stat-item">
 						<div class="rtbcb-stat-label"><?php echo esc_html( $stat['company_size'] ); ?></div>
-						<div class="rtbcb-stat-value"><?php echo esc_html( $stat['count'] ); ?> leads</div>
+								<div class="rtbcb-stat-value"><?php printf( esc_html__( '%d leads', 'rtbcb' ), intval( $stat['count'] ) ); ?></div>
 						<div class="rtbcb-stat-percentage">
 							<?php echo $total_leads > 0 ? esc_html( number_format( ( $stat['count'] / $total_leads ) * 100, 1 ) ) : '0'; ?>%
 						</div>
@@ -191,7 +191,7 @@ $enable_charts = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_setting(
 							<?php
 							printf(
 								esc_html__( '%1$s is recommended for %2$d%% of leads (%3$d out of %4$d).', 'rtbcb' ),
-								esc_html( $top_cat_name ?? 'Unknown' ),
+									esc_html( $top_cat_name ?? __( 'Unknown', 'rtbcb' ) ),
 								esc_html( number_format( $top_percentage ?? 0, 1 ) ),
 								esc_html( $top_category['count'] ?? 0 ),
 								esc_html( $total_leads )

--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -112,7 +112,7 @@ jQuery(function($){
 			if (resp.success) {
 				location.reload();
 			} else {
-				alert(resp.data && resp.data.message ? resp.data.message : 'Error');
+								alert(resp.data && resp.data.message ? resp.data.message : '<?php echo esc_js( __( 'Error', 'rtbcb' ) ); ?>');
 			}
 		});
 	});
@@ -131,7 +131,7 @@ jQuery(function($){
 			if (resp.success) {
 				$('tr[data-id="' + id + '"]').remove();
 			} else {
-				alert(resp.data && resp.data.message ? resp.data.message : 'Error');
+								alert(resp.data && resp.data.message ? resp.data.message : '<?php echo esc_js( __( 'Error', 'rtbcb' ) ); ?>');
 			}
 		});
 	});
@@ -142,7 +142,7 @@ jQuery(function($){
 		var res = $row.attr('data-response');
 		try { req = JSON.stringify(JSON.parse(req), null, 2); } catch (err) {}
 		try { res = JSON.stringify(JSON.parse(res), null, 2); } catch (err) {}
-		var content = 'Request:\n' + req + '\n\nResponse:\n' + res;
+								var content = '<?php echo esc_js( __( 'Request:', 'rtbcb' ) ); ?>\n' + req + '\n\n<?php echo esc_js( __( 'Response:', 'rtbcb' ) ); ?>\n' + res;
 		$('#rtbcb-log-detail').text(content);
 		$('#rtbcb-log-modal').show();
 	});

--- a/admin/dashboard-page.php
+++ b/admin/dashboard-page.php
@@ -164,7 +164,8 @@ $avg_roi = intval( $roi_stats['avg_base'] ?? 0 );
 
 						$categories = RTBCB_Category_Recommender::get_all_categories();
 						$top_cat_info = $categories[ $top_category['recommended_category'] ] ?? [];
-						echo esc_html( $top_cat_info['name'] ?? 'TMS' );
+			$top_cat_name = $top_cat_info['name'] ?? __( 'TMS', 'rtbcb' );
+			echo esc_html( $top_cat_name );
 					} else {
 						esc_html_e( 'N/A', 'rtbcb' );
 					}
@@ -201,7 +202,7 @@ $avg_roi = intval( $roi_stats['avg_base'] ?? 0 );
 									<span class="rtbcb-company-size"><?php echo esc_html( $lead['company_size'] ); ?></span>
 									<?php if ( $lead['roi_base'] > 0 ) : ?>
 										<span class="rtbcb-lead-separator">•</span>
-										<span class="rtbcb-roi">$<?php echo esc_html( number_format( $lead['roi_base'] ) ); ?> ROI</span>
+								<span class="rtbcb-roi"><?php printf( esc_html__( '%s ROI', 'rtbcb' ), esc_html( '$' . number_format( $lead['roi_base'] ) ) ); ?></span>
 									<?php endif; ?>
 								</div>
 							</div>
@@ -290,7 +291,7 @@ $avg_roi = intval( $roi_stats['avg_base'] ?? 0 );
 					<div class="rtbcb-category-item">
 						<div class="rtbcb-category-header">
 							<span class="rtbcb-category-name"><?php echo esc_html( $cat_name ); ?></span>
-							<span class="rtbcb-category-count"><?php echo esc_html( $stat['count'] ); ?> leads</span>
+								<span class="rtbcb-category-count"><?php printf( esc_html__( '%d leads', 'rtbcb' ), intval( $stat['count'] ) ); ?></span>
 						</div>
 						<div class="rtbcb-category-bar">
 							<div class="rtbcb-category-fill rtbcb-cat-<?php echo esc_attr( $stat['recommended_category'] ); ?>"

--- a/admin/workflow-visualizer-page.php
+++ b/admin/workflow-visualizer-page.php
@@ -33,7 +33,7 @@ defined( 'ABSPATH' ) || exit;
 <div class="rtbcb-step-description"><?php echo esc_html__( 'Validate and sanitize user inputs', 'rtbcb' ); ?></div>
 <div class="rtbcb-step-metrics">
 <span class="rtbcb-step-duration">-</span>
-<span class="rtbcb-step-status">pending</span>
+<span class="rtbcb-step-status"><?php esc_html_e( 'pending', 'rtbcb' ); ?></span>
 </div>
 </div>
 
@@ -45,7 +45,7 @@ defined( 'ABSPATH' ) || exit;
 <div class="rtbcb-step-description"><?php echo esc_html__( 'Single consolidated AI analysis', 'rtbcb' ); ?></div>
 <div class="rtbcb-step-metrics">
 <span class="rtbcb-step-duration">-</span>
-<span class="rtbcb-step-status">pending</span>
+<span class="rtbcb-step-status"><?php esc_html_e( 'pending', 'rtbcb' ); ?></span>
 </div>
 <div class="rtbcb-step-details">
 <div class="rtbcb-detail-item">
@@ -62,7 +62,7 @@ defined( 'ABSPATH' ) || exit;
 <div class="rtbcb-step-description"><?php echo esc_html__( 'AI-enhanced financial modeling', 'rtbcb' ); ?></div>
 <div class="rtbcb-step-metrics">
 <span class="rtbcb-step-duration">-</span>
-<span class="rtbcb-step-status">pending</span>
+<span class="rtbcb-step-status"><?php esc_html_e( 'pending', 'rtbcb' ); ?></span>
 </div>
 </div>
 
@@ -74,7 +74,7 @@ defined( 'ABSPATH' ) || exit;
 <div class="rtbcb-step-description"><?php echo esc_html__( 'AI-enhanced category selection', 'rtbcb' ); ?></div>
 <div class="rtbcb-step-metrics">
 <span class="rtbcb-step-duration">-</span>
-<span class="rtbcb-step-status">pending</span>
+<span class="rtbcb-step-status"><?php esc_html_e( 'pending', 'rtbcb' ); ?></span>
 </div>
 </div>
 
@@ -86,7 +86,7 @@ defined( 'ABSPATH' ) || exit;
 <div class="rtbcb-step-description"><?php echo esc_html__( 'RAG + AI strategic analysis', 'rtbcb' ); ?></div>
 <div class="rtbcb-step-metrics">
 <span class="rtbcb-step-duration">-</span>
-<span class="rtbcb-step-status">pending</span>
+<span class="rtbcb-step-status"><?php esc_html_e( 'pending', 'rtbcb' ); ?></span>
 </div>
 <div class="rtbcb-step-details">
 <div class="rtbcb-detail-item">
@@ -103,7 +103,7 @@ defined( 'ABSPATH' ) || exit;
 <div class="rtbcb-step-description"><?php echo esc_html__( 'Prepare structured report data', 'rtbcb' ); ?></div>
 <div class="rtbcb-step-metrics">
 <span class="rtbcb-step-duration">-</span>
-<span class="rtbcb-step-status">pending</span>
+<span class="rtbcb-step-status"><?php esc_html_e( 'pending', 'rtbcb' ); ?></span>
 </div>
 </div>
 </div>

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -63,7 +63,7 @@ $processing_time = $metadata['processing_time'] ?? 0;
 					<div class="rtbcb-meta-item">
 						<span class="rtbcb-meta-icon">⚡</span>
 						<span class="rtbcb-meta-label"><?php echo esc_html__( 'Processing Time', 'rtbcb' ); ?></span>
-						<span class="rtbcb-meta-value"><?php echo esc_html( round( $processing_time, 1 ) ); ?>s</span>
+									<span class="rtbcb-meta-value"><?php printf( esc_html__( '%ss', 'rtbcb' ), esc_html( round( $processing_time, 1 ) ) ); ?></span>
 					</div>
 										<div class="rtbcb-meta-item">
 												<span class="rtbcb-meta-icon">📊</span>
@@ -73,7 +73,7 @@ $processing_time = $metadata['processing_time'] ?? 0;
 										<div class="rtbcb-meta-item">
 												<span class="rtbcb-meta-icon">🏷️</span>
 												<span class="rtbcb-meta-label"><?php echo esc_html__( 'Version', 'rtbcb' ); ?></span>
-												<span class="rtbcb-meta-value"><?php echo esc_html( defined( 'RTBCB_VERSION' ) ? RTBCB_VERSION : 'dev' ); ?></span>
+									<span class="rtbcb-meta-value"><?php echo esc_html( defined( 'RTBCB_VERSION' ) ? RTBCB_VERSION : __( 'dev', 'rtbcb' ) ); ?></span>
 										</div>
 								</div>
 			</div>
@@ -98,7 +98,7 @@ $processing_time = $metadata['processing_time'] ?? 0;
 						<div class="rtbcb-metric-icon">⏱️</div>
 						<div class="rtbcb-metric-content">
 							<div class="rtbcb-metric-value">
-								<?php echo esc_html( $financial_analysis['payback_analysis']['payback_months'] ?? 'N/A' ); ?>
+										<?php echo esc_html( $financial_analysis['payback_analysis']['payback_months'] ?? __( 'N/A', 'rtbcb' ) ); ?>
 							</div>
 							<div class="rtbcb-metric-label"><?php echo esc_html__( 'Months to Payback', 'rtbcb' ); ?></div>
 						</div>


### PR DESCRIPTION
## Summary
- Wrap hardcoded admin and template strings with translation helpers using the `rtbcb` text domain
- Localize default labels in workflow visualizer and analytics dashboard
- Translate API log alerts and template metadata fallbacks

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b5c682d9308331be6d7f24a6e964d5