### PR TITLE
Allow report scripts to execute

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1497,7 +1497,7 @@ function rtbcb_proxy_openai_responses() {
 		}
 
         if ( isset( $_POST['nonce'] ) ) {
-                check_ajax_referer( 'rtbcb_openai_responses', 'nonce' );
+		 check_ajax_referer( 'rtbcb_openai_responses', 'nonce' );
         }
 
 	$body = isset( $_POST['body'] ) ? wp_unslash( $_POST['body'] ) : '';
@@ -1941,12 +1941,20 @@ function rtbcb_get_report_allowed_html() {
 		'data-*' => true,
 	];
 
+	$allowed['script'] = [
+		'type'   => true,
+		'id'     => true,
+		'src'    => true,
+		'data-*' => true,
+	];
+
 	foreach ( $allowed as $tag => $attrs ) {
 		$allowed[ $tag ]['data-*'] = true;
 	}
 
-		return $allowed;
+	return $allowed;
 }
+
 
 /**
 	* Increment the RAG search cache version to invalidate cached results.

--- a/public/js/rtbcb-report.js
+++ b/public/js/rtbcb-report.js
@@ -567,11 +567,16 @@ function sanitizeReportHTML(htmlContent) {
     const allowedTags = [
         'a', 'p', 'br', 'strong', 'em', 'ul', 'ol', 'li',
         'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'span',
-        'table', 'thead', 'tbody', 'tr', 'th', 'td'
+        'table', 'thead', 'tbody', 'tr', 'th', 'td', 'script'
     ];
-    const allowedAttr = [ 'href', 'title', 'target', 'rel', 'style' ];
+    const allowedAttr = [ 'href', 'title', 'target', 'rel', 'style', 'src', 'type' ];
     return typeof DOMPurify !== 'undefined'
-        ? DOMPurify.sanitize(htmlContent, { ALLOWED_TAGS: allowedTags, ALLOWED_ATTR: allowedAttr })
+        ? DOMPurify.sanitize(htmlContent, {
+            ALLOWED_TAGS: allowedTags,
+            ALLOWED_ATTR: allowedAttr,
+            ADD_TAGS: ['script'],
+            ADD_ATTR: ['src', 'type']
+        })
         : htmlContent;
 }
 


### PR DESCRIPTION
## Summary
- Permit `<script>` tags in sanitized report HTML
- Whitelist script tags and attributes during client-side report sanitization

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: document.querySelectorAll is not a function / ReferenceError: generateProfessionalReport is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6691aafec8331b7ec9f3ccec83f33