### PR TITLE
Refine AJAX handler and clean JSON responses

### DIFF
--- a/public/js/rtbcb.js
+++ b/public/js/rtbcb.js
@@ -105,8 +105,8 @@ async function rtbcbRefreshNonce() {
             return false;
         }
         const data = await response.json();
-        if ( data && data.success && data.data ) {
-            rtbcb_ajax.nonce = data.data;
+        if ( data && data.success ) {
+            rtbcb_ajax.nonce = data.data || data.nonce || data;
             return true;
         }
     } catch ( err ) {
@@ -279,7 +279,7 @@ async function pollJobStatus(jobId, progressContainer, formContainer) {
             return;
         }
 
-        const statusData = data.data;
+        const statusData = data.data || data;
         const status = statusData.status;
         if (status === 'completed') {
             if (progressContainer) {

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2041,26 +2041,31 @@ $missing_sections  = array_diff( $required_sections, array_keys( $comprehensive_
 				rtbcb_log_error( 'Failed to save lead', $e->getMessage() );
 			}
 		}
+		// Clean API response if it's JSON encoded
+		if ( is_string( $comprehensive_analysis ) ) {
+			$comprehensive_analysis = json_decode( wp_unslash( $comprehensive_analysis ), true );
+		}
 
-		// Prepare final response
-		$response_data = [
-			'scenarios'		 => $formatted_scenarios,
-			'recommendation'	 => $recommendation,
-			'comprehensive_analysis' => $comprehensive_analysis,
-			'narrative'		 => $comprehensive_analysis,
-			'rag_context'		 => $rag_context,
-			'report_html'		 => $report_html,
-			'lead_id'		 => $lead_id,
-			'company_name'		 => $user_inputs['company_name'],
-			'analysis_type'		 => rtbcb_get_analysis_type(),
-			'api_used'               => rtbcb_has_openai_api_key(),
-			'fallback_used'		 => isset( $comprehensive_analysis['enhanced_fallback'] ),
-			'memory_info'		 => rtbcb_get_memory_status(),
+		// Prepare clean response for frontend
+		$clean_response = [
+			'success'       => true,
+			'report_html'   => $report_html,
+			'api_data'      => $comprehensive_analysis,
+			'scenarios'     => $formatted_scenarios,
+			'recommendation'=> $recommendation,
+			'rag_context'   => $rag_context,
+			'lead_id'       => $lead_id,
+			'company_name'  => $user_inputs['company_name'],
+			'analysis_type' => rtbcb_get_analysis_type(),
+			'api_used'      => rtbcb_has_openai_api_key(),
+			'fallback_used' => isset( $comprehensive_analysis['enhanced_fallback'] ),
+			'memory_info'   => rtbcb_get_memory_status(),
 		];
 
 		rtbcb_log_memory_usage( 'before_response' );
 
-		wp_send_json_success( $response_data );
+		// Send response without additional escaping
+		wp_send_json( $clean_response, 200 );
 		return;
 
 		} catch ( Exception $e ) {

--- a/tests/handle-string-error-response.test.js
+++ b/tests/handle-string-error-response.test.js
@@ -29,7 +29,7 @@ class SimpleFormData {
 global.FormData = SimpleFormData;
 
 global.fetch = function() {
-    const payload = { success: false, data: 'Please enter your company name.' };
+    const payload = { success: false, message: 'Please enter your company name.' };
     const response = {
         ok: false,
         status: 400,

--- a/tests/handle-submit-error.test.js
+++ b/tests/handle-submit-error.test.js
@@ -31,7 +31,8 @@ global.FormData = SimpleFormData;
 global.fetch = function() {
     const payload = {
         success: false,
-        data: { message: 'Bad narrative', error_code: 'BAD_NARRATIVE' }
+        message: 'Bad narrative',
+        error_code: 'BAD_NARRATIVE'
     };
     const response = {
         ok: true,

--- a/tests/handle-submit-nonce-retry.test.js
+++ b/tests/handle-submit-nonce-retry.test.js
@@ -33,7 +33,7 @@ const fetchCalls = [];
 global.fetch = function(url, options) {
 fetchCalls.push({ url, options });
 if (fetchCalls.length === 1) {
-const payload = { success: false, data: { message: 'Security check failed.' } };
+const payload = { success: false, message: 'Security check failed.' };
 const response = {
 ok: true,
 status: 200,
@@ -44,7 +44,7 @@ clone() { return this; }
 };
 return Promise.resolve(response);
 }
-const payload = { success: true, data: { job_id: 'job-123' } };
+const payload = { success: true, job_id: 'job-123' };
 const response = {
 ok: true,
 status: 200,

--- a/tests/handle-submit-success.test.js
+++ b/tests/handle-submit-success.test.js
@@ -37,7 +37,7 @@ global.FormData = SimpleFormData;
       receivedHeaders = options.headers;
       const payload = {
           success: true,
-          data: { job_id: 'job-123' }
+          job_id: 'job-123'
       };
       const response = {
           ok: true,

--- a/tests/wizard-report-flow.test.js
+++ b/tests/wizard-report-flow.test.js
@@ -75,7 +75,7 @@ global.rtbcb_ajax = { ajax_url: 'http://example.com/ajax', nonce: 'test' };
 global.fetch = async () => ({
   ok: true,
   status: 200,
-  text: async () => JSON.stringify({ success: true, data: { report_html: sampleReport } })
+  text: async () => JSON.stringify({ success: true, report_html: sampleReport })
 });
 
 // Load report and wizard scripts


### PR DESCRIPTION
## Summary
- sanitize LLM responses before JSON output
- avoid WordPress auto-escaping by using `wp_send_json`
- adjust frontend JS and tests for new response structure

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b72be6d1788331bd987f28f30320f7