### PR TITLE
fix: use chat completions max_tokens parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A comprehensive WordPress plugin that helps treasury teams quantify the benefits
    ```php
    $client->chat()->create([
    'model' => 'gpt-5-mini',
-   'max_output_tokens' => 256,
+   'max_tokens' => 256,
   ]);
   ```
 

--- a/inc/OpenAI_Client.php
+++ b/inc/OpenAI_Client.php
@@ -228,10 +228,10 @@ return false !== $json ? $json : '{}';
  * Send request to OpenAI and parse JSON response with one retry on failure.
  *
  * @param array $user_payload User payload sections.
- * @param int   $max_output_tokens Optional token limit.
+ * @param int   $max_tokens Optional token limit.
  * @return array|WP_Error Decoded response or error.
  */
-public function request( array $user_payload, $max_output_tokens = null ) {
+public function request( array $user_payload, $max_tokens = null ) {
 $messages = $this->build_messages( $user_payload );
 $body     = [
 'model'           => $this->model,
@@ -240,8 +240,8 @@ $body     = [
 'temperature'     => 0.2,
 'response_format' => [ 'type' => 'json_object' ],
 ];
-if ( $max_output_tokens ) {
-$body['max_output_tokens'] = (int) $max_output_tokens;
+if ( $max_tokens ) {
+$body['max_tokens'] = (int) $max_tokens;
 }
 
 $response = $this->send_request( $body );


### PR DESCRIPTION
## Summary
- replace `max_output_tokens` with `max_tokens` for chat completions
- update README example to reflect `max_tokens` usage

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b72a3e297c8331a2bc042f4fc682e2