### PR TITLE
Expand comprehensive response parsing

### DIFF
--- a/tests/parse-comprehensive-response.test.php
+++ b/tests/parse-comprehensive-response.test.php
@@ -60,31 +60,71 @@ $method->setAccessible( true );
 
 $valid_json = [
         'executive_summary' => [
-                'strategic_positioning'   => 'pos',
-                'business_case_strength'  => 'Strong',
-                'key_value_drivers'       => [ 'driver' ],
-                'executive_recommendation'=> 'rec',
-                'confidence_level'        => 0.9,
+                'strategic_positioning'    => 'pos',
+                'business_case_strength'   => 'Strong',
+                'key_value_drivers'        => [ 'driver' ],
+                'executive_recommendation' => 'rec',
+                'confidence_level'         => 0.9,
+        ],
+        'company_intelligence' => [
+                'enriched_profile' => [
+                        'name'                => 'Corp',
+                        'industry'            => 'Finance',
+                        'size'                => 'Mid',
+                        'maturity_level'      => 'intermediate',
+                        'key_challenges'      => [ 'challenge' ],
+                        'strategic_priorities'=> [ 'priority' ],
+                ],
+                'industry_context' => [
+                        'competitive_pressure'   => 'high',
+                        'regulatory_environment' => 'strict',
+                        'sector_trends'          => 'growth',
+                ],
+                'maturity_assessment' => [ 'stage' => 'intermediate' ],
+                'competitive_position' => [ 'rank' => '2nd' ],
+        ],
+        'operational_insights' => [
+                'current_state_assessment' => [ 'state' ],
+                'process_improvements'     => [ 'improve' ],
+                'automation_opportunities' => [ 'auto' ],
+        ],
+        'risk_analysis' => [
+                'implementation_risks' => [ 'risk' ],
+                'mitigation_strategies' => [ 'mitigate' ],
+                'success_factors'       => [ 'factor' ],
+        ],
+        'action_plan' => [
+                'immediate_steps'      => [ 'step1' ],
+                'short_term_milestones'=> [ 'mile1' ],
+                'long_term_objectives' => [ 'obj1' ],
+        ],
+        'industry_insights' => [
+                'sector_trends'            => [ 'trend1' ],
+                'competitive_benchmarks'   => [ 'bench1' ],
+                'regulatory_considerations'=> [ 'reg1' ],
+        ],
+        'technology_strategy' => [
+                'recommended_category' => 'cat',
+                'category_details'     => [ 'detail' ],
+                'implementation_roadmap' => [
+                        [
+                                'phase'      => 'p1',
+                                'timeline'   => 'Q1',
+                                'activities' => [ 'step1' ],
+                        ],
+                ],
+                'vendor_considerations' => [ 'vendor1' ],
         ],
         'financial_analysis' => [
-                'roi_scenarios' => [ [ 'scenario' => 'base', 'roi' => 10 ] ],
+                'roi_scenarios' => [ [ 'scenario' => 'base', 'roi' => 10, 'total_annual_benefit' => 1000 ] ],
+                'investment_breakdown' => [ [ 'category' => 'capex', 'amount' => 500 ] ],
                 'payback_analysis' => [
                         'payback_months' => 12,
                         'roi_3_year'     => 50,
                         'npv_analysis'   => 'npv',
                 ],
-        ],
-       'industry_insights' => [
-               'sector_trends'          => [ 'trend1' ],
-               'competitive_benchmarks' => [ 'bench1' ],
-               'regulatory_considerations' => [ 'reg1' ],
-       ],
-        'implementation_roadmap' => [
-                [
-                        'phase'      => 'p1',
-                        'timeline'   => 'Q1',
-                        'activities' => [ 'step1' ],
-                ],
+                'sensitivity_analysis' => [ [ 'factor' => 'growth', 'impact' => 'high' ] ],
+                'chart_data' => [ 1, 2, 3 ],
         ],
 ];
 
@@ -101,7 +141,17 @@ if ( is_wp_error( $result ) ) {
 	exit( 1 );
 }
 
-$required = [ 'executive_summary', 'financial_analysis', 'industry_insights', 'implementation_roadmap' ];
+$required = [
+        'executive_summary',
+        'company_intelligence',
+        'operational_insights',
+        'risk_analysis',
+        'action_plan',
+        'industry_insights',
+        'technology_strategy',
+        'financial_analysis',
+        'implementation_roadmap',
+];
 
 foreach ( $required as $key ) {
 	if ( ! isset( $result[ $key ] ) ) {

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -25,13 +25,13 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	}
 }
 if ( ! function_exists( 'add_action' ) ) {
-	function add_action( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
+        function add_action( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
 }
 if ( ! function_exists( 'do_action' ) ) {
-	function do_action( $tag, ...$args ) {}
+        function do_action( $tag, ...$args ) {}
 }
 if ( ! function_exists( 'wp_die' ) ) {
-	function wp_die( $message = '' ) {}
+        function wp_die( $message = '' ) {}
 }
 if ( ! function_exists( 'did_action' ) ) {
 	function did_action( $tag ) {
@@ -44,9 +44,9 @@ if ( ! function_exists( 'is_admin' ) ) {
 	}
 }
 if ( ! function_exists( 'get_option' ) ) {
-	function get_option( $option, $default = false ) {
-		return $default;
-	}
+        function get_option( $option, $default = false ) {
+                return $default;
+        }
 }
 if ( ! function_exists( 'update_option' ) ) {
 	function update_option( $option, $value ) {
@@ -79,9 +79,15 @@ if ( ! function_exists( 'wp_trim_words' ) ) {
 	}
 }
 if ( ! function_exists( 'wp_json_encode' ) ) {
-	function wp_json_encode( $data ) {
-		return json_encode( $data );
-	}
+        function wp_json_encode( $data ) {
+                return json_encode( $data );
+        }
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+       function is_wp_error( $thing ) {
+               return $thing instanceof WP_Error;
+       }
 }
 if ( ! class_exists( 'RTBCB_Category_Recommender' ) ) {
 	class RTBCB_Category_Recommender {


### PR DESCRIPTION
## Summary
- Fully parse nested sections of comprehensive LLM responses, sanitizing fields and providing defaults
- Update comprehensive response test to cover new nested structure
- Add `is_wp_error` stub in test utilities for PHPUnit compatibility

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=sk-test RTBCB_TEST_MODEL=gpt-5-mini bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b6f991743483319f3a45ff38455575