### PR TITLE
Add response integrity utilities

### DIFF
--- a/inc/class-rtbcb-response-integrity.php
+++ b/inc/class-rtbcb-response-integrity.php
@@ -1,0 +1,173 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+/**
+* Response integrity utilities for OpenAI API interactions.
+*
+* @package RealTreasuryBusinessCaseBuilder
+*/
+class RTBCB_Response_Integrity {
+	/**
+	* Validate JSON structure integrity.
+	*
+	* @param string $response JSON response string.
+	* @return bool True when valid JSON, false otherwise.
+	*/
+	public static function validateResponse( $response ) {
+		$response = function_exists( 'wp_unslash' ) ? wp_unslash( $response ) : $response;
+		json_decode( $response );
+		$valid = JSON_ERROR_NONE === json_last_error();
+		
+		if ( class_exists( 'RTBCB_Logger' ) ) {
+			RTBCB_Logger::log(
+			'response_validate',
+			[
+			'valid'  => $valid,
+			'length' => strlen( $response ),
+			]
+			);
+		}
+		
+		return $valid;
+	}
+	
+	/**
+	* Detect corruption patterns between stored and original responses.
+	*
+	* @param string $storedResponse   Stored response string.
+	* @param string $originalResponse Original response string.
+	* @return array{corrupted:bool,issues:array}
+	*/
+	public static function detectCorruption( $storedResponse, $originalResponse ) {
+		$issues = [];
+		
+		json_decode( $storedResponse );
+		if ( JSON_ERROR_NONE !== json_last_error() ) {
+			$issues[] = 'invalid_json';
+		}
+		
+		if ( $storedResponse !== $originalResponse ) {
+			$issues[] = 'mismatch';
+		}
+		
+		$result = [
+		'corrupted' => ! empty( $issues ),
+		'issues'    => $issues,
+		];
+		
+		if ( class_exists( 'RTBCB_Logger' ) ) {
+			RTBCB_Logger::log( 'response_detect_corruption', $result );
+		}
+		
+		return $result;
+	}
+	
+	/**
+	* Attempt automatic repair of minor JSON issues.
+	*
+	* @param string $corruptedResponse Possibly corrupted JSON.
+	* @return string Repaired JSON string or original when unrepaired.
+	*/
+	public static function repairResponse( $corruptedResponse ) {
+		$attempts = [
+		$corruptedResponse,
+		str_replace( ',}', '}', $corruptedResponse ),
+		str_replace( ',]', ']', $corruptedResponse ),
+		];
+		
+		foreach ( $attempts as $attempt ) {
+			json_decode( $attempt );
+			if ( JSON_ERROR_NONE === json_last_error() ) {
+				if ( class_exists( 'RTBCB_Logger' ) ) {
+					RTBCB_Logger::log(
+					'response_repair_success',
+					[
+					'original_length' => strlen( $corruptedResponse ),
+					'repaired_length' => strlen( $attempt ),
+					]
+					);
+				}
+				return wp_json_encode( json_decode( $attempt, true ) );
+			}
+		}
+		
+		if ( class_exists( 'RTBCB_Logger' ) ) {
+			RTBCB_Logger::log( 'response_repair_failed', [ 'length' => strlen( $corruptedResponse ) ] );
+		}
+		
+		return $corruptedResponse;
+	}
+	
+	/**
+	* Generate integrity report for a log entry.
+	*
+	* @param int $logId Log identifier.
+	* @return array Report details.
+	*/
+	public static function generateIntegrityReport( $logId ) {
+		$logId = intval( $logId );
+		if ( $logId <= 0 || ! class_exists( 'RTBCB_API_Log' ) ) {
+			return [];
+		}
+		
+		$logs  = RTBCB_API_Log::get_logs( 200 );
+		$entry = null;
+		foreach ( $logs as $log ) {
+			if ( intval( $log['id'] ) === $logId ) {
+				$entry = $log;
+				break;
+			}
+		}
+		
+		if ( ! $entry ) {
+			return [];
+		}
+		
+		$result                = self::detectCorruption( $entry['response_json'], $entry['response_json'] );
+		$result['log_id']    = $logId;
+		$result['valid_json'] = self::validateResponse( $entry['response_json'] );
+		
+		if ( class_exists( 'RTBCB_Logger' ) ) {
+			RTBCB_Logger::log( 'response_integrity_report', $result );
+		}
+		
+		return $result;
+	}
+	
+	/**
+	* Re-process corrupted historical data.
+	*
+	* @param callable $callback Callback invoked with (log, repaired_json).
+	* @param int      $limit    Number of logs to inspect.
+	* @return int Number of logs reprocessed.
+	*/
+	public static function reprocessHistoricalData( callable $callback, $limit = 100 ) {
+		if ( ! class_exists( 'RTBCB_API_Log' ) ) {
+			return 0;
+		}
+		
+		$logs  = RTBCB_API_Log::get_logs( $limit );
+		$count = 0;
+		
+		foreach ( $logs as $log ) {
+			$check = self::detectCorruption( $log['response_json'], $log['response_json'] );
+			if ( $check['corrupted'] ) {
+				$repaired = self::repairResponse( $log['response_json'] );
+				call_user_func( $callback, $log, $repaired );
+				$count++;
+			}
+		}
+		
+		if ( class_exists( 'RTBCB_Logger' ) ) {
+			RTBCB_Logger::log(
+			'response_reprocess',
+			[
+			'processed' => $count,
+			'limit'     => $limit,
+			]
+			);
+		}
+		
+		return $count;
+	}
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,6 +4,7 @@
     <testsuite name="rtbcb">
       <file>tests/RTBCB_ValidatorTest.php</file>
       <file>tests/RTBCB_ParseGpt5ResponseTest.php</file>
+          <file>tests/RTBCB_ResponseIntegrityTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -285,6 +285,7 @@ return true;
                                    'inc/class-rtbcb-llm-optimized.php'   => 'RTBCB_LLM_Optimized',
 				   'inc/class-rtbcb-intelligent-recommender.php' => 'RTBCB_Intelligent_Recommender',
                                    'inc/class-rtbcb-json-error.php'     => 'RTBCB_JSON_Error',
+                                   'inc/class-rtbcb-response-integrity.php' => 'RTBCB_Response_Integrity',
                                    'inc/class-rtbcb-router.php'		 => 'RTBCB_Router',
 				   'inc/class-rtbcb-tests.php'		 => 'RTBCB_Tests',
 				   'inc/class-rtbcb-api-tester.php'		 => 'RTBCB_API_Tester',

--- a/tests/RTBCB_ResponseIntegrityTest.php
+++ b/tests/RTBCB_ResponseIntegrityTest.php
@@ -1,0 +1,53 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+
+define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/wp-stubs.php';
+
+if ( ! class_exists( 'RTBCB_Logger' ) ) {
+class RTBCB_Logger {
+public static function log( $event, $context = [] ) {}
+}
+}
+
+if ( ! class_exists( 'RTBCB_API_Log' ) ) {
+class RTBCB_API_Log {
+public static function get_logs( $limit = 50 ) {
+return [
+[ 'id' => 1, 'response_json' => '{"foo":"bar"}' ],
+[ 'id' => 2, 'response_json' => '{"foo":}' ],
+];
+}
+}
+}
+
+require_once __DIR__ . '/../inc/class-rtbcb-response-integrity.php';
+
+final class RTBCB_ResponseIntegrityTest extends TestCase {
+public function test_validate_response() {
+$this->assertTrue( RTBCB_Response_Integrity::validateResponse( '{"a":1}' ) );
+$this->assertFalse( RTBCB_Response_Integrity::validateResponse( '{"a":}' ) );
+}
+
+public function test_repair_response() {
+$corrupted = '{"a":1,}';
+$repaired  = RTBCB_Response_Integrity::repairResponse( $corrupted );
+$this->assertTrue( RTBCB_Response_Integrity::validateResponse( $repaired ) );
+}
+
+public function test_detect_corruption_and_reprocess() {
+$result = RTBCB_Response_Integrity::detectCorruption( '{"a":1}', '{"a":2}' );
+$this->assertTrue( $result['corrupted'] );
+$this->assertContains( 'mismatch', $result['issues'] );
+
+$processed = RTBCB_Response_Integrity::reprocessHistoricalData( function( $log, $repaired ) use ( & $ids ) {
+$ids[] = $log['id'];
+} );
+$this->assertSame( 1, $processed );
+$this->assertSame( [2], $ids );
+}
+}


### PR DESCRIPTION
## Summary
- add `RTBCB_Response_Integrity` for validating, repairing and reporting on stored OpenAI responses
- load new integrity helper in plugin bootstrap
- cover response integrity helper with unit tests

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b74d8fee60833190a1b1c0fa186bbe