### PR TITLE
Implement professional report generation with streaming support

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1573,10 +1573,14 @@ $msg = sanitize_text_field( $error );
 	* @return void
 	*/
 function rtbcb_generate_report() {
-	if ( isset( $_POST['rtbcb_nonce'] ) && ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ), 'rtbcb_generate' ) ) {
-	wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ] );
-}
-
+	if ( empty( $_POST['rtbcb_nonce'] ) ) {
+		wp_send_json_error( [ 'message' => __( 'Missing security token.', 'rtbcb' ) ], 400 );
+	}
+	
+	if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rtbcb_nonce'] ) ), 'rtbcb_generate' ) ) {
+		wp_send_json_error( [ 'message' => __( 'Security check failed.', 'rtbcb' ) ], 403 );
+	}
+	
 	nocache_headers();
 	header( 'Content-Type: text/html; charset=utf-8' );
 	echo wp_kses_post( '<p>' . __( 'Report generation endpoint not yet implemented.', 'rtbcb' ) . '</p>' );


### PR DESCRIPTION
## Summary
- add placeholder `rtbcb_generate_report` backend handler
- wire `rtbcb_generate_report` AJAX hooks for logged-in and public requests
- require nonce for report generation endpoint

## Testing
- `php -l inc/helpers.php`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*
- `phpcs --standard=WordPress inc/helpers.php` *(fails: FOUND 788 ERRORS AND 92 WARNINGS AFFECTING 753 LINES)*

------
https://chatgpt.com/codex/tasks/task_e_68b6693c973883319daf5978a110bd2a