### PR TITLE
fix: render sensitivity chart with supported Chart.js type

### DIFF
--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -698,9 +698,10 @@ const sensitivityCtx = document.getElementById('rtbcb-sensitivity-chart');
 if (sensitivityCtx && window.rtbcbSensitivityData) {
 try {
 new Chart(sensitivityCtx, {
-type: 'horizontalBar',
+type: 'bar',
 data: window.rtbcbSensitivityData,
 options: {
+indexAxis: 'y',
 responsive: true,
 maintainAspectRatio: false,
 plugins: {


### PR DESCRIPTION
## Summary
- render sensitivity chart using Chart.js `bar` type and `indexAxis: 'y'` for horizontal orientation

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b6489c7c048331a24892ff79320b60