### PR TITLE
Fix progress overlay sizing

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -355,10 +355,9 @@ html {
 
 .rtbcb-progress-overlay {
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
+    inset: 0;
+    width: 100%;
+    height: 100%;
     background: rgba(0, 0, 0, 0.8);
     backdrop-filter: blur(4px);
     display: flex;


### PR DESCRIPTION
## Summary
- ensure progress overlay fills viewport without overflowing by using `inset:0` and 100% width/height

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b637b1230c8331a869546df7c39457