### PR TITLE
Handle background job exceptions

### DIFF
--- a/inc/class-rtbcb-background-job.php
+++ b/inc/class-rtbcb-background-job.php
@@ -104,8 +104,23 @@ $job_id,
 10,
 1
 );
-
+$result = null;
+try {
 $result = RTBCB_Ajax::process_comprehensive_case( $user_inputs, $job_id );
+} catch ( \Throwable $e ) {
+if ( function_exists( 'rtbcb_log_error' ) ) {
+rtbcb_log_error( 'Background job error', $e->getMessage() );
+}
+self::update_status(
+$job_id,
+'error',
+[
+'message' => $e->getMessage(),
+'percent' => 100,
+]
+);
+return;
+}
 
 if ( is_wp_error( $result ) ) {
 	self::update_status(


### PR DESCRIPTION
## Summary
- prevent background-job polling hang by catching throwable errors and marking job as failed
- add unit test ensuring thrown exceptions update job status

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b61dee56248331a8ccbbb8478bac6c