### PR TITLE
Relocate fatal error handler registration

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -12,15 +12,6 @@
 */
 defined( 'ABSPATH' ) || exit;
 
-// Add error handler to catch fatal errors.
-register_shutdown_function(
-	function() {
-		$error = error_get_last();
-		if ( $error && in_array( $error['type'], [ E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR ], true ) ) {
-			error_log( 'RTBCB Fatal Error: ' . $error['message'] . ' in ' . $error['file'] . ':' . $error['line'] );
-		}
-	}
-);
 
 define( 'RTBCB_VERSION', '2.1.9' );
 define( 'RTBCB_FILE', __FILE__ );
@@ -86,6 +77,16 @@ class RTBCB_Main {
 	*/
 	private function __construct() {
 		try {
+			// Add error handler to catch fatal errors.
+			register_shutdown_function(
+				function() {
+					$error = error_get_last();
+					if ( $error && in_array( $error['type'], [ E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR ], true ) ) {
+						error_log( 'RTBCB Fatal Error: ' . $error['message'] . ' in ' . $error['file'] . ':' . $error['line'] );
+					}
+				}
+			);
+
 			if ( $this->is_jetpack_request() ) {
 				return;
 			}


### PR DESCRIPTION
## Summary
- register the fatal error handler during class construction rather than at file load

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*
- `vendor/bin/phpcs --standard=WordPress real-treasury-business-case-builder.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6121b16ec8331b962e20dd5d8ba87