### PR TITLE
Increase progress overlay height

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -377,7 +377,7 @@ html {
     box-shadow: 0 25px 50px rgba(0, 0, 0, 0.25);
     width: 90%;
     max-width: 480px;
-    min-height: 300px;
+	min-height: 420px;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -459,9 +459,9 @@ html {
     }
 
     .rtbcb-progress-content {
-        padding: 30px 20px;
-        min-height: 280px;
-        max-width: 95vw;
+		padding: 30px 20px;
+		min-height: 360px;
+		max-width: 95vw;
     }
 
     .rtbcb-progress-spinner {
@@ -492,8 +492,8 @@ html {
 
 @media (max-width: 320px) {
     .rtbcb-progress-content {
-        padding: 25px 15px;
-        min-height: 260px;
+		padding: 25px 15px;
+		min-height: 320px;
     }
 
     .rtbcb-progress-text {


### PR DESCRIPTION
## Summary
- Increase progress overlay minimum height to provide more vertical space
- Adjust responsive breakpoints to keep taller overlay on small screens

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b63fe5a3c08331b61e01375e7c142c