### PR TITLE
Fix DataTables column count warning on API logs table

### DIFF
--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -69,10 +69,6 @@ if ( ! current_user_can( 'manage_options' ) ) {
 						</td>
 					</tr>
 					<?php endforeach; ?>
-				<?php else : ?>
-	                               <tr>
-	                                       <td colspan="9"><?php esc_html_e( 'No logs found.', 'rtbcb' ); ?></td>
-	                               </tr>
 				<?php endif; ?>
 			</tbody>
 		</table>
@@ -88,7 +84,10 @@ if ( ! current_user_can( 'manage_options' ) ) {
 	jQuery(function($){
 var table = $('#rtbcb-api-logs-table').DataTable({
 pageLength: 20,
-order: [[0, 'desc']]
+order: [[0, 'desc']],
+language: {
+emptyTable: '<?php echo esc_js( __( 'No logs found.', 'rtbcb' ) ); ?>'
+}
 });
 var initialSearch = new URLSearchParams(window.location.search).get('search');
 if (initialSearch) {


### PR DESCRIPTION
## Summary
- remove manual "No logs" row that caused DataTables column mismatch
- configure DataTables to show a localized empty-table message

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: RTBCB: OpenAI API key not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b751e934008331924b78130c2d1477