### PR TITLE
Fix operational analysis section data key

### DIFF
--- a/templates/report-template.php
+++ b/templates/report-template.php
@@ -45,15 +45,15 @@ $rag_context   = $business_case_data['rag_context'] ?? [];
 	<?php endif; ?>
 
 	<?php
-	$operational_analysis = array_map(
+	$operational_insights = array_map(
 	'sanitize_text_field',
-	(array) ( $business_case_data['operational_analysis']['current_state_assessment'] ?? [] )
+	(array) ( $business_case_data['operational_insights']['current_state_assessment'] ?? [] )
 	);
-	if ( ! empty( $operational_analysis ) ) :
+	if ( ! empty( $operational_insights ) ) :
 	?>
 	<h3><?php echo esc_html__( 'Operational Analysis', 'rtbcb' ); ?></h3>
 	<ul>
-	<?php foreach ( $operational_analysis as $assessment ) : ?>
+	<?php foreach ( $operational_insights as $assessment ) : ?>
 	<li><?php echo esc_html( $assessment ); ?></li>
 	<?php endforeach; ?>
 	</ul>


### PR DESCRIPTION
## Summary
- read operational analysis items from the `operational_insights` key so the section renders

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ebedb9408331aa1ffa0d038382e6