### PR TITLE
Add is_admin stub for Jetpack compatibility test

### DIFF
--- a/tests/jetpack-compatibility.test.php
+++ b/tests/jetpack-compatibility.test.php
@@ -5,10 +5,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 defined( 'ABSPATH' ) || exit;
 require_once __DIR__ . '/wp-stubs.php';
 
+if ( ! function_exists( 'is_admin' ) ) {
+        function is_admin() {
+                return false;
+        }
+}
+
 if ( ! function_exists( 'plugin_dir_url' ) ) {
-	function plugin_dir_url( $file ) {
-		return '';
-	}
+        function plugin_dir_url( $file ) {
+                return '';
+        }
 }
 if ( ! function_exists( 'plugin_dir_path' ) ) {
 	function plugin_dir_path( $file ) {


### PR DESCRIPTION
## Summary
- prevent fatal error in Jetpack compatibility check by stubbing `is_admin`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b6140d58088331ae0dcf651d60213a