### PR TITLE
Remove memory and timeout overrides from plugin initialization

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -12,16 +12,6 @@
 */
 defined( 'ABSPATH' ) || exit;
 
-// Prevent memory crashes.
-if ( ! defined( 'WP_MEMORY_LIMIT' ) ) {
-	define( 'WP_MEMORY_LIMIT', '256M' );
-}
-
-// Prevent execution timeout crashes.
-if ( ! ini_get( 'safe_mode' ) ) {
-	set_time_limit( 60 );
-}
-
 // Add error handler to catch fatal errors.
 register_shutdown_function(
 	function() {


### PR DESCRIPTION
## Summary
- remove unconditional WP memory limit increase and time limit extension

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Call to undefined function is_admin in jetpack-compatibility.test.php)*

------
https://chatgpt.com/codex/tasks/task_e_68b60e5f42848331af9f306023e17b84