### PR TITLE
Handle cron fallback and improve job error messaging

### DIFF
--- a/inc/class-rtbcb-background-job.php
+++ b/inc/class-rtbcb-background-job.php
@@ -43,13 +43,16 @@ public static function enqueue( $user_inputs ) {
 	
 	self::update_status( $job_id, 'queued' );
 	
-	$scheduled = wp_schedule_single_event(
-	time(),
-	'rtbcb_process_job',
-	[ $job_id, $user_inputs ]
-	);
-	
 	$cron_disabled = defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON;
+	
+	$scheduled = false;
+	if ( ! $cron_disabled ) {
+		$scheduled = wp_schedule_single_event(
+		time(),
+		'rtbcb_process_job',
+		[ $job_id, $user_inputs ]
+		);
+	}
 	
 	if ( function_exists( 'spawn_cron' ) && ( ! function_exists( 'wp_doing_cron' ) || ! wp_doing_cron() ) && ! $cron_disabled ) {
 	spawn_cron();


### PR DESCRIPTION
## Summary
- Skip scheduling background jobs when WP-Cron is disabled to avoid duplicate runs

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*
- `vendor/bin/phpcs --standard=WordPress` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6564f377c8331a8b9c93515b7f82f