### PR TITLE
Validate GPT-5 response input

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2997,17 +2997,21 @@ $max_output_tokens = min( 128000, max( $min_tokens, $max_output_tokens ) );
 	*
 	* @param array $response  HTTP response array from wp_remote_post().
 	* @param bool  $store_raw Optional. Include full raw payload. Default false.
-	* @return array {
-	*     @type string $output_text    Combined output text from the response.
-	*     @type array  $reasoning      Reasoning segments provided by the model.
-	*     @type array  $function_calls Function call items returned by the model.
-	*     @type array  $raw            Raw decoded response body.
-	*     @type bool   $truncated      Whether the response hit the token limit.
+	* @return array|WP_Error {
+	* @type string $output_text    Combined output text from the response.
+	* @type array  $reasoning      Reasoning segments provided by the model.
+	* @type array  $function_calls Function call items returned by the model.
+	* @type array  $raw            Raw decoded response body.
+	* @type bool   $truncated      Whether the response hit the token limit.
 	* }
-	*/
+ */
 function rtbcb_parse_gpt5_response( $response, $store_raw = false ) {
-	$body    = wp_remote_retrieve_body( $response );
-	$decoded = json_decode( $body, true );
+       if ( ! is_array( $response ) ) {
+               return new WP_Error( 'invalid_response', __( 'Invalid response.', 'rtbcb' ) );
+       }
+
+       $body    = wp_remote_retrieve_body( $response );
+       $decoded = json_decode( $body, true );
 
 	if ( ! is_array( $decoded ) ) {
 		return [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,7 @@
   <testsuites>
     <testsuite name="rtbcb">
       <file>tests/RTBCB_ValidatorTest.php</file>
+      <file>tests/RTBCB_ParseGpt5ResponseTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/RTBCB_ParseGpt5ResponseTest.php
+++ b/tests/RTBCB_ParseGpt5ResponseTest.php
@@ -1,0 +1,28 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/wp-stubs.php';
+require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) {
+		return $text;
+	}
+}
+
+final class RTBCB_ParseGpt5ResponseTest extends TestCase {
+	public function test_returns_wp_error_when_response_not_array() {
+		$result = rtbcb_parse_gpt5_response( null );
+		$this->assertInstanceOf( WP_Error::class, $result );
+	}
+}
+


### PR DESCRIPTION
## Summary
- guard `rtbcb_parse_gpt5_response` against non-array input and return a `WP_Error`
- add PHPUnit test ensuring the parser rejects invalid responses
- wire the new test into `phpunit.xml`

## Testing
- `bash tests/run-tests.sh`
- `vendor/bin/phpunit tests/RTBCB_ParseGpt5ResponseTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6dd5d58ac8331bba473a0d749b50d