### PR TITLE
Refactor comprehensive case parsing

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -213,7 +213,6 @@ function rtbcb_is_openai_configuration_error( $e ) {
 	* @return array Current company data.
 	*/
 function rtbcb_get_current_company() {
-return function_exists( 'get_option' ) ? get_option( 'rtbcb_current_company', [] ) : [];
 }
 
 /**
@@ -342,7 +341,6 @@ $test_results = function_exists( 'get_option' ) ? get_option( 'rtbcb_test_result
 		$sections = [
 		'rtbcb-test-company-overview'      => [
 			'label'    => __( 'Company Overview', 'rtbcb' ),
-			'option'   => 'rtbcb_current_company',
 			'requires' => [],
 			'phase'    => 1,
 			'action'   => 'rtbcb_test_company_overview',
@@ -363,7 +361,6 @@ $test_results = function_exists( 'get_option' ) ? get_option( 'rtbcb_test_result
 		],
 		'rtbcb-test-maturity-model'        => [
 			'label'    => __( 'Maturity Model', 'rtbcb' ),
-			'option'   => 'rtbcb_maturity_model',
 			'requires' => [ 'rtbcb-test-data-storage' ],
 			'phase'    => 2,
 			'action'   => 'rtbcb_test_maturity_model',
@@ -384,7 +381,6 @@ $test_results = function_exists( 'get_option' ) ? get_option( 'rtbcb_test_result
 		],
 		'rtbcb-test-industry-overview'      => [
 			'label'    => __( 'Industry Overview', 'rtbcb' ),
-			'option'   => 'rtbcb_industry_insights',
 			'requires' => [ 'rtbcb-test-value-proposition' ],
 			'phase'    => 2,
 			'action'   => 'rtbcb_test_industry_overview',
@@ -1780,54 +1776,36 @@ function rtbcb_handle_comprehensive_analysis( $company_name, $job_id ) {
 
 	$timestamp = current_time( 'mysql' );
 
-	update_option( 'rtbcb_current_company', $analysis['company_overview'] );
-	update_option( 'rtbcb_industry_insights', $analysis['industry_analysis'] );
-	update_option( 'rtbcb_maturity_model', $analysis['treasury_maturity'] );
 	update_option( 'rtbcb_rag_market_analysis', $vendor_list );
 	update_option( 'rtbcb_roadmap_plan', $analysis['implementation_roadmap'] );
 	update_option( 'rtbcb_value_proposition', $analysis['executive_summary']['executive_recommendation'] ?? '' );
 	update_option( 'rtbcb_estimated_benefits', $analysis['financial_analysis'] );
 	update_option( 'rtbcb_executive_summary', $analysis['executive_summary'] );
 
-	$results = [
-		'company_overview' => [
-			'summary'   => $analysis['company_overview'],
-			'stored_in' => 'rtbcb_current_company',
-		],
-		'industry_analysis' => [
-			'summary'   => $analysis['industry_analysis'],
-			'stored_in' => 'rtbcb_industry_insights',
-		],
-		'treasury_maturity' => [
-			'summary'   => $analysis['treasury_maturity'],
-			'stored_in' => 'rtbcb_maturity_model',
-		],
-		'market_analysis' => [
-			'summary'   => $vendor_list,
-			'stored_in' => 'rtbcb_rag_market_analysis',
-		],
-		'implementation_roadmap' => [
-			'summary'   => $analysis['implementation_roadmap'],
-			'stored_in' => 'rtbcb_roadmap_plan',
-		],
-		'value_proposition' => [
-			'summary'   => $analysis['executive_summary'],
-			'stored_in' => 'rtbcb_value_proposition',
-		],
-		'financial_analysis' => [
-			'summary'   => $analysis['financial_analysis'],
-			'stored_in' => 'rtbcb_estimated_benefits',
-		],
-		'executive_summary' => [
-			'summary'   => $analysis['executive_summary'],
-			'stored_in' => 'rtbcb_executive_summary',
-		],
-	];
+$results = [
+'market_analysis' => [
+'summary'   => $vendor_list,
+'stored_in' => 'rtbcb_rag_market_analysis',
+],
+'implementation_roadmap' => [
+'summary'   => $analysis['implementation_roadmap'],
+'stored_in' => 'rtbcb_roadmap_plan',
+],
+'value_proposition' => [
+'summary'   => $analysis['executive_summary'],
+'stored_in' => 'rtbcb_value_proposition',
+],
+'financial_analysis' => [
+'summary'   => $analysis['financial_analysis'],
+'stored_in' => 'rtbcb_estimated_benefits',
+],
+'executive_summary' => [
+'summary'   => $analysis['executive_summary'],
+'stored_in' => 'rtbcb_executive_summary',
+],
+];
 
 	$usage_map = [
-		[ 'component' => __( 'Company Overview & Metrics', 'rtbcb' ), 'used_in' => __( 'Company Overview Test', 'rtbcb' ), 'option' => 'rtbcb_current_company' ],
-		[ 'component' => __( 'Industry Analysis', 'rtbcb' ), 'used_in' => __( 'Industry Overview Test', 'rtbcb' ), 'option' => 'rtbcb_industry_insights' ],
-		[ 'component' => __( 'Treasury Maturity Assessment', 'rtbcb' ), 'used_in' => __( 'Maturity Model Test', 'rtbcb' ), 'option' => 'rtbcb_maturity_model' ],
 		[ 'component' => __( 'Market Analysis & Vendors', 'rtbcb' ), 'used_in' => __( 'RAG Market Analysis Test', 'rtbcb' ), 'option' => 'rtbcb_rag_market_analysis' ],
 		[ 'component' => __( 'Value Proposition Paragraph', 'rtbcb' ), 'used_in' => __( 'Value Proposition Test', 'rtbcb' ), 'option' => 'rtbcb_value_proposition' ],
 		[ 'component' => __( 'Financial Benefits Breakdown', 'rtbcb' ), 'used_in' => __( 'Estimated Benefits Test', 'rtbcb' ), 'option' => 'rtbcb_estimated_benefits' ],
@@ -1842,7 +1820,7 @@ function rtbcb_handle_comprehensive_analysis( $company_name, $job_id ) {
 			'timestamp'            => $timestamp,
 			'results'              => $results,
 			'usage_map'            => $usage_map,
-			'components_generated' => 7,
+'components_generated' => 5,
 		]
 	);
 }

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1284,7 +1284,7 @@ public function generate_business_analysis( $user_inputs, $scenarios, $recommend
 			];
 		}
 
-		$required_keys = [ 'executive_summary', 'financial_analysis', 'industry_analysis', 'implementation_roadmap', 'risk_mitigation', 'next_steps' ];
+$required_keys = [ 'executive_summary', 'financial_analysis', 'implementation_roadmap' ];
 		$missing_keys  = array_diff( $required_keys, array_keys( $result ) );
 
 		if ( ! empty( $missing_keys ) ) {
@@ -1833,8 +1833,8 @@ public function generate_business_analysis( $user_inputs, $scenarios, $recommend
 					);
 					return;
 				}
-				$required_sections = [ 'executive_summary', 'financial_analysis', 'industry_analysis', 'implementation_roadmap', 'risk_mitigation', 'next_steps' ];
-				$missing_sections  = array_diff( $required_sections, array_keys( $comprehensive_analysis ) );
+$required_sections = [ 'executive_summary', 'financial_analysis', 'implementation_roadmap' ];
+$missing_sections  = array_diff( $required_sections, array_keys( $comprehensive_analysis ) );
 
 				if ( ! empty( $missing_sections ) ) {
 					rtbcb_log_error( 'LLM missing required sections', [ 'missing' => $missing_sections ] );
@@ -2284,16 +2284,13 @@ public function generate_business_analysis( $user_inputs, $scenarios, $recommend
 		],
 	];
 
-	$required_sections = [
-		'metadata',
-		'executive_summary',
-		'financial_analysis',
-		'company_intelligence',
-		'technology_strategy',
-		'operational_insights',
-		'risk_analysis',
-		'action_plan',
-	];
+$required_sections = [
+'metadata',
+'executive_summary',
+'financial_analysis',
+'company_intelligence',
+'technology_strategy',
+];
 
 	$section_defaults = [
 		'metadata'	     => [

--- a/tests/parse-comprehensive-response.test.php
+++ b/tests/parse-comprehensive-response.test.php
@@ -59,59 +59,28 @@ $method = new ReflectionMethod( RTBCB_LLM::class, 'parse_comprehensive_response'
 $method->setAccessible( true );
 
 $valid_json = [
-	'executive_summary' => [
-		'strategic_positioning'   => 'pos',
-		'business_case_strength'  => 'Strong',
-		'key_value_drivers'       => [ 'driver' ],
-		'executive_recommendation'=> 'rec',
-		'confidence_level'        => 0.9,
-	],
-	'operational_analysis' => [
-		'current_state_assessment' => [
-			'efficiency_rating'    => 'Good',
-			'benchmark_comparison' => 'peer',
-			'capacity_utilization' => 'high',
-		],
-		'process_inefficiencies'  => [],
-		'automation_opportunities'=> [],
-	],
-	'industry_insights' => [
-		'sector_trends'          => 'trend',
-		'competitive_benchmarks' => 'bench',
-		'regulatory_considerations' => 'reg',
-	],
-	'technology_recommendations' => [
-		'primary_solution' => [
-			'category'     => 'cat',
-			'rationale'    => 'why',
-			'key_features' => [ 'feature' ],
-		],
-		'implementation_approach' => [
-			'phase_1'        => 'p1',
-			'phase_2'        => 'p2',
-			'success_metrics'=> [ 'metric' ],
-		],
-	],
-	'financial_analysis' => [
-		'investment_breakdown' => [
-			'software_licensing'      => 'cost',
-			'implementation_services' => 'cost',
-			'training_change_management' => 'cost',
-		],
-		'payback_analysis' => [
-			'payback_months' => 12,
-			'roi_3_year'     => 50,
-			'npv_analysis'   => 'npv',
-		],
-	],
-	'risk_mitigation' => [
-		'implementation_risks' => [ 'risk' ],
-		'mitigation_strategies' => [
-			'risk_1_mitigation' => 'mit1',
-			'risk_2_mitigation' => 'mit2',
-		],
-	],
-	'next_steps' => [ 'step' ],
+        'executive_summary' => [
+                'strategic_positioning'   => 'pos',
+                'business_case_strength'  => 'Strong',
+                'key_value_drivers'       => [ 'driver' ],
+                'executive_recommendation'=> 'rec',
+                'confidence_level'        => 0.9,
+        ],
+        'financial_analysis' => [
+                'roi_scenarios' => [ [ 'scenario' => 'base', 'roi' => 10 ] ],
+                'payback_analysis' => [
+                        'payback_months' => 12,
+                        'roi_3_year'     => 50,
+                        'npv_analysis'   => 'npv',
+                ],
+        ],
+        'implementation_roadmap' => [
+                [
+                        'phase'      => 'p1',
+                        'timeline'   => 'Q1',
+                        'activities' => [ 'step1' ],
+                ],
+        ],
 ];
 
 $response = [
@@ -127,7 +96,7 @@ if ( is_wp_error( $result ) ) {
 	exit( 1 );
 }
 
-$required = [ 'executive_summary', 'operational_analysis', 'industry_insights', 'technology_recommendations', 'financial_analysis', 'risk_mitigation', 'next_steps' ];
+$required = [ 'executive_summary', 'financial_analysis', 'implementation_roadmap' ];
 
 foreach ( $required as $key ) {
 	if ( ! isset( $result[ $key ] ) ) {

--- a/tests/template-fallback.test.php
+++ b/tests/template-fallback.test.php
@@ -98,13 +98,13 @@ echo "Validation did not produce WP_Error\n";
 exit( 1 );
 }
 $data = $result->get_error_data();
-if ( $data['operational_insights'][0] !== 'No data provided' ) {
-echo "Operational fallback failed\n";
+if ( ! isset( $data['executive_summary'] ) ) {
+echo "Missing executive_summary fallback\n";
 exit( 1 );
 }
-if ( $data['risk_analysis']['implementation_risks'][0] !== 'No data provided' ) {
-echo "Risk fallback failed\n";
+if ( isset( $data['risk_analysis'] ) ) {
+echo "Unexpected risk_analysis section\n";
 exit( 1 );
 }
 
-echo "operational-risks-fallback.test.php passed\n";
+echo "template-fallback.test.php passed\n";


### PR DESCRIPTION
## Summary
- align consumer checks with new `executive_summary`, `financial_analysis`, and `implementation_roadmap` schema
- remove storage of deprecated analysis sections
- update tests for streamlined comprehensive case output

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b63a69a0ac833190b5d919e7e05ce1