### PR TITLE
Avoid RTBCB_LLM_Optimized stub redeclaration in tests

### DIFF
--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -84,23 +84,6 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
         }
 }
 
-if ( ! class_exists( 'RTBCB_LLM_Optimized' ) ) {
-	class RTBCB_LLM_Optimized {
-		public function generate_comprehensive_business_case( $user_inputs, $scenarios, $rag_context, $chunk_callback = null ) {
-			$mode = class_exists( 'RTBCB_LLM' ) && property_exists( 'RTBCB_LLM', 'mode' ) ? RTBCB_LLM::$mode : 'generic';
-			
-			if ( 'no_api_key' === $mode ) {
-				return new WP_Error( 'no_api_key', 'OpenAI API key not configured.' );
-			}
-			
-			if ( 'http_status' === $mode ) {
-				return new WP_Error( 'llm_http_status', 'Teapot', [ 'status' => 418 ] );
-			}
-			
-			return new WP_Error( 'llm_error', 'LLM failed' );
-		}
-	}
-}
 
 if ( ! function_exists( 'is_wp_error' ) ) {
        function is_wp_error( $thing ) {


### PR DESCRIPTION
## Summary
- remove RTBCB_LLM_Optimized stub from `tests/wp-stubs.php` so the real class can be loaded

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=test-model bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b7531096648331a6fc6eebafbf6994