### PR TITLE
Bump plugin to version 2.1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Real Treasury Business Case Builder - Enhanced Version 2.1.8
+# Real Treasury Business Case Builder - Enhanced Version 2.1.9
 
 A comprehensive WordPress plugin that helps treasury teams quantify the benefits of modern treasury tools, generate professional business case reports, and track lead engagement with advanced analytics.
 
-## 🚀 What's New in Version 2.1.8
+## 🚀 What's New in Version 2.1.9
 
 ### ✨ Enhancements
 - Fixed bulk lead deletion actions within the lead management dashboard.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: realtreasury
 Tags: business, case, builder, roi, treasury
 Requires at least: 6.0
 Tested up to: 6.0
-Stable tag: 2.1.8
+Stable tag: 2.1.9
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -156,6 +156,9 @@ Reports are rendered as HTML in the browser. Use your browser's print or save fu
 The analytics dashboard uses Chart.js for its visualizations. The library is bundled with the plugin to reduce blocking by privacy tools, but strict ad blockers may still prevent it from loading. Allow the plugin's scripts in your browser to enable the charts.
 
 == Changelog ==
+= 2.1.9 =
+* Bump version for release.
+
 = 2.1.8 =
 * Fixed bulk lead deletion actions within the lead management dashboard.
 * Added test coverage to ensure asynchronous jobs are marked complete correctly.

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2,7 +2,7 @@
 /**
 	* Plugin Name: Real Treasury - Business Case Builder (Enhanced Pro)
 	* Description: Professional-grade ROI calculator and comprehensive business case generator for treasury technology with advanced analysis and consultant-style reports.
-	* Version: 2.1.8
+* Version: 2.1.9
 	* Requires PHP: 7.4
 	* Author: Real Treasury
 	* Text Domain: rtbcb
@@ -13,7 +13,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'RTBCB_VERSION', '2.1.8' );
+define( 'RTBCB_VERSION', '2.1.9' );
 define( 'RTBCB_FILE', __FILE__ );
 define( 'RTBCB_URL', plugin_dir_url( RTBCB_FILE ) );
 define( 'RTBCB_DIR', plugin_dir_path( RTBCB_FILE ) );


### PR DESCRIPTION
## Summary
- Update plugin header and RTBCB_VERSION constant to 2.1.9
- Refresh README and readme.txt to reference version 2.1.9
- Add changelog entry for 2.1.9

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c96522308331a6dc6d61a6b8ad56