### PR TITLE
Fix progress overlay escape handling

### DIFF
--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -522,7 +522,15 @@ if ( e.key === 'Escape' && progressContainer.style.display === 'flex' ) {
 if ( window.businessCaseBuilder && typeof window.businessCaseBuilder.cancelPolling === 'function' ) {
 window.businessCaseBuilder.cancelPolling();
 }
+if ( window.businessCaseBuilder && typeof window.businessCaseBuilder.hideLoading === 'function' ) {
+window.businessCaseBuilder.hideLoading();
+} else {
 progressContainer.style.display = 'none';
+const formContainer = document.querySelector( '.rtbcb-form-container' );
+if ( formContainer ) {
+formContainer.style.display = '';
+}
+}
 document.body.style.overflow = '';
 }
 } );


### PR DESCRIPTION
## Summary
- restore form container when progress overlay is closed via Escape

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b630faad90833188a93c7cff76af69