### PR TITLE
Remove script whitelist from sanitized reports

### DIFF
--- a/public/js/rtbcb-report.js
+++ b/public/js/rtbcb-report.js
@@ -567,9 +567,9 @@ function sanitizeReportHTML(htmlContent) {
     const allowedTags = [
         'a', 'p', 'br', 'strong', 'em', 'ul', 'ol', 'li',
         'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'span',
-        'table', 'thead', 'tbody', 'tr', 'th', 'td', 'script'
+        'table', 'thead', 'tbody', 'tr', 'th', 'td'
     ];
-    const allowedAttr = [ 'href', 'title', 'target', 'rel', 'style', 'src', 'type' ];
+    const allowedAttr = [ 'href', 'title', 'target', 'rel', 'style' ];
     return typeof DOMPurify !== 'undefined'
         ? DOMPurify.sanitize(htmlContent, { ALLOWED_TAGS: allowedTags, ALLOWED_ATTR: allowedAttr })
         : htmlContent;


### PR DESCRIPTION
## Summary
- prevent execution of untrusted report content by disallowing `<script>` tags and related attributes in DOMPurify

## Testing
- `bash tests/run-tests.sh` *(fails: ReferenceError: RTBCB_GPT5_MIN_TOKENS is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6715f27e88331b176d429a5b0d783