### PR TITLE
Filter non-ROI elements from ROI scenarios

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -535,13 +535,14 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 			       'competitive_benchmarks' => (array) ( $final_analysis['industry_insights']['competitive_benchmarks'] ?? [] ),
 			       'regulatory_considerations' => (array) ( $final_analysis['industry_insights']['regulatory_considerations'] ?? [] ),
 		       ],
-					'financial_analysis' => [
-							'roi_scenarios'        => self::format_roi_scenarios( $roi_scenarios ),
-							'investment_breakdown' => $final_analysis['financial_analysis']['investment_breakdown'] ?? [],
-							'payback_analysis'     => $final_analysis['financial_analysis']['payback_analysis'] ?? [],
-							'sensitivity_analysis' => $roi_scenarios['sensitivity_analysis'] ?? [],
-							'chart_data'           => $chart_data,
-					],
+                                       'financial_analysis' => [
+                                                       'roi_scenarios'        => self::format_roi_scenarios( $roi_scenarios ),
+                                                       'investment_breakdown' => $final_analysis['financial_analysis']['investment_breakdown'] ?? [],
+                                                       'payback_analysis'     => $final_analysis['financial_analysis']['payback_analysis'] ?? [],
+                                                       'sensitivity_analysis' => $roi_scenarios['sensitivity_analysis'] ?? [],
+                                                       'confidence_metrics'   => $roi_scenarios['confidence_metrics'] ?? [],
+                                                       'chart_data'           => $chart_data,
+                                       ],
 			'technology_strategy' => [
 				'recommended_category' => $recommendation['recommended'],
 				'category_details'     => $recommendation['category_info'],
@@ -658,8 +659,17 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 			return $base > 0 ? 'strong' : 'weak';
 	}
 
-	private static function format_roi_scenarios( $roi_scenarios ) {
-	       return $roi_scenarios;
+       private static function format_roi_scenarios( $roi_scenarios ) {
+               $allowed   = array( 'conservative', 'base', 'optimistic' );
+               $formatted = array();
+
+               foreach ( $allowed as $key ) {
+                       if ( isset( $roi_scenarios[ $key ] ) && is_array( $roi_scenarios[ $key ] ) ) {
+                               $formatted[ $key ] = $roi_scenarios[ $key ];
+                       }
+               }
+
+               return $formatted;
        }
 
        /**

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -594,38 +594,42 @@ $html = rtbcb_sanitize_report_html( $html );
 	*
 	* @return array
 	*/
-	private function format_roi_scenarios( $data ) {
-	// Try to get ROI data from various possible locations.
-	if ( ! empty( $data['scenarios'] ) ) {
-		return $data['scenarios'];
-	}
+       private function format_roi_scenarios( $data ) {
+       $allowed = array( 'conservative', 'base', 'optimistic' );
 
-	if ( ! empty( $data['roi_scenarios'] ) ) {
-		return $data['roi_scenarios'];
-	}
+       // Try to get ROI data from various possible locations.
+       if ( ! empty( $data['scenarios'] ) && is_array( $data['scenarios'] ) ) {
+               return array_intersect_key( $data['scenarios'], array_flip( $allowed ) );
+       }
 
-	// Fallback to default structure.
-	return [
-		'conservative' => [
-			'total_annual_benefit' => $data['roi_low'] ?? 0,
-			'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
-			'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
-			'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
-		],
-		'base' => [
-			'total_annual_benefit' => $data['roi_base'] ?? 0,
-			'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
-			'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
-			'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
-		],
-		'optimistic' => [
-			'total_annual_benefit' => $data['roi_high'] ?? 0,
-			'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
-			'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
-			'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
-		],
-	];
-	}
+       if ( ! empty( $data['roi_scenarios'] ) && is_array( $data['roi_scenarios'] ) ) {
+               return array_intersect_key( $data['roi_scenarios'], array_flip( $allowed ) );
+       }
+
+       // Fallback to default structure.
+       $scenarios = [
+               'conservative' => [
+                       'total_annual_benefit' => $data['roi_low'] ?? 0,
+                       'labor_savings'        => ( $data['roi_low'] ?? 0 ) * 0.6,
+                       'fee_savings'          => ( $data['roi_low'] ?? 0 ) * 0.3,
+                       'error_reduction'      => ( $data['roi_low'] ?? 0 ) * 0.1,
+               ],
+               'base' => [
+                       'total_annual_benefit' => $data['roi_base'] ?? 0,
+                       'labor_savings'        => ( $data['roi_base'] ?? 0 ) * 0.6,
+                       'fee_savings'          => ( $data['roi_base'] ?? 0 ) * 0.3,
+                       'error_reduction'      => ( $data['roi_base'] ?? 0 ) * 0.1,
+               ],
+               'optimistic' => [
+                       'total_annual_benefit' => $data['roi_high'] ?? 0,
+                       'labor_savings'        => ( $data['roi_high'] ?? 0 ) * 0.6,
+                       'fee_savings'          => ( $data['roi_high'] ?? 0 ) * 0.3,
+                       'error_reduction'      => ( $data['roi_high'] ?? 0 ) * 0.1,
+               ],
+       ];
+
+       return $scenarios;
+       }
 
        /**
        * Determine business case strength based on ROI.

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2436,51 +2436,52 @@ $html = rtbcb_sanitize_report_html( $html );
 		*
 		* @return array
 		*/
-	   private function format_roi_scenarios_enhanced( $data ) {
-			   // Try multiple data sources for ROI scenarios.
-			   if ( ! empty( $data['scenarios'] ) ) {
-					   return $data['scenarios'];
-			   }
+           private function format_roi_scenarios_enhanced( $data ) {
+                           $allowed = array( 'conservative', 'base', 'optimistic' );
 
-			   if ( ! empty( $data['roi_scenarios'] ) ) {
-					   return $data['roi_scenarios'];
-			   }
+                           // Try multiple data sources for ROI scenarios.
+                           if ( ! empty( $data['scenarios'] ) && is_array( $data['scenarios'] ) ) {
+                                           return array_intersect_key( $data['scenarios'], array_flip( $allowed ) );
+                           }
 
-			   // Extract from financial_analysis if nested.
-			   if ( ! empty( $data['financial_analysis']['roi_scenarios'] ) ) {
-					   return $data['financial_analysis']['roi_scenarios'];
-			   }
+                           if ( ! empty( $data['roi_scenarios'] ) && is_array( $data['roi_scenarios'] ) ) {
+                                           return array_intersect_key( $data['roi_scenarios'], array_flip( $allowed ) );
+                           }
 
-			   // Generate from basic ROI values with enhanced structure.
-			   $conservative_roi = floatval( $data['roi_low'] ?? 0 );
-			   $base_roi         = floatval( $data['roi_base'] ?? 0 );
-			   $optimistic_roi   = floatval( $data['roi_high'] ?? 0 );
+                           // Extract from financial_analysis if nested.
+                           if ( ! empty( $data['financial_analysis']['roi_scenarios'] ) && is_array( $data['financial_analysis']['roi_scenarios'] ) ) {
+                                           return array_intersect_key( $data['financial_analysis']['roi_scenarios'], array_flip( $allowed ) );
+                           }
 
-			   return [
-					   'conservative' => [
-							   'total_annual_benefit' => $conservative_roi,
-							   'labor_savings'        => round( $conservative_roi * 0.6 ),
-							   'fee_savings'          => round( $conservative_roi * 0.25 ),
-							   'error_reduction'      => round( $conservative_roi * 0.15 ),
-							   'roi_percentage'       => $conservative_roi > 0 ? round( ( $conservative_roi / 50000 ) * 100 ) : 0,
-					   ],
-					   'base' => [
-							   'total_annual_benefit' => $base_roi,
-							   'labor_savings'        => round( $base_roi * 0.6 ),
-							   'fee_savings'          => round( $base_roi * 0.25 ),
-							   'error_reduction'      => round( $base_roi * 0.15 ),
-							   'roi_percentage'       => $base_roi > 0 ? round( ( $base_roi / 50000 ) * 100 ) : 0,
-					   ],
-					   'optimistic' => [
-							   'total_annual_benefit' => $optimistic_roi,
-							   'labor_savings'        => round( $optimistic_roi * 0.6 ),
-							   'fee_savings'          => round( $optimistic_roi * 0.25 ),
-							   'error_reduction'      => round( $optimistic_roi * 0.15 ),
-							   'roi_percentage'       => $optimistic_roi > 0 ? round( ( $optimistic_roi / 50000 ) * 100 ) : 0,
-					   ],
-					   'sensitivity_analysis' => $data['sensitivity_analysis'] ?? [],
-			   ];
-	   }
+                           // Generate from basic ROI values with enhanced structure.
+                           $conservative_roi = floatval( $data['roi_low'] ?? 0 );
+                           $base_roi         = floatval( $data['roi_base'] ?? 0 );
+                           $optimistic_roi   = floatval( $data['roi_high'] ?? 0 );
+
+                           return [
+                                           'conservative' => [
+                                                           'total_annual_benefit' => $conservative_roi,
+                                                           'labor_savings'        => round( $conservative_roi * 0.6 ),
+                                                           'fee_savings'          => round( $conservative_roi * 0.25 ),
+                                                           'error_reduction'      => round( $conservative_roi * 0.15 ),
+                                                           'roi_percentage'       => $conservative_roi > 0 ? round( ( $conservative_roi / 50000 ) * 100 ) : 0,
+                                           ],
+                                           'base' => [
+                                                           'total_annual_benefit' => $base_roi,
+                                                           'labor_savings'        => round( $base_roi * 0.6 ),
+                                                           'fee_savings'          => round( $base_roi * 0.25 ),
+                                                           'error_reduction'      => round( $base_roi * 0.15 ),
+                                                           'roi_percentage'       => $base_roi > 0 ? round( ( $base_roi / 50000 ) * 100 ) : 0,
+                                           ],
+                                           'optimistic' => [
+                                                           'total_annual_benefit' => $optimistic_roi,
+                                                           'labor_savings'        => round( $optimistic_roi * 0.6 ),
+                                                           'fee_savings'          => round( $optimistic_roi * 0.25 ),
+                                                           'error_reduction'      => round( $optimistic_roi * 0.15 ),
+                                                           'roi_percentage'       => $optimistic_roi > 0 ? round( ( $optimistic_roi / 50000 ) * 100 ) : 0,
+                                           ],
+                           ];
+           }
 
 	   /**
 		* Generate Chart.js compatible data structure.

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -235,8 +235,12 @@ $company_intelligence  = $report_data['company_intelligence'] ?? [];
 			<div class="rtbcb-roi-breakdown-enhanced">
 				<h3><?php echo esc_html__( 'ROI Component Breakdown', 'rtbcb' ); ?></h3>
 				<div class="rtbcb-roi-components">
-					<?php foreach ( $financial_analysis['roi_scenarios'] as $scenario_name => $scenario ) : ?>
-						<div class="rtbcb-scenario-card <?php echo esc_attr( $scenario_name ); ?>">
+					<?php foreach ( $financial_analysis['roi_scenarios'] as $scenario_name => $scenario ) :
+						if ( in_array( $scenario_name, array( 'sensitivity_analysis', 'confidence_metrics' ), true ) ) {
+						continue;
+						}
+					?>
+					<div class="rtbcb-scenario-card <?php echo esc_attr( $scenario_name ); ?>">
 							<h4><?php echo esc_html( ucfirst( $scenario_name ) ); ?> <?php echo esc_html__( 'Case', 'rtbcb' ); ?></h4>
 							<div class="rtbcb-scenario-metrics">
 								<div class="rtbcb-scenario-metric">
@@ -636,7 +640,7 @@ $sensitivity_data = [
 
 // Output JavaScript with proper escaping
 $json_flags = JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_APOS;
-?>
+					?>
 
 <script>
 // Global data for RTBCB Enhanced Report


### PR DESCRIPTION
## Summary
- remove non-scenario entries from ROI data before rendering
- expose confidence metrics separately in financial analysis
- skip sensitivity and confidence metrics when building ROI breakdown cards

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b72b4730d0833186016540c0935011