### PR TITLE
Escape citation links and JSON output

### DIFF
--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -575,5 +575,8 @@ function rtbcbExportPDF() {
 	if ( function_exists( 'wp_localize_script' ) ) {
 		wp_localize_script( 'rtbcb-report', 'rtbcbReportData', $data );
 	} else {
-		echo '<script>var rtbcbReportData = ' . ( function_exists( 'wp_json_encode' ) ? wp_json_encode( $data ) : json_encode( $data ) ) . '</script>';
+		printf(
+			'<script>var rtbcbReportData = %s</script>',
+			function_exists( 'wp_json_encode' ) ? wp_json_encode( $data, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_APOS ) : json_encode( $data )
+		);
 }

--- a/templates/report-template.php
+++ b/templates/report-template.php
@@ -45,9 +45,13 @@ $rag_context   = $business_case_data['rag_context'] ?? [];
 				<li>
 					<?php
 					if ( is_array( $citation ) && ! empty( $citation['url'] ) ) {
-						$url  = esc_url( $citation['url'] );
-						$text = ! empty( $citation['text'] ) ? esc_html( $citation['text'] ) : $url;
-						echo '<a href="' . $url . '">' . $text . '</a>';
+						$url  = $citation['url'];
+						$text = ! empty( $citation['text'] ) ? $citation['text'] : $url;
+						printf(
+							'<a href="%s">%s</a>',
+							esc_url( $url ),
+							esc_html( $text )
+						);
 					} else {
 						echo esc_html( is_array( $citation ) ? wp_json_encode( $citation ) : $citation );
 					}


### PR DESCRIPTION
## Summary
- Sanitize citation URLs and text using `printf`, `esc_url`, and `esc_html` in the report template.
- Ensure structured data is JSON-encoded safely when localizing scripts in the comprehensive report template.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`
- `phpcs --standard=WordPress templates/report-template.php templates/comprehensive-report-template.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cea3400c833197ad2d09f1f7d4dc