### PR TITLE
Fix PHPUnit configuration and validator test

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,8 +2,7 @@
 <phpunit>
   <testsuites>
     <testsuite name="rtbcb">
-      <file>tests/validator.test.php</file>
-      <file>tests/edge-cases.test.php</file>
+      <file>tests/RTBCB_ValidatorTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/RTBCB_ValidatorTest.php
+++ b/tests/RTBCB_ValidatorTest.php
@@ -6,6 +6,7 @@ defined( 'ABSPATH' ) || exit;
 
 use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/wp-stubs.php';
+require_once __DIR__ . '/../inc/helpers.php';
 
 if ( ! function_exists( '__' ) ) {
 function __( $text, $domain = null ) {
@@ -13,10 +14,11 @@ return $text;
 }
 }
 
-require_once __DIR__ . '/../inc/helpers.php';
-require_once __DIR__ . '/../inc/class-rtbcb-validator.php';
-
 final class RTBCB_ValidatorTest extends TestCase {
+	protected function setUp(): void {
+		require_once __DIR__ . '/../inc/class-rtbcb-validator.php';
+	}
+
 public function test_missing_required_fields() {
 $validator = new RTBCB_Validator();
 


### PR DESCRIPTION
## Summary
- ensure PHPUnit config only runs validator suite
- load validator class during tests to avoid misdetection

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b5d1ca6e9c83318025715acd53c21d