### PR TITLE
Skip heavy processing during Jetpack proxy requests

### DIFF
--- a/inc/class-rtbcb-background-job.php
+++ b/inc/class-rtbcb-background-job.php
@@ -16,7 +16,7 @@ class RTBCB_Background_Job {
 	* @param array  $payload Additional fields such as step, percent, or partial results.
 	* @return void
 	*/
-public static function update_status( $job_id, $state, $payload = [] ) {
+	public static function update_status( $job_id, $state, $payload = [] ) {
 $current = get_transient( $job_id );
 if ( ! is_array( $current ) ) {
 $current = [
@@ -65,10 +65,6 @@ $job_id = uniqid( 'rtbcb_job_', true );
 	* @return void
 	*/
 	public static function process_job( $job_id, $user_inputs ) {
-	if ( rtbcb_heavy_features_disabled() ) {
-		return;
-	}
-
 		self::update_status( $job_id, 'processing' );
 
 		$basic_roi = RTBCB_Ajax::process_basic_roi_step( $user_inputs );


### PR DESCRIPTION
## Summary
- Detect Jetpack REST proxy access and bypass plugin initialization
- Auto-disable heavy AI features for Jetpack requests and short-circuit background jobs
- Prevent OpenAI calls when heavy features are disabled
- Continue background job processing when heavy features are disabled so job status updates correctly

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-5-mini bash tests/run-tests.sh`
- `phpcs --standard=WordPress` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5eae81e888331a360eeda4fc12d3c