### PR TITLE
Add capability checks and nonce validation to admin pages

### DIFF
--- a/admin/analytics-page.php
+++ b/admin/analytics-page.php
@@ -5,6 +5,10 @@ defined( 'ABSPATH' ) || exit;
  * Analytics admin page for Real Treasury Business Case Builder plugin.
  */
 
+if ( ! current_user_can( 'manage_options' ) ) {
+	return;
+}
+
 $categories = RTBCB_Category_Recommender::get_all_categories();
 $total_leads = $stats['total_leads'] ?? 0;
 $recent_leads = $stats['recent_leads'] ?? 0;

--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -7,6 +7,10 @@ defined( 'ABSPATH' ) || exit;
  * @package RealTreasuryBusinessCaseBuilder
  */
 
+if ( ! current_user_can( 'manage_options' ) ) {
+	return;
+}
+
 ?>
 <div class="wrap">
 	<h1><?php echo esc_html__( 'API Logs', 'rtbcb' ); ?></h1>

--- a/admin/calculations-page.php
+++ b/admin/calculations-page.php
@@ -7,6 +7,10 @@ defined( 'ABSPATH' ) || exit;
  * @package RealTreasuryBusinessCaseBuilder
  */
 
+if ( ! current_user_can( 'manage_options' ) ) {
+	return;
+}
+
 $labor_cost = get_option( 'rtbcb_labor_cost_per_hour', 0 );
 $bank_fee   = get_option( 'rtbcb_bank_fee_baseline', 0 );
 ?>

--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -331,11 +331,19 @@ $enable_charts = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_setting(
 	* @return void
 	*/
 	public function render_leads() {
-		$page = isset( $_GET['paged'] ) ? intval( wp_unslash( $_GET['paged'] ) ) : 1;
-		$search = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
-		$category = isset( $_GET['category'] ) ? sanitize_text_field( wp_unslash( $_GET['category'] ) ) : '';
-		$date_from = isset( $_GET['date_from'] ) ? sanitize_text_field( wp_unslash( $_GET['date_from'] ) ) : '';
-		$date_to = isset( $_GET['date_to'] ) ? sanitize_text_field( wp_unslash( $_GET['date_to'] ) ) : '';
+	       if ( ! current_user_can( 'manage_options' ) ) {
+	               return;
+	       }
+
+	       if ( isset( $_GET['rtbcb_leads_filter_nonce'] ) && ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['rtbcb_leads_filter_nonce'] ) ), 'rtbcb_leads_filter' ) ) {
+	               wp_die( esc_html__( 'Invalid filter request.', 'rtbcb' ) );
+	       }
+
+	       $page = isset( $_GET['paged'] ) ? intval( wp_unslash( $_GET['paged'] ) ) : 1;
+	       $search = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
+	       $category = isset( $_GET['category'] ) ? sanitize_text_field( wp_unslash( $_GET['category'] ) ) : '';
+	       $date_from = isset( $_GET['date_from'] ) ? sanitize_text_field( wp_unslash( $_GET['date_from'] ) ) : '';
+	       $date_to = isset( $_GET['date_to'] ) ? sanitize_text_field( wp_unslash( $_GET['date_to'] ) ) : '';
 
 		$orderby = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'created_at';
 		$allowed_orderby = [ 'email', 'created_at' ];

--- a/admin/dashboard-page.php
+++ b/admin/dashboard-page.php
@@ -5,6 +5,10 @@ defined( 'ABSPATH' ) || exit;
  * Enhanced Dashboard admin page for Real Treasury Business Case Builder plugin.
  */
 
+if ( ! current_user_can( 'manage_options' ) ) {
+	return;
+}
+
 $total_leads = $stats['total_leads'] ?? 0;
 $recent_leads = $stats['recent_leads'] ?? 0;
 $category_stats = $stats['by_category'] ?? [];

--- a/admin/leads-page-enhanced.php
+++ b/admin/leads-page-enhanced.php
@@ -5,6 +5,10 @@ defined( 'ABSPATH' ) || exit;
  * Enhanced Leads admin page for Real Treasury Business Case Builder plugin.
  */
 
+if ( ! current_user_can( 'manage_options' ) ) {
+	return;
+}
+
 $current_page = $leads_data['current_page'] ?? 1;
 $total_pages = $leads_data['total_pages'] ?? 1;
 $total_leads = $leads_data['total'] ?? 0;
@@ -31,10 +35,11 @@ $date_to   = isset( $leads_data['date_to'] ) ? sanitize_text_field( $leads_data[
 		</div>
 	</div>
 
-	<!-- Filters -->
+<!-- Filters -->
 	<div class="rtbcb-filters">
 		<form method="get" action="">
 			<input type="hidden" name="page" value="rtbcb-leads" />
+			<?php wp_nonce_field( 'rtbcb_leads_filter', 'rtbcb_leads_filter_nonce' ); ?>
 
 			<div class="rtbcb-filter-row">
 				<div class="rtbcb-filter-group">
@@ -45,13 +50,13 @@ $date_to   = isset( $leads_data['date_to'] ) ? sanitize_text_field( $leads_data[
 				<div class="rtbcb-filter-group">
 					<label for="category"><?php esc_html_e( 'Category:', 'rtbcb' ); ?></label>
 					<select id="category" name="category">
-						<option value=""><?php esc_html_e( 'All Categories', 'rtbcb' ); ?></option>
+				<option value=""><?php esc_html_e( 'All Categories', 'rtbcb' ); ?></option>
 						<?php foreach ( $categories as $key => $cat_info ) : ?>
-							<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $category, $key ); ?>>
+				<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $category, $key ); ?>>
 								<?php echo esc_html( $cat_info['name'] ); ?>
 							</option>
 						<?php endforeach; ?>
-					</select>
+			</select>
 				</div>
 
 				<div class="rtbcb-filter-group">
@@ -65,7 +70,7 @@ $date_to   = isset( $leads_data['date_to'] ) ? sanitize_text_field( $leads_data[
 				</div>
 
 				<div class="rtbcb-filter-actions">
-					<button type="submit" class="button button-primary"><?php esc_html_e( 'Filter', 'rtbcb' ); ?></button>
+			<button type="submit" class="button button-primary"><?php esc_html_e( 'Filter', 'rtbcb' ); ?></button>
 					<a href="<?php echo esc_url( admin_url( 'admin.php?page=rtbcb-leads' ) ); ?>" class="button button-secondary"><?php esc_html_e( 'Clear', 'rtbcb' ); ?></a>
 				</div>
 			</div>
@@ -74,11 +79,12 @@ $date_to   = isset( $leads_data['date_to'] ) ? sanitize_text_field( $leads_data[
 
 	<!-- Bulk Actions -->
 	<div class="rtbcb-bulk-actions">
-		<form id="rtbcb-bulk-form">
+		<form id="rtbcb-bulk-form" method="post">
 			<select id="rtbcb-bulk-action">
 				<option value=""><?php esc_html_e( 'Bulk Actions', 'rtbcb' ); ?></option>
 				<option value="delete"><?php esc_html_e( 'Delete', 'rtbcb' ); ?></option>
 			</select>
+			<?php wp_nonce_field( 'rtbcb_nonce', 'rtbcb_nonce' ); ?>
 			<button type="submit" class="button button-secondary" disabled><?php esc_html_e( 'Apply', 'rtbcb' ); ?></button>
 		</form>
 	</div>

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -5,6 +5,10 @@ defined( 'ABSPATH' ) || exit;
  * Settings admin page for Real Treasury Business Case Builder plugin.
  */
 
+if ( ! current_user_can( 'manage_options' ) ) {
+	return;
+}
+
 $api_key         = function_exists( 'get_option' ) ? get_option( 'rtbcb_openai_api_key', '' ) : '';
 $mini_model      = function_exists( 'get_option' ) ? get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) ) : rtbcb_get_default_model( 'mini' );
 $premium_model   = function_exists( 'get_option' ) ? get_option( 'rtbcb_premium_model', rtbcb_get_default_model( 'premium' ) ) : rtbcb_get_default_model( 'premium' );

--- a/admin/test-dashboard-page.php
+++ b/admin/test-dashboard-page.php
@@ -6,6 +6,10 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package RealTreasuryBusinessCaseBuilder
  */
+
+if ( ! current_user_can( 'manage_options' ) ) {
+	return;
+}
 $company_data   = get_option( 'rtbcb_company_data', [] );
 $company_name   = isset( $company_data['name'] ) ? sanitize_text_field( $company_data['name'] ) : '';
 $test_results  = get_option( 'rtbcb_test_results', [] );

--- a/admin/workflow-visualizer-page.php
+++ b/admin/workflow-visualizer-page.php
@@ -7,6 +7,10 @@ defined( 'ABSPATH' ) || exit;
  * @package RealTreasuryBusinessCaseBuilder
  */
 
+if ( ! current_user_can( 'manage_options' ) ) {
+	return;
+}
+
 ?>
 <div class="wrap rtbcb-workflow-visualizer">
 <h1><?php echo esc_html__( 'Treasury Report Workflow Visualizer', 'rtbcb' ); ?></h1>


### PR DESCRIPTION
## Summary
- Guard all admin page templates with `current_user_can( 'manage_options' )`
- Secure leads filter and bulk action forms with nonces and verify them in `render_leads`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5ce9f3dc88331a7229052daa104ab