### PR TITLE
Use URL sanitization for log endpoint

### DIFF
--- a/inc/class-rtbcb-logger.php
+++ b/inc/class-rtbcb-logger.php
@@ -37,8 +37,8 @@ class RTBCB_Logger {
 
 		error_log( 'RTBCB_LOG: ' . wp_json_encode( $record ) );
 
-		$endpoint = function_exists( 'get_option' ) ? get_option( 'rtbcb_log_endpoint', '' ) : '';
-		$endpoint = function_exists( 'sanitize_text_field' ) ? sanitize_text_field( $endpoint ) : $endpoint;
+$endpoint = function_exists( 'get_option' ) ? get_option( 'rtbcb_log_endpoint', '' ) : '';
+$endpoint = function_exists( 'esc_url_raw' ) ? esc_url_raw( $endpoint ) : $endpoint;
 
 		if ( $endpoint ) {
 			rtbcb_wp_remote_post_with_retry(


### PR DESCRIPTION
## Summary
- Sanitize log endpoint using `esc_url_raw` to preserve full URL when sending log records

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`
- `phpcs --standard=WordPress inc/class-rtbcb-logger.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b77f4e01f483319f4efb4b5fc9f875