### PR TITLE
feat: add industry insights to template data

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -2259,9 +2259,12 @@ function rtbcb_transform_data_for_template( $business_case_data ) {
 	}
 	// Prepare industry insights.
 	if ( ! empty( $business_case_data['industry_insights'] ) ) {
-	        $industry_insights = rtbcb_sanitize_recursive( $business_case_data['industry_insights'] );
+		$industry_insights = rtbcb_sanitize_recursive( $business_case_data['industry_insights'] );
+		if ( empty( $industry_insights ) ) {
+			$industry_insights = rtbcb_generate_industry_insights_fallbacks( $business_case_data );
+		}
 	} else {
-	        $industry_insights = rtbcb_generate_industry_insights_fallbacks( $business_case_data );
+		$industry_insights = rtbcb_generate_industry_insights_fallbacks( $business_case_data );
 	}
 
 	// Prepare action plan.

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -983,6 +983,8 @@ return true;
 		return;
 		}
 
+		$business_case_data = $report_data;
+
 		try {
 		$rag = new RTBCB_RAG();
 		$rag->rebuild_index();
@@ -2204,6 +2206,7 @@ $missing_sections  = array_diff( $required_sections, array_keys( $comprehensive_
 		}
 		}
 
+		$business_case_data = $report_data;
 		try {
 	set_error_handler(
 	static function ( $severity, $message, $file, $line ) {


### PR DESCRIPTION
## Summary
- ensure industry insights array falls back when empty
- pass transformed report data to templates so industry insights render

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b7699b40d48331aed0da32130ffe30