### PR TITLE
Improve AJAX handler memory handling

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -852,17 +852,24 @@ function rtbcb_increase_memory_limit() {
 	}
 }
 
-function rtbcb_log_memory_usage( $stage ) {
-	$usage = memory_get_usage( true );
-	$peak  = memory_get_peak_usage( true );
-	error_log(
-		sprintf(
-			'RTBCB Memory [%s]: Current: %s, Peak: %s',
-			$stage,
-			size_format( $usage ),
-			size_format( $peak )
-		)
-	);
+/**
+ * Log memory usage at a checkpoint.
+ *
+ * @param string $checkpoint Checkpoint label.
+ *
+ * @return void
+ */
+function rtbcb_log_memory_usage( $checkpoint ) {
+        $usage = memory_get_usage( true );
+        $peak  = memory_get_peak_usage( true );
+        error_log(
+                sprintf(
+                        'RTBCB Memory [%s]: Current: %s, Peak: %s',
+                        $checkpoint,
+                        size_format( $usage ),
+                        size_format( $peak )
+                )
+        );
 }
 
 function rtbcb_get_memory_status() {

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2830,16 +2830,25 @@ if ( ! defined( 'RTBCB_NO_BOOTSTRAP' ) ) {
 if ( ! function_exists( 'rtbcb_ajax_generate_case' ) ) {
 	/**
 	 * Handle AJAX requests for comprehensive case generation.
-	 *
-	 * @return void
-	 */
-	function rtbcb_ajax_generate_case() {
-		if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
-			wp_die( __( 'Invalid request', 'rtbcb' ) );
-		}
+        *
+        * @return void
+        */
+       function rtbcb_ajax_generate_case() {
+               if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
+                       wp_die( __( 'Invalid request', 'rtbcb' ) );
+               }
 
-		RTBCB_Ajax::generate_comprehensive_case();
-	}
+               rtbcb_increase_memory_limit();
+
+               $timeout = absint( rtbcb_get_api_timeout() );
+               if ( ! ini_get( 'safe_mode' ) && $timeout > 0 ) {
+                       set_time_limit( $timeout );
+               }
+
+               rtbcb_log_memory_usage( 'ajax_start' );
+
+               RTBCB_Ajax::generate_comprehensive_case();
+       }
 }
 
 // Helper functions for use in templates and other plugins

--- a/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
+++ b/tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
@@ -75,7 +75,7 @@ if ( ! function_exists( 'rtbcb_increase_memory_limit' ) ) {
 }
 
 if ( ! function_exists( 'rtbcb_log_memory_usage' ) ) {
-	function rtbcb_log_memory_usage( $stage ) {}
+	function rtbcb_log_memory_usage( $checkpoint ) {}
 }
 
 if ( ! class_exists( 'RTBCB_LLM' ) ) {


### PR DESCRIPTION
## Summary
- expand AJAX report generator to raise memory limit and set runtime based on `rtbcb_get_api_timeout`
- add memory usage logging helper with documentation

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b62613d34483319a20f053c06e8569