### PR TITLE
Handle missing cURL extension

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2656,6 +2656,9 @@ return new WP_Error( 'heavy_features_disabled', __( 'AI features temporarily dis
 if ( empty( $this->api_key ) ) {
 return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
 }
+if ( ! function_exists( 'curl_init' ) ) {
+return new WP_Error( 'missing_curl', __( 'The cURL PHP extension is required.', 'rtbcb' ) );
+}
 
 $endpoint         = 'https://api.openai.com/v1/responses'; // Correct endpoint.
 $model_name       = sanitize_text_field( $model ?: 'gpt-5-mini' );

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1452,10 +1452,13 @@ $api_key = function_exists( 'get_option' ) ? get_option( 'rtbcb_openai_api_key' 
 if ( empty( $api_key ) ) {
 wp_send_json_error( [ 'message' => __( 'OpenAI API key not configured.', 'rtbcb' ) ], 500 );
 }
+if ( ! function_exists( 'curl_init' ) ) {
+wp_send_json_error( [ 'message' => __( 'The cURL PHP extension is required.', 'rtbcb' ) ], 500 );
+}
 
-	if ( isset( $_POST['nonce'] ) ) {
-		check_ajax_referer( 'rtbcb_openai_responses', 'nonce' );
-	}
+        if ( isset( $_POST['nonce'] ) ) {
+                check_ajax_referer( 'rtbcb_openai_responses', 'nonce' );
+        }
 
 	$body = isset( $_POST['body'] ) ? wp_unslash( $_POST['body'] ) : '';
 	if ( '' === $body ) {


### PR DESCRIPTION
## Summary
- Prevent fatal errors if the cURL PHP extension is unavailable by returning clear WP_Error messages
- Stop OpenAI proxy requests when cURL is missing to provide immediate user feedback

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b620f907648331a8302eab26e158f3