### PR TITLE
Link logs to leads for easier troubleshooting

### DIFF
--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -23,8 +23,9 @@ if ( ! current_user_can( 'manage_options' ) ) {
 		<table class="widefat fixed striped">
 			<thead>
 				<tr>
-					<th><?php esc_html_e( 'ID', 'rtbcb' ); ?></th>
-					<th><?php esc_html_e( 'Email', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'ID', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'Lead ID', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'Email', 'rtbcb' ); ?></th>
 					<th><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></th>
 					<th><?php esc_html_e( 'Request', 'rtbcb' ); ?></th>
 					<th><?php esc_html_e( 'Tokens', 'rtbcb' ); ?></th>
@@ -47,8 +48,9 @@ if ( ! current_user_can( 'manage_options' ) ) {
 						$status = isset( $response['error'] ) ? __( 'Error', 'rtbcb' ) : __( 'OK', 'rtbcb' );
 					?>
 					<tr data-id="<?php echo esc_attr( $log['id'] ); ?>" data-request="<?php echo esc_attr( $log['request_json'] ); ?>" data-response="<?php echo esc_attr( $log['response_json'] ); ?>">
-						<td><?php echo esc_html( $log['id'] ); ?></td>
-						<td><?php echo esc_html( $log['user_email'] ); ?></td>
+                                               <td><?php echo esc_html( $log['id'] ); ?></td>
+                                               <td><?php echo esc_html( $log['lead_id'] ); ?></td>
+                                               <td><?php echo esc_html( $log['user_email'] ); ?></td>
 						<td><?php echo esc_html( $log['company_name'] ); ?></td>
 						<td><?php echo esc_html( $summary ); ?></td>
 						<td><?php echo esc_html( $log['total_tokens'] ); ?></td>
@@ -65,9 +67,9 @@ if ( ! current_user_can( 'manage_options' ) ) {
 					</tr>
 					<?php endforeach; ?>
 				<?php else : ?>
-					<tr>
-						<td colspan="8"><?php esc_html_e( 'No logs found.', 'rtbcb' ); ?></td>
-					</tr>
+                                       <tr>
+                                               <td colspan="9"><?php esc_html_e( 'No logs found.', 'rtbcb' ); ?></td>
+                                       </tr>
 				<?php endif; ?>
 			</tbody>
 		</table>

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -303,11 +303,17 @@ class RTBCB_Leads {
 					return false;
 				}
 
-				self::update_cached_statistics();
-				if ( function_exists( 'rtbcb_clear_report_cache' ) ) {
-					rtbcb_clear_report_cache();
-				}
-				return intval( $existing_lead['id'] );
+                               self::update_cached_statistics();
+                               if ( function_exists( 'rtbcb_clear_report_cache' ) ) {
+                                       rtbcb_clear_report_cache();
+                               }
+                               if ( function_exists( 'rtbcb_set_current_lead' ) ) {
+                                       rtbcb_set_current_lead( $existing_lead['id'], $sanitized_data['email'] );
+                               }
+                               if ( class_exists( 'RTBCB_API_Log' ) ) {
+                                       RTBCB_API_Log::associate_lead( $existing_lead['id'], $sanitized_data['email'] );
+                               }
+                               return intval( $existing_lead['id'] );
 			} else {
 				// Insert new lead
 				$result = $wpdb->insert(
@@ -321,13 +327,19 @@ class RTBCB_Leads {
 					return false;
 				}
 
-				$lead_id = $wpdb->insert_id;
-				self::update_cached_statistics();
-				if ( function_exists( 'rtbcb_clear_report_cache' ) ) {
-					rtbcb_clear_report_cache();
-				}
-				return $lead_id;
-			}
+                               $lead_id = $wpdb->insert_id;
+                               self::update_cached_statistics();
+                               if ( function_exists( 'rtbcb_clear_report_cache' ) ) {
+                                       rtbcb_clear_report_cache();
+                               }
+                               if ( function_exists( 'rtbcb_set_current_lead' ) ) {
+                                       rtbcb_set_current_lead( $lead_id, $sanitized_data['email'] );
+                               }
+                               if ( class_exists( 'RTBCB_API_Log' ) ) {
+                                       RTBCB_API_Log::associate_lead( $lead_id, $sanitized_data['email'] );
+                               }
+                               return $lead_id;
+                       }
 		} catch ( Exception $e ) {
 			error_log( 'RTBCB: Exception in save_lead: ' . $e->getMessage() );
 			return false;

--- a/inc/class-rtbcb-logger.php
+++ b/inc/class-rtbcb-logger.php
@@ -15,12 +15,25 @@ class RTBCB_Logger {
 	 * @param array  $context Context data.
 	 * @return void
 	 */
-	public static function log( $event, $context = [] ) {
-		$record = [
-			'timestamp' => gmdate( 'c' ),
-			'event'     => $event,
-			'context'   => $context,
-		];
+       public static function log( $event, $context = [] ) {
+               if ( function_exists( 'rtbcb_get_current_lead' ) ) {
+                       $lead = rtbcb_get_current_lead();
+                       if ( $lead ) {
+                               $context = array_merge(
+                                       [
+                                               'lead_id'    => intval( $lead['id'] ),
+                                               'lead_email' => $lead['email'],
+                                       ],
+                                       $context
+                               );
+                       }
+               }
+
+               $record = [
+                       'timestamp' => gmdate( 'c' ),
+                       'event'     => $event,
+                       'context'   => $context,
+               ];
 
 		error_log( 'RTBCB_LOG: ' . wp_json_encode( $record ) );
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -824,26 +824,57 @@ function rtbcb_recursive_sanitize_text_field( $data ) {
 }
 
 /**
-	* Log API debug messages.
-	*
-	* @param string $message Log message.
-	* @param mixed  $data    Optional data.
-	* @return void
-	*/
+* Set the current lead context for logging.
+*
+* @param int    $lead_id    Lead ID.
+* @param string $lead_email Lead email address.
+* @return void
+*/
+function rtbcb_set_current_lead( $lead_id, $lead_email = '' ) {
+		$GLOBALS['rtbcb_current_lead'] = [
+	'id'    => intval( $lead_id ),
+	'email' => sanitize_email( $lead_email ),
+	];
+}
+
+/**
+* Retrieve the current lead context.
+*
+* @return array|null Array with 'id' and 'email' or null if not set.
+*/
+function rtbcb_get_current_lead() {
+		return isset( $GLOBALS['rtbcb_current_lead'] ) ? $GLOBALS['rtbcb_current_lead'] : null;
+}
+
+/**
+* Log API debug messages.
+*
+* @param string $message Log message.
+* @param mixed  $data    Optional data.
+* @return void
+*/
 function rtbcb_log_api_debug( $message, $data = null ) {
-	$log_message = 'RTBCB API Debug: ' . $message;
-	if ( $data ) {
-		$log_message .= ' - ' . wp_json_encode( $data );
-	}
-	error_log( $log_message );
+		$lead = rtbcb_get_current_lead();
+	if ( $lead ) {
+	$message .= ' [Lead ID: ' . $lead['id'] . ' Email: ' . $lead['email'] . ']';
+}
+$log_message = 'RTBCB API Debug: ' . $message;
+if ( $data ) {
+$log_message .= ' - ' . wp_json_encode( $data );
+}
+error_log( $log_message );
 }
 
 function rtbcb_log_error( $message, $context = null ) {
-	$log_message = 'RTBCB Error: ' . $message;
-	if ( $context ) {
-		$log_message .= ' - Context: ' . wp_json_encode( $context );
-	}
-	error_log( $log_message );
+		$lead = rtbcb_get_current_lead();
+	if ( $lead ) {
+	$message .= ' [Lead ID: ' . $lead['id'] . ' Email: ' . $lead['email'] . ']';
+}
+$log_message = 'RTBCB Error: ' . $message;
+if ( $context ) {
+$log_message .= ' - Context: ' . wp_json_encode( $context );
+}
+error_log( $log_message );
 }
 
 function rtbcb_setup_ajax_logging() {


### PR DESCRIPTION
## Summary
- capture current lead info and attach it to log messages
- store lead IDs in API logs and associate logs with saved leads
- show linked lead IDs in the API Logs admin page

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b6319aa6888331a948a9b071aef308