### PR TITLE
Add executive summary and analysis sections

### DIFF
--- a/templates/report-template.php
+++ b/templates/report-template.php
@@ -12,31 +12,83 @@ defined( 'ABSPATH' ) || exit;
 $metadata      = $business_case_data['metadata'] ?? [];
 $analysis_type = $metadata['analysis_type'] ?? 'basic';
 $rag_context   = $business_case_data['rag_context'] ?? [];
+$executive_summary    = $business_case_data['executive_summary'] ?? [];
+$operational_analysis = $business_case_data['operational_analysis'] ?? [];
+$industry_insights    = $business_case_data['industry_insights'] ?? [];
 ?>
 <div class="rtbcb-report">
-	<h2><?php echo esc_html__( 'Business Case Report', 'rtbcb' ); ?></h2>
-	<p class="rtbcb-version-tag"><?php printf( esc_html__( 'Version %s', 'rtbcb' ), esc_html( defined( 'RTBCB_VERSION' ) ? RTBCB_VERSION : 'dev' ) ); ?></p>
-	<?php if ( ! empty( $business_case_data['narrative'] ) ) : ?>
-		<p><?php echo esc_html( $business_case_data['narrative'] ); ?></p>
-	<?php endif; ?>
+        <h2><?php echo esc_html__( 'Business Case Report', 'rtbcb' ); ?></h2>
+        <p class="rtbcb-version-tag"><?php printf( esc_html__( 'Version %s', 'rtbcb' ), esc_html( defined( 'RTBCB_VERSION' ) ? RTBCB_VERSION : 'dev' ) ); ?></p>
 
-	<?php if ( ! empty( $business_case_data['risks'] ) ) : ?>
-		<h3><?php echo esc_html__( 'Risks', 'rtbcb' ); ?></h3>
-		<ul>
-			<?php foreach ( (array) $business_case_data['risks'] as $risk ) : ?>
-				<li><?php echo esc_html( $risk ); ?></li>
-			<?php endforeach; ?>
-		</ul>
-	<?php endif; ?>
+       <?php if ( ! empty( $executive_summary['strategic_positioning'] ) || ! empty( $business_case_data['business_case_strength'] ) || ! empty( $business_case_data['key_value_drivers'] ) || ! empty( $business_case_data['executive_recommendation'] ) ) : ?>
+               <h3><?php echo esc_html__( 'Executive Summary', 'rtbcb' ); ?></h3>
+               <?php if ( ! empty( $executive_summary['strategic_positioning'] ) ) : ?>
+                       <p><?php echo esc_html( $executive_summary['strategic_positioning'] ); ?></p>
+               <?php endif; ?>
+               <?php if ( ! empty( $business_case_data['business_case_strength'] ) ) : ?>
+                       <p><?php echo esc_html( $business_case_data['business_case_strength'] ); ?></p>
+               <?php endif; ?>
+               <?php if ( ! empty( $business_case_data['key_value_drivers'] ) ) : ?>
+                       <h4><?php echo esc_html__( 'Key Value Drivers', 'rtbcb' ); ?></h4>
+                       <?php if ( is_array( $business_case_data['key_value_drivers'] ) ) : ?>
+                               <ul>
+                                       <?php foreach ( $business_case_data['key_value_drivers'] as $driver ) : ?>
+                                               <li><?php echo esc_html( $driver ); ?></li>
+                                       <?php endforeach; ?>
+                               </ul>
+                       <?php else : ?>
+                               <p><?php echo esc_html( $business_case_data['key_value_drivers'] ); ?></p>
+                       <?php endif; ?>
+               <?php endif; ?>
+               <?php if ( ! empty( $business_case_data['executive_recommendation'] ) ) : ?>
+                       <p><?php echo esc_html( $business_case_data['executive_recommendation'] ); ?></p>
+               <?php endif; ?>
+       <?php endif; ?>
 
-	<?php if ( ! empty( $business_case_data['assumptions_explained'] ) ) : ?>
-		<h3><?php echo esc_html__( 'Assumptions', 'rtbcb' ); ?></h3>
-		<ul>
-			<?php foreach ( (array) $business_case_data['assumptions_explained'] as $assumption ) : ?>
-				<li><?php echo esc_html( $assumption ); ?></li>
-			<?php endforeach; ?>
-		</ul>
-	<?php endif; ?>
+       <?php if ( ! empty( $operational_analysis['current_state_assessment'] ) ) : ?>
+               <h3><?php echo esc_html__( 'Operational Analysis', 'rtbcb' ); ?></h3>
+               <p><?php echo esc_html( $operational_analysis['current_state_assessment'] ); ?></p>
+       <?php endif; ?>
+
+       <?php if ( ! empty( $industry_insights['sector_trends'] ) || ! empty( $industry_insights['competitive_benchmarks'] ) || ! empty( $industry_insights['regulatory_considerations'] ) ) : ?>
+               <h3><?php echo esc_html__( 'Industry Insights', 'rtbcb' ); ?></h3>
+               <?php if ( ! empty( $industry_insights['sector_trends'] ) ) : ?>
+                       <h4><?php echo esc_html__( 'Sector Trends', 'rtbcb' ); ?></h4>
+                       <?php if ( is_array( $industry_insights['sector_trends'] ) ) : ?>
+                               <ul>
+                                       <?php foreach ( $industry_insights['sector_trends'] as $trend ) : ?>
+                                               <li><?php echo esc_html( $trend ); ?></li>
+                                       <?php endforeach; ?>
+                               </ul>
+                       <?php else : ?>
+                               <p><?php echo esc_html( $industry_insights['sector_trends'] ); ?></p>
+                       <?php endif; ?>
+               <?php endif; ?>
+               <?php if ( ! empty( $industry_insights['competitive_benchmarks'] ) ) : ?>
+                       <h4><?php echo esc_html__( 'Competitive Benchmarks', 'rtbcb' ); ?></h4>
+                       <?php if ( is_array( $industry_insights['competitive_benchmarks'] ) ) : ?>
+                               <ul>
+                                       <?php foreach ( $industry_insights['competitive_benchmarks'] as $benchmark ) : ?>
+                                               <li><?php echo esc_html( $benchmark ); ?></li>
+                                       <?php endforeach; ?>
+                               </ul>
+                       <?php else : ?>
+                               <p><?php echo esc_html( $industry_insights['competitive_benchmarks'] ); ?></p>
+                       <?php endif; ?>
+               <?php endif; ?>
+               <?php if ( ! empty( $industry_insights['regulatory_considerations'] ) ) : ?>
+                       <h4><?php echo esc_html__( 'Regulatory Considerations', 'rtbcb' ); ?></h4>
+                       <?php if ( is_array( $industry_insights['regulatory_considerations'] ) ) : ?>
+                               <ul>
+                                       <?php foreach ( $industry_insights['regulatory_considerations'] as $reg ) : ?>
+                                               <li><?php echo esc_html( $reg ); ?></li>
+                                       <?php endforeach; ?>
+                               </ul>
+                       <?php else : ?>
+                               <p><?php echo esc_html( $industry_insights['regulatory_considerations'] ); ?></p>
+                       <?php endif; ?>
+               <?php endif; ?>
+       <?php endif; ?>
 
 	<?php if ( ! empty( $business_case_data['citations'] ) ) : ?>
 		<h3><?php echo esc_html__( 'Citations', 'rtbcb' ); ?></h3>

--- a/tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
+++ b/tests/RTBCB_GenerateBusinessAnalysisTimeoutTest.php
@@ -132,25 +132,35 @@ private function generate_fallback_analysis( $user_inputs, $scenarios ) {
 $company_name = $user_inputs['company_name'];
 $base_roi     = $scenarios['base']['total_annual_benefit'] ?? 0;
 
+
 return [
-'executive_summary' => sprintf(
+'executive_summary' => [
+'strategic_positioning' => sprintf(
 __( '%s has significant opportunities to improve treasury operations through technology automation. Based on current processes, implementing a modern treasury management system could deliver substantial ROI while reducing operational risk.', 'rtbcb' ),
 $company_name
 ),
-'narrative'         => sprintf(
-__( 'Our analysis of %s treasury operations reveals opportunities for process automation and efficiency gains. Key areas for improvement include cash management, bank reconciliation, and reporting processes.', 'rtbcb' ),
-$company_name
+],
+'business_case_strength'   => sprintf(
+__( 'Projected ROI is %s based on current estimates.', 'rtbcb' ),
+$base_roi
 ),
-'key_benefits'      => [
+'key_value_drivers'        => [
 __( 'Automated cash positioning and forecasting', 'rtbcb' ),
 __( 'Streamlined bank reconciliation processes', 'rtbcb' ),
 __( 'Enhanced regulatory compliance and reporting', 'rtbcb' ),
 __( 'Improved operational risk management', 'rtbcb' ),
 ],
-'risks'             => [
-__( 'Implementation complexity and timeline risk', 'rtbcb' ),
-__( 'User adoption and change management challenges', 'rtbcb' ),
-__( 'Integration complexity with existing systems', 'rtbcb' ),
+'executive_recommendation' => __( 'Proceed with a phased implementation focusing on high-impact processes first.', 'rtbcb' ),
+'operational_analysis'     => [
+'current_state_assessment' => sprintf(
+__( '%s currently relies on manual processes for key treasury functions.', 'rtbcb' ),
+$company_name
+),
+],
+'industry_insights'        => [
+'sector_trends'           => [ __( 'Increasing adoption of AI in treasury operations', 'rtbcb' ) ],
+'competitive_benchmarks'  => [ __( 'Peers report 20% efficiency gains post-automation', 'rtbcb' ) ],
+'regulatory_considerations' => [ __( 'Upcoming regulations will mandate real-time reporting', 'rtbcb' ) ],
 ],
 'next_actions'      => [
 __( 'Secure executive sponsorship and project funding', 'rtbcb' ),
@@ -161,7 +171,9 @@ __( 'Develop implementation roadmap and timeline', 'rtbcb' ),
 'confidence'        => 0.75,
 'enhanced_fallback' => true,
 ];
+
 }
+
 }
 
 final class RTBCB_GenerateBusinessAnalysisTimeoutTest extends TestCase {

--- a/tests/report-memory-usage.test.php
+++ b/tests/report-memory-usage.test.php
@@ -52,9 +52,20 @@ if (!function_exists('wp_convert_hr_to_bytes')) {
 	}
 }
 $business_case_data = [
-	'narrative' => 'Sample report narrative.',
-	'risks' => ['Risk1'],
-	'assumptions_explained' => ['Assumption1'],
+       'executive_summary'    => [
+               'strategic_positioning' => 'Sample strategic positioning.',
+       ],
+       'business_case_strength'    => 'Sample case strength.',
+       'key_value_drivers'         => [ 'Driver1' ],
+       'executive_recommendation'  => 'Sample recommendation.',
+       'operational_analysis'      => [
+               'current_state_assessment' => 'Sample current state assessment.',
+       ],
+       'industry_insights'         => [
+               'sector_trends'           => [ 'Trend1' ],
+               'competitive_benchmarks'  => [ 'Benchmark1' ],
+               'regulatory_considerations' => [ 'Reg1' ],
+       ],
 ];
 ob_start();
 include __DIR__ . '/../templates/report-template.php';


### PR DESCRIPTION
## Summary
- Replace narrative and risk sections with Executive Summary, Operational Analysis, and Industry Insights blocks in the report template.
- Update tests to use new business case data fields and fallback analysis structure.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: RTBCB: OpenAI API key not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b6dc9109f48331b2ef728b9ddf494a