### PR TITLE
Fix script type regex to avoid data-type attribute bypass

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1974,7 +1974,7 @@ return preg_replace_callback(
 '#<script\\b([^>]*)>(.*?)</script>#is',
 function ( $matches ) {
 $attrs = $matches[1];
-if ( preg_match( '/\btype=(["\'])(.*?)\1/i', $attrs, $type_match ) ) {
+if ( preg_match( '/(?:^|\s)type\s*=\s*(["\'])(.*?)\1/i', $attrs, $type_match ) ) {
 $type          = strtolower( $type_match[2] );
 $allowed_types = [ 'application/json', 'application/ld+json' ];
 if ( in_array( $type, $allowed_types, true ) ) {

--- a/tests/RTBCB_GetReportAllowedHtmlTest.php
+++ b/tests/RTBCB_GetReportAllowedHtmlTest.php
@@ -71,5 +71,6 @@ final class RTBCB_GetReportAllowedHtmlTest extends TestCase {
             $this->assertSame( '', rtbcb_sanitize_report_html( '<script type="text/javascript">alert(1)</script>' ) );
             $this->assertSame( '', rtbcb_sanitize_report_html( '<script src="//evil.test/evil.js"></script>' ) );
             $this->assertSame( '', rtbcb_sanitize_report_html( '<script id="no-type">alert(1)</script>' ) );
+            $this->assertSame( '', rtbcb_sanitize_report_html( '<script data-type="application/json">alert(1)</script>' ) );
         }
-}
+    }


### PR DESCRIPTION
## Summary
- tighten script `type` attribute detection to ignore similarly named attributes
- extend sanitization tests to cover `data-type` bypass

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4o-mini bash tests/run-tests.sh` *(fails: ReferenceError: generateProfessionalReport is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b66b3c48a0833180500ea73837fd50