### PR TITLE
Handle large API log responses without corruption

### DIFF
--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -45,7 +45,10 @@ if ( ! current_user_can( 'manage_options' ) ) {
 						} else {
 							$summary = wp_trim_words( $log['request_json'], 10, '...' );
 						}
-						$status = isset( $response['error'] ) ? __( 'Error', 'rtbcb' ) : __( 'OK', 'rtbcb' );
+                                               $status = isset( $response['error'] ) ? __( 'Error', 'rtbcb' ) : __( 'OK', 'rtbcb' );
+                                               if ( ! empty( $log['response_truncated'] ) ) {
+                                                       $status .= ' (' . __( 'Truncated', 'rtbcb' ) . ')';
+                                               }
 					?>
 					<tr data-id="<?php echo esc_attr( $log['id'] ); ?>" data-request="<?php echo esc_attr( $log['request_json'] ); ?>" data-response="<?php echo esc_attr( $log['response_json'] ); ?>">
 	                                       <td><?php echo esc_html( $log['id'] ); ?></td>


### PR DESCRIPTION
## Summary
- Extend API log table to store `response_truncated` flag
- Preserve JSON structure when truncating and raise response limit to 1MB
- Show truncated status in admin API log listing

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b74d2bd3388331b46ce496c7b0914e