### PR TITLE
docs: update version references for 2.1.9 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-# Real Treasury Business Case Builder - Enhanced Version 2.1.8
+# Real Treasury Business Case Builder - Enhanced Version 2.1.9
 
 A comprehensive WordPress plugin that helps treasury teams quantify the benefits of modern treasury tools, generate professional business case reports, and track lead engagement with advanced analytics.
 
-## 🚀 What's New in Version 2.1.8
+## 🚀 What's New in Version 2.1.9
 
 ### ✨ Enhancements
-- Fixed bulk lead deletion actions within the lead management dashboard.
-- Added test coverage to ensure asynchronous jobs are marked complete correctly.
-- Reshaped job status data for clearer progress reporting.
-- 📚 Added detailed wizard and API flow documentation in [docs/WIZARD_FORM_API_FLOW.md](docs/WIZARD_FORM_API_FLOW.md).
-- Cached OpenAI model list via WordPress object caching for faster connection tests.
+- Hardened security with ABSPATH guards across admin and template files.
+- Wrapped user-visible strings with translation functions for better localization.
+- Documented Composer install step and added PHPUnit checks to test scripts.
+- Streamlined developer tooling with improved linting and code quality fixes.
 
 
 ## 📋 Installation & Setup

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: realtreasury
 Tags: business, case, builder, roi, treasury
 Requires at least: 6.0
 Tested up to: 6.0
-Stable tag: 2.1.8
+Stable tag: 2.1.9
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -156,6 +156,12 @@ Reports are rendered as HTML in the browser. Use your browser's print or save fu
 The analytics dashboard uses Chart.js for its visualizations. The library is bundled with the plugin to reduce blocking by privacy tools, but strict ad blockers may still prevent it from loading. Allow the plugin's scripts in your browser to enable the charts.
 
 == Changelog ==
+= 2.1.9 =
+* Hardened security with ABSPATH guards across admin and template files.
+* Wrapped user-visible strings with translation functions for better localization.
+* Documented Composer install step and added PHPUnit checks to test scripts.
+* Streamlined developer tooling with improved linting and code quality fixes.
+
 = 2.1.8 =
 * Fixed bulk lead deletion actions within the lead management dashboard.
 * Added test coverage to ensure asynchronous jobs are marked complete correctly.


### PR DESCRIPTION
## Summary
- bump documentation to 2.1.9
- add changelog and What's New details for the 2.1.9 release

## Testing
- `npx markdownlint-cli docs/**/*.md`
- `npx markdown-link-check README.md` *(fails: 5 dead links – 403 for platform.openai.com, hyperdb, redis-cache, memcached; 400 for mailto)*
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b5d22aad9c8331b06d5c7ed2532a68