### PR TITLE
Improve AJAX memory and timeout handling

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -12,10 +12,17 @@ class RTBCB_Ajax {
 	*
 	* @return void
 	*/
-               public static function generate_comprehensive_case() {
-                               if ( ! function_exists( 'check_ajax_referer' ) ) {
-                                               wp_die( 'WordPress not ready' );
-                               }
+	public static function generate_comprehensive_case() {
+		rtbcb_increase_memory_limit();
+		$timeout = absint( rtbcb_get_api_timeout() );
+		if ( ! ini_get( 'safe_mode' ) && $timeout > 0 ) {
+			set_time_limit( $timeout );
+		}
+		rtbcb_log_memory_usage( 'start' );
+
+		if ( ! function_exists( 'check_ajax_referer' ) ) {
+			wp_die( 'WordPress not ready' );
+		}
 
                                if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
                                                wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
@@ -47,10 +54,17 @@ class RTBCB_Ajax {
 		*
 		* @return void
 		*/
-                public static function stream_analysis() {
-                                if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
-                                                wp_die( 'Invalid request' );
-                                }
+	public static function stream_analysis() {
+		rtbcb_increase_memory_limit();
+		$timeout = absint( rtbcb_get_api_timeout() );
+		if ( ! ini_get( 'safe_mode' ) && $timeout > 0 ) {
+			set_time_limit( $timeout );
+		}
+		rtbcb_log_memory_usage( 'start' );
+
+		if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
+			wp_die( 'Invalid request' );
+		}
 
                                 if ( ! function_exists( 'check_ajax_referer' ) ) {
                                                 wp_die( 'WordPress not ready' );

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -852,17 +852,17 @@ function rtbcb_increase_memory_limit() {
 	}
 }
 
-function rtbcb_log_memory_usage( $stage ) {
+/**
+	* Log current and peak memory usage.
+	*
+	* @param string $checkpoint Identifier for log position.
+	* @return void
+	*/
+function rtbcb_log_memory_usage( $checkpoint ) {
 	$usage = memory_get_usage( true );
 	$peak  = memory_get_peak_usage( true );
-	error_log(
-		sprintf(
-			'RTBCB Memory [%s]: Current: %s, Peak: %s',
-			$stage,
-			size_format( $usage ),
-			size_format( $peak )
-		)
-	);
+
+	error_log( 'RTBCB Memory [' . $checkpoint . ']: Current=' . size_format( $usage ) . ', Peak=' . size_format( $peak ) );
 }
 
 function rtbcb_get_memory_status() {

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -21,6 +21,7 @@ if ( ! defined( 'RTBCB_DEBUG' ) ) {
 define( 'RTBCB_DEBUG', false );
 }
 
+
 if ( ! function_exists( 'rt_bcb_log' ) ) {
 /**
  * Simple logger for debugging.
@@ -306,7 +307,8 @@ return true;
 		       error_log( 'RTBCB: Fatal error during class loading: ' . $e->getMessage() );
 		       return false;
 	       }
-       }
+	}
+
 
 	/**
 	* Plugin initialization.
@@ -2853,25 +2855,35 @@ if ( ! function_exists( 'rtbcb_ajax_generate_case' ) ) {
 	 *
 	 * @return void
 	 */
-       function rtbcb_ajax_generate_case() {
-               error_log( 'RTBCB: AJAX request received - Action: rtbcb_generate_case' );
-               error_log( 'RTBCB: POST data keys: ' . implode( ', ', array_keys( $_POST ) ) );
-               error_log( 'RTBCB: User agent: ' . ( $_SERVER['HTTP_USER_AGENT'] ?? 'unknown' ) );
+	function rtbcb_ajax_generate_case() {
+		rtbcb_increase_memory_limit();
+		$timeout = absint( rtbcb_get_api_timeout() );
+		if ( ! ini_get( 'safe_mode' ) && $timeout > 0 ) {
+			set_time_limit( $timeout );
+		}
 
-               if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
-                       error_log( 'RTBCB: Not an AJAX request' );
-                       wp_die( __( 'Invalid request', 'rtbcb' ) );
-               }
+		rtbcb_log_memory_usage( 'start' );
 
-               if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
-                       error_log( 'RTBCB: Nonce verification failed' );
-                       error_log( 'RTBCB: Expected action: rtbcb_generate' );
-                       error_log( 'RTBCB: Provided nonce: ' . ( $_POST['rtbcb_nonce'] ?? 'none' ) );
-                       wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
-                       return;
-               }
+		error_log( 'RTBCB: AJAX request received - Action: rtbcb_generate_case' );
+		error_log( 'RTBCB: POST data keys: ' . implode( ', ', array_keys( $_POST ) ) );
+		error_log( 'RTBCB: User agent: ' . ( $_SERVER['HTTP_USER_AGENT'] ?? 'unknown' ) );
 
-               RTBCB_Ajax::generate_comprehensive_case();
+		if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
+			error_log( 'RTBCB: Not an AJAX request' );
+			wp_die( __( 'Invalid request', 'rtbcb' ) );
+		}
+
+
+		if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
+			error_log( 'RTBCB: Nonce verification failed' );
+			error_log( 'RTBCB: Expected action: rtbcb_generate' );
+			error_log( 'RTBCB: Provided nonce: ' . ( $_POST['rtbcb_nonce'] ?? 'none' ) );
+			wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
+			return;
+		}
+
+
+		RTBCB_Ajax::generate_comprehensive_case();
        }
 }
 


### PR DESCRIPTION
## Summary
- Raise memory and execution time limits at start of report generation AJAX endpoints
- Add memory usage logger helper for monitoring
- Log initial memory usage in AJAX handlers

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b62a6543948331900ef36d42b89c2d