### PR TITLE
Handle AJAX nonce refresh on failure

### DIFF
--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -342,18 +342,15 @@ async function rtbcbStreamAnalysis(formData, onChunk) {
             method: 'POST',
             body: formData
         });
-        if (response.status === 403) {
-            const text = await response.text();
-            if (text.includes('Security check failed') && attempt === 0) {
-                const refreshed = await rtbcbRefreshNonce();
-                if (refreshed) {
-                    formData.set('rtbcb_nonce', rtbcb_ajax.nonce);
-                    attempt++;
-                    continue;
-                }
-                handleSubmissionError('Security validation failed. Please reload the page.', '');
-                return;
+        if (response.status === 403 && attempt === 0) {
+            const refreshed = await rtbcbRefreshNonce();
+            if (refreshed) {
+                formData.set('rtbcb_nonce', rtbcb_ajax.nonce);
+                attempt++;
+                continue;
             }
+            handleSubmissionError('Security validation failed. Please reload the page.', '');
+            return;
         }
         break;
     }


### PR DESCRIPTION
## Summary
- Retry AJAX requests once by refreshing nonce on 403 or nonce errors
- Add `rtbcb_get_nonce` endpoint to supply fresh nonces
- Show user-friendly errors when nonce refresh fails
- Refresh nonce on any 403 response during streaming, avoiding locale-specific checks

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: ReferenceError: generateProfessionalReport is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6562f8f24833183b8430aac0c465f