### PR TITLE
Fix JSON decoding to avoid stripping escape sequences

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -110,8 +110,11 @@ class RTBCB_LLM {
                        $response_body = stripslashes( $response_body );
                }
 
-               $response_body = wp_unslash( $response_body );
-               $decoded       = json_decode( $response_body, true );
+               $decoded = json_decode( $response_body, true );
+
+               if ( JSON_ERROR_NONE !== json_last_error() ) {
+                       $decoded = json_decode( wp_unslash( $response_body ), true );
+               }
 
                if ( JSON_ERROR_NONE !== json_last_error() ) {
                        error_log( 'JSON decode error: ' . json_last_error_msg() );


### PR DESCRIPTION
## Summary
- avoid unslashing OpenAI responses before decoding, retry unslash only on decode failure

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Class "RTBCB_LLM_Optimized" not found; npm process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b7417b44248331b67c99c9c67d32e2