### PR TITLE
Handle large API log responses safely

### DIFF
--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -46,7 +46,9 @@ if ( ! current_user_can( 'manage_options' ) ) {
 							$summary = wp_trim_words( $log['request_json'], 10, '...' );
 						}
                                                $status = isset( $response['error'] ) ? __( 'Error', 'rtbcb' ) : __( 'OK', 'rtbcb' );
-                                               if ( ! empty( $log['response_truncated'] ) ) {
+                                               if ( ! empty( $log['corruption_detected'] ) ) {
+                                                       $status .= ' (' . __( 'Corrupt', 'rtbcb' ) . ')';
+                                               } elseif ( ! empty( $log['is_truncated'] ) ) {
                                                        $status .= ' (' . __( 'Truncated', 'rtbcb' ) . ')';
                                                }
 					?>

--- a/inc/class-rtbcb-db.php
+++ b/inc/class-rtbcb-db.php
@@ -14,7 +14,7 @@ class RTBCB_DB {
 	/**
 	* Current database version.
 	*/
-        const DB_VERSION = '2.0.4';
+       const DB_VERSION = '2.0.5';
 
 	/**
 	/**
@@ -84,11 +84,17 @@ class RTBCB_DB {
 			RTBCB_Leads::compress_existing_report_html();
 		}
 
-		if ( version_compare( $from_version, '2.0.4', '<' ) ) {
-			RTBCB_Leads::add_api_response_column();
-		}
+               if ( version_compare( $from_version, '2.0.4', '<' ) ) {
+                       RTBCB_Leads::add_api_response_column();
+               }
 
-	// Future migrations can be handled here.
+               if ( version_compare( $from_version, '2.0.5', '<' ) ) {
+                       if ( class_exists( 'RTBCB_API_Log' ) ) {
+                               RTBCB_API_Log::migrate_table();
+                       }
+               }
+
+       // Future migrations can be handled here.
 
 		// Log the upgrade.
 		error_log( 'RTBCB: Database upgraded from version ' . $from_version . ' to ' . self::DB_VERSION );


### PR DESCRIPTION
## Summary
- expand API log schema with UTF8MB4 longtext fields and metadata for truncation and corruption
- add safe JSON encoding that tracks original size and truncation
- update admin log viewer and database upgrade to use new columns

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b752a645708331ba02584ee268e612