### PR TITLE
Add company and start time to workflow logs

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -117,8 +117,12 @@ wp_localize_script(
 'lead'            => __( 'Lead', 'rtbcb' ),
 'unknown_lead'    => __( 'Unknown Lead', 'rtbcb' ),
 'not_run'         => __( 'Not run', 'rtbcb' ),
-                               'seconds'         => __( 's', 'rtbcb' ),
-                               'elapsed_suffix' => __( 's elapsed', 'rtbcb' ),
+                                'company'         => __( 'Company', 'rtbcb' ),
+                                'unknown_company' => __( 'Unknown Company', 'rtbcb' ),
+                                'started'         => __( 'Started', 'rtbcb' ),
+                                'unknown_start'   => __( 'Unknown Start', 'rtbcb' ),
+                                'seconds'         => __( 's', 'rtbcb' ),
+                                'elapsed_suffix' => __( 's elapsed', 'rtbcb' ),
 ],
 ]
 );
@@ -1882,12 +1886,14 @@ wp_localize_script(
 		if ( ! current_user_can( 'manage_options' ) ) {
 		wp_send_json_error( __( 'Insufficient permissions', 'rtbcb' ) );
 		}
-		$raw_history = $this->get_workflow_history_from_logs();
+               $raw_history = $this->get_workflow_history_from_logs();
 $history     = array_map(
 function ( $entry ) {
-$lead_id = isset( $entry['lead_id'] ) ? intval( $entry['lead_id'] ) : 0;
-$email   = isset( $entry['lead_email'] ) ? sanitize_email( $entry['lead_email'] ) : '';
-$steps   = [];
+$lead_id  = isset( $entry['lead_id'] ) ? intval( $entry['lead_id'] ) : 0;
+$email    = isset( $entry['lead_email'] ) ? sanitize_email( $entry['lead_email'] ) : '';
+$company  = isset( $entry['company_name'] ) ? sanitize_text_field( $entry['company_name'] ) : '';
+$started  = isset( $entry['started_at'] ) ? sanitize_text_field( $entry['started_at'] ) : '';
+$steps    = [];
 if ( isset( $entry['steps'] ) && is_array( $entry['steps'] ) ) {
 foreach ( $entry['steps'] as $step ) {
 $steps[] = [
@@ -1899,9 +1905,11 @@ $steps[] = [
 }
 }
 return [
-'lead_id' => $lead_id,
-'email'   => $email,
-'steps'   => $steps,
+'lead_id'    => $lead_id,
+'email'      => $email,
+'company'    => $company,
+'started_at' => $started,
+'steps'      => $steps,
 ];
 },
 $raw_history
@@ -1942,13 +1950,15 @@ $raw_history
 			return [];
 			}
 			return array_map(
-				function ( $entry ) {
-				$entry['lead_id']    = isset( $entry['lead_id'] ) ? intval( $entry['lead_id'] ) : 0;
-				$entry['lead_email'] = isset( $entry['lead_email'] ) ? sanitize_email( $entry['lead_email'] ) : '';
-				return $entry;
-			},
-			$history
-			);
+function ( $entry ) {
+$entry['lead_id']      = isset( $entry['lead_id'] ) ? intval( $entry['lead_id'] ) : 0;
+$entry['lead_email']   = isset( $entry['lead_email'] ) ? sanitize_email( $entry['lead_email'] ) : '';
+$entry['company_name'] = isset( $entry['company_name'] ) ? sanitize_text_field( $entry['company_name'] ) : '';
+$entry['started_at']   = isset( $entry['started_at'] ) ? sanitize_text_field( $entry['started_at'] ) : '';
+return $entry;
+},
+$history
+);
 		}
 
 	private function calculate_average_duration( $history ) {

--- a/admin/js/workflow-visualizer.js
+++ b/admin/js/workflow-visualizer.js
@@ -35,22 +35,35 @@ jQuery(function ($) {
 							});
 						}
 					});
-					var html =
-						'<div class="rtbcb-history-table-wrapper"><table class="widefat rtbcb-history-table"><thead><tr><th>' +
-						rtbcbWorkflow.strings.lead +
-						"</th>";
-					stepNames.forEach(function (name) {
-						html += "<th>" + $("<div>").text(name).html() + "</th>";
-					});
-					html += "</tr></thead><tbody>";
-					history.forEach(function (item) {
-						var lead =
-							item.email ||
-							(item.lead_id
-								? "ID " + item.lead_id
-								: rtbcbWorkflow.strings.unknown_lead);
-						html += "<tr><td>" + $("<div>").text(lead).html() + "</td>";
-						stepNames.forEach(function (name) {
+                                       var html =
+                                               '<div class="rtbcb-history-table-wrapper"><table class="widefat rtbcb-history-table"><thead><tr><th>' +
+                                               rtbcbWorkflow.strings.lead +
+                                               "</th><th>" +
+                                               rtbcbWorkflow.strings.company +
+                                               "</th><th>" +
+                                               rtbcbWorkflow.strings.started +
+                                               "</th>";
+                                       stepNames.forEach(function (name) {
+                                               html += "<th>" + $("<div>").text(name).html() + "</th>";
+                                       });
+                                       html += "</tr></thead><tbody>";
+                                       history.forEach(function (item) {
+                                               var lead =
+                                                       item.email ||
+                                                       (item.lead_id
+                                                               ? "ID " + item.lead_id
+                                                               : rtbcbWorkflow.strings.unknown_lead);
+                                               var company = item.company || rtbcbWorkflow.strings.unknown_company;
+                                               var started = item.started_at || rtbcbWorkflow.strings.unknown_start;
+                                               html +=
+                                                       "<tr><td>" +
+                                                       $("<div>").text(lead).html() +
+                                                       "</td><td>" +
+                                                       $("<div>").text(company).html() +
+                                                       "</td><td>" +
+                                                       $("<div>").text(started).html() +
+                                                       "</td>";
+                                               stepNames.forEach(function (name) {
                                                         var status = rtbcbWorkflow.strings.not_run;
                                                         var time = "";
                                                         if (item.steps) {

--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -217,7 +217,7 @@ $enable_ai        = ! $bypass_heavy && ( class_exists( 'RTBCB_Settings' ) ? RTBC
 								if ( $lead_email ) {
 										$debug_info['lead_email'] = $lead_email;
 								}
-								self::store_workflow_history( $debug_info, $lead_id, $lead_email );
+                                                       self::store_workflow_history( $debug_info, $lead_id, $lead_email, $user_inputs['company_name'] ?? '' );
 
 								return [
 										'report_data'   => $structured_report_data,
@@ -322,7 +322,7 @@ $enable_ai        = ! $bypass_heavy && ( class_exists( 'RTBCB_Settings' ) ? RTBC
 			if ( $lead_email ) {
 			$debug_info['lead_email'] = $lead_email;
 			}
-			self::store_workflow_history( $debug_info, $lead_id, $lead_email );
+                       self::store_workflow_history( $debug_info, $lead_id, $lead_email, $user_inputs['company_name'] ?? '' );
 
 			return [
 				'report_data'   => $structured_report_data,
@@ -339,7 +339,7 @@ $enable_ai        = ! $bypass_heavy && ( class_exists( 'RTBCB_Settings' ) ? RTBC
 			if ( $lead_email ) {
 			$debug_info['lead_email'] = $lead_email;
 			}
-			self::store_workflow_history( $debug_info, isset( $lead_id ) ? $lead_id : null, $lead_email );
+                       self::store_workflow_history( $debug_info, isset( $lead_id ) ? $lead_id : null, $lead_email, $user_inputs['company_name'] ?? '' );
 			return new WP_Error( 'generation_failed', __( 'An error occurred while generating your business case. Please try again.', 'rtbcb' ) );
 		}
 	}
@@ -630,7 +630,7 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 			return $base > 0 ? 'strong' : 'weak';
 	}
 
-       private static function format_roi_scenarios( $roi_scenarios ) {
+	private static function format_roi_scenarios( $roi_scenarios ) {
                return $roi_scenarios;
        }
 
@@ -639,7 +639,7 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
         *
         * @return array
         */
-       private static function get_sanitized_params() {
+	private static function get_sanitized_params() {
                $params = [];
                foreach ( $_REQUEST as $key => $value ) {
                        if ( is_scalar( $value ) ) {
@@ -658,7 +658,7 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
         * @param array  $extra  Additional context.
         * @return void
         */
-       private static function log_request( $action, $params, $status, $extra = [] ) {
+	private static function log_request( $action, $params, $status, $extra = [] ) {
                if ( class_exists( 'RTBCB_Logger' ) ) {
                        $context = array_merge(
                                [
@@ -681,7 +681,7 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
         * @param array  $data   Data to store.
         * @return void
         */
-       private static function safe_update_status( $job_id, $state, $data ) {
+	private static function safe_update_status( $job_id, $state, $data ) {
                if ( ! $job_id ) {
                        return;
                }
@@ -702,7 +702,7 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
         * @param string    $lead_email  Lead email address.
         * @return void
         */
-       private static function store_workflow_history( $debug_info, $lead_id = null, $lead_email = '' ) {
+	private static function store_workflow_history( $debug_info, $lead_id = null, $lead_email = '', $company_name = '' ) {
                $history = function_exists( 'get_option' ) ? get_option( 'rtbcb_workflow_history', [] ) : [];
                if ( ! is_array( $history ) ) {
                        $history = [];
@@ -710,6 +710,9 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
                $debug_info['lead_id'] = $lead_id ? intval( $lead_id ) : null;
                if ( ! empty( $lead_email ) ) {
                        $debug_info['lead_email'] = sanitize_email( $lead_email );
+               }
+               if ( ! empty( $company_name ) ) {
+                       $debug_info['company_name'] = sanitize_text_field( $company_name );
                }
                $history[] = $debug_info;
                if ( count( $history ) > 20 ) {

--- a/inc/class-rtbcb-workflow-tracker.php
+++ b/inc/class-rtbcb-workflow-tracker.php
@@ -29,6 +29,13 @@ private $current_step = null;
 private $start_time;
 
 /**
+	* Workflow start timestamp.
+	*
+	* @var string
+	*/
+private $start_timestamp;
+
+/**
 	* Recorded warnings.
 	*
 	* @var array
@@ -60,7 +67,8 @@ private $prompts = [];
 	* Constructor.
 	*/
 public function __construct() {
-$this->start_time = microtime( true );
+$this->start_time      = microtime( true );
+$this->start_timestamp = function_exists( 'current_time' ) ? current_time( 'mysql' ) : gmdate( 'Y-m-d H:i:s' );
 }
 
 /**
@@ -221,15 +229,16 @@ return $this->warnings;
 	*/
 public function get_debug_info() {
 return [
-'total_steps'    => count( $this->steps ),
-'total_duration' => microtime( true ) - $this->start_time,
-'ai_calls'       => $this->ai_calls,
-'warnings_count' => count( $this->warnings ),
-'errors_count'   => count( $this->errors ),
-'steps'          => $this->get_completed_steps(),
-'prompts'        => $this->prompts,
-'warnings'       => $this->warnings,
-'errors'         => $this->errors,
+'started_at'    => $this->start_timestamp,
+'total_steps'   => count( $this->steps ),
+'total_duration'=> microtime( true ) - $this->start_time,
+'ai_calls'      => $this->ai_calls,
+'warnings_count'=> count( $this->warnings ),
+'errors_count'  => count( $this->errors ),
+'steps'         => $this->get_completed_steps(),
+'prompts'       => $this->prompts,
+'warnings'      => $this->warnings,
+'errors'        => $this->errors,
 ];
 }
 


### PR DESCRIPTION
## Summary
- track workflow start timestamp and expose it in debug info
- persist company name with workflow history and surface it via admin UI
- show company and start time columns on workflow visualization page

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b65b9aae288331bdc34ee4f1be483b