### PR TITLE
Add admin debug diagnostics utility

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -95,6 +95,22 @@ $enable_charts = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_setting(
 			RTBCB_VERSION
 		);
 
+		wp_enqueue_script(
+			'rtbcb-debug',
+			RTBCB_URL . 'admin/js/rtbcb-debug.js',
+			[],
+			RTBCB_VERSION,
+			true
+		);
+		wp_localize_script(
+			'rtbcb-debug',
+			'rtbcb_ajax',
+			[
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'rtbcb_generate' ),
+			]
+		);
+
 		if ( 'rtbcb-workflow-visualizer' === $page ) {
 			wp_enqueue_script(
 				'rtbcb-workflow-visualizer',


### PR DESCRIPTION
## Summary
- add `rtbcb-debug.js` to run a sequence of AJAX and form submission diagnostics
- expose `window.rtbcbDebug.runFullDiagnostics()` and autorun when `?rtbcb_debug=1`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b656173b8083319ee8abe200e1ed28