### PR TITLE
Enable select-all for reports list table

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -96,17 +96,21 @@ class RTBCB_Admin {
 			RTBCB_VERSION,
 			true
 		);
-		wp_enqueue_style(
-			'rtbcb-admin',
-			RTBCB_URL . 'admin/css/rtbcb-admin.css',
-			[],
-			RTBCB_VERSION
-		);
+                wp_enqueue_style(
+                        'rtbcb-admin',
+                        RTBCB_URL . 'admin/css/rtbcb-admin.css',
+                        [],
+                        RTBCB_VERSION
+                );
 
-		if ( 'rtbcb-workflow-visualizer' === $page ) {
-			wp_enqueue_script(
-				'rtbcb-workflow-visualizer',
-				RTBCB_URL . 'admin/js/workflow-visualizer.js',
+                if ( 'rtbcb-reports' === $page ) {
+                        wp_enqueue_script( 'list-table' );
+                }
+
+                if ( 'rtbcb-workflow-visualizer' === $page ) {
+                        wp_enqueue_script(
+                                'rtbcb-workflow-visualizer',
+                                RTBCB_URL . 'admin/js/workflow-visualizer.js',
 				[ 'jquery' ],
 				RTBCB_VERSION,
 				true

--- a/admin/class-rtbcb-reports-table.php
+++ b/admin/class-rtbcb-reports-table.php
@@ -42,6 +42,7 @@ class RTBCB_Reports_Table extends WP_List_Table {
      */
     public function get_columns() {
         return [
+            // The 'cb' column activates WordPress' select-all checkbox.
             'cb'       => '<input type="checkbox" />',
             'file'     => __( 'File', 'rtbcb' ),
             'size'     => __( 'Size', 'rtbcb' ),
@@ -69,7 +70,7 @@ class RTBCB_Reports_Table extends WP_List_Table {
      * @return string
      */
     protected function column_cb( $item ) {
-        return '<input type="checkbox" name="files[]" value="' . esc_attr( $item['file'] ) . '" />';
+        return '<input type="checkbox" name="reports[]" value="' . esc_attr( $item['file'] ) . '" />';
     }
 
     /**
@@ -192,11 +193,11 @@ class RTBCB_Reports_Table extends WP_List_Table {
 
         check_admin_referer( 'rtbcb_reports_action' );
 
-        $files = isset( $_POST['files'] ) ? (array) wp_unslash( $_POST['files'] ) : [];
-        $files = array_map( 'sanitize_file_name', $files );
+        $reports = isset( $_POST['reports'] ) ? (array) wp_unslash( $_POST['reports'] ) : [];
+        $reports = array_map( 'sanitize_file_name', $reports );
 
-        foreach ( $files as $file ) {
-            $file_path = trailingslashit( $this->reports_dir ) . $file;
+        foreach ( $reports as $report ) {
+            $file_path = trailingslashit( $this->reports_dir ) . $report;
             if ( file_exists( $file_path ) ) {
                 unlink( $file_path );
             }


### PR DESCRIPTION
## Summary
- make the reports list table use WordPress' `'cb'` column so the header checkbox is rendered
- rename bulk-action checkbox inputs to `reports[]` and handle them server-side
- load WordPress' `list-table` script on the reports page to toggle row checkboxes

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b7485543f08331a57a6f236ca693ba