### PR TITLE
Skip heavy processing during Jetpack proxy requests

### DIFF
--- a/inc/class-rtbcb-background-job.php
+++ b/inc/class-rtbcb-background-job.php
@@ -41,7 +41,7 @@ set_transient( $job_id, $current, HOUR_IN_SECONDS );
 public static function enqueue( $user_inputs ) {
 $job_id = uniqid( 'rtbcb_job_', true );
 
-self::update_status( $job_id, 'queued' );
+	self::update_status( $job_id, 'queued' );
 
 				wp_schedule_single_event(
 						time(),
@@ -64,12 +64,16 @@ self::update_status( $job_id, 'queued' );
 	* @param array  $user_inputs User inputs.
 	* @return void
 	*/
-public static function process_job( $job_id, $user_inputs ) {
-self::update_status( $job_id, 'processing' );
+	public static function process_job( $job_id, $user_inputs ) {
+	if ( rtbcb_heavy_features_disabled() ) {
+		return;
+	}
 
-$basic_roi = RTBCB_Ajax::process_basic_roi_step( $user_inputs );
+		self::update_status( $job_id, 'processing' );
 
-self::update_status(
+		$basic_roi = RTBCB_Ajax::process_basic_roi_step( $user_inputs );
+
+		self::update_status(
 $job_id,
 'processing',
 [

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2649,18 +2649,21 @@ return $analysis;
 	* @param callable|null $chunk_handler    Optional streaming handler.
 	* @return array|WP_Error HTTP response array or WP_Error on failure.
 	*/
-	private function call_openai( $model, $prompt, $max_output_tokens = null, $chunk_handler = null ) {
-		if ( empty( $this->api_key ) ) {
-			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-		}
+private function call_openai( $model, $prompt, $max_output_tokens = null, $chunk_handler = null ) {
+if ( rtbcb_heavy_features_disabled() ) {
+return new WP_Error( 'heavy_features_disabled', __( 'AI features temporarily disabled.', 'rtbcb' ) );
+}
+if ( empty( $this->api_key ) ) {
+return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+}
 
-		$endpoint         = 'https://api.openai.com/v1/responses'; // Correct endpoint.
-		$model_name       = sanitize_text_field( $model ?: 'gpt-5-mini' );
-		$model_name       = rtbcb_normalize_model_name( $model_name );
-		$default_tokens    = intval( $this->gpt5_config['max_output_tokens'] ?? 8000 );
-		$max_output_tokens = intval( $max_output_tokens ?? $default_tokens );
-		$min_tokens        = intval( $this->gpt5_config['min_output_tokens'] ?? 1 );
-		$max_output_tokens = min( 128000, max( $min_tokens, $max_output_tokens ) );
+$endpoint         = 'https://api.openai.com/v1/responses'; // Correct endpoint.
+$model_name       = sanitize_text_field( $model ?: 'gpt-5-mini' );
+$model_name       = rtbcb_normalize_model_name( $model_name );
+$default_tokens    = intval( $this->gpt5_config['max_output_tokens'] ?? 8000 );
+$max_output_tokens = intval( $max_output_tokens ?? $default_tokens );
+$min_tokens        = intval( $this->gpt5_config['min_output_tokens'] ?? 1 );
+$max_output_tokens = min( 128000, max( $min_tokens, $max_output_tokens ) );
 
 		if ( is_array( $prompt ) && isset( $prompt['input'] ) ) {
 			$instructions = sanitize_textarea_field( $prompt['instructions'] ?? '' );

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -87,10 +87,28 @@ function rtbcb_has_openai_api_key() {
 	* @return bool True if heavy features should be bypassed.
 	*/
 function rtbcb_heavy_features_disabled() {
-       $disabled = function_exists( 'get_option' ) ? get_option( 'rtbcb_disable_heavy_features', 0 ) : 0;
-       $fast     = function_exists( 'get_option' ) ? get_option( 'rtbcb_fast_mode', 0 ) : 0;
+$disabled = function_exists( 'get_option' ) ? get_option( 'rtbcb_disable_heavy_features', 0 ) : 0;
+$fast     = function_exists( 'get_option' ) ? get_option( 'rtbcb_fast_mode', 0 ) : 0;
+$auto     = false;
 
-       return (bool) ( $disabled || $fast );
+if ( function_exists( 'wp_doing_cron' ) && wp_doing_cron() ) {
+if ( isset( $_SERVER['HTTP_X_JETPACK_SIGNATURE'] ) || isset( $_SERVER['HTTP_JETPACK_SIGNATURE'] ) ) {
+$auto = true;
+}
+} else {
+$for         = isset( $_GET['for'] ) ? sanitize_key( wp_unslash( $_GET['for'] ) ) : '';
+$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+
+if ( 'jetpack' === $for || ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) ) {
+$auto = true;
+} elseif ( isset( $_SERVER['HTTP_X_JETPACK_SIGNATURE'] ) || isset( $_SERVER['HTTP_JETPACK_SIGNATURE'] ) ) {
+$auto = true;
+} elseif ( false !== strpos( $request_uri, '/jetpack/' ) || false !== strpos( $request_uri, '/wp-admin/rest-proxy/' ) ) {
+$auto = true;
+}
+}
+
+return (bool) ( $disabled || $fast || $auto );
 }
 
 /**

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -106,12 +106,15 @@ class RTBCB_Main {
 		return true;
 		}
 
-		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
-		if ( false !== strpos( $request_uri, '/jetpack/' ) ) {
-			return true;
-		}
-		}
+if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+if (
+false !== strpos( $request_uri, '/jetpack/' ) ||
+false !== strpos( $request_uri, '/wp-admin/rest-proxy/' )
+) {
+return true;
+}
+}
 
 		return false;
 	}


### PR DESCRIPTION
## Summary
- Detect Jetpack REST proxy access and bypass plugin initialization
- Auto-disable heavy AI features for Jetpack requests and short-circuit background jobs
- Prevent OpenAI calls when heavy features are disabled

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-5-mini bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5e75fec588331a9ef2fbd4cd2ae33