### PR TITLE
Fix logging class and workflow hooks

### DIFF
--- a/inc/class-rtbcb-logger.php
+++ b/inc/class-rtbcb-logger.php
@@ -6,18 +6,15 @@ defined( 'ABSPATH' ) || exit;
 	*
 	* @package RealTreasuryBusinessCaseBuilder
 	*/
+class RTBCB_Logger {
 
-/**
-		* Structured logging for API interactions.
-		*/
-		class RTBCB_Logger {
-			/**
-			* Send a structured log record.
-			*
-			* @param string $event   Event name.
-			* @param array  $context Context data.
-			* @return void
-			*/
+	/**
+	 * Send a structured log record.
+	 *
+	 * @param string $event   Event name.
+	 * @param array  $context Context data.
+	 * @return void
+	 */
 	public static function log( $event, $context = [] ) {
 		$record = [
 			'timestamp' => gmdate( 'c' ),
@@ -27,27 +24,28 @@ defined( 'ABSPATH' ) || exit;
 
 		error_log( 'RTBCB_LOG: ' . wp_json_encode( $record ) );
 
-$endpoint = function_exists( 'get_option' ) ? get_option( 'rtbcb_log_endpoint', '' ) : '';
-$endpoint = function_exists( 'sanitize_text_field' ) ? sanitize_text_field( $endpoint ) : $endpoint;
-if ( $endpoint ) {
-rtbcb_wp_remote_post_with_retry(
-$endpoint,
-[
-'headers' => [ 'Content-Type' => 'application/json' ],
-'body'    => wp_json_encode( $record ),
-'timeout' => 2,
-]
-);
-}
+		$endpoint = function_exists( 'get_option' ) ? get_option( 'rtbcb_log_endpoint', '' ) : '';
+		$endpoint = function_exists( 'sanitize_text_field' ) ? sanitize_text_field( $endpoint ) : $endpoint;
+
+		if ( $endpoint ) {
+			rtbcb_wp_remote_post_with_retry(
+				$endpoint,
+				[
+					'headers' => [ 'Content-Type' => 'application/json' ],
+					'body'    => wp_json_encode( $record ),
+					'timeout' => 2,
+				]
+			);
+		}
 	}
 
 	/**
-	* Log request details on shutdown.
-	*
-	* @param float $start_time Request start time.
-	* @param array $payload    Sanitized request payload.
-	* @return void
-	*/
+	 * Log request details on shutdown.
+	 *
+	 * @param float $start_time Request start time.
+	 * @param array $payload    Sanitized request payload.
+	 * @return void
+	 */
 	public static function log_shutdown( $start_time, $payload ) {
 		$duration = ( microtime( true ) - $start_time ) * 1000;
 		$code     = http_response_code();
@@ -71,10 +69,10 @@ $endpoint,
 	}
 
 	/**
-	* Increment timeout counter and trigger alert if threshold exceeded.
-	*
-	* @return void
-	*/
+	 * Increment timeout counter and trigger alert if threshold exceeded.
+	 *
+	 * @return void
+	 */
 	public static function record_timeout() {
 		$count = (int) get_transient( 'rtbcb_timeout_count' );
 		$count++;
@@ -87,13 +85,13 @@ $endpoint,
 	}
 
 	/**
-	* Send timeout alert email.
-	*
-	* @param int $count Timeout count.
-	* @return void
-	*/
-private static function send_timeout_alert( $count ) {
-$admin_email = function_exists( 'get_option' ) ? get_option( 'admin_email' ) : '';
+	 * Send timeout alert email.
+	 *
+	 * @param int $count Timeout count.
+	 * @return void
+	 */
+	private static function send_timeout_alert( $count ) {
+		$admin_email = function_exists( 'get_option' ) ? get_option( 'admin_email' ) : '';
 		$subject     = __( 'Business Case Builder timeout alert', 'rtbcb' );
 		$message     = sprintf(
 			__( 'The Business Case Builder API timed out %d times in the last five minutes.', 'rtbcb' ),
@@ -102,4 +100,3 @@ $admin_email = function_exists( 'get_option' ) ? get_option( 'admin_email' ) : '
 		wp_mail( $admin_email, $subject, $message );
 	}
 }
-

--- a/inc/class-rtbcb-workflow-tracker.php
+++ b/inc/class-rtbcb-workflow-tracker.php
@@ -117,16 +117,17 @@ error_log( 'RTBCB Workflow: Completed step ' . $step_name . ' in ' . round( $thi
 	* @return void
 	*/
 public function add_warning( $code, $message ) {
-$step_name = $this->current_step ? $this->current_step['name'] : ( $this->steps ? end( $this->steps )['name'] : 'unknown' );
-$warning   = [
-'code'      => $code,
-'message'   => $message,
-'timestamp' => microtime( true ),
-'step'      => $step_name,
-];
+	$step_name = $this->current_step ? $this->current_step['name'] : ( $this->steps ? end( $this->steps )['name'] : 'unknown' );
+	$warning   = [
+		'code'      => $code,
+		'message'   => $message,
+		'timestamp' => microtime( true ),
+		'step'      => $step_name,
+	];
 
-$this->warnings[] = $warning;
-error_log( "RTBCB Workflow Warning [{$code}]: {$message}" );
+	$this->warnings[] = $warning;
+	error_log( "RTBCB Workflow Warning [{$code}]: {$message}" );
+	do_action( 'rtbcb_workflow_warning', $warning );
 }
 
 /**
@@ -137,16 +138,17 @@ error_log( "RTBCB Workflow Warning [{$code}]: {$message}" );
 	* @return void
 	*/
 public function add_error( $code, $message ) {
-$step_name = $this->current_step ? $this->current_step['name'] : ( $this->steps ? end( $this->steps )['name'] : 'unknown' );
-$error     = [
-'code'      => $code,
-'message'   => $message,
-'timestamp' => microtime( true ),
-'step'      => $step_name,
-];
+	$step_name = $this->current_step ? $this->current_step['name'] : ( $this->steps ? end( $this->steps )['name'] : 'unknown' );
+	$error     = [
+		'code'      => $code,
+		'message'   => $message,
+		'timestamp' => microtime( true ),
+		'step'      => $step_name,
+	];
 
-$this->errors[] = $error;
-error_log( "RTBCB Workflow Error [{$code}]: {$message}" );
+	$this->errors[] = $error;
+	error_log( "RTBCB Workflow Error [{$code}]: {$message}" );
+	do_action( 'rtbcb_workflow_error', $error );
 }
 
 /**


### PR DESCRIPTION
## Summary
- tidy RTBCB_Logger with proper formatting and remote log handling
- emit workflow warning and error hooks in RTBCB_Workflow_Tracker

## Testing
- `bash tests/run-tests.sh` *(fails: vendor/bin/phpunit: No such file or directory)*
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b5caaa43ec8331a0ffc790f8def199