### PR TITLE
Ensure tests run outside WordPress

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -186,6 +186,9 @@ class RTBCB_Router {
 				]
 			);
 		} catch ( Exception $e ) {
+			if ( class_exists( 'RTBCB_JSON_Error' ) && $e instanceof RTBCB_JSON_Error ) {
+				throw $e;
+			}
 			// Log the detailed error to debug.log.
 			error_log( 'RTBCB Form Submission Error: ' . $e->getMessage() );
 
@@ -195,7 +198,7 @@ class RTBCB_Router {
 					'message' => sprintf(
 						__( 'An unexpected error occurred while generating your report. Please check the server logs for more details. Error: %s', 'rtbcb' ),
 						$e->getMessage()
-					),
+						),
 				],
 				500
 			);

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -134,7 +134,7 @@ $processing_time = $metadata['processing_time'] ?? 0;
 
 	<!-- Executive Summary with Enhanced Visual Design -->
 	<?php if ( ! empty( $executive_summary ) ) : ?>
-	<div class="rtbcb-section-enhanced rtbcb-executive-summary-enhanced">
+<div class="rtbcb-section-enhanced rtbcb-executive-summary rtbcb-executive-summary-enhanced">
 		<div class="rtbcb-section-header-enhanced">
 			<h2 class="rtbcb-section-title">
 				<span class="rtbcb-section-icon">📋</span>
@@ -479,7 +479,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 	// Initialize interactive elements
 	initializeInteractiveFeatures();
-});
+	});
 
 function initializeROIChart() {
 	const ctx = document.getElementById('rtbcb-roi-chart');
@@ -487,7 +487,7 @@ function initializeROIChart() {
 		return;
 	}
 
-	const chartData = <?php echo wp_json_encode( $financial_analysis['chart_data'] ?? [] ); ?>;
+	const chartData = <?php echo function_exists( 'wp_json_encode' ) ? wp_json_encode( $financial_analysis['chart_data'] ?? [] ) : json_encode( $financial_analysis['chart_data'] ?? [] ); ?>;
 	if ( ! chartData.labels ) {
 		return;
 	}
@@ -532,7 +532,7 @@ function initializeSectionToggles() {
 			if (content) {
 				content.style.display = content.style.display === 'none' ? 'block' : 'none';
 				arrow.textContent = content.style.display === 'none' ? '▼' : '▲';
-				text.textContent = content.style.display === 'none' ? '<?php echo esc_js( __( 'Expand', 'rtbcb' ) ); ?>' : '<?php echo esc_js( __( 'Collapse', 'rtbcb' ) ); ?>';
+				text.textContent = content.style.display === 'none' ? '<?php echo function_exists( 'esc_js' ) ? esc_js( __( 'Expand', 'rtbcb' ) ) : htmlspecialchars( __( 'Expand', 'rtbcb' ), ENT_QUOTES ); ?>' : '<?php echo function_exists( 'esc_js' ) ? esc_js( __( 'Collapse', 'rtbcb' ) ) : htmlspecialchars( __( 'Collapse', 'rtbcb' ), ENT_QUOTES ); ?>';
 			}
 		});
 	});
@@ -560,15 +560,20 @@ function rtbcbExportPDF() {
 </script>
 
 <?php
-// Pass structured data to JavaScript for charts and interactivity
-wp_localize_script( 'rtbcb-report', 'rtbcbReportData', [
-	'roiScenarios' => $financial_analysis['roi_scenarios'] ?? [],
-	'companyName' => $company_name,
-	'confidence' => $confidence_level,
-	'strings' => [
-		'exportPDF' => __( 'Export as PDF', 'rtbcb' ),
-		'printReport' => __( 'Print Report', 'rtbcb' ),
-		'expandSection' => __( 'Expand Section', 'rtbcb' ),
-		'collapseSection' => __( 'Collapse Section', 'rtbcb' )
-	]
-] );
+	// Pass structured data to JavaScript for charts and interactivity.
+	$data = [
+		'roiScenarios' => $financial_analysis['roi_scenarios'] ?? [],
+		'companyName'  => $company_name,
+		'confidence'   => $confidence_level,
+		'strings'      => [
+			'exportPDF'       => __( 'Export as PDF', 'rtbcb' ),
+			'printReport'     => __( 'Print Report', 'rtbcb' ),
+			'expandSection'   => __( 'Expand Section', 'rtbcb' ),
+			'collapseSection' => __( 'Collapse Section', 'rtbcb' ),
+		],
+	];
+	if ( function_exists( 'wp_localize_script' ) ) {
+		wp_localize_script( 'rtbcb-report', 'rtbcbReportData', $data );
+	} else {
+		echo '<script>var rtbcbReportData = ' . ( function_exists( 'wp_json_encode' ) ? wp_json_encode( $data ) : json_encode( $data ) ) . '</script>';
+}

--- a/tests/RTBCB_GenerateBusinessAnalysisTest.php
+++ b/tests/RTBCB_GenerateBusinessAnalysisTest.php
@@ -153,7 +153,7 @@ return [ 'fallback' => true ];
 }
 }
 
-final class Generate_Business_Analysis_Test extends TestCase {
+final class RTBCB_GenerateBusinessAnalysisTest extends TestCase {
 	private $plugin;
 
 	protected function setUp(): void {

--- a/tests/RTBCB_ReportErrorHandlingTest.php
+++ b/tests/RTBCB_ReportErrorHandlingTest.php
@@ -109,7 +109,7 @@ require_once __DIR__ . '/../inc/class-rtbcb-validator.php';
 require_once __DIR__ . '/../inc/class-rtbcb-ajax.php';
 require_once __DIR__ . '/../inc/class-rtbcb-router.php';
 
-final class Report_Error_Handling_Test extends TestCase {
+final class RTBCB_ReportErrorHandlingTest extends TestCase {
 protected function setUp(): void {
 $_POST = [];
 }

--- a/tests/render-comprehensive-template.test.php
+++ b/tests/render-comprehensive-template.test.php
@@ -33,14 +33,16 @@ if ( ! function_exists( 'current_time' ) ) {
 }
 
 $business_case_data = [
-	'company_name'      => 'Demo Corp',
-	'executive_summary' => [
-		'strategic_positioning'   => 'Positioned well.',
-		'business_case_strength'  => 'Strong',
-		'key_value_drivers'       => [ 'Efficiency', 'Compliance' ],
-		'executive_recommendation'=> 'Proceed',
-	],
+        'company_name'      => 'Demo Corp',
+        'executive_summary' => [
+                'strategic_positioning'   => 'Positioned well.',
+                'business_case_strength'  => 'Strong',
+                'key_value_drivers'       => [ 'Efficiency', 'Compliance' ],
+                'executive_recommendation'=> 'Proceed',
+        ],
 ];
+
+$report_data = $business_case_data;
 
 ob_start();
 include __DIR__ . '/../templates/comprehensive-report-template.php';

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -76,7 +76,7 @@ echo "15. Running AJAX error handling tests..."
 vendor/bin/phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
 vendor/bin/phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
 vendor/bin/phpunit tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
-vendor/bin/phpunit tests/report-error-handling.test.php
+vendor/bin/phpunit tests/RTBCB_ReportErrorHandlingTest.php
 
 # Background job test
 echo "14. Running background job tests..."
@@ -88,7 +88,7 @@ php tests/job-status.test.php
 
 # Business analysis generation test
 echo "14c. Running business analysis generation test..."
-vendor/bin/phpunit tests/generate-business-analysis.test.php
+vendor/bin/phpunit tests/RTBCB_GenerateBusinessAnalysisTest.php
 echo "14d. Running Jetpack compatibility test..."
 php tests/jetpack-compatibility.test.php
 


### PR DESCRIPTION
## Summary
- safeguard router error handling by rethrowing JSON errors before generic logging
- add WordPress function fallbacks in comprehensive report template
- stabilize lead storage and template rendering tests with lightweight stubs

## Testing
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5c98301ac83318a43142f2daff6e4