### PR TITLE
Handle fallback operational insights arrays

### DIFF
--- a/templates/report-template.php
+++ b/templates/report-template.php
@@ -45,10 +45,11 @@ $rag_context   = $business_case_data['rag_context'] ?? [];
 	<?php endif; ?>
 
 	<?php
-	$operational_insights = array_map(
-	'sanitize_text_field',
-	(array) ( $business_case_data['operational_insights']['current_state_assessment'] ?? [] )
-	);
+	$operational_insights_raw = $business_case_data['operational_insights'] ?? [];
+	if ( isset( $operational_insights_raw['current_state_assessment'] ) ) {
+		$operational_insights_raw = $operational_insights_raw['current_state_assessment'];
+	}
+	$operational_insights = array_map( 'sanitize_text_field', (array) $operational_insights_raw );
 	if ( ! empty( $operational_insights ) ) :
 	?>
 	<h3><?php echo esc_html__( 'Operational Analysis', 'rtbcb' ); ?></h3>


### PR DESCRIPTION
## Summary
- support top-level operational insights arrays in report template

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Call to undefined function is_wp_error())*

------
https://chatgpt.com/codex/tasks/task_e_68b6eea1919c83318d221cfc15549bc7