### PR TITLE
Capture user email in business case inputs

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -191,10 +191,10 @@ class RTBCB_LLM {
                        'num_banks'              => intval( $user_inputs['num_banks'] ?? 0 ),
                        'ftes'                   => floatval( $user_inputs['ftes'] ?? 0 ),
                        'pain_points'            => array_map( 'sanitize_text_field', (array) ( $user_inputs['pain_points'] ?? [] ) ),
+                       'email'                  => sanitize_email( $user_inputs['email'] ?? '' ),
                ];
 
                $this->current_inputs            = $inputs;
-               $this->current_inputs['email']   = sanitize_email( $user_inputs['email'] ?? '' );
 
 		if ( empty( $this->api_key ) ) {
 			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );


### PR DESCRIPTION
## Summary
- include sanitized `email` in business case input array so it’s persisted in API logs
- remove manual email assignment and store updated inputs on the class instance

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b753a8a58083318cee42af4a35e92a