### PR TITLE
Add tests for debug handlers and nonce retries

### DIFF
--- a/tests/RTBCB_EmergencyDebugHandlerTest.php
+++ b/tests/RTBCB_EmergencyDebugHandlerTest.php
@@ -1,0 +1,164 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! class_exists( 'WP_Error' ) ) {
+class WP_Error {}
+}
+
+if ( ! function_exists( '__' ) ) {
+function __( $text, $domain = null ) {
+return $text;
+}
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+function sanitize_text_field( $text ) {
+return is_string( $text ) ? trim( $text ) : '';
+}
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+function sanitize_key( $key ) {
+return $key;
+}
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+function wp_unslash( $value ) {
+return $value;
+}
+}
+if ( ! function_exists( 'is_admin' ) ) {
+function is_admin() {
+return false;
+}
+}
+if ( ! function_exists( 'wp_verify_nonce' ) ) {
+function wp_verify_nonce( $nonce, $action ) {
+return 'valid' === $nonce;
+}
+}
+if ( ! function_exists( 'size_format' ) ) {
+function size_format( $bytes ) {
+return '1 MB';
+}
+}
+if ( ! function_exists( 'rtbcb_has_openai_api_key' ) ) {
+function rtbcb_has_openai_api_key() {
+return true;
+}
+}
+if ( ! function_exists( 'plugin_dir_url' ) ) {
+function plugin_dir_url( $file ) {
+return '';
+}
+}
+if ( ! function_exists( 'plugin_dir_path' ) ) {
+function plugin_dir_path( $file ) {
+return __DIR__ . '/../';
+}
+}
+if ( ! function_exists( 'register_activation_hook' ) ) {
+function register_activation_hook() {}
+}
+if ( ! function_exists( 'register_deactivation_hook' ) ) {
+function register_deactivation_hook() {}
+}
+if ( ! function_exists( 'register_uninstall_hook' ) ) {
+function register_uninstall_hook() {}
+}
+if ( ! function_exists( 'add_action' ) ) {
+function add_action() {}
+}
+if ( ! function_exists( 'add_shortcode' ) ) {
+function add_shortcode() {}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+function add_filter() {}
+}
+if ( ! function_exists( 'plugin_basename' ) ) {
+function plugin_basename() {
+return '';
+}
+}
+if ( ! function_exists( 'get_file_data' ) ) {
+function get_file_data() {
+return [];
+}
+}
+
+if ( ! class_exists( 'RTBCB_JSON_Response' ) ) {
+class RTBCB_JSON_Response extends Exception {
+public $data;
+public function __construct( $data ) {
+parent::__construct();
+$this->data = $data;
+}
+}
+}
+if ( ! function_exists( 'wp_send_json_success' ) ) {
+function wp_send_json_success( $data = null ) {
+throw new RTBCB_JSON_Response(
+[
+'success' => true,
+'data'    => $data,
+]
+);
+}
+}
+
+if ( ! class_exists( 'RTBCB_Calculator' ) ) {
+class RTBCB_Calculator {}
+}
+if ( ! class_exists( 'RTBCB_DB' ) ) {
+class RTBCB_DB {}
+}
+
+if ( ! defined( 'RTBCB_NO_BOOTSTRAP' ) ) {
+define( 'RTBCB_NO_BOOTSTRAP', true );
+}
+require_once __DIR__ . '/../real-treasury-business-case-builder.php';
+
+final class RTBCB_EmergencyDebugHandlerTest extends TestCase {
+protected function setUp(): void {
+global $wpdb;
+$wpdb       = new class() {
+public $prefix = 'wp_';
+public function prepare( $query, $table ) {
+return sprintf( $query, $table );
+}
+public function get_var( $query ) {
+return 'wp_rtbcb_leads';
+}
+};
+$_POST = [];
+}
+
+public function test_debug_handler_valid_nonce() {
+$_POST['rtbcb_nonce'] = 'valid';
+try {
+$ref    = new ReflectionClass( 'RTBCB_Main' );
+$plugin = $ref->newInstanceWithoutConstructor();
+$plugin->debug_ajax_handler();
+$this->fail( 'Expected RTBCB_JSON_Response' );
+} catch ( RTBCB_JSON_Response $e ) {
+$this->assertTrue( $e->data['success'] );
+$this->assertTrue( $e->data['data']['nonce_valid'] );
+$this->assertTrue( $e->data['data']['db_table_exists'] );
+}
+}
+
+public function test_debug_handler_invalid_nonce() {
+$_POST['rtbcb_nonce'] = 'bad';
+try {
+$ref    = new ReflectionClass( 'RTBCB_Main' );
+$plugin = $ref->newInstanceWithoutConstructor();
+$plugin->debug_ajax_handler();
+$this->fail( 'Expected RTBCB_JSON_Response' );
+} catch ( RTBCB_JSON_Response $e ) {
+$this->assertFalse( $e->data['data']['nonce_valid'] );
+}
+}
+}

--- a/tests/RTBCB_NonceRegenerationEndpointTest.php
+++ b/tests/RTBCB_NonceRegenerationEndpointTest.php
@@ -1,0 +1,140 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! class_exists( 'WP_Error' ) ) {
+class WP_Error {}
+}
+if ( ! function_exists( '__' ) ) {
+function __( $text, $domain = null ) {
+return $text;
+}
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+function sanitize_text_field( $text ) {
+return is_string( $text ) ? trim( $text ) : '';
+}
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+function wp_unslash( $value ) {
+return $value;
+}
+}
+$GLOBALS['rtbcb_test_nonce_valid'] = true;
+if ( ! function_exists( 'is_admin' ) ) {
+function is_admin() {
+return false;
+}
+}
+if ( ! function_exists( 'check_ajax_referer' ) ) {
+function check_ajax_referer( $action, $query_arg = false, $die = true ) {
+return $GLOBALS['rtbcb_test_nonce_valid'];
+}
+}
+if ( ! class_exists( 'RTBCB_JSON_Response' ) ) {
+class RTBCB_JSON_Response extends Exception {
+public $data;
+public function __construct( $data ) {
+parent::__construct();
+$this->data = $data;
+}
+}
+}
+if ( ! function_exists( 'wp_send_json_error' ) ) {
+function wp_send_json_error( $data = null, $status = 400 ) {
+throw new RTBCB_JSON_Response(
+[
+'success' => false,
+'data'    => $data,
+'status'  => $status,
+]
+);
+}
+}
+if ( ! function_exists( 'plugin_dir_url' ) ) {
+function plugin_dir_url( $file ) {
+return '';
+}
+}
+if ( ! function_exists( 'plugin_dir_path' ) ) {
+function plugin_dir_path( $file ) {
+return __DIR__ . '/../';
+}
+}
+if ( ! function_exists( 'register_activation_hook' ) ) {
+function register_activation_hook() {}
+}
+if ( ! function_exists( 'register_deactivation_hook' ) ) {
+function register_deactivation_hook() {}
+}
+if ( ! function_exists( 'register_uninstall_hook' ) ) {
+function register_uninstall_hook() {}
+}
+if ( ! function_exists( 'add_action' ) ) {
+function add_action() {}
+}
+if ( ! function_exists( 'add_shortcode' ) ) {
+function add_shortcode() {}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+function add_filter() {}
+}
+if ( ! function_exists( 'plugin_basename' ) ) {
+function plugin_basename() {
+return '';
+}
+}
+if ( ! function_exists( 'get_file_data' ) ) {
+function get_file_data() {
+return [];
+}
+}
+if ( ! function_exists( 'rtbcb_increase_memory_limit' ) ) {
+function rtbcb_increase_memory_limit() {}
+}
+if ( ! function_exists( 'rtbcb_get_api_timeout' ) ) {
+function rtbcb_get_api_timeout() {
+return 0;
+}
+}
+if ( ! function_exists( 'rtbcb_log_memory_usage' ) ) {
+function rtbcb_log_memory_usage( $label ) {}
+}
+if ( ! function_exists( 'absint' ) ) {
+function absint( $n ) {
+return (int) abs( $n );
+}
+}
+
+class RTBCB_Ajax {}
+if ( ! defined( 'DOING_AJAX' ) ) {
+define( 'DOING_AJAX', true );
+}
+
+if ( ! defined( 'RTBCB_NO_BOOTSTRAP' ) ) {
+define( 'RTBCB_NO_BOOTSTRAP', true );
+}
+require_once __DIR__ . '/../real-treasury-business-case-builder.php';
+
+final class RTBCB_NonceRegenerationEndpointTest extends TestCase {
+protected function setUp(): void {
+$_POST = [];
+$GLOBALS['rtbcb_test_nonce_valid'] = false;
+}
+
+public function test_generate_case_nonce_failure() {
+$_POST['rtbcb_nonce'] = 'bad';
+try {
+rtbcb_ajax_generate_case();
+$this->fail( 'Expected RTBCB_JSON_Response' );
+} catch ( RTBCB_JSON_Response $e ) {
+$this->assertFalse( $e->data['success'] );
+$this->assertEquals( 'Security check failed.', $e->data['data'] );
+$this->assertEquals( 403, $e->data['status'] );
+}
+}
+}

--- a/tests/RTBCB_SimpleTestHandlerTest.php
+++ b/tests/RTBCB_SimpleTestHandlerTest.php
@@ -1,0 +1,153 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! class_exists( 'WP_Error' ) ) {
+class WP_Error {}
+}
+if ( ! function_exists( '__' ) ) {
+function __( $text, $domain = null ) {
+return $text;
+}
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+function sanitize_text_field( $text ) {
+return is_string( $text ) ? trim( $text ) : '';
+}
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+function wp_unslash( $value ) {
+return $value;
+}
+}
+if ( ! function_exists( 'is_admin' ) ) {
+function is_admin() {
+return false;
+}
+}
+$GLOBALS['rtbcb_test_nonce_valid'] = true;
+if ( ! function_exists( 'check_ajax_referer' ) ) {
+function check_ajax_referer( $action, $query_arg = false, $die = true ) {
+return $GLOBALS['rtbcb_test_nonce_valid'];
+}
+}
+if ( ! class_exists( 'RTBCB_JSON_Response' ) ) {
+class RTBCB_JSON_Response extends Exception {
+public $data;
+public function __construct( $data ) {
+parent::__construct();
+$this->data = $data;
+}
+}
+}
+if ( ! function_exists( 'wp_send_json_success' ) ) {
+function wp_send_json_success( $data = null ) {
+throw new RTBCB_JSON_Response(
+[
+'success' => true,
+'data'    => $data,
+]
+);
+}
+}
+if ( ! function_exists( 'wp_send_json_error' ) ) {
+function wp_send_json_error( $data = null, $status = 400 ) {
+throw new RTBCB_JSON_Response(
+[
+'success' => false,
+'data'    => $data,
+'status'  => $status,
+]
+);
+}
+}
+if ( ! function_exists( 'plugin_dir_url' ) ) {
+function plugin_dir_url( $file ) {
+return '';
+}
+}
+if ( ! function_exists( 'plugin_dir_path' ) ) {
+function plugin_dir_path( $file ) {
+return __DIR__ . '/../';
+}
+}
+if ( ! function_exists( 'register_activation_hook' ) ) {
+function register_activation_hook() {}
+}
+if ( ! function_exists( 'register_deactivation_hook' ) ) {
+function register_deactivation_hook() {}
+}
+if ( ! function_exists( 'register_uninstall_hook' ) ) {
+function register_uninstall_hook() {}
+}
+if ( ! function_exists( 'add_action' ) ) {
+function add_action() {}
+}
+if ( ! function_exists( 'add_shortcode' ) ) {
+function add_shortcode() {}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+function add_filter() {}
+}
+if ( ! function_exists( 'plugin_basename' ) ) {
+function plugin_basename() {
+return '';
+}
+}
+if ( ! function_exists( 'get_file_data' ) ) {
+function get_file_data() {
+return [];
+}
+}
+if ( ! class_exists( 'RTBCB_Calculator' ) ) {
+class RTBCB_Calculator {}
+}
+if ( ! class_exists( 'RTBCB_DB' ) ) {
+class RTBCB_DB {}
+}
+if ( ! defined( 'RTBCB_NO_BOOTSTRAP' ) ) {
+define( 'RTBCB_NO_BOOTSTRAP', true );
+}
+require_once __DIR__ . '/../real-treasury-business-case-builder.php';
+
+final class RTBCB_SimpleTestHandlerTest extends TestCase {
+protected function setUp(): void {
+$_POST = [];
+$GLOBALS['rtbcb_test_nonce_valid'] = true;
+}
+
+public function test_simple_handler_success() {
+$_POST['investment'] = '100';
+$_POST['returns']    = '150';
+$_POST['rtbcb_nonce'] = 'valid';
+try {
+$ref    = new ReflectionClass( 'RTBCB_Main' );
+$plugin = $ref->newInstanceWithoutConstructor();
+$plugin->ajax_generate_case_simple();
+$this->fail( 'Expected RTBCB_JSON_Response' );
+} catch ( RTBCB_JSON_Response $e ) {
+$this->assertTrue( $e->data['success'] );
+$this->assertEquals( 50, $e->data['data']['roi'] );
+}
+}
+
+public function test_simple_handler_nonce_failure() {
+$_POST['investment'] = '100';
+$_POST['returns']    = '150';
+$GLOBALS['rtbcb_test_nonce_valid'] = false;
+try {
+$ref    = new ReflectionClass( 'RTBCB_Main' );
+$plugin = $ref->newInstanceWithoutConstructor();
+$plugin->ajax_generate_case_simple();
+$this->fail( 'Expected RTBCB_JSON_Response' );
+} catch ( RTBCB_JSON_Response $e ) {
+$this->assertFalse( $e->data['success'] );
+$this->assertEquals( 'Security check failed.', $e->data['data'] );
+$this->assertEquals( 403, $e->data['status'] );
+}
+}
+}

--- a/tests/handle-submit-nonce-retry.test.js
+++ b/tests/handle-submit-nonce-retry.test.js
@@ -1,0 +1,114 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+require('./jsdom-setup');
+
+global.rtbcb_ajax = { ajax_url: '', nonce: 'bad-nonce' };
+global.ajaxurl = 'https://fallback.example.com';
+
+class SimpleFormData {
+constructor(form) {
+this._data = [];
+if (form && form.fields) {
+for (const [key, value] of Object.entries(form.fields)) {
+this._data.push([key, value]);
+}
+}
+}
+append(key, value) {
+this._data.push([key, value]);
+}
+entries() {
+return this._data[Symbol.iterator]();
+}
+[Symbol.iterator]() {
+return this.entries();
+}
+}
+
+global.FormData = SimpleFormData;
+
+const fetchCalls = [];
+global.fetch = function(url, options) {
+fetchCalls.push({ url, options });
+if (fetchCalls.length === 1) {
+const payload = { success: false, data: { message: 'Security check failed.' } };
+const response = {
+ok: true,
+status: 200,
+json: async () => payload,
+text: async () => JSON.stringify(payload),
+headers: { get: () => 'application/json' },
+clone() { return this; }
+};
+return Promise.resolve(response);
+}
+const payload = { success: true, data: { job_id: 'job-123' } };
+const response = {
+ok: true,
+status: 200,
+json: async () => payload,
+text: async () => JSON.stringify(payload),
+headers: { get: () => 'application/json' },
+clone() { return this; }
+};
+return Promise.resolve(response);
+};
+
+const form = {
+fields: {
+email: 'test@example.com',
+company_name: 'Test Co',
+company_size: '100',
+industry: 'Finance',
+hours_reconciliation: '1',
+hours_cash_positioning: '1',
+num_banks: '1',
+ftes: '1',
+business_objective: 'growth',
+implementation_timeline: '3 months',
+budget_range: '1000',
+'pain_points[]': 'manual'
+},
+querySelector: (sel) => sel === '[name="company_name"]' ? { value: 'Test Co' } : null,
+querySelectorAll: () => [],
+addEventListener: () => {},
+closest: () => ({ style: {} })
+};
+
+const formElem = document.createElement('form');
+formElem.id = 'rtbcbForm';
+Object.assign(formElem, form);
+document.body.appendChild(formElem);
+
+document.readyState = 'complete';
+const overlay = document.createElement('div');
+overlay.id = 'rtbcbModalOverlay';
+document.body.appendChild(overlay);
+const progressContainer = document.createElement('div');
+progressContainer.id = 'rtbcb-progress-container';
+document.body.appendChild(progressContainer);
+
+const code = fs.readFileSync('public/js/rtbcb-wizard.js', 'utf8');
+vm.runInThisContext(code);
+
+const builder = new BusinessCaseBuilder();
+builder.form = form;
+let errorMessage = null;
+builder.showProgress = () => {};
+builder.showResults = () => {};
+builder.showEnhancedError = (msg) => { errorMessage = msg; };
+builder.pollJob = () => {};
+
+(async () => {
+await builder.handleSubmit();
+assert.strictEqual(errorMessage, 'Session expired. Please refresh the page and try again.');
+errorMessage = null;
+global.rtbcb_ajax.nonce = 'good-nonce';
+await builder.handleSubmit();
+assert.strictEqual(fetchCalls.length, 2);
+assert.strictEqual(fetchCalls[0].url, 'https://fallback.example.com');
+assert.strictEqual(fetchCalls[1].url, 'https://fallback.example.com');
+console.log('Nonce retry test passed.');
+})().catch(err => { console.error(err); process.exit(1); });

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -83,6 +83,10 @@ vendor/bin/phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseErrorTest.php
 vendor/bin/phpunit tests/RTBCB_AjaxGenerateComprehensiveCaseFatalErrorTest.php
 vendor/bin/phpunit tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
 vendor/bin/phpunit tests/RTBCB_ReportErrorHandlingTest.php
+echo "15b. Running debug and nonce handler tests..."
+vendor/bin/phpunit tests/RTBCB_EmergencyDebugHandlerTest.php
+vendor/bin/phpunit tests/RTBCB_SimpleTestHandlerTest.php
+vendor/bin/phpunit tests/RTBCB_NonceRegenerationEndpointTest.php
 
 # Background job test
 echo "14. Running background job tests..."
@@ -109,6 +113,7 @@ node tests/handle-invalid-server-response.test.js
 node tests/handle-string-error-response.test.js
 node tests/handle-submit-invalid-ajax-url.test.js
 node tests/rtbcb-handle-submit-invalid-ajax-url.test.js
+node tests/handle-submit-nonce-retry.test.js
 node tests/is-valid-url.test.js
 node tests/temperature-model.test.js
 node tests/min-output-tokens.test.js


### PR DESCRIPTION
## Summary
- cover emergency debug handler, simple ROI handler, and nonce rejection in PHP unit tests
- add a handle-submit nonce retry JS test
- extend run-tests script to execute new unit and JS tests

## Testing
- `vendor/bin/phpunit tests/RTBCB_EmergencyDebugHandlerTest.php tests/RTBCB_SimpleTestHandlerTest.php tests/RTBCB_NonceRegenerationEndpointTest.php`
- `node tests/handle-submit-nonce-retry.test.js`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68b6526839a88331b4b182ce4438f0ab