### PR TITLE
Add debug logging and nonce check to AJAX handler

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2833,13 +2833,26 @@ if ( ! function_exists( 'rtbcb_ajax_generate_case' ) ) {
 	 *
 	 * @return void
 	 */
-	function rtbcb_ajax_generate_case() {
-		if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
-			wp_die( __( 'Invalid request', 'rtbcb' ) );
-		}
+       function rtbcb_ajax_generate_case() {
+               error_log( 'RTBCB: AJAX request received - Action: rtbcb_generate_case' );
+               error_log( 'RTBCB: POST data keys: ' . implode( ', ', array_keys( $_POST ) ) );
+               error_log( 'RTBCB: User agent: ' . ( $_SERVER['HTTP_USER_AGENT'] ?? 'unknown' ) );
 
-		RTBCB_Ajax::generate_comprehensive_case();
-	}
+               if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
+                       error_log( 'RTBCB: Not an AJAX request' );
+                       wp_die( __( 'Invalid request', 'rtbcb' ) );
+               }
+
+               if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
+                       error_log( 'RTBCB: Nonce verification failed' );
+                       error_log( 'RTBCB: Expected action: rtbcb_generate' );
+                       error_log( 'RTBCB: Provided nonce: ' . ( $_POST['rtbcb_nonce'] ?? 'none' ) );
+                       wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
+                       return;
+               }
+
+               RTBCB_Ajax::generate_comprehensive_case();
+       }
 }
 
 // Helper functions for use in templates and other plugins


### PR DESCRIPTION
## Summary
- add detailed debug logs to `rtbcb_ajax_generate_case` AJAX handler
- enforce nonce verification and log failures in AJAX handler

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b625fe0ae883319964bbf78d1296b2