### PR TITLE
Add crash protection to plugin bootstrap

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2698,9 +2698,23 @@ if ( ! class_exists( 'Real_Treasury_BCB' ) ) {
 	class_alias( RTBCB_Main::class, 'Real_Treasury_BCB' );
 }
 
-// Initialize the plugin
+// Initialize the plugin with crash protection
 if ( ! defined( 'RTBCB_NO_BOOTSTRAP' ) ) {
-	RTBCB_Main::instance();
+	try {
+		RTBCB_Main::instance();
+	} catch ( Throwable $e ) {
+		error_log( 'RTBCB: Plugin failed to start: ' . $e->getMessage() );
+
+		// Show admin notice instead of crashing
+		add_action( 'admin_notices', function() use ( $e ) {
+			if ( current_user_can( 'manage_options' ) ) {
+				echo '<div class="notice notice-error is-dismissible">';
+				echo '<p><strong>' . esc_html__( 'Real Treasury Business Case Builder Error:', 'rtbcb' ) . '</strong> ';
+				echo esc_html( $e->getMessage() );
+				echo '</p></div>';
+			}
+		} );
+	}
 }
 
 

--- a/tests/operational-risks-fallback.test.php
+++ b/tests/operational-risks-fallback.test.php
@@ -84,10 +84,8 @@ return [];
 }
 }
 
-$plugin_code = file_get_contents( __DIR__ . '/../real-treasury-business-case-builder.php' );
-$plugin_code = preg_replace( '/
-?\/\/ Initialize the plugin\s*RTBCB_Main::instance\(\);/', '', $plugin_code );
-eval( '?>' . $plugin_code );
+define( 'RTBCB_NO_BOOTSTRAP', true );
+require_once __DIR__ . '/../real-treasury-business-case-builder.php';
 
 $ref  = new ReflectionClass( 'RTBCB_Main' );
 $plugin = $ref->newInstanceWithoutConstructor();


### PR DESCRIPTION
## Summary
- Wrap plugin bootstrap in try/catch and show admin notice instead of fatal error
- Update operational risk test to bypass bootstrap via `RTBCB_NO_BOOTSTRAP`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=dummy bash tests/run-tests.sh`
- `phpcs --standard=WordPress` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fe3cce8483318ab1adf0aa80b0ee