### PR TITLE
Auto-purge API logs after 72 hours

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -466,6 +466,7 @@ wp_localize_script(
 			return;
 		}
 
+		RTBCB_API_Log::purge_old_logs();
 		$logs  = RTBCB_API_Log::get_all_logs();
 		$nonce = wp_create_nonce( 'rtbcb_api_logs' );
 

--- a/inc/class-rtbcb-api-log.php
+++ b/inc/class-rtbcb-api-log.php
@@ -255,12 +255,21 @@ class RTBCB_API_Log {
 
 		$threshold = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
 
-		return $wpdb->query(
-			$wpdb->prepare(
-				'DELETE FROM ' . self::$table_name . ' WHERE created_at < %s',
-				$threshold
-			)
-		);
+                return $wpdb->query(
+                        $wpdb->prepare(
+                                'DELETE FROM ' . self::$table_name . ' WHERE created_at < %s',
+                                $threshold
+                        )
+                );
+        }
+
+	/**
+	 * Purge logs older than 72 hours.
+	 *
+	 * @return int Rows deleted.
+	 */
+	public static function purge_old_logs() {
+		return self::purge_logs( 3 );
 	}
 
 	/**

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -536,16 +536,23 @@ return true;
 
 		   add_action( 'rtbcb_cleanup_data', [ $this, 'scheduled_data_cleanup' ] );
 
-		   // Schedule background job cleanup
-		   if ( ! wp_next_scheduled( 'rtbcb_cleanup_jobs' ) ) {
-			   wp_schedule_event( time(), 'hourly', 'rtbcb_cleanup_jobs' );
-		   }
+		// Schedule background job cleanup
+		if ( ! wp_next_scheduled( 'rtbcb_cleanup_jobs' ) ) {
+		wp_schedule_event( time(), 'hourly', 'rtbcb_cleanup_jobs' );
+		}
+		// Schedule API log cleanup
+		if ( ! wp_next_scheduled( 'rtbcb_purge_api_logs' ) ) {
+			wp_schedule_event( time(), 'hourly', 'rtbcb_purge_api_logs' );
+		}
 
+		if ( class_exists( 'RTBCB_API_Log' ) ) {
+			add_action( 'rtbcb_purge_api_logs', [ 'RTBCB_API_Log', 'purge_old_logs' ] );
+		}
 
-		   // Schedule lead metrics refresh
-		   if ( ! wp_next_scheduled( 'rtbcb_refresh_lead_metrics' ) ) {
-			   wp_schedule_event( time(), 'hourly', 'rtbcb_refresh_lead_metrics' );
-		   }
+		// Schedule lead metrics refresh
+		if ( ! wp_next_scheduled( 'rtbcb_refresh_lead_metrics' ) ) {
+			wp_schedule_event( time(), 'hourly', 'rtbcb_refresh_lead_metrics' );
+		}
 
 		   if ( class_exists( 'RTBCB_Leads' ) ) {
 			   add_action( 'rtbcb_refresh_lead_metrics', [ 'RTBCB_Leads', 'update_cached_statistics' ] );
@@ -3130,9 +3137,10 @@ $html = rtbcb_sanitize_report_html( $html );
 	 */
 	public function deactivate() {
 		// Clear scheduled events
-		wp_clear_scheduled_hook( 'rtbcb_rebuild_rag_index' );
-		wp_clear_scheduled_hook( 'rtbcb_cleanup_data' );
-		wp_clear_scheduled_hook( 'rtbcb_refresh_lead_metrics' );
+               wp_clear_scheduled_hook( 'rtbcb_rebuild_rag_index' );
+               wp_clear_scheduled_hook( 'rtbcb_cleanup_data' );
+               wp_clear_scheduled_hook( 'rtbcb_refresh_lead_metrics' );
+		wp_clear_scheduled_hook( 'rtbcb_purge_api_logs' );
 		
 		// Flush rewrite rules
 		flush_rewrite_rules();


### PR DESCRIPTION
## Summary
- Delete API logs older than 72 hours on admin load and via hourly cron job
- Clear API log cleanup cron hook on plugin deactivation

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(errors: Class "RTBCB_LLM_Optimized" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74a030548833182aded853c12d776