### PR TITLE
Improve AJAX handler memory handling

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -947,7 +947,10 @@ return $use_comprehensive;
 
 		$timeout = absint( rtbcb_get_api_timeout() );
 		if ( ! ini_get( 'safe_mode' ) && $timeout > 0 ) {
-			set_time_limit( $timeout );
+			$disabled_functions = array_map( 'trim', explode( ',', ini_get( 'disable_functions' ) ) );
+			if ( function_exists( 'set_time_limit' ) && ! in_array( 'set_time_limit', $disabled_functions, true ) ) {
+				set_time_limit( $timeout );
+			}
 		}
 
 		// Collect and validate user inputs.
@@ -1416,7 +1419,10 @@ public function generate_business_analysis( $user_inputs, $scenarios, $recommend
 	rtbcb_increase_memory_limit();
 	$timeout = absint( rtbcb_get_api_timeout() );
 	if ( ! ini_get( 'safe_mode' ) && $timeout > 0 ) {
-		set_time_limit( $timeout );
+		$disabled_functions = array_map( 'trim', explode( ',', ini_get( 'disable_functions' ) ) );
+		if ( function_exists( 'set_time_limit' ) && ! in_array( 'set_time_limit', $disabled_functions, true ) ) {
+			set_time_limit( $timeout );
+		}
 	}
 
 		try {
@@ -1461,7 +1467,10 @@ public function generate_business_analysis( $user_inputs, $scenarios, $recommend
 			);
 			return;
 		}
-		set_time_limit( $timeout );
+		$disabled_functions = array_map( 'trim', explode( ',', ini_get( 'disable_functions' ) ) );
+		if ( function_exists( 'set_time_limit' ) && ! in_array( 'set_time_limit', $disabled_functions, true ) ) {
+			set_time_limit( $timeout );
+		}
 		}
 
 		// Clear any buffered output before sending JSON responses.
@@ -2842,7 +2851,10 @@ if ( ! function_exists( 'rtbcb_ajax_generate_case' ) ) {
 
                $timeout = absint( rtbcb_get_api_timeout() );
                if ( ! ini_get( 'safe_mode' ) && $timeout > 0 ) {
-                       set_time_limit( $timeout );
+                       $disabled_functions = array_map( 'trim', explode( ',', ini_get( 'disable_functions' ) ) );
+                       if ( function_exists( 'set_time_limit' ) && ! in_array( 'set_time_limit', $disabled_functions, true ) ) {
+                               set_time_limit( $timeout );
+                       }
                }
 
                rtbcb_log_memory_usage( 'ajax_start' );


### PR DESCRIPTION
## Summary
- expand AJAX report generator to raise memory limit and set runtime based on `rtbcb_get_api_timeout`
- add memory usage logging helper with documentation
- guard `set_time_limit` calls when the function is disabled

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b62a2c7834833194eb6d669dc996b6