### PR TITLE
Enhance API log table and expand request field limit

### DIFF
--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -19,13 +19,13 @@ if ( ! current_user_can( 'manage_options' ) ) {
 			<?php esc_html_e( 'Clear All Logs', 'rtbcb' ); ?>
 		</button>
 	</p>
-	<div class="rtbcb-log-table-wrapper">
-		<table class="widefat fixed striped">
+       <div class="rtbcb-log-table-wrapper">
+<table id="rtbcb-api-logs-table" class="widefat fixed striped">
 			<thead>
 				<tr>
-                                       <th><?php esc_html_e( 'ID', 'rtbcb' ); ?></th>
-                                       <th><?php esc_html_e( 'Lead ID', 'rtbcb' ); ?></th>
-                                       <th><?php esc_html_e( 'Email', 'rtbcb' ); ?></th>
+	                               <th><?php esc_html_e( 'ID', 'rtbcb' ); ?></th>
+	                               <th><?php esc_html_e( 'Lead ID', 'rtbcb' ); ?></th>
+	                               <th><?php esc_html_e( 'Email', 'rtbcb' ); ?></th>
 					<th><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></th>
 					<th><?php esc_html_e( 'Request', 'rtbcb' ); ?></th>
 					<th><?php esc_html_e( 'Tokens', 'rtbcb' ); ?></th>
@@ -35,8 +35,8 @@ if ( ! current_user_can( 'manage_options' ) ) {
 				</tr>
 			</thead>
 			<tbody>
-				<?php if ( ! empty( $logs_data['logs'] ) ) : ?>
-					<?php foreach ( $logs_data['logs'] as $log ) :
+<?php if ( ! empty( $logs ) ) : ?>
+<?php foreach ( $logs as $log ) :
 						$request  = json_decode( $log['request_json'], true );
 						$response = json_decode( $log['response_json'], true );
 						$summary  = '';
@@ -48,9 +48,9 @@ if ( ! current_user_can( 'manage_options' ) ) {
 						$status = isset( $response['error'] ) ? __( 'Error', 'rtbcb' ) : __( 'OK', 'rtbcb' );
 					?>
 					<tr data-id="<?php echo esc_attr( $log['id'] ); ?>" data-request="<?php echo esc_attr( $log['request_json'] ); ?>" data-response="<?php echo esc_attr( $log['response_json'] ); ?>">
-                                               <td><?php echo esc_html( $log['id'] ); ?></td>
-                                               <td><?php echo esc_html( $log['lead_id'] ); ?></td>
-                                               <td><?php echo esc_html( $log['user_email'] ); ?></td>
+	                                       <td><?php echo esc_html( $log['id'] ); ?></td>
+	                                       <td><?php echo esc_html( $log['lead_id'] ); ?></td>
+	                                       <td><?php echo esc_html( $log['user_email'] ); ?></td>
 						<td><?php echo esc_html( $log['company_name'] ); ?></td>
 						<td><?php echo esc_html( $summary ); ?></td>
 						<td><?php echo esc_html( $log['total_tokens'] ); ?></td>
@@ -67,36 +67,13 @@ if ( ! current_user_can( 'manage_options' ) ) {
 					</tr>
 					<?php endforeach; ?>
 				<?php else : ?>
-                                       <tr>
-                                               <td colspan="9"><?php esc_html_e( 'No logs found.', 'rtbcb' ); ?></td>
-                                       </tr>
+	                               <tr>
+	                                       <td colspan="9"><?php esc_html_e( 'No logs found.', 'rtbcb' ); ?></td>
+	                               </tr>
 				<?php endif; ?>
 			</tbody>
 		</table>
 	</div>
-	<?php
-	$total_pages = ceil( $logs_data['total'] / $per_page );
-	if ( $total_pages > 1 ) :
-		?>
-		<div class="tablenav">
-			<div class="tablenav-pages">
-				<?php
-				echo wp_kses_post(
-					paginate_links(
-						[
-							'base'      => add_query_arg( 'paged', '%#%' ),
-							'format'    => '',
-							'prev_text' => __( '&laquo;', 'rtbcb' ),
-							'next_text' => __( '&raquo;', 'rtbcb' ),
-							'total'     => $total_pages,
-							'current'   => $paged,
-						]
-					)
-				);
-				?>
-			</div>
-		</div>
-	<?php endif; ?>
 </div>
 <div id="rtbcb-log-modal" style="display:none;">
 	<div class="rtbcb-modal-content">
@@ -105,56 +82,60 @@ if ( ! current_user_can( 'manage_options' ) ) {
 	</div>
 </div>
 <script type="text/javascript">
-jQuery(function($){
+	jQuery(function($){
+	var table = $('#rtbcb-api-logs-table').DataTable({
+	pageLength: 20,
+	order: [[0, 'desc']]
+	});
 	$('#rtbcb-clear-logs').on('click', function(e){
-		e.preventDefault();
-		if (!confirm('<?php echo esc_js( __( 'Are you sure you want to clear all logs?', 'rtbcb' ) ); ?>')) {
-			return;
-		}
-		$.post(window.rtbcbAdmin.ajax_url, {
-			action: 'rtbcb_clear_logs',
-			nonce: $(this).data('nonce')
-		}, function(resp){
-			if (resp.success) {
-				location.reload();
-			} else {
-								alert(resp.data && resp.data.message ? resp.data.message : '<?php echo esc_js( __( 'Error', 'rtbcb' ) ); ?>');
+			e.preventDefault();
+			if (!confirm('<?php echo esc_js( __( 'Are you sure you want to clear all logs?', 'rtbcb' ) ); ?>')) {
+				return;
 			}
+			$.post(window.rtbcbAdmin.ajax_url, {
+				action: 'rtbcb_clear_logs',
+				nonce: $(this).data('nonce')
+			}, function(resp){
+				if (resp.success) {
+					location.reload();
+				} else {
+									alert(resp.data && resp.data.message ? resp.data.message : '<?php echo esc_js( __( 'Error', 'rtbcb' ) ); ?>');
+				}
+			});
+		});
+	$('#rtbcb-api-logs-table').on('click', '.rtbcb-delete-log', function(e){
+			e.preventDefault();
+			if (!confirm('<?php echo esc_js( __( 'Delete this log?', 'rtbcb' ) ); ?>')) {
+				return;
+			}
+			var id = $(this).data('id');
+			var nonce = $(this).data('nonce');
+			$.post(window.rtbcbAdmin.ajax_url, {
+				action: 'rtbcb_delete_log',
+				nonce: nonce,
+				id: id
+			}, function(resp){
+	if (resp.success) {
+	table.row( $('tr[data-id="' + id + '"]') ).remove().draw();
+	} else {
+									alert(resp.data && resp.data.message ? resp.data.message : '<?php echo esc_js( __( 'Error', 'rtbcb' ) ); ?>');
+				}
+			});
+		});
+	$('#rtbcb-api-logs-table').on('click', '.rtbcb-view-log', function(e){
+			e.preventDefault();
+			var $row = $(this).closest('tr');
+			var req = $row.attr('data-request');
+			var res = $row.attr('data-response');
+			try { req = JSON.stringify(JSON.parse(req), null, 2); } catch (err) {}
+			try { res = JSON.stringify(JSON.parse(res), null, 2); } catch (err) {}
+									var content = '<?php echo esc_js( __( 'Request:', 'rtbcb' ) ); ?>\n' + req + '\n\n<?php echo esc_js( __( 'Response:', 'rtbcb' ) ); ?>\n' + res;
+			$('#rtbcb-log-detail').text(content);
+			$('#rtbcb-log-modal').show();
+		});
+		$('#rtbcb-close-log').on('click', function(){
+			$('#rtbcb-log-modal').hide();
 		});
 	});
-	$('.rtbcb-delete-log').on('click', function(e){
-		e.preventDefault();
-		if (!confirm('<?php echo esc_js( __( 'Delete this log?', 'rtbcb' ) ); ?>')) {
-			return;
-		}
-		var id = $(this).data('id');
-		var nonce = $(this).data('nonce');
-		$.post(window.rtbcbAdmin.ajax_url, {
-			action: 'rtbcb_delete_log',
-			nonce: nonce,
-			id: id
-		}, function(resp){
-			if (resp.success) {
-				$('tr[data-id="' + id + '"]').remove();
-			} else {
-								alert(resp.data && resp.data.message ? resp.data.message : '<?php echo esc_js( __( 'Error', 'rtbcb' ) ); ?>');
-			}
-		});
-	});
-	$('.rtbcb-view-log').on('click', function(e){
-		e.preventDefault();
-		var $row = $(this).closest('tr');
-		var req = $row.attr('data-request');
-		var res = $row.attr('data-response');
-		try { req = JSON.stringify(JSON.parse(req), null, 2); } catch (err) {}
-		try { res = JSON.stringify(JSON.parse(res), null, 2); } catch (err) {}
-								var content = '<?php echo esc_js( __( 'Request:', 'rtbcb' ) ); ?>\n' + req + '\n\n<?php echo esc_js( __( 'Response:', 'rtbcb' ) ); ?>\n' + res;
-		$('#rtbcb-log-detail').text(content);
-		$('#rtbcb-log-modal').show();
-	});
-	$('#rtbcb-close-log').on('click', function(){
-		$('#rtbcb-log-modal').hide();
-	});
-});
 </script>
 

--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -96,14 +96,30 @@ class RTBCB_Admin {
 			RTBCB_VERSION,
 			true
 		);
-		wp_enqueue_style(
-			'rtbcb-admin',
-			RTBCB_URL . 'admin/css/rtbcb-admin.css',
-			[],
-			RTBCB_VERSION
-		);
+	wp_enqueue_style(
+		'rtbcb-admin',
+		RTBCB_URL . 'admin/css/rtbcb-admin.css',
+		[],
+		RTBCB_VERSION
+	);
 
-		if ( 'rtbcb-workflow-visualizer' === $page ) {
+	if ( 'rtbcb-api-logs' === $page ) {
+		wp_enqueue_style(
+			'datatables',
+			'https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css',
+			[],
+			'1.13.6'
+		);
+		wp_enqueue_script(
+			'datatables',
+			'https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js',
+			[ 'jquery' ],
+			'1.13.6',
+			true
+		);
+	}
+
+if ( 'rtbcb-workflow-visualizer' === $page ) {
 			wp_enqueue_script(
 				'rtbcb-workflow-visualizer',
 				RTBCB_URL . 'admin/js/workflow-visualizer.js',
@@ -450,10 +466,8 @@ wp_localize_script(
 			return;
 		}
 
-		$paged     = isset( $_GET['paged'] ) ? intval( wp_unslash( $_GET['paged'] ) ) : 1;
-		$per_page  = 20;
-		$logs_data = RTBCB_API_Log::get_logs_paginated( $paged, $per_page );
-		$nonce     = wp_create_nonce( 'rtbcb_api_logs' );
+		$logs  = RTBCB_API_Log::get_all_logs();
+		$nonce = wp_create_nonce( 'rtbcb_api_logs' );
 
 		include RTBCB_DIR . 'admin/api-logs-page.php';
 	}

--- a/inc/class-rtbcb-api-log.php
+++ b/inc/class-rtbcb-api-log.php
@@ -151,7 +151,7 @@ class RTBCB_API_Log {
                $request_json  = wp_json_encode( $request );
                $response_json = wp_json_encode( $response );
 
-		$request_json  = substr( $request_json, 0, 10000 );
+		$request_json  = substr( $request_json, 0, 20000 );
 		$response_json = substr( $response_json, 0, 10000 );
 		$usage             = $response['usage'] ?? [];
 		$prompt_tokens     = intval( $usage['prompt_tokens'] ?? $usage['input_tokens'] ?? 0 );
@@ -336,4 +336,22 @@ class RTBCB_API_Log {
 			'total' => $total,
 		];
 	}
-}
+
+/**
+ * Retrieve all logs.
+ *
+ * @return array
+ */
+	public static function get_all_logs() {
+		global $wpdb;
+
+		if ( empty( self::$table_name ) ) {
+			self::init();
+		}
+
+		return $wpdb->get_results(
+			'SELECT id, user_id, user_email, lead_id, company_name, request_json, response_json, prompt_tokens, completion_tokens, total_tokens, created_at FROM ' . self::$table_name . ' ORDER BY created_at DESC',
+		ARRAY_A
+		);
+	}
+	}


### PR DESCRIPTION
## Summary
- Increase API log request field truncation to 20k characters and expose all logs for admin viewing
- Enqueue DataTables assets and render API logs in a searchable, sortable table with delegated actions
- Add helper to retrieve all logs and update admin page to use dynamic table

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b74622637483319871bf9a074f346e