### PR TITLE
Add WordPress readiness check

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -96,6 +96,10 @@ class RTBCB_Main {
 	*/
 	private function __construct() {
 		try {
+			if ( ! $this->check_wp_ready() ) {
+				return;
+			}
+
 			if ( $this->is_jetpack_request() ) {
 				return;
 			}
@@ -127,6 +131,21 @@ class RTBCB_Main {
 				'</p></div>';
 			} );
 		}
+	}
+
+	/**
+	* Check if WordPress environment is ready.
+	*
+	* @return bool
+	*/
+	private function check_wp_ready() {
+		return (
+			function_exists( 'add_action' ) &&
+			function_exists( 'wp_die' ) &&
+			function_exists( 'get_option' ) &&
+			defined( 'ABSPATH' ) &&
+			did_action( 'init' ) !== false
+		);
 	}
 
 	/**

--- a/tests/jetpack-cron.test.php
+++ b/tests/jetpack-cron.test.php
@@ -32,6 +32,11 @@ if ( ! function_exists( 'add_action' ) ) {
 	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
 	}
 }
+if ( ! function_exists( 'is_admin' ) ) {
+	function is_admin() {
+		return false;
+	}
+}
 
 $_SERVER['HTTP_X_JETPACK_SIGNATURE'] = 'sig';
 

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -14,6 +14,19 @@ if ( ! function_exists( 'add_action' ) ) {
 if ( ! function_exists( 'do_action' ) ) {
 	function do_action( $tag, ...$args ) {}
 }
+if ( ! function_exists( 'wp_die' ) ) {
+	function wp_die( $message = '' ) {}
+}
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $tag ) {
+		return 1;
+	}
+}
+if ( ! function_exists( 'is_admin' ) ) {
+	function is_admin() {
+		return false;
+	}
+}
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( $option, $default = false ) {
 		return $default;


### PR DESCRIPTION
## Summary
- guard plugin initialization with a WordPress readiness check
- add wp_die, did_action, and is_admin stubs for tests
- stub is_admin in jetpack cron test

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b60e99823883318989f881f36d3fc9