### PR TITLE
Handle operational_insights key in wizard results

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -1483,7 +1483,7 @@ class BusinessCaseBuilder {
                 reasoning: data.recommendation?.reasoning || data.technology_strategy?.recommended_category || ''
             },
             executiveSummary: data.executive_summary || data.narrative || {},
-            operationalAnalysis: data.operational_analysis || {},
+            operationalAnalysis: data.operational_insights || data.operational_analysis || {},
             industryInsights: {
                 sector_trends: data.industry_insights?.sector_trends || [],
                 competitive_benchmarks: data.industry_insights?.competitive_benchmarks || [],


### PR DESCRIPTION
## Summary
- Read operational insights from `operational_insights` key while keeping legacy fallback

## Testing
- `composer install`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b76a6534808331b878e85b500e5a7f