### PR TITLE
Add delete all reports admin control

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -471,6 +471,26 @@ wp_localize_script(
 		$upload_dir  = wp_upload_dir();
 		$reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'rtbcb-reports';
 
+		if ( isset( $_GET['rtbcb_reports_deleted'] ) ) {
+			echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__( 'All reports deleted.', 'rtbcb' ) . '</p></div>';
+		}
+
+		if ( isset( $_POST['rtbcb_delete_all_reports'] ) ) {
+			check_admin_referer( 'rtbcb_delete_all_reports' );
+
+			if ( current_user_can( 'manage_options' ) ) {
+				$files = glob( $reports_dir . '/*.{html,pdf}', GLOB_BRACE );
+				$files = $files ? $files : [];
+
+				foreach ( $files as $filepath ) {
+					unlink( $filepath );
+				}
+			}
+
+			wp_safe_redirect( add_query_arg( 'rtbcb_reports_deleted', 1, admin_url( 'admin.php?page=rtbcb-reports' ) ) );
+			exit;
+		}
+
 		if ( isset( $_POST['rtbcb_delete_old_reports'] ) ) {
 			check_admin_referer( 'rtbcb_delete_old_reports' );
 

--- a/admin/reports-page.php
+++ b/admin/reports-page.php
@@ -10,15 +10,20 @@ defined( 'ABSPATH' ) || exit;
 ?>
 <div class="wrap">
 	<h1><?php esc_html_e( 'Generated Reports', 'rtbcb' ); ?></h1>
-	<form method="post" class="rtbcb-delete-old-reports">
-		<?php wp_nonce_field( 'rtbcb_delete_old_reports' ); ?>
-		<label for="rtbcb-delete-days"><?php esc_html_e( 'Delete reports older than (days):', 'rtbcb' ); ?></label>
-		<input type="number" name="rtbcb_delete_days" id="rtbcb-delete-days" value="30" min="1" />
-		<?php submit_button( __( 'Delete Old Reports', 'rtbcb' ), 'secondary', 'rtbcb_delete_old_reports', false ); ?>
-	</form>
+       <form method="post" class="rtbcb-delete-old-reports">
+               <?php wp_nonce_field( 'rtbcb_delete_old_reports' ); ?>
+               <label for="rtbcb-delete-days"><?php esc_html_e( 'Delete reports older than (days):', 'rtbcb' ); ?></label>
+               <input type="number" name="rtbcb_delete_days" id="rtbcb-delete-days" value="30" min="1" />
+               <?php submit_button( __( 'Delete Old Reports', 'rtbcb' ), 'secondary', 'rtbcb_delete_old_reports', false ); ?>
+       </form>
+
+       <form method="post" class="rtbcb-delete-all-reports">
+               <?php wp_nonce_field( 'rtbcb_delete_all_reports' ); ?>
+               <?php submit_button( __( 'Delete All Reports', 'rtbcb' ), 'delete', 'rtbcb_delete_all_reports', false ); ?>
+       </form>
 
 
-	<?php if ( empty( $report_files ) ) : ?>
+       <?php if ( empty( $report_files ) ) : ?>
 		<p><?php esc_html_e( 'No reports found.', 'rtbcb' ); ?></p>
 	<?php else : ?>
 		<table class="widefat fixed">


### PR DESCRIPTION
## Summary
- add Delete All Reports button on reports admin page
- support bulk report deletion with capability and nonce checks and redirect notice

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Class `RTBCB_LLM_Optimized` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b745f826b08331a92850f969b843db