### PR TITLE
Support environment-based OpenAI API key configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ For manual verification during development, `debug_ajax_handler()` includes runt
 
 - **Missing API Key Logging**
   ```php
-  if ( '' === get_option( 'rtbcb_openai_api_key' ) ) {
+  if ( ! rtbcb_has_openai_api_key() ) {
       error_log( 'rtbcb_openai_api_key option is empty' );
   }
   ```

--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -403,9 +403,9 @@ $enable_charts = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_setting(
 	* @return void
 	*/
 	public function render_test_dashboard() {
-		$test_results   = get_option( 'rtbcb_test_results', [] );
-		$openai_key     = get_option( 'rtbcb_openai_api_key', '' );
-		$openai_status  = empty( $openai_key ) ? false : true;
+               $test_results   = get_option( 'rtbcb_test_results', [] );
+               $openai_key     = rtbcb_get_openai_api_key();
+               $openai_status  = rtbcb_has_openai_api_key();
 		$portal_active   = $this->check_portal_integration();
 		$rag_health_info = $this->check_rag_health();
 		$rag_health      = ( 'healthy' === ( $rag_health_info['status'] ?? '' ) );
@@ -649,10 +649,10 @@ $enable_charts = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_setting(
 			wp_send_json_error( [ 'message' => __( 'Permission denied.', 'rtbcb' ) ], 403 );
 		}
 
-		$api_key = get_option( 'rtbcb_openai_api_key' );
-		if ( empty( $api_key ) ) {
-			wp_send_json_error( [ 'message' => __( 'Missing API key.', 'rtbcb' ) ] );
-		}
+               $api_key = rtbcb_get_openai_api_key();
+               if ( ! rtbcb_has_openai_api_key() ) {
+                       wp_send_json_error( [ 'message' => __( 'Missing API key.', 'rtbcb' ) ] );
+               }
 
 		$cache_key = 'rtbcb_openai_models';
 		$response  = wp_cache_get( $cache_key );

--- a/admin/dashboard-page.php
+++ b/admin/dashboard-page.php
@@ -17,8 +17,8 @@ $roi_stats = $stats['average_roi'] ?? [];
 $leads = $recent_leads_data['leads'] ?? [];
 
 // System health checks
-$api_key       = get_option( 'rtbcb_openai_api_key' );
-$api_key_configured = ! empty( $api_key );
+$api_key       = rtbcb_get_openai_api_key();
+$api_key_configured = rtbcb_has_openai_api_key();
 $api_key_valid = $api_key_configured && rtbcb_is_valid_openai_api_key( $api_key );
 $portal_active = (bool) ( has_filter( 'rt_portal_get_vendors' ) || has_filter( 'rt_portal_get_vendor_notes' ) );
 $last_indexed  = get_option( 'rtbcb_last_indexed', '' );

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -9,7 +9,7 @@ if ( ! current_user_can( 'manage_options' ) ) {
 	return;
 }
 
-$api_key         = function_exists( 'get_option' ) ? get_option( 'rtbcb_openai_api_key', '' ) : '';
+$api_key         = rtbcb_get_openai_api_key();
 $mini_model      = function_exists( 'get_option' ) ? get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) ) : rtbcb_get_default_model( 'mini' );
 $premium_model   = function_exists( 'get_option' ) ? get_option( 'rtbcb_premium_model', rtbcb_get_default_model( 'premium' ) ) : rtbcb_get_default_model( 'premium' );
 $advanced_model  = function_exists( 'get_option' ) ? get_option( 'rtbcb_advanced_model', rtbcb_get_default_model( 'advanced' ) ) : rtbcb_get_default_model( 'advanced' );

--- a/inc/class-rtbcb-rag.php
+++ b/inc/class-rtbcb-rag.php
@@ -207,9 +207,9 @@ class RTBCB_RAG {
 	* @return array Embedding vector.
 	*/
 	private function get_embedding( $text ) {
-$api_key = function_exists( 'get_option' ) ? get_option( 'rtbcb_openai_api_key' ) : '';
-$model   = function_exists( 'get_option' ) ? get_option( 'rtbcb_embedding_model', 'text-embedding-3-small' ) : 'text-embedding-3-small';
-
+		$api_key = rtbcb_get_openai_api_key();
+		$model   = function_exists( 'get_option' ) ? get_option( 'rtbcb_embedding_model', 'text-embedding-3-small' ) : 'text-embedding-3-small';
+	
 		if ( empty( $api_key ) ) {
 			return [];
 		}

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1033,13 +1033,13 @@ function rtbcb_test_generate_category_recommendation( $analysis ) {
 	];
 
 	try {
-$api_key = function_exists( 'get_option' ) ? get_option( 'rtbcb_openai_api_key' ) : '';
-if ( empty( $api_key ) ) {
-return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-}
+		$api_key = rtbcb_get_openai_api_key();
+		if ( ! rtbcb_has_openai_api_key() ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
 
-$model_option = function_exists( 'get_option' ) ? get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) ) : rtbcb_get_default_model( 'mini' );
-$model        = function_exists( 'sanitize_text_field' ) ? sanitize_text_field( $model_option ) : $model_option;
+		$model_option = function_exists( 'get_option' ) ? get_option( 'rtbcb_mini_model', rtbcb_get_default_model( 'mini' ) ) : rtbcb_get_default_model( 'mini' );
+		$model        = function_exists( 'sanitize_text_field' ) ? sanitize_text_field( $model_option ) : $model_option;
 
 		$system_prompt = 'You are a treasury technology advisor. Based on the company overview, industry insights, technology overview, and treasury challenges provided, recommend the most suitable solution category (cash_tools, tms_lite, trms). Return JSON with keys "recommended", "reasoning", and "alternatives" (array of objects with "category" and "reasoning").';
 
@@ -1460,13 +1460,13 @@ function rtbcb_parse_gpt5_business_case_response( $response ) {
 	* @return void
 	*/
 function rtbcb_proxy_openai_responses() {
-$api_key = function_exists( 'get_option' ) ? get_option( 'rtbcb_openai_api_key' ) : '';
-if ( empty( $api_key ) ) {
-wp_send_json_error( [ 'message' => __( 'OpenAI API key not configured.', 'rtbcb' ) ], 500 );
-}
-if ( ! function_exists( 'curl_init' ) ) {
-wp_send_json_error( [ 'message' => __( 'The cURL PHP extension is required.', 'rtbcb' ) ], 500 );
-}
+		$api_key = rtbcb_get_openai_api_key();
+		if ( ! rtbcb_has_openai_api_key() ) {
+			wp_send_json_error( [ 'message' => __( 'OpenAI API key not configured.', 'rtbcb' ) ], 500 );
+		}
+		if ( ! function_exists( 'curl_init' ) ) {
+			wp_send_json_error( [ 'message' => __( 'The cURL PHP extension is required.', 'rtbcb' ) ], 500 );
+		}
 
         if ( isset( $_POST['nonce'] ) ) {
                 check_ajax_referer( 'rtbcb_openai_responses', 'nonce' );
@@ -1550,8 +1550,8 @@ function rtbcb_handle_openai_responses_job( $job_id, $user_id ) {
 	$job_id  = sanitize_key( $job_id );
 	$user_id = intval( $user_id );
 
-$api_key = function_exists( 'get_option' ) ? get_option( 'rtbcb_openai_api_key' ) : '';
-	if ( empty( $api_key ) ) {
+	$api_key = rtbcb_get_openai_api_key();
+	if ( ! rtbcb_has_openai_api_key() ) {
 		set_transient(
 			'rtbcb_openai_job_' . $job_id,
 			[

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -60,16 +60,28 @@ function rtbcb_get_analysis_type() {
 }
 
 /**
-	* Retrieve the OpenAI API key from plugin settings.
+	* Retrieve the OpenAI API key from environment or plugin settings.
 	*
-	* Reads the value stored in the WordPress options table.
+	* Checks the `RTBCB_OPENAI_API_KEY` environment variable first and falls back
+	* to the value stored in the WordPress options table.
 	*
 	* @return string Sanitized API key.
 	*/
 function rtbcb_get_openai_api_key() {
-       $api_key = function_exists( 'get_option' ) ? get_option( 'rtbcb_openai_api_key', '' ) : '';
-
-       return function_exists( 'sanitize_text_field' ) ? sanitize_text_field( $api_key ) : $api_key;
+	$api_key = '';
+	
+	if ( function_exists( 'getenv' ) ) {
+		$env_key = getenv( 'RTBCB_OPENAI_API_KEY' );
+		if ( false !== $env_key && '' !== $env_key ) {
+			$api_key = $env_key;
+		}
+	}
+	
+	if ( '' === $api_key && function_exists( 'get_option' ) ) {
+		$api_key = get_option( 'rtbcb_openai_api_key', '' );
+	}
+	
+	return function_exists( 'sanitize_text_field' ) ? sanitize_text_field( $api_key ) : $api_key;
 }
 
 /**

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1956,7 +1956,7 @@ public function generate_business_analysis( $user_inputs, $scenarios, $recommend
 			'lead_id'		 => $lead_id,
 			'company_name'		 => $user_inputs['company_name'],
 			'analysis_type'		 => rtbcb_get_analysis_type(),
-			'api_used'		 => ! empty( get_option( 'rtbcb_openai_api_key' ) ),
+			'api_used'               => rtbcb_has_openai_api_key(),
 			'fallback_used'		 => isset( $comprehensive_analysis['enhanced_fallback'] ),
 			'memory_info'		 => rtbcb_get_memory_status(),
 		];
@@ -2449,8 +2449,8 @@ public function generate_business_analysis( $user_inputs, $scenarios, $recommend
 	}
 
 	public function admin_notices() {
-		// Check if API key is configured
-		if ( current_user_can( 'manage_options' ) && empty( get_option( 'rtbcb_openai_api_key' ) ) ) {
+	// Check if API key is configured
+	if ( current_user_can( 'manage_options' ) && ! rtbcb_has_openai_api_key() ) {
 		$settings_url = admin_url( 'admin.php?page=rtbcb-settings' );
 		echo '<div class="notice notice-warning is-dismissible">';
 		echo '<p>';
@@ -2683,7 +2683,6 @@ public function generate_business_analysis( $user_inputs, $scenarios, $recommend
 		$nonce_valid = wp_verify_nonce( $nonce, 'rtbcb_debug' );
 
 		$post_keys = array_map( 'sanitize_key', array_keys( $_POST ) );
-		$api_key   = get_option( 'rtbcb_openai_api_key', '' );
 
 		global $wpdb;
 		$table_name   = $wpdb->prefix . 'rtbcb_leads';
@@ -2694,7 +2693,7 @@ public function generate_business_analysis( $user_inputs, $scenarios, $recommend
 		'required_classes' => class_exists( 'RTBCB_Calculator' ) && class_exists( 'RTBCB_DB' ),
 		'nonce_valid'	   => $nonce_valid,
 		'post_keys'	   => $post_keys,
-		'api_key_present'  => ! empty( $api_key ),
+		'api_key_present'  => rtbcb_has_openai_api_key(),
 		'db_table_exists'  => $table_exists,
 		'memory_usage'	   => size_format( memory_get_usage( true ) ),
 		];
@@ -2753,7 +2752,7 @@ public function generate_business_analysis( $user_inputs, $scenarios, $recommend
 		'enhanced_css_exists'	      => file_exists( RTBCB_DIR . 'public/css/enhanced-report.css' ),
 		'chart_js_exists'	      => file_exists( RTBCB_DIR . 'public/js/chart.min.js' ),
 		'comprehensive_analysis_enabled' => get_option( 'rtbcb_comprehensive_analysis', true ),
-		'openai_key_configured'	      => ! empty( get_option( 'rtbcb_openai_api_key' ) ),
+		'openai_key_configured'       => rtbcb_has_openai_api_key(),
 		'required_classes'	      => [
 		'RTBCB_Calculator'	    => class_exists( 'RTBCB_Calculator' ),
 		'RTBCB_Category_Recommender'=> class_exists( 'RTBCB_Category_Recommender' ),
@@ -2879,9 +2878,9 @@ if ( ! function_exists( 'rtbcb_is_configured' ) ) {
 	*
 	* @return bool
 	*/
-	function rtbcb_is_configured() {
-		return ! empty( get_option( 'rtbcb_openai_api_key' ) );
-	}
+function rtbcb_is_configured() {
+	return rtbcb_has_openai_api_key();
+}
 }
 
 


### PR DESCRIPTION
## Summary
- Allow `RTBCB_OPENAI_API_KEY` environment variable to supply the OpenAI key, falling back to the existing `rtbcb_openai_api_key` option
- Use the helper when retrieving the key for RAG embeddings to keep access consistent

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b6233a855c83319f9ca48a1ef17ade