### PR TITLE
Add bulk report deletion option

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -471,6 +471,25 @@ wp_localize_script(
 		$upload_dir  = wp_upload_dir();
 		$reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
 
+		if ( isset( $_POST['rtbcb_delete_old_reports'] ) ) {
+			check_admin_referer( 'rtbcb_delete_old_reports' );
+
+			$days      = isset( $_POST['rtbcb_delete_days'] ) ? intval( sanitize_text_field( wp_unslash( $_POST['rtbcb_delete_days'] ) ) ) : 30;
+			$days      = max( 1, $days );
+			$threshold = time() - ( $days * DAY_IN_SECONDS );
+			$files     = glob( $reports_dir . '/*.{html,pdf}', GLOB_BRACE );
+			$files     = $files ? $files : [];
+
+			foreach ( $files as $filepath ) {
+				if ( filemtime( $filepath ) < $threshold ) {
+					unlink( $filepath );
+				}
+			}
+
+			wp_safe_redirect( admin_url( 'admin.php?page=rtbcb-reports' ) );
+			exit;
+		}
+
 		if ( isset( $_GET['delete'] ) ) {
 			$file  = sanitize_file_name( wp_unslash( $_GET['delete'] ) );
 			$nonce = isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '';

--- a/admin/reports-page.php
+++ b/admin/reports-page.php
@@ -10,6 +10,13 @@ defined( 'ABSPATH' ) || exit;
 ?>
 <div class="wrap">
 	<h1><?php esc_html_e( 'Generated Reports', 'rtbcb' ); ?></h1>
+	<form method="post" class="rtbcb-delete-old-reports">
+		<?php wp_nonce_field( 'rtbcb_delete_old_reports' ); ?>
+		<label for="rtbcb-delete-days"><?php esc_html_e( 'Delete reports older than (days):', 'rtbcb' ); ?></label>
+		<input type="number" name="rtbcb_delete_days" id="rtbcb-delete-days" value="30" min="1" />
+		<?php submit_button( __( 'Delete Old Reports', 'rtbcb' ), 'secondary', 'rtbcb_delete_old_reports', false ); ?>
+	</form>
+
 
 	<?php if ( empty( $report_files ) ) : ?>
 		<p><?php esc_html_e( 'No reports found.', 'rtbcb' ); ?></p>


### PR DESCRIPTION
## Summary
- add form in reports admin page to remove reports older than a set number of days
- handle bulk deletion in `render_reports` with nonce check and age filtering

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b711607c148331acd4fd1eca90ce0d