### PR TITLE
Validate required sections in comprehensive response parser

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -917,6 +917,27 @@ $batch_prompts['tech'] = [
                       return new WP_Error( 'llm_response_parse_error', __( 'Invalid JSON from language model.', 'rtbcb' ) );
               }
 
+              $required_sections = [
+                      'executive_summary',
+                      'company_intelligence',
+                      'operational_insights',
+                      'risk_analysis',
+                      'action_plan',
+                      'industry_insights',
+                      'technology_strategy',
+                      'financial_analysis',
+              ];
+
+              foreach ( $required_sections as $section ) {
+                      if ( empty( $json[ $section ] ) || ! is_array( $json[ $section ] ) ) {
+                              /* translators: %s: missing section name */
+                              return new WP_Error(
+                                      'llm_missing_section',
+                                      sprintf( __( 'Missing required section: %s', 'rtbcb' ), $section )
+                              );
+                      }
+              }
+
               $sanitize = function ( $value ) use ( &$sanitize ) {
                       if ( is_array( $value ) ) {
                               return array_map( $sanitize, $value );


### PR DESCRIPTION
## Summary
- add validation for required top-level sections in comprehensive LLM responses

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=sk-test RTBCB_TEST_MODEL=gpt-5-mini bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fd44404c8331b2590f89fae46149