### PR TITLE
Improve OpenAI JSON response parsing

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -97,84 +97,200 @@ class RTBCB_LLM {
                return $this->last_response;
        }
 
-       /**
-        * Decode and clean JSON responses from OpenAI.
-        *
-        * Normalizes slashes, ensures UTF-8 encoding and decodes the JSON body.
-        * Falls back to a secondary decode attempt if the initial decode fails
-        * due to encoding issues.
-        *
-        * @param string $response_body Raw response body.
-        * @return array|false Decoded array on success, false on failure.
-        */
-       public function process_openai_response( $response_body ) {
-               if ( function_exists( 'wp_unslash' ) ) {
-                       $response_body = wp_unslash( $response_body );
-               }
+	/**
+	 * Enhanced JSON response processing with better error handling.
+	 *
+	 * Attempts multiple strategies to decode JSON responses, including
+	 * handling of markdown code blocks and streaming formats. Logs useful
+	 * debugging information when failures occur.
+	 *
+	 * @param string $response_body Raw response body.
+	 * @return array|string|false Decoded content or false on failure.
+	 */
+	public function process_openai_response( $response_body ) {
+		// Log the raw response for debugging.
+		error_log( 'RTBCB: Raw API response: ' . substr( $response_body, 0, 500 ) . '...' );
+		
+		if ( empty( $response_body ) ) {
+		error_log( 'RTBCB: Empty response body received' );
+		return false;
+		}
+		
+		// Clean up the response body.
+		$response_body = trim( $response_body );
+		$response_body = preg_replace( '/\x{FEFF}/u', '', $response_body );
+		
+		if ( function_exists( 'wp_unslash' ) ) {
+		$response_body = wp_unslash( $response_body );
+		}
+		
+		if ( function_exists( 'mb_detect_encoding' ) ) {
+		$encoding = mb_detect_encoding( $response_body, [ 'UTF-8', 'ISO-8859-1', 'ASCII' ], true );
+		if ( $encoding && 'UTF-8' !== $encoding ) {
+		if ( function_exists( 'mb_convert_encoding' ) ) {
+		$converted = mb_convert_encoding( $response_body, 'UTF-8', $encoding );
+		if ( false !== $converted ) {
+		$response_body = $converted;
+		}
+		}
+		}
+		}
+		
+		// First attempt: Direct JSON decode.
+		$decoded    = json_decode( $response_body, true );
+		$json_error = json_last_error();
+		
+		if ( JSON_ERROR_NONE === $json_error && is_array( $decoded ) ) {
+		error_log( 'RTBCB: JSON decoded successfully on first attempt' );
+		return $this->extract_content_from_decoded_response( $decoded );
+		}
+		
+		error_log( 'RTBCB: JSON decode failed: ' . json_last_error_msg() );
+		
+		// Second attempt: Handle potential markdown wrapping.
+		if ( preg_match( '/```(?:json)?\s*(\{.*\})\s*```/s', $response_body, $matches ) ) {
+		$json_content = trim( $matches[1] );
+		$decoded      = json_decode( $json_content, true );
+		if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
+		error_log( 'RTBCB: JSON extracted from markdown successfully' );
+		return $this->extract_content_from_decoded_response( $decoded );
+		}
+		}
+		
+		// Third attempt: Extract JSON from mixed content.
+		if ( preg_match( '/\{.*\}/s', $response_body, $matches ) ) {
+		$json_content = $matches[0];
+		$decoded      = json_decode( $json_content, true );
+		if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
+		error_log( 'RTBCB: JSON extracted from mixed content successfully' );
+		return $this->extract_content_from_decoded_response( $decoded );
+		}
+		}
+		
+		// Fourth attempt: Handle streaming response format.
+		if ( $this->is_streaming_response( $response_body ) ) {
+		return $this->parse_streaming_response( $response_body );
+		}
+		
+error_log( 'RTBCB: All JSON parsing attempts failed for response: ' . substr( $response_body, 0, 200 ) );
+return false;
+}
 
-               if ( function_exists( 'mb_detect_encoding' ) ) {
-                       $encoding = mb_detect_encoding( $response_body, [ 'UTF-8', 'ISO-8859-1', 'ASCII' ], true );
-                       if ( $encoding && 'UTF-8' !== $encoding ) {
-                               if ( function_exists( 'mb_convert_encoding' ) ) {
-                                       $converted = mb_convert_encoding( $response_body, 'UTF-8', $encoding );
-                                       if ( false === $converted ) {
-                                               error_log( 'Failed to convert response to UTF-8.' );
-                                               return false;
-                                       }
-                                       $response_body = $converted;
-                               } else {
-                                       error_log( 'mbstring extension missing for UTF-8 conversion.' );
-                                       return false;
-                               }
-                       }
-               }
-
-               $decoded = json_decode( $response_body, true );
-
-               if ( JSON_ERROR_UTF8 === json_last_error() && function_exists( 'mb_convert_encoding' ) ) {
-                       $response_body = mb_convert_encoding( $response_body, 'UTF-8', 'auto' );
-                       $decoded       = json_decode( $response_body, true );
-               }
-
-               if ( JSON_ERROR_NONE !== json_last_error() ) {
-                       error_log( 'JSON decode error: ' . json_last_error_msg() );
-                       return false;
-               }
-
-               if ( isset( $decoded['output_text'] ) && is_string( $decoded['output_text'] ) ) {
-                       $inner = json_decode( $decoded['output_text'], true );
-                       if ( JSON_ERROR_NONE === json_last_error() ) {
-                               if ( is_array( $inner ) && isset( $decoded['usage'] ) ) {
-                                       $inner['usage'] = $decoded['usage'];
-                               }
-                               return $inner;
-                       }
-                       error_log( 'JSON decode error: ' . json_last_error_msg() );
-                       return false;
-               }
-
-               if ( isset( $decoded['output'] ) && is_array( $decoded['output'] ) ) {
-                       foreach ( $decoded['output'] as $chunk ) {
-                               if ( 'message' === ( $chunk['type'] ?? '' ) && isset( $chunk['content'] ) && is_array( $chunk['content'] ) ) {
-                                       foreach ( $chunk['content'] as $piece ) {
-                                               if ( isset( $piece['text'] ) && is_string( $piece['text'] ) ) {
-                                                       $inner = json_decode( $piece['text'], true );
-                                                       if ( JSON_ERROR_NONE === json_last_error() ) {
-                                                               if ( is_array( $inner ) && isset( $decoded['usage'] ) ) {
-                                                                       $inner['usage'] = $decoded['usage'];
-                                                               }
-                                                               return $inner;
-                                                       }
-                                                       error_log( 'JSON decode error: ' . json_last_error_msg() );
-                                                       return false;
-                                               }
-                                       }
-                               }
-                       }
-               }
-
-               return $decoded;
-       }
+	/**
+	 * Extract content from successfully decoded response.
+	 *
+	 * Handles different response structures and attempts to decode nested JSON
+	 * when present.
+	 *
+	 * @param array $decoded Decoded JSON response.
+	 * @return array|string Decoded content.
+	 */
+		private function extract_content_from_decoded_response( $decoded ) {
+		// Direct content structure.
+		if ( isset( $decoded['choices'][0]['message']['content'] ) ) {
+		$content = $decoded['choices'][0]['message']['content'];
+		if ( is_string( $content ) ) {
+		if ( $this->looks_like_json( $content ) ) {
+		$inner_decoded = json_decode( $content, true );
+		if ( JSON_ERROR_NONE === json_last_error() ) {
+		return $inner_decoded;
+		}
+		}
+		return $content;
+		}
+		}
+		
+		// GPT-5 Responses API format.
+		if ( isset( $decoded['output'] ) && is_array( $decoded['output'] ) ) {
+		foreach ( $decoded['output'] as $chunk ) {
+		if ( 'message' === ( $chunk['type'] ?? '' ) && isset( $chunk['content'] ) ) {
+		if ( is_array( $chunk['content'] ) ) {
+		foreach ( $chunk['content'] as $piece ) {
+		if ( isset( $piece['text'] ) ) {
+		$text = $piece['text'];
+		if ( $this->looks_like_json( $text ) ) {
+		$inner_decoded = json_decode( $text, true );
+		if ( JSON_ERROR_NONE === json_last_error() ) {
+		return $inner_decoded;
+		}
+		}
+		return $text;
+		}
+		}
+		}
+		}
+		}
+		}
+		
+		// Direct output_text field.
+		if ( isset( $decoded['output_text'] ) ) {
+		$content = $decoded['output_text'];
+		if ( $this->looks_like_json( $content ) ) {
+		$inner_decoded = json_decode( $content, true );
+		if ( JSON_ERROR_NONE === json_last_error() ) {
+		return $inner_decoded;
+		}
+		}
+		return $content;
+		}
+		
+		// Return the decoded response as-is if it's already structured.
+		return $decoded;
+		}
+		
+		/**
+		 * Check if content looks like JSON.
+		 *
+		 * @param string $content Content to evaluate.
+		 * @return bool True if the content appears to be JSON.
+		 */
+		private function looks_like_json( $content ) {
+		$content = trim( $content );
+		return ( substr( $content, 0, 1 ) === '{' && substr( $content, -1 ) === '}' ) ||
+		( substr( $content, 0, 1 ) === '[' && substr( $content, -1 ) === ']' );
+		}
+		
+		/**
+		 * Check if response is in streaming format.
+		 *
+		 * @param string $response_body Raw response body.
+		 * @return bool True if streaming markers are found.
+		 */
+		private function is_streaming_response( $response_body ) {
+		return strpos( $response_body, 'data: {' ) !== false ||
+		strpos( $response_body, 'event: ' ) !== false;
+		}
+		
+		/**
+		 * Parse streaming response format.
+		 *
+		 * Extracts the first JSON object from a streaming response and returns the
+		 * decoded content.
+		 *
+		 * @param string $response_body Raw response body.
+		 * @return array|string|false Decoded content or false on failure.
+		 */
+		private function parse_streaming_response( $response_body ) {
+		$lines    = explode( "\n", $response_body );
+		$json_data = '';
+		
+		foreach ( $lines as $line ) {
+		$line = trim( $line );
+		if ( strpos( $line, 'data: {' ) === 0 ) {
+		$json_data = substr( $line, 6 );
+		break;
+		}
+		}
+		
+		if ( $json_data ) {
+		$decoded = json_decode( $json_data, true );
+		if ( JSON_ERROR_NONE === json_last_error() ) {
+		return $this->extract_content_from_decoded_response( $decoded );
+		}
+		}
+		
+		return false;
+		}
 
 	/**
 	* Estimate token usage from a desired word count.


### PR DESCRIPTION
## Summary
- enhance process_openai_response to handle markdown, mixed, and streaming formats with additional logging
- add helpers for extracting content, detecting JSON patterns, and parsing streaming responses

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*
- `phpcs --standard=WordPress inc/class-rtbcb-llm.php` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b773228dd88331a1a49a09130fb147