### PR TITLE
Allow inline script data in report HTML

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -120,7 +120,7 @@ $auto = true;
 }
 }
 
-return (bool) ( $disabled || $fast || $auto );
+	return (bool) ( $disabled || $fast || $auto );
 }
 
 /**
@@ -1804,7 +1804,7 @@ $results = [
 'summary'   => $analysis['executive_summary'],
 'stored_in' => 'rtbcb_executive_summary',
 ],
-];
+	];
 
 	$usage_map = [
 		[ 'component' => __( 'Market Analysis & Vendors', 'rtbcb' ), 'used_in' => __( 'RAG Market Analysis Test', 'rtbcb' ), 'option' => 'rtbcb_rag_market_analysis' ],
@@ -1837,7 +1837,7 @@ if ( function_exists( 'add_action' ) ) {
 	*/
 function rtbcb_get_analysis_job_result( $job_id ) {
 $job_id = sanitize_key( $job_id );
-return function_exists( 'get_option' ) ? get_option( 'rtbcb_analysis_job_' . $job_id, null ) : null;
+	return function_exists( 'get_option' ) ? get_option( 'rtbcb_analysis_job_' . $job_id, null ) : null;
 }
 
 /**
@@ -1942,10 +1942,15 @@ function rtbcb_get_report_allowed_html() {
 	];
 
 	foreach ( $allowed as $tag => $attrs ) {
-		$allowed[ $tag ]['data-*'] = true;
-	}
+	$allowed[ $tag ]['data-*'] = true;
+}
 
-		return $allowed;
+	$allowed['script'] = [
+		'id'   => true,
+		'type' => true,
+	];
+
+	return $allowed;
 }
 
 /**

--- a/tests/RTBCB_GetReportAllowedHtmlTest.php
+++ b/tests/RTBCB_GetReportAllowedHtmlTest.php
@@ -1,0 +1,65 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/wp-stubs.php';
+
+if ( ! function_exists( 'wp_kses_allowed_html' ) ) {
+	function wp_kses_allowed_html( $context = 'post' ) {
+	    return [];
+	}
+}
+
+if ( ! function_exists( 'wp_kses' ) ) {
+	function wp_kses( $string, $allowed_html ) {
+	    return preg_replace_callback(
+	        '#<([a-z0-9]+)([^>]*)>(.*?)</\\1>#is',
+	        function ( $matches ) use ( $allowed_html ) {
+	            $tag     = strtolower( $matches[1] );
+	            $attrs   = $matches[2];
+	            $content = $matches[3];
+
+	            if ( ! isset( $allowed_html[ $tag ] ) ) {
+	                return '';
+	            }
+
+	            $allowed_attrs = $allowed_html[ $tag ];
+	            $new_attrs     = '';
+
+	            if ( preg_match_all( '#([a-zA-Z0-9-:]+)="([^"]*)"#', $attrs, $attr_matches, PREG_SET_ORDER ) ) {
+	                foreach ( $attr_matches as $attr ) {
+	                    $name  = $attr[1];
+	                    $value = $attr[2];
+	                    if ( isset( $allowed_attrs[ $name ] ) ) {
+	                        $new_attrs .= ' ' . $name . '="' . $value . '"';
+	                    }
+	                }
+	            }
+
+	            return '<' . $tag . $new_attrs . '>' . $content . '</' . $tag . '>';
+	        },
+	        $string
+	    );
+	}
+}
+
+require_once __DIR__ . '/../inc/helpers.php';
+
+final class RTBCB_GetReportAllowedHtmlTest extends TestCase {
+	public function test_allows_minimal_script_attributes() {
+	    $allowed = rtbcb_get_report_allowed_html();
+	    $this->assertArrayHasKey( 'script', $allowed );
+	    $this->assertSame( [ 'id' => true, 'type' => true ], $allowed['script'] );
+	    $sanitized = wp_kses( '<script type="application/json" id="init">{}</script>', $allowed );
+	    $this->assertSame( '<script type="application/json" id="init">{}</script>', $sanitized );
+	}
+
+	public function test_disallows_untrusted_script_attributes() {
+	    $allowed   = rtbcb_get_report_allowed_html();
+	    $sanitized = wp_kses( '<script src="//evil.test/evil.js"></script>', $allowed );
+	    $this->assertSame( '<script></script>', $sanitized );
+	}
+}


### PR DESCRIPTION
## Summary
- permit `<script>` tags with `id` and `type` in report HTML sanitization
- test that only limited script attributes are preserved and disallowed ones are stripped

## Testing
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4o-mini bash tests/run-tests.sh`
- `./vendor/bin/phpunit tests/RTBCB_GetReportAllowedHtmlTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b65fb399188331b453466e18dcc4f7