### PR TITLE
Guard memory helpers behind WP readiness checks

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -13,6 +13,10 @@ class RTBCB_Ajax {
 	* @return void
 	*/
 	public static function generate_comprehensive_case() {
+		if ( ! function_exists( 'check_ajax_referer' ) ) {
+			wp_die( 'WordPress not ready' );
+		}
+
 		rtbcb_increase_memory_limit();
 		$timeout = absint( rtbcb_get_api_timeout() );
 		if ( ! ini_get( 'safe_mode' ) && $timeout > 0 ) {
@@ -20,9 +24,6 @@ class RTBCB_Ajax {
 		}
 		rtbcb_log_memory_usage( 'start' );
 
-		if ( ! function_exists( 'check_ajax_referer' ) ) {
-			wp_die( 'WordPress not ready' );
-		}
 
                                if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
                                                wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );
@@ -55,12 +56,6 @@ class RTBCB_Ajax {
 		* @return void
 		*/
 	public static function stream_analysis() {
-		rtbcb_increase_memory_limit();
-		$timeout = absint( rtbcb_get_api_timeout() );
-		if ( ! ini_get( 'safe_mode' ) && $timeout > 0 ) {
-			set_time_limit( $timeout );
-		}
-		rtbcb_log_memory_usage( 'start' );
 
 		if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
 			wp_die( 'Invalid request' );
@@ -69,6 +64,13 @@ class RTBCB_Ajax {
                                 if ( ! function_exists( 'check_ajax_referer' ) ) {
                                                 wp_die( 'WordPress not ready' );
                                 }
+
+		rtbcb_increase_memory_limit();
+		$timeout = absint( rtbcb_get_api_timeout() );
+		if ( ! ini_get( 'safe_mode' ) && $timeout > 0 ) {
+			set_time_limit( $timeout );
+		}
+		rtbcb_log_memory_usage( 'start' );
 
                                 if ( ! check_ajax_referer( 'rtbcb_generate', 'rtbcb_nonce', false ) ) {
                                                 wp_send_json_error( __( 'Security check failed.', 'rtbcb' ), 403 );


### PR DESCRIPTION
## Summary
- Move memory limit and logging helpers after verifying WordPress AJAX functions
- Avoid fatal errors when handlers are executed without a WordPress context

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b62d1fcb908331a063e34aebc364d9