### PR TITLE
Set fixed timeout for LLM requests

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -1497,7 +1497,6 @@ SYSTEM;
 			$body['temperature'] = floatval( $this->gpt5_config['temperature'] ?? 0.7 );
 		}
 
-	$timeout  = intval( $this->gpt5_config['timeout'] ?? 300 );
 		$response = wp_remote_post(
 			'https://api.openai.com/v1/responses',
 			[
@@ -1506,7 +1505,7 @@ SYSTEM;
 					'Content-Type'  => 'application/json',
 				],
 				'body'    => wp_json_encode( $body ),
-				'timeout' => $timeout,
+				'timeout' => 600,
 			]
 		);
 


### PR DESCRIPTION
## Summary
- ensure LLM requests via `wp_remote_post` use a 600-second timeout

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`
- `phpcs --standard=WordPress inc/class-rtbcb-llm.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5eba5767c8331bf1a12be1425b56c