### PR TITLE
docs: document composer install before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ capability. AJAX actions from the dashboard require nonces such as
 reporting flow is available in [docs/TEST_DASHBOARD_FLOW.md](docs/TEST_DASHBOARD_FLOW.md).
 
 ### Automated Tests
-Run `composer install` before executing tests to ensure PHP dependencies like PHPUnit are installed.
+Run `composer install` before executing `tests/run-tests.sh`. This installs `phpunit/phpunit` in `vendor/bin/phpunit`, which the test script relies on.
 The plugin includes integration tests for all major components. These can be run programmatically:
 ```php
 // Run integration tests

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,5 +1,6 @@
 # AI Test Guidelines
 
+- Run `composer install` before executing `tests/run-tests.sh` to install `phpunit/phpunit` in `vendor/bin/phpunit`.
 - Before committing changes, run `bash tests/run-tests.sh` from the repository root.
 - The `run-tests.sh` script performs:
     - PHP linting and unit tests via `phpunit`.


### PR DESCRIPTION
## Summary
- remind contributors to run `composer install` before `tests/run-tests.sh`
- explain that this installs `phpunit/phpunit` in `vendor/bin/phpunit`

## Testing
- `composer install --dry-run`
- `bash tests/run-tests.sh` *(fails: OpenAI API key not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ceafece8833187b5f6ebd90b5fd2