### PR TITLE
Add AJAX URL fallbacks and logging

### DIFF
--- a/tests/handle-submit-invalid-ajax-url.test.js
+++ b/tests/handle-submit-invalid-ajax-url.test.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 require('./jsdom-setup');
 
-global.rtbcb_ajax = { ajax_url: 'ftp://example.com', nonce: 'test-nonce' };
+global.rtbcb_ajax = { ajax_url: 'ftp://example.com', nonce: 'test-nonce', strings: { generating: 'Generating...' } };
 
 class SimpleFormData {
     constructor(form) {
@@ -28,10 +28,15 @@ class SimpleFormData {
 
 global.FormData = SimpleFormData;
 
-let fetchCalled = false;
-global.fetch = function() {
-    fetchCalled = true;
-    return Promise.resolve();
+let fetchUrl = '';
+global.fetch = function(url) {
+    fetchUrl = url;
+    return Promise.resolve({
+        ok: false,
+        status: 500,
+        statusText: 'Error',
+        text: () => Promise.resolve('{"data":{"message":"Server error","error_code":"E1"}}')
+    });
 };
 
 const form = {
@@ -78,10 +83,11 @@ builder.showResults = () => {};
 builder.showEnhancedError = (msg) => { errorMessage = msg; };
 
 (async () => {
+    builder.startProgressiveLoading = () => {};
     await builder.handleSubmit();
-    assert.strictEqual(fetchCalled, false);
-    assert.strictEqual(errorMessage, 'Service unavailable. Please reload the page.');
-    console.log('Invalid ajaxUrl test passed.');
+    assert.strictEqual(fetchUrl, '/wp-admin/admin-ajax.php');
+    assert.strictEqual(errorMessage, 'Server error');
+    console.log('Invalid ajaxUrl fallback test passed.');
 })().catch(err => {
     console.error(err);
     process.exit(1);

--- a/tests/is-valid-url.test.js
+++ b/tests/is-valid-url.test.js
@@ -12,5 +12,6 @@ assert.strictEqual(isValidUrl('https://example.com'), true);
 assert.strictEqual(isValidUrl('http://example.com'), true);
 assert.strictEqual(isValidUrl('ftp://example.com'), false);
 assert.strictEqual(isValidUrl(''), false);
+assert.strictEqual(isValidUrl('/wp-admin/admin-ajax.php'), true);
 
 console.log('isValidUrl tests passed.');

--- a/tests/rtbcb-handle-submit-invalid-ajax-url.test.js
+++ b/tests/rtbcb-handle-submit-invalid-ajax-url.test.js
@@ -32,10 +32,15 @@ class SimpleFormData {
 
 global.FormData = SimpleFormData;
 
-let fetchCalled = false;
-global.fetch = function() {
-    fetchCalled = true;
-    return Promise.resolve();
+let fetchUrl = '';
+global.fetch = function(url) {
+    fetchUrl = url;
+    return Promise.resolve({
+        ok: false,
+        status: 500,
+        statusText: 'Error',
+        text: () => Promise.resolve('{"data":{"message":"Server error","error_code":"E1"}}')
+    });
 };
 
 const form = {
@@ -65,9 +70,9 @@ handleSubmissionError = (msg) => { errorMessage = msg; };
 
 (async () => {
     await handleSubmit({ preventDefault: () => {}, target: formElem });
-    assert.strictEqual(fetchCalled, false);
-    assert.strictEqual(errorMessage, 'Service unavailable. Please reload the page.');
-    console.log('rtbcb handleSubmit invalid ajaxUrl test passed.');
+    assert.strictEqual(fetchUrl, '/wp-admin/admin-ajax.php');
+    assert.strictEqual(errorMessage, 'Server error');
+    console.log('rtbcb handleSubmit invalid ajaxUrl fallback test passed.');
 })().catch(err => {
     console.error(err);
     process.exit(1);


### PR DESCRIPTION
## Summary
- Allow relative URLs and add fallback logic for AJAX requests
- Retry requests against `rtbcb_ajax.ajax_url`, `ajaxurl`, then `/wp-admin/admin-ajax.php`
- Log each attempt and expose retry status in console
- Update tests for new URL handling

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b6524a3e788331b1b89bd4a924b3e0