### PR TITLE
Bump version to 2.1.10 and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# Real Treasury Business Case Builder - Enhanced Version 2.1.9
+# Real Treasury Business Case Builder - Enhanced Version 2.1.10
 
 A comprehensive WordPress plugin that helps treasury teams quantify the benefits of modern treasury tools, generate professional business case reports, and track lead engagement with advanced analytics.
 
-## 🚀 What's New in Version 2.1.9
+## 🚀 What's New in Version 2.1.10
 
 ### ✨ Enhancements
 - Hardened security with ABSPATH guards across admin and template files.
 - Wrapped user-visible strings with translation functions for better localization.
 - Documented Composer install step and added PHPUnit checks to test scripts.
 - Streamlined developer tooling with improved linting and code quality fixes.
+- Updated documentation and bumped version number to keep release notes current.
 
 
 ## 📋 Installation & Setup

--- a/docs/REPOSITORY_STRUCTURE.md
+++ b/docs/REPOSITORY_STRUCTURE.md
@@ -1,5 +1,7 @@
 # Repository Structure
 
+Documentation reflects repository layout for version 2.1.10.
+
 ## Directory Tree
 
 Output of `find . -maxdepth 2 -type d -not -path './.git*'`:

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: realtreasury
 Tags: business, case, builder, roi, treasury
 Requires at least: 6.0
 Tested up to: 6.0
-Stable tag: 2.1.9
+Stable tag: 2.1.10
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -156,6 +156,9 @@ Reports are rendered as HTML in the browser. Use your browser's print or save fu
 The analytics dashboard uses Chart.js for its visualizations. The library is bundled with the plugin to reduce blocking by privacy tools, but strict ad blockers may still prevent it from loading. Allow the plugin's scripts in your browser to enable the charts.
 
 == Changelog ==
+= 2.1.10 =
+* Updated documentation and bumped version number.
+
 = 2.1.9 =
 * Hardened security with ABSPATH guards across admin and template files.
 * Wrapped user-visible strings with translation functions for better localization.

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2,7 +2,7 @@
 /**
 	* Plugin Name: Real Treasury - Business Case Builder (Enhanced Pro)
 	* Description: Professional-grade ROI calculator and comprehensive business case generator for treasury technology with advanced analysis and consultant-style reports.
-* Version: 2.1.9
+* Version: 2.1.10
 	* Requires PHP: 7.4
 	* Author: Real Treasury
 	* Text Domain: rtbcb
@@ -12,7 +12,7 @@
 */
 defined( 'ABSPATH' ) || exit;
 
-define( 'RTBCB_VERSION', '2.1.9' );
+define( 'RTBCB_VERSION', '2.1.10' );
 define( 'RTBCB_FILE', __FILE__ );
 define( 'RTBCB_URL', plugin_dir_url( RTBCB_FILE ) );
 define( 'RTBCB_DIR', plugin_dir_path( RTBCB_FILE ) );


### PR DESCRIPTION
## Summary
- bump plugin to v2.1.10
- refresh readme and documentation

## Testing
- `npx markdownlint-cli docs/**/*.md`
- `npx markdown-link-check docs/REPOSITORY_STRUCTURE.md`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: undefined WordPress and Node functions)*

------
https://chatgpt.com/codex/tasks/task_e_68b64f9d8e008331b18fd708b6f5ad46