### PR TITLE
Ensure API logs capture user email and company name

### DIFF
--- a/inc/class-rtbcb-api-log.php
+++ b/inc/class-rtbcb-api-log.php
@@ -124,7 +124,15 @@ class RTBCB_API_Log {
 		global $wpdb;
 
 		if ( empty( self::$table_name ) ) {
-			self::init();
+		self::init();
+		}
+		
+		if ( empty( $user_email ) && ! empty( $request['email'] ) ) {
+		$user_email = $request['email'];
+		}
+		
+		if ( empty( $company_name ) && ! empty( $request['company_name'] ) ) {
+		$company_name = $request['company_name'];
 		}
 
 		$request_json  = wp_json_encode( $request );

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2785,9 +2785,8 @@ $max_output_tokens = min( 128000, max( $min_tokens, $max_output_tokens ) );
 			error_log( 'RTBCB: Malformed LLM response: ' . $response_body );
 
 			if ( class_exists( 'RTBCB_API_Log' ) ) {
-				$company      = rtbcb_get_current_company();
-				$user_email   = $this->current_inputs['email'] ?? ( $company['email'] ?? '' );
-				$company_name = $this->current_inputs['company_name'] ?? ( $company['name'] ?? '' );
+				$user_email   = $this->current_inputs['email'] ?? '';
+				$company_name = $this->current_inputs['company_name'] ?? '';
 				RTBCB_API_Log::save_log( $body, [ 'raw_body' => $response_body ], get_current_user_id(), $user_email, $company_name );
 			}
 
@@ -2805,9 +2804,8 @@ $max_output_tokens = min( 128000, max( $min_tokens, $max_output_tokens ) );
 		$this->last_response = $response;
 
 		if ( class_exists( 'RTBCB_API_Log' ) ) {
-			$company      = rtbcb_get_current_company();
-			$user_email   = $this->current_inputs['email'] ?? ( $company['email'] ?? '' );
-			$company_name = $this->current_inputs['company_name'] ?? ( $company['name'] ?? '' );
+			$user_email   = $this->current_inputs['email'] ?? '';
+			$company_name = $this->current_inputs['company_name'] ?? '';
 			RTBCB_API_Log::save_log( $body, $decoded, get_current_user_id(), $user_email, $company_name );
 		}
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1562,19 +1562,18 @@ $api_key = function_exists( 'get_option' ) ? get_option( 'rtbcb_openai_api_key' 
 	}
 	delete_transient( 'rtbcb_openai_job_' . $job_id . '_body' );
 
-		$body_array = json_decode( $body, true );
-		if ( ! is_array( $body_array ) ) {
-				$body_array = [];
-		}
-
-		$company      = rtbcb_get_current_company();
-		$user_email   = isset( $company['email'] ) ? sanitize_email( $company['email'] ) : '';
-		$company_name = isset( $company['name'] ) ? sanitize_text_field( $company['name'] ) : '';
-
-$timeout = intval( function_exists( 'get_option' ) ? get_option( 'rtbcb_responses_timeout', 120 ) : 120 );
-if ( $timeout <= 0 ) {
-$timeout = 120;
-}
+	$body_array = json_decode( $body, true );
+	if ( ! is_array( $body_array ) ) {
+		$body_array = [];
+	}
+	
+	$user_email   = isset( $body_array['email'] ) ? sanitize_email( $body_array['email'] ) : '';
+	$company_name = isset( $body_array['company_name'] ) ? sanitize_text_field( $body_array['company_name'] ) : '';
+	
+	$timeout = intval( function_exists( 'get_option' ) ? get_option( 'rtbcb_responses_timeout', 120 ) : 120 );
+	if ( $timeout <= 0 ) {
+		$timeout = 120;
+	}
 
 		$response = rtbcb_wp_remote_post_with_retry(
 				'https://api.openai.com/v1/responses',


### PR DESCRIPTION
## Summary
- Populate user email and company name before saving API log entries
- Always pull email and company name from the submitted form data

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b61d736154833196a3122e6b145897