### PR TITLE
Handle AJAX nonce refresh on failure

### DIFF
--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -91,6 +91,31 @@ if ( typeof rtbcb_ajax !== 'undefined' && ! isValidUrl( rtbcb_ajax.ajax_url ) ) 
 }
 
 /**
+ * Refresh the AJAX nonce.
+ *
+ * @return {Promise<boolean>} True on success.
+ */
+async function rtbcbRefreshNonce() {
+    if ( typeof rtbcb_ajax === 'undefined' || ! isValidUrl( rtbcb_ajax.ajax_url ) ) {
+        return false;
+    }
+    try {
+        const response = await fetch( `${ rtbcb_ajax.ajax_url }?action=rtbcb_get_nonce` );
+        if ( ! response.ok ) {
+            return false;
+        }
+        const data = await response.json();
+        if ( data && data.success && data.data ) {
+            rtbcb_ajax.nonce = data.data;
+            return true;
+        }
+    } catch ( err ) {
+        console.error( 'RTBCB: Nonce refresh failed', err );
+    }
+    return false;
+}
+
+/**
  * Handles the form submission by sending data to the backend.
  * @param {Event} e - The form submission event.
  */
@@ -150,21 +175,37 @@ async function handleSubmit(e) {
 
     var response;
     var responseText;
-    try {
-        if (!isValidUrl(rtbcb_ajax.ajax_url)) {
-            handleSubmissionError('Service unavailable. Please reload the page.', '');
+    var attempt = 0;
+    while (attempt < 2) {
+        try {
+            if (!isValidUrl(rtbcb_ajax.ajax_url)) {
+                handleSubmissionError('Service unavailable. Please reload the page.', '');
+                rtbcbIsSubmitting = false;
+                return;
+            }
+            response = await fetch(rtbcb_ajax.ajax_url, {
+                method: 'POST',
+                body: formData
+            });
+            responseText = await response.text();
+        } catch (networkError) {
+            handleSubmissionError('Network error. Please try again later.', '');
             rtbcbIsSubmitting = false;
             return;
         }
-        response = await fetch(rtbcb_ajax.ajax_url, {
-            method: 'POST',
-            body: formData
-        });
-        responseText = await response.text();
-    } catch (networkError) {
-        handleSubmissionError('Network error. Please try again later.', '');
-        rtbcbIsSubmitting = false;
-        return;
+
+        if ((response.status === 403 || responseText.includes('Security check failed')) && attempt === 0) {
+            const refreshed = await rtbcbRefreshNonce();
+            if (refreshed) {
+                formData.set('rtbcb_nonce', rtbcb_ajax.nonce);
+                attempt++;
+                continue;
+            }
+            handleSubmissionError('Security validation failed. Please reload the page.', '');
+            rtbcbIsSubmitting = false;
+            return;
+        }
+        break;
     }
 
     if (!response.ok) {
@@ -210,9 +251,27 @@ async function pollJobStatus(jobId, progressContainer, formContainer) {
             rtbcbIsSubmitting = false;
             return;
         }
-        const nonce = rtbcb_ajax.nonce ? rtbcb_ajax.nonce : '';
-        const response = await fetch(`${rtbcb_ajax.ajax_url}?action=rtbcb_job_status&job_id=${encodeURIComponent(jobId)}&rtbcb_nonce=${nonce}`);
-        const data = await response.json();
+        let nonce = rtbcb_ajax.nonce ? rtbcb_ajax.nonce : '';
+        let attempt = 0;
+        let response;
+        let responseText;
+        while (attempt < 2) {
+            response = await fetch(`${rtbcb_ajax.ajax_url}?action=rtbcb_job_status&job_id=${encodeURIComponent(jobId)}&rtbcb_nonce=${nonce}`);
+            responseText = await response.text();
+            if ((response.status === 403 || responseText.includes('Security check failed')) && attempt === 0) {
+                const refreshed = await rtbcbRefreshNonce();
+                if (refreshed) {
+                    nonce = rtbcb_ajax.nonce;
+                    attempt++;
+                    continue;
+                }
+                handleSubmissionError('Security validation failed. Please reload the page.', '');
+                rtbcbIsSubmitting = false;
+                return;
+            }
+            break;
+        }
+        const data = JSON.parse(responseText);
 
         if (!data.success) {
             handleSubmissionError('Unable to retrieve job status.', '');
@@ -276,10 +335,28 @@ async function rtbcbStreamAnalysis(formData, onChunk) {
     if (rtbcb_ajax.nonce) {
         formData.append('rtbcb_nonce', rtbcb_ajax.nonce);
     }
-    const response = await fetch(rtbcb_ajax.ajax_url, {
-        method: 'POST',
-        body: formData
-    });
+    let response;
+    let attempt = 0;
+    while (attempt < 2) {
+        response = await fetch(rtbcb_ajax.ajax_url, {
+            method: 'POST',
+            body: formData
+        });
+        if (response.status === 403) {
+            const text = await response.text();
+            if (text.includes('Security check failed') && attempt === 0) {
+                const refreshed = await rtbcbRefreshNonce();
+                if (refreshed) {
+                    formData.set('rtbcb_nonce', rtbcb_ajax.nonce);
+                    attempt++;
+                    continue;
+                }
+                handleSubmissionError('Security validation failed. Please reload the page.', '');
+                return;
+            }
+        }
+        break;
+    }
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     while (true) {

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -222,12 +222,16 @@ return true;
 		}
 
 		// Streamed analysis handler
-		if ( class_exists( 'RTBCB_Ajax' ) ) {
-			add_action( 'wp_ajax_rtbcb_stream_analysis', [ 'RTBCB_Ajax', 'stream_analysis' ] );
-		}
-		if ( class_exists( 'RTBCB_Ajax' ) ) {
-			add_action( 'wp_ajax_nopriv_rtbcb_stream_analysis', [ 'RTBCB_Ajax', 'stream_analysis' ] );
-		}
+                if ( class_exists( 'RTBCB_Ajax' ) ) {
+                        add_action( 'wp_ajax_rtbcb_stream_analysis', [ 'RTBCB_Ajax', 'stream_analysis' ] );
+                }
+                if ( class_exists( 'RTBCB_Ajax' ) ) {
+                        add_action( 'wp_ajax_nopriv_rtbcb_stream_analysis', [ 'RTBCB_Ajax', 'stream_analysis' ] );
+                }
+
+                // Nonce refresh handler
+                add_action( 'wp_ajax_rtbcb_get_nonce', 'rtbcb_get_nonce' );
+                add_action( 'wp_ajax_nopriv_rtbcb_get_nonce', 'rtbcb_get_nonce' );
 
 		// OpenAI proxy handlers
 	add_action( 'wp_ajax_rtbcb_openai_responses', 'rtbcb_proxy_openai_responses' );
@@ -3357,6 +3361,17 @@ if ( ! function_exists( 'rtbcb_ajax_generate_case' ) ) {
 		RTBCB_Ajax::generate_comprehensive_case();
 	   }
 }
+
+if ( ! function_exists( 'rtbcb_get_nonce' ) ) {
+	/**
+	 * Return a fresh nonce for AJAX requests.
+	 *
+	 * @return void
+	 */
+	function rtbcb_get_nonce() {
+		wp_send_json_success( wp_create_nonce( 'rtbcb_generate' ) );
+	}
+	}
 
 // Helper functions for use in templates and other plugins
 if ( ! function_exists( 'rtbcb_get_leads_count' ) ) {


### PR DESCRIPTION
## Summary
- Retry AJAX requests once by refreshing nonce on 403 or nonce errors
- Add `rtbcb_get_nonce` endpoint to supply fresh nonces
- Show user-friendly errors when nonce refresh fails

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b65250af7c83319ead813e3aa92fc4