### PR TITLE
Return response from OpenAI retry helper

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2474,7 +2474,7 @@ wp_cache_set( $cache_key, $body, 'rtbcb_llm', $ttl );
 set_transient( $cache_key, $body, $ttl );
 }
 }
-	return ;
+	return $response;
 }
 
 $error_code = $response->get_error_code();


### PR DESCRIPTION
## Summary
- return the OpenAI HTTP response from `call_openai_with_retry`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b6d68f088c8331bd2d5d0244cfb882