### PR TITLE
Allow script tags in report output

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1940,6 +1940,11 @@ function rtbcb_get_report_allowed_html() {
 		'style'  => true,
 		'data-*' => true,
 	];
+	$allowed['script'] = [
+		'type'   => true,
+		'id'     => true,
+		'class'  => true,
+	];
 
 	foreach ( $allowed as $tag => $attrs ) {
 		$allowed[ $tag ]['data-*'] = true;


### PR DESCRIPTION
## Summary
- permit `<script>` in `rtbcb_get_report_allowed_html` so inline report data is no longer displayed as plain text

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: handle-submit-nonce-retry.test.js, other JS tests due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b6691aafec8331b7ec9f3ccec83f33