### PR TITLE
fix: carry rag context through template transform

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -2306,6 +2306,9 @@ function rtbcb_transform_data_for_template( $business_case_data ) {
 	        ];
 	}
 
+	// Prepare RAG context.
+	$rag_context = array_map( 'sanitize_text_field', (array) ( $business_case_data['rag_context'] ?? [] ) );
+
 	// Create structured data format expected by template.
 	$report_data = [
 	        'metadata'           => [
@@ -2352,6 +2355,7 @@ function rtbcb_transform_data_for_template( $business_case_data ) {
 	                'implementation_risks' => $implementation_risks,
 	        ],
 	        'action_plan'          => $action_plan,
+		'rag_context'         => $rag_context,
 	];
 
 	return $report_data;

--- a/tests/rag-context-propagation.test.php
+++ b/tests/rag-context-propagation.test.php
@@ -1,0 +1,27 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/wp-stubs.php';
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) {
+		return $text;
+	}
+}
+
+require_once __DIR__ . '/../real-treasury-business-case-builder.php';
+
+$input  = [ 'rag_context' => [ 'First context', 'Second context' ] ];
+$result = rtbcb_transform_data_for_template( $input );
+
+$expected = array_map( 'sanitize_text_field', $input['rag_context'] );
+if ( $result['rag_context'] !== $expected ) {
+	echo "rag context not preserved\n";
+	exit( 1 );
+}
+
+echo "rag-context-propagation.test.php passed\n";
+


### PR DESCRIPTION
## Summary
- carry forward rag context when building report data
- add regression test ensuring rag context persists

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b76320250883319f291efed93a5973