### PR TITLE
Clarify report template usage in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ their own `AGENTS.md` with additional rules.
 │  ├── AGENTS.md
 │  ├── business-case-form.php
 │  ├── comprehensive-report-template.php
+│  ├── fast-report-template.php
 │  └── report-template.php
 ├── tests
 │  ├── RTBCB_AdminAjaxReportTest.php
@@ -250,8 +251,10 @@ their own `AGENTS.md` with additional rules.
 
 ## 📄 HTML Reports
 
-- Reports are rendered server-side using `templates/report-template.php`.
-- After form submission, `RTBCB_Router` returns the report HTML via AJAX as `report_html`.
+- By default the plugin renders reports with `templates/comprehensive-report-template.php` when comprehensive analysis is enabled and assets exist.
+- If the comprehensive template or its CSS is missing, rendering falls back to `templates/report-template.php`.
+- Fast-mode reports use `templates/fast-report-template.php` for minimal output.
+- After form submission, `RTBCB_Router` returns the selected template HTML via AJAX as `report_html`.
 - `public/js/rtbcb.js` injects this HTML into `#rtbcb-report-container` for immediate viewing.
 - Reports are not saved as files; only lead metadata is stored in the database.
 - Users can save or print the report directly from their browser, including printing to PDF.
@@ -291,9 +294,9 @@ their own `AGENTS.md` with additional rules.
 - Confidence scoring and alternative suggestions
 
 **HTML Report Rendering (`RTBCB_Router`)**
-- Uses `templates/report-template.php` for dynamic reports
-- Returns sanitized HTML for inline display
-- No external rendering dependencies
+ - Uses `templates/comprehensive-report-template.php` by default and falls back to `templates/report-template.php`
+ - Returns sanitized HTML for inline display
+ - No external rendering dependencies
 
 **Lead Tracking System (`RTBCB_Leads`)**
 - Complete audit trail of user interactions

--- a/readme.txt
+++ b/readme.txt
@@ -119,6 +119,7 @@ requests.
 │  ├── AGENTS.md
 │  ├── business-case-form.php
 │  ├── comprehensive-report-template.php
+│  ├── fast-report-template.php
 │  └── report-template.php
 ├── tests
 │  ├── RTBCB_AdminAjaxReportTest.php
@@ -144,6 +145,12 @@ requests.
 └── vendor
    └── AGENTS.md
 ```
+
+== Report Templates ==
+The plugin selects a report template based on configuration and available assets:
+* `templates/comprehensive-report-template.php` – default template when comprehensive analysis is enabled.
+* `templates/report-template.php` – basic fallback if the comprehensive template or its CSS is missing.
+* `templates/fast-report-template.php` – used for fast-mode reports with minimal output.
 
 == Frequently Asked Questions ==
 = How do I display the calculator? =


### PR DESCRIPTION
## Summary
- Document the report template selection process, clarifying default, fallback, and fast-mode templates.
- Add fast-report-template.php to repository structure examples.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(PHPUnit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ec382dac8331b9263f46b2896430