### PR TITLE
Use JSON fallback for report citations

### DIFF
--- a/templates/report-template.php
+++ b/templates/report-template.php
@@ -49,7 +49,8 @@ $rag_context   = $business_case_data['rag_context'] ?? [];
 						$text = ! empty( $citation['text'] ) ? esc_html( $citation['text'] ) : $url;
 						echo '<a href="' . $url . '">' . $text . '</a>';
 					} else {
-						echo esc_html( is_array( $citation ) ? wp_json_encode( $citation ) : $citation );
+						$encoded_citation = is_array( $citation ) ? ( function_exists( 'wp_json_encode' ) ? wp_json_encode( $citation ) : json_encode( $citation ) ) : $citation;
+						echo esc_html( $encoded_citation );
 					}
 					?>
 				</li>


### PR DESCRIPTION
## Summary
- prevent fatal errors in report template by falling back to `json_encode` when `wp_json_encode` is unavailable

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ce77dbf48331a101a8ac57bbee34