### PR TITLE
Preserve usage tokens in OpenAI response logs

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -129,45 +129,51 @@ class RTBCB_LLM {
                        }
                }
 
-		$decoded = json_decode( $response_body, true );
+               $decoded = json_decode( $response_body, true );
 
-		if ( JSON_ERROR_UTF8 === json_last_error() && function_exists( 'mb_convert_encoding' ) ) {
-			$response_body = mb_convert_encoding( $response_body, 'UTF-8', 'auto' );
-			$decoded       = json_decode( $response_body, true );
-		}
+               if ( JSON_ERROR_UTF8 === json_last_error() && function_exists( 'mb_convert_encoding' ) ) {
+                       $response_body = mb_convert_encoding( $response_body, 'UTF-8', 'auto' );
+                       $decoded       = json_decode( $response_body, true );
+               }
 
-		if ( JSON_ERROR_NONE !== json_last_error() ) {
-			error_log( 'JSON decode error: ' . json_last_error_msg() );
-			return false;
-		}
+               if ( JSON_ERROR_NONE !== json_last_error() ) {
+                       error_log( 'JSON decode error: ' . json_last_error_msg() );
+                       return false;
+               }
 
-		if ( isset( $decoded['output_text'] ) && is_string( $decoded['output_text'] ) ) {
-			$inner = json_decode( $decoded['output_text'], true );
-			if ( JSON_ERROR_NONE === json_last_error() ) {
-				return $inner;
-			}
-			error_log( 'JSON decode error: ' . json_last_error_msg() );
-			return false;
-		}
+               if ( isset( $decoded['output_text'] ) && is_string( $decoded['output_text'] ) ) {
+                       $inner = json_decode( $decoded['output_text'], true );
+                       if ( JSON_ERROR_NONE === json_last_error() ) {
+                               if ( is_array( $inner ) && isset( $decoded['usage'] ) ) {
+                                       $inner['usage'] = $decoded['usage'];
+                               }
+                               return $inner;
+                       }
+                       error_log( 'JSON decode error: ' . json_last_error_msg() );
+                       return false;
+               }
 
-		if ( isset( $decoded['output'] ) && is_array( $decoded['output'] ) ) {
-			foreach ( $decoded['output'] as $chunk ) {
-				if ( 'message' === ( $chunk['type'] ?? '' ) && isset( $chunk['content'] ) && is_array( $chunk['content'] ) ) {
-					foreach ( $chunk['content'] as $piece ) {
-						if ( isset( $piece['text'] ) && is_string( $piece['text'] ) ) {
-							$inner = json_decode( $piece['text'], true );
-							if ( JSON_ERROR_NONE === json_last_error() ) {
-								return $inner;
-							}
-							error_log( 'JSON decode error: ' . json_last_error_msg() );
-							return false;
-						}
-					}
-				}
-			}
-		}
+               if ( isset( $decoded['output'] ) && is_array( $decoded['output'] ) ) {
+                       foreach ( $decoded['output'] as $chunk ) {
+                               if ( 'message' === ( $chunk['type'] ?? '' ) && isset( $chunk['content'] ) && is_array( $chunk['content'] ) ) {
+                                       foreach ( $chunk['content'] as $piece ) {
+                                               if ( isset( $piece['text'] ) && is_string( $piece['text'] ) ) {
+                                                       $inner = json_decode( $piece['text'], true );
+                                                       if ( JSON_ERROR_NONE === json_last_error() ) {
+                                                               if ( is_array( $inner ) && isset( $decoded['usage'] ) ) {
+                                                                       $inner['usage'] = $decoded['usage'];
+                                                               }
+                                                               return $inner;
+                                                       }
+                                                       error_log( 'JSON decode error: ' . json_last_error_msg() );
+                                                       return false;
+                                               }
+                                       }
+                               }
+                       }
+               }
 
-		return $decoded;
+               return $decoded;
        }
 
 	/**

--- a/tests/RTBCB_Z_ProcessOpenAIResponseTest.php
+++ b/tests/RTBCB_Z_ProcessOpenAIResponseTest.php
@@ -48,11 +48,26 @@ final class RTBCB_Z_ProcessOpenAIResponseTest extends TestCase {
 		ini_set( 'error_log', $orig );
 	}
 
-	public function test_handles_large_response() {
-		$large   = str_repeat( 'a', 10000 );
-		$json    = '{"text":"' . $large . '"}';
-		$decoded = $this->llm->process_openai_response( $json );
-		$this->assertSame( $large, $decoded['text'] );
-	}
+       public function test_handles_large_response() {
+               $large   = str_repeat( 'a', 10000 );
+               $json    = '{"text":"' . $large . '"}';
+               $decoded = $this->llm->process_openai_response( $json );
+               $this->assertSame( $large, $decoded['text'] );
+       }
+
+       public function test_preserves_usage_data() {
+               $payload = [
+                       'output_text' => json_encode( [ 'result' => 'ok' ] ),
+                       'usage'       => [
+                               'input_tokens'  => 5,
+                               'output_tokens' => 7,
+                               'total_tokens'  => 12,
+                       ],
+               ];
+               $json    = json_encode( $payload );
+               $decoded = $this->llm->process_openai_response( $json );
+               $this->assertSame( 5, $decoded['usage']['input_tokens'] );
+               $this->assertSame( 'ok', $decoded['result'] );
+       }
 }
 


### PR DESCRIPTION
## Summary
- Preserve `usage` data when decoding OpenAI responses so token counts are stored in API logs
- Test that `process_openai_response` keeps usage information for logging

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4 bash tests/run-tests.sh`
- `vendor/bin/phpcs --standard=WordPress inc/class-rtbcb-llm.php tests/RTBCB_Z_ProcessOpenAIResponseTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b771a72d848331b89908150ed25b8e