### PR TITLE
Ensure valid AJAX targets to avoid about:blank errors

### DIFF
--- a/admin/js/rtbcb-admin.js
+++ b/admin/js/rtbcb-admin.js
@@ -5,6 +5,33 @@ if ( typeof ajaxurl === 'undefined' ) {
     var ajaxurl = window.location.origin + '/wp-admin/admin-ajax.php';
 }
 
+/**
+ * Validate a URL uses http or https.
+ *
+ * @param {string} url URL to validate.
+ * @return {boolean} True if the URL is valid.
+ */
+function isValidUrl( url ) {
+    if ( ! url ) {
+        return false;
+    }
+
+    try {
+        var parsed = new URL( url, window.location.origin );
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch ( e ) {
+        return false;
+    }
+}
+
+// Ensure admin AJAX URL is valid to prevent about:blank requests.
+if ( 'object' !== typeof window.rtbcbAdmin ) {
+    window.rtbcbAdmin = {};
+}
+if ( ! isValidUrl( window.rtbcbAdmin.ajax_url ) ) {
+    window.rtbcbAdmin.ajax_url = isValidUrl( ajaxurl ) ? ajaxurl : '';
+}
+
 jQuery(document).ready(function($) {
     'use strict';
     

--- a/public/js/rtbcb-report.js
+++ b/public/js/rtbcb-report.js
@@ -47,6 +47,13 @@ function isValidUrl(url) {
     }
 }
 
+// Fallback for missing or invalid AJAX URL to avoid about:blank requests.
+if ( typeof rtbcbReport !== 'undefined' && ! isValidUrl( rtbcbReport.ajax_url ) ) {
+    if ( typeof ajaxurl !== 'undefined' && isValidUrl( ajaxurl ) ) {
+        rtbcbReport.ajax_url = ajaxurl;
+    }
+}
+
 async function buildEnhancedPrompt(businessContext) {
     if (!isValidUrl(rtbcbReport.template_url)) {
         throw new Error('Template URL must use HTTP or HTTPS protocol');

--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -21,6 +21,13 @@ function isValidUrl(url) {
     }
 }
 
+// Normalize global AJAX URL if provided.
+if ( typeof rtbcb_ajax !== 'undefined' && ! isValidUrl( rtbcb_ajax.ajax_url ) ) {
+    if ( typeof ajaxurl !== 'undefined' && isValidUrl( ajaxurl ) ) {
+        rtbcb_ajax.ajax_url = ajaxurl;
+    }
+}
+
 // Ensure modal functions are available immediately
 window.openBusinessCaseModal = function() {
     const overlay = document.getElementById('rtbcbModalOverlay');
@@ -69,7 +76,7 @@ class BusinessCaseBuilder {
         this.totalSteps = 5;
         this.form = document.getElementById('rtbcbForm');
         this.overlay = document.getElementById('rtbcbModalOverlay');
-        this.ajaxUrl = ( typeof rtbcb_ajax !== 'undefined' && rtbcb_ajax.ajax_url ) ? rtbcb_ajax.ajax_url : '';
+        this.ajaxUrl = ( typeof rtbcb_ajax !== 'undefined' && isValidUrl( rtbcb_ajax.ajax_url ) ) ? rtbcb_ajax.ajax_url : '';
         this.pollTimeout = null;
         this.pollingCancelled = false;
         this.activeJobId = null;

--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -83,6 +83,13 @@ function isValidUrl(url) {
     }
 }
 
+// Normalize AJAX URL to prevent empty fetch requests.
+if ( typeof rtbcb_ajax !== 'undefined' && ! isValidUrl( rtbcb_ajax.ajax_url ) ) {
+    if ( typeof ajaxurl !== 'undefined' && isValidUrl( ajaxurl ) ) {
+        rtbcb_ajax.ajax_url = ajaxurl;
+    }
+}
+
 /**
  * Handles the form submission by sending data to the backend.
  * @param {Event} e - The form submission event.


### PR DESCRIPTION
## Summary
- Validate and sanitize AJAX URLs across admin and public scripts
- Fallback to WordPress `ajaxurl` when plugin URLs are missing or invalid
- Guard against empty URLs causing `about:blank` requests

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b5da4ee24083318b965b32f840af24