### PR TITLE
Add bulk delete-all option for report management

### DIFF
--- a/admin/class-rtbcb-reports-table.php
+++ b/admin/class-rtbcb-reports-table.php
@@ -109,7 +109,8 @@ class RTBCB_Reports_Table extends WP_List_Table {
      */
     protected function get_bulk_actions() {
         return [
-            'delete' => __( 'Delete', 'rtbcb' ),
+            'delete'     => __( 'Delete', 'rtbcb' ),
+            'delete_all' => __( 'Delete All', 'rtbcb' ),
         ];
     }
 
@@ -186,11 +187,26 @@ class RTBCB_Reports_Table extends WP_List_Table {
      * @return void
      */
     public function process_bulk_action() {
-        if ( 'delete' !== $this->current_action() ) {
+        $action = $this->current_action();
+
+        if ( 'delete' !== $action && 'delete_all' !== $action ) {
             return;
         }
 
         check_admin_referer( 'rtbcb_reports_action' );
+
+        if ( 'delete_all' === $action ) {
+            $files = glob( trailingslashit( $this->reports_dir ) . '*.{html,pdf}', GLOB_BRACE );
+            $files = $files ? $files : [];
+
+            foreach ( $files as $file_path ) {
+                if ( file_exists( $file_path ) ) {
+                    unlink( $file_path );
+                }
+            }
+
+            return;
+        }
 
         $files = isset( $_POST['files'] ) ? (array) wp_unslash( $_POST['files'] ) : [];
         $files = array_map( 'sanitize_file_name', $files );


### PR DESCRIPTION
## Summary
- allow deleting all generated reports at once via a new "Delete All" bulk action
- handle new action in the reports table to remove every report file

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b74a3ccbb08331a12e1dfe5b0e31c3