### PR TITLE
chore: bump version and refresh docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-# Real Treasury Business Case Builder - Enhanced Version 2.1.10
+# Real Treasury Business Case Builder - Enhanced Version 2.1.11
 
 A comprehensive WordPress plugin that helps treasury teams quantify the benefits of modern treasury tools, generate professional business case reports, and track lead engagement with advanced analytics.
 
-## 🚀 What's New in Version 2.1.10
+## 🚀 What's New in Version 2.1.11
 
 ### ✨ Enhancements
-- Hardened security with ABSPATH guards across admin and template files.
-- Wrapped user-visible strings with translation functions for better localization.
-- Documented Composer install step and added PHPUnit checks to test scripts.
-- Streamlined developer tooling with improved linting and code quality fixes.
-- Updated documentation and bumped version number to keep release notes current.
+- Added JSON error handling with a dedicated `RTBCB_JSON_Error` class.
+- Improved report verification logic with graceful fallback handling.
+- Allowed HTML fragment reports and safe script tags for flexible rendering.
 
 
 ## 📋 Installation & Setup

--- a/docs/REPOSITORY_STRUCTURE.md
+++ b/docs/REPOSITORY_STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-Documentation reflects repository layout for version 2.1.10.
+Documentation reflects repository layout for version 2.1.11.
 
 ## Directory Tree
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: realtreasury
 Tags: business, case, builder, roi, treasury
 Requires at least: 6.0
 Tested up to: 6.0
-Stable tag: 2.1.10
+Stable tag: 2.1.11
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -156,6 +156,10 @@ Reports are rendered as HTML in the browser. Use your browser's print or save fu
 The analytics dashboard uses Chart.js for its visualizations. The library is bundled with the plugin to reduce blocking by privacy tools, but strict ad blockers may still prevent it from loading. Allow the plugin's scripts in your browser to enable the charts.
 
 == Changelog ==
+= 2.1.11 =
+* Improved report verification logic with fallback handling.
+* Added JSON error class and allowed HTML fragment reports.
+
 = 2.1.10 =
 * Updated documentation and bumped version number.
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2,7 +2,7 @@
 /**
 	* Plugin Name: Real Treasury - Business Case Builder (Enhanced Pro)
 	* Description: Professional-grade ROI calculator and comprehensive business case generator for treasury technology with advanced analysis and consultant-style reports.
-* Version: 2.1.10
+* Version: 2.1.11
 	* Requires PHP: 7.4
 	* Author: Real Treasury
 	* Text Domain: rtbcb
@@ -12,7 +12,7 @@
 */
 defined( 'ABSPATH' ) || exit;
 
-define( 'RTBCB_VERSION', '2.1.10' );
+define( 'RTBCB_VERSION', '2.1.11' );
 define( 'RTBCB_FILE', __FILE__ );
 define( 'RTBCB_URL', plugin_dir_url( RTBCB_FILE ) );
 define( 'RTBCB_DIR', plugin_dir_path( RTBCB_FILE ) );


### PR DESCRIPTION
## Summary
- bump plugin version to 2.1.11
- update plugin and repository docs to reflect new release

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=test-model bash tests/run-tests.sh`
- `phpcs --standard=WordPress` *(fails: command not found)*
- `npx -y markdownlint-cli docs/REPOSITORY_STRUCTURE.md`
- `npx -y markdown-link-check docs/REPOSITORY_STRUCTURE.md`


------
https://chatgpt.com/codex/tasks/task_e_68b6727cc8e48331a38cba405310d8ca