### PR TITLE
Restrict report HTML scripts to safe types

### DIFF
--- a/inc/class-rtbcb-background-job.php
+++ b/inc/class-rtbcb-background-job.php
@@ -131,7 +131,7 @@ public static function enqueue( $user_inputs ) {
 	ob_start();
 	include RTBCB_DIR . 'templates/comprehensive-report-template.php';
 	$report_html = ob_get_clean();
-	$report_html = wp_kses( $report_html, rtbcb_get_report_allowed_html() );
+$report_html = rtbcb_sanitize_report_html( $report_html );
 	} else {
 	$report_html = '<html></html>';
 	}

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -298,7 +298,7 @@ $premium_model = function_exists( 'get_option' ) ? get_option( 'rtbcb_premium_mo
 		ob_start();
 		include $template_path;
 		$html = ob_get_clean();
-		$html = wp_kses( $html, rtbcb_get_report_allowed_html() );
+$html = rtbcb_sanitize_report_html( $html );
 
 		wp_cache_set( $cache_key, $html, 'rtbcb_reports', HOUR_IN_SECONDS );
 
@@ -327,7 +327,7 @@ $premium_model = function_exists( 'get_option' ) ? get_option( 'rtbcb_premium_mo
 		include $template_path;
 		$html = ob_get_clean();
 
-		return wp_kses( $html, rtbcb_get_report_allowed_html() );
+return rtbcb_sanitize_report_html( $html );
 	}
 
 	/**
@@ -368,7 +368,7 @@ $premium_model = function_exists( 'get_option' ) ? get_option( 'rtbcb_premium_mo
 	ob_start();
 	include $template_path;
 	$html = ob_get_clean();
-	$html = wp_kses( $html, rtbcb_get_report_allowed_html() );
+$html = rtbcb_sanitize_report_html( $html );
 
 	wp_cache_set( $cache_key, $html, 'rtbcb_reports', HOUR_IN_SECONDS );
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2202,7 +2202,7 @@ $missing_sections  = array_diff( $required_sections, array_keys( $comprehensive_
 	);
 		}
 
-		$html = wp_kses( $html, rtbcb_get_report_allowed_html() );
+$html = rtbcb_sanitize_report_html( $html );
 		wp_cache_set( $cache_key, $html, 'rtbcb_reports', HOUR_IN_SECONDS );
 
 		return $html;


### PR DESCRIPTION
## Summary
- whitelist only non-executable `script` tag types in allowed report HTML
- add `rtbcb_sanitize_report_html()` to strip disallowed scripts
- use new sanitizer across report generation and extend tests

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4o-mini bash tests/run-tests.sh` *(fails: ReferenceError generateProfessionalReport is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b662b7c82083319ecb1cda3bb72b72