### PR TITLE
feat: handle nested LLM JSON responses

### DIFF
--- a/tests/RTBCB_ExtractOpenAIJsonTest.php
+++ b/tests/RTBCB_ExtractOpenAIJsonTest.php
@@ -1,0 +1,38 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/wp-stubs.php';
+require_once __DIR__ . '/../inc/helpers.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests rtbcb_extract_json_from_openai_response().
+ */
+final class RTBCB_ExtractOpenAIJsonTest extends TestCase {
+	public function test_extracts_nested_json() {
+		$raw_body = json_encode(
+			[
+				'output' => [
+					[
+						'id'      => 'reasoning',
+						'type'    => 'reasoning',
+						'content' => [ [ 'type' => 'reasoning', 'text' => 'thinking' ] ],
+					],
+					[
+						'id'      => 'message',
+						'type'    => 'message',
+						'content' => [ [ 'type' => 'output_text', 'text' => '{"foo":"bar"}' ] ],
+					],
+				],
+			]
+		);
+
+		$decoded = rtbcb_extract_json_from_openai_response( $raw_body );
+		$this->assertIsArray( $decoded );
+		$this->assertSame( 'bar', $decoded['foo'] );
+	}
+}


### PR DESCRIPTION
## Summary
- add `rtbcb_extract_json_from_openai_response` helper to decode nested model responses
- parse OpenAI job responses with new helper
- cover nested JSON parsing with unit test

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b75866571483318d2be36a2a545f63