### PR TITLE
Refactor LLM into helper classes

### DIFF
--- a/inc/class-rtbcb-llm-config.php
+++ b/inc/class-rtbcb-llm-config.php
@@ -1,0 +1,119 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Configuration helper for LLM integration.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/helpers.php';
+
+class RTBCB_LLM_Config {
+/**
+ * OpenAI API key.
+ *
+ * @var string
+ */
+private $api_key;
+
+/**
+ * GPT-5 configuration settings.
+ *
+ * @var array
+ */
+private $gpt5_config;
+
+/**
+ * Constructor.
+ */
+public function __construct() {
+$this->api_key = rtbcb_get_openai_api_key();
+
+$timeout           = rtbcb_get_api_timeout();
+$max_output_tokens = intval( function_exists( 'get_option' ) ? get_option( 'rtbcb_gpt5_max_output_tokens', 8000 ) : 8000 );
+$this->gpt5_config = rtbcb_get_gpt5_config(
+array_merge(
+function_exists( 'get_option' ) ? get_option( 'rtbcb_gpt5_config', [] ) : [],
+[
+'timeout'           => $timeout,
+'max_output_tokens' => $max_output_tokens,
+]
+)
+);
+}
+
+/**
+ * Get the configured API key.
+ *
+ * @return string API key.
+ */
+public function get_api_key() {
+return $this->api_key;
+}
+
+/**
+ * Get GPT-5 configuration settings.
+ *
+ * @return array Configuration array.
+ */
+public function get_gpt5_config() {
+return $this->gpt5_config;
+}
+
+/**
+ * Get the configured model for a tier.
+ *
+ * @param string $tier Model tier.
+ * @return string Model name.
+ */
+public function get_model( $tier ) {
+$tier    = sanitize_key( $tier );
+$default = rtbcb_get_default_model( $tier );
+$model_option = function_exists( 'get_option' ) ? get_option( "rtbcb_{$tier}_model", $default ) : $default;
+return function_exists( 'sanitize_text_field' ) ? sanitize_text_field( $model_option ) : $model_option;
+}
+
+/**
+ * Estimate token usage from a desired word count.
+ *
+ * @param int $words Desired word count.
+ * @return int Estimated token count.
+ */
+public function estimate_tokens( $words ) {
+$words      = max( 0, intval( $words ) );
+$tokens     = (int) ceil( $words * 1.5 );
+$limit      = intval( $this->gpt5_config['max_output_tokens'] ?? 8000 );
+$min_tokens = intval( $this->gpt5_config['min_output_tokens'] ?? 1 );
+$limit      = min( 128000, max( $min_tokens, $limit ) );
+
+return max( $min_tokens, min( $tokens, $limit ) );
+}
+
+/**
+ * Determine token limit for a report type.
+ *
+ * @param string $type Report type identifier.
+ * @return int Estimated token count for the report.
+ */
+public function tokens_for_report( $type ) {
+$targets = [
+'business_case'               => 600,
+'industry_commentary'         => 60,
+'company_overview'            => 400,
+'industry_overview'           => 400,
+'treasury_tech_overview'      => 400,
+'real_treasury_overview'      => 400,
+'category_recommendation'     => 200,
+'benefits_estimate'           => 200,
+'comprehensive_business_case' => 2000,
+'competitive_context'         => 200,
+'industry_analysis'           => 400,
+'tech_research'               => 400,
+];
+
+$words = $targets[ $type ] ?? 800;
+
+return $this->estimate_tokens( $words );
+}
+}

--- a/inc/class-rtbcb-llm-prompt.php
+++ b/inc/class-rtbcb-llm-prompt.php
@@ -1,0 +1,39 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Prompt assembly helper for LLM.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+class RTBCB_LLM_Prompt {
+/**
+ * Build context array for Responses API.
+ *
+ * @param array       $history       Message history.
+ * @param string|null $system_prompt Optional system prompt.
+ * @return array Context array.
+ */
+public function build_context_for_responses( $history, $system_prompt = null ) {
+$default_system = 'You are a senior treasury technology consultant. Provide detailed, research-driven analysis in the exact JSON format requested. Do not include any text outside the JSON structure.';
+
+$system_prompt = $system_prompt ? $system_prompt : $default_system;
+
+$input_parts = [];
+
+foreach ( (array) $history as $item ) {
+if ( ! is_array( $item ) || 'user' !== ( $item['role'] ?? '' ) || ! isset( $item['content'] ) ) {
+continue;
+}
+
+$input_parts[] = function_exists( 'sanitize_textarea_field' ) ? sanitize_textarea_field( $item['content'] ) : $item['content'];
+}
+
+$instructions = function_exists( 'sanitize_textarea_field' ) ? sanitize_textarea_field( $system_prompt ) : $system_prompt;
+
+return [
+'instructions' => $instructions,
+'input'        => implode( "\n", $input_parts ),
+];
+}
+}

--- a/inc/class-rtbcb-llm-response-parser.php
+++ b/inc/class-rtbcb-llm-response-parser.php
@@ -1,0 +1,184 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Response parsing helper for LLM.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+class RTBCB_LLM_Response_Parser {
+/**
+ * Process raw OpenAI response body.
+ *
+ * @param string $response_body Raw response.
+ * @return array|string|false Parsed content or false on failure.
+ */
+public function process_openai_response( $response_body ) {
+// Log the raw response for debugging.
+error_log( 'RTBCB: Raw API response: ' . substr( $response_body, 0, 500 ) . '...' );
+
+if ( empty( $response_body ) ) {
+error_log( 'RTBCB: Empty response body received' );
+return false;
+}
+
+$response_body = trim( $response_body );
+$response_body = preg_replace( '/\x{FEFF}/u', '', $response_body );
+
+if ( function_exists( 'wp_unslash' ) ) {
+$response_body = wp_unslash( $response_body );
+}
+
+if ( function_exists( 'mb_detect_encoding' ) ) {
+$encoding = mb_detect_encoding( $response_body, [ 'UTF-8', 'ISO-8859-1', 'ASCII' ], true );
+if ( $encoding && 'UTF-8' !== $encoding ) {
+if ( function_exists( 'mb_convert_encoding' ) ) {
+$converted = mb_convert_encoding( $response_body, 'UTF-8', $encoding );
+if ( false !== $converted ) {
+$response_body = $converted;
+}
+}
+}
+}
+
+$decoded    = json_decode( $response_body, true );
+$json_error = json_last_error();
+
+if ( JSON_ERROR_NONE === $json_error && is_array( $decoded ) ) {
+error_log( 'RTBCB: JSON decoded successfully on first attempt' );
+return $this->extract_content_from_decoded_response( $decoded );
+}
+
+error_log( 'RTBCB: JSON decode failed: ' . json_last_error_msg() );
+
+if ( preg_match( '/```(?:json)?\s*(\{.*\})\s*```/s', $response_body, $matches ) ) {
+$json_content = trim( $matches[1] );
+$decoded      = json_decode( $json_content, true );
+if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
+error_log( 'RTBCB: JSON extracted from markdown successfully' );
+return $this->extract_content_from_decoded_response( $decoded );
+}
+}
+
+if ( preg_match( '/\{.*\}/s', $response_body, $matches ) ) {
+$json_content = $matches[0];
+$decoded      = json_decode( $json_content, true );
+if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
+error_log( 'RTBCB: JSON extracted from mixed content successfully' );
+return $this->extract_content_from_decoded_response( $decoded );
+}
+}
+
+if ( $this->is_streaming_response( $response_body ) ) {
+return $this->parse_streaming_response( $response_body );
+}
+
+error_log( 'RTBCB: All JSON parsing attempts failed for response: ' . substr( $response_body, 0, 200 ) );
+return false;
+}
+
+/**
+ * Extract content from decoded response.
+ *
+ * @param array $decoded Decoded JSON.
+ * @return array|string Parsed content.
+ */
+private function extract_content_from_decoded_response( $decoded ) {
+if ( isset( $decoded['choices'][0]['message']['content'] ) ) {
+$content = $decoded['choices'][0]['message']['content'];
+if ( is_string( $content ) ) {
+if ( $this->looks_like_json( $content ) ) {
+$inner = json_decode( $content, true );
+if ( JSON_ERROR_NONE === json_last_error() ) {
+return $inner;
+}
+}
+return $content;
+}
+}
+
+if ( isset( $decoded['output'] ) && is_array( $decoded['output'] ) ) {
+foreach ( $decoded['output'] as $chunk ) {
+if ( 'message' === ( $chunk['type'] ?? '' ) && isset( $chunk['content'] ) ) {
+if ( is_array( $chunk['content'] ) ) {
+foreach ( $chunk['content'] as $piece ) {
+if ( isset( $piece['text'] ) ) {
+$text = $piece['text'];
+if ( $this->looks_like_json( $text ) ) {
+$inner = json_decode( $text, true );
+if ( JSON_ERROR_NONE === json_last_error() ) {
+return $inner;
+}
+}
+return $text;
+}
+}
+}
+}
+}
+}
+
+if ( isset( $decoded['output_text'] ) ) {
+$content = $decoded['output_text'];
+if ( $this->looks_like_json( $content ) ) {
+$inner = json_decode( $content, true );
+if ( JSON_ERROR_NONE === json_last_error() ) {
+return $inner;
+}
+}
+return $content;
+}
+
+return $decoded;
+}
+
+/**
+ * Check if content looks like JSON.
+ *
+ * @param string $content Content string.
+ * @return bool Whether content appears JSON.
+ */
+private function looks_like_json( $content ) {
+$content = trim( $content );
+return ( substr( $content, 0, 1 ) === '{' && substr( $content, -1 ) === '}' ) ||
+( substr( $content, 0, 1 ) === '[' && substr( $content, -1 ) === ']' );
+}
+
+/**
+ * Check if response is streaming format.
+ *
+ * @param string $response_body Body string.
+ * @return bool Streaming detected.
+ */
+private function is_streaming_response( $response_body ) {
+return strpos( $response_body, 'data: {' ) !== false || strpos( $response_body, 'event: ' ) !== false;
+}
+
+/**
+ * Parse streaming response format.
+ *
+ * @param string $response_body Body string.
+ * @return array|string|false Parsed content or false.
+ */
+private function parse_streaming_response( $response_body ) {
+$lines     = explode( "\n", $response_body );
+$json_data = '';
+
+foreach ( $lines as $line ) {
+$line = trim( $line );
+if ( strpos( $line, 'data: {' ) === 0 ) {
+$json_data = substr( $line, 6 );
+break;
+}
+}
+
+if ( $json_data ) {
+$decoded = json_decode( $json_data, true );
+if ( JSON_ERROR_NONE === json_last_error() ) {
+return $this->extract_content_from_decoded_response( $decoded );
+}
+}
+
+return false;
+}
+}

--- a/inc/class-rtbcb-llm-transport.php
+++ b/inc/class-rtbcb-llm-transport.php
@@ -1,0 +1,114 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * API transport helper for LLM.
+ *
+ * @package RealTreasuryBusinessCaseBuilder
+ */
+require_once __DIR__ . '/helpers.php';
+
+class RTBCB_LLM_Transport {
+/**
+ * API key.
+ *
+ * @var string
+ */
+private $api_key;
+
+/**
+ * GPT-5 configuration.
+ *
+ * @var array
+ */
+private $gpt5_config;
+
+/**
+ * Last request body.
+ *
+ * @var array|null
+ */
+private $last_request;
+
+/**
+ * Last response from API.
+ *
+ * @var array|WP_Error|null
+ */
+private $last_response;
+
+/**
+ * Constructor.
+ *
+ * @param RTBCB_LLM_Config $config Configuration instance.
+ */
+public function __construct( RTBCB_LLM_Config $config ) {
+$this->api_key     = $config->get_api_key();
+$this->gpt5_config = $config->get_gpt5_config();
+}
+
+/**
+ * Get last request body.
+ *
+ * @return array|null
+ */
+public function get_last_request() {
+return $this->last_request;
+}
+
+/**
+ * Get last response.
+ *
+ * @return array|WP_Error|null
+ */
+public function get_last_response() {
+return $this->last_response;
+}
+
+/**
+ * Call OpenAI Responses API.
+ *
+ * @param string       $model             Model name.
+ * @param array|string $prompt            Prompt data.
+ * @param int|null     $max_output_tokens Optional max output tokens.
+ * @param int|null     $max_retries       Optional retries.
+ * @param callable|null $chunk_handler    Optional streaming handler.
+ * @return array|WP_Error Response array or WP_Error.
+ */
+public function call_openai_with_retry( $model, $prompt, $max_output_tokens = null, $max_retries = null, $chunk_handler = null ) {
+if ( rtbcb_heavy_features_disabled() ) {
+return new WP_Error( 'heavy_features_disabled', __( 'AI features temporarily disabled.', 'rtbcb' ) );
+}
+
+if ( empty( $this->api_key ) ) {
+return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+}
+
+$input = is_array( $prompt ) ? ( $prompt['input'] ?? '' ) : $prompt;
+if ( '' === trim( (string) $input ) ) {
+return new WP_Error( 'empty_prompt', __( 'Prompt cannot be empty.', 'rtbcb' ) );
+}
+
+$endpoint = 'https://api.openai.com/v1/responses';
+$body     = is_array( $prompt ) ? $prompt : [ 'input' => $prompt ];
+$body['model'] = sanitize_text_field( $model ?: 'gpt-5-mini' );
+if ( $max_output_tokens ) {
+$body['max_output_tokens'] = intval( $max_output_tokens );
+}
+
+$args = [
+'headers' => [
+'Authorization' => 'Bearer ' . $this->api_key,
+'Content-Type'  => 'application/json',
+],
+'body'    => wp_json_encode( $body ),
+'timeout' => intval( $this->gpt5_config['timeout'] ?? 300 ),
+];
+
+$this->last_request  = $body;
+$response            = function_exists( 'wp_remote_post' ) ? wp_remote_post( $endpoint, $args ) : new WP_Error( 'http_unavailable', __( 'HTTP transport unavailable.', 'rtbcb' ) );
+$this->last_response = $response;
+
+return $response;
+}
+}

--- a/tests/RTBCB_LLM_ConfigTest.php
+++ b/tests/RTBCB_LLM_ConfigTest.php
@@ -1,0 +1,31 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/wp-stubs.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for RTBCB_LLM_Config.
+ */
+final class RTBCB_LLM_ConfigTest extends TestCase {
+/**
+ * Config instance.
+ *
+ * @var RTBCB_LLM_Config
+ */
+private $config;
+
+protected function setUp(): void {
+require_once __DIR__ . '/../inc/class-rtbcb-llm-config.php';
+$this->config = new RTBCB_LLM_Config();
+}
+
+public function test_get_model_defaults() {
+$model = $this->config->get_model( 'mini' );
+$this->assertSame( rtbcb_get_default_model( 'mini' ), $model );
+}
+}

--- a/tests/RTBCB_LLM_PromptTest.php
+++ b/tests/RTBCB_LLM_PromptTest.php
@@ -1,0 +1,35 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/wp-stubs.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for RTBCB_LLM_Prompt.
+ */
+final class RTBCB_LLM_PromptTest extends TestCase {
+/**
+ * Prompt builder.
+ *
+ * @var RTBCB_LLM_Prompt
+ */
+private $prompt;
+
+protected function setUp(): void {
+require_once __DIR__ . '/../inc/class-rtbcb-llm-prompt.php';
+$this->prompt = new RTBCB_LLM_Prompt();
+}
+
+public function test_build_context_for_responses() {
+$history = [
+[ 'role' => 'user', 'content' => 'Hello' ],
+];
+$context = $this->prompt->build_context_for_responses( $history, 'System' );
+$this->assertSame( 'System', $context['instructions'] );
+$this->assertSame( 'Hello', $context['input'] );
+}
+}

--- a/tests/RTBCB_LLM_ResponseParserTest.php
+++ b/tests/RTBCB_LLM_ResponseParserTest.php
@@ -9,34 +9,34 @@ require_once __DIR__ . '/wp-stubs.php';
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests for RTBCB_LLM::process_openai_response().
+ * Tests for RTBCB_LLM_Response_Parser::process_openai_response().
  */
 /**
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-final class RTBCB_Z_ProcessOpenAIResponseTest extends TestCase {
-	/**
-	* LLM instance.
-	*
-	* @var RTBCB_LLM
-	*/
-	private $llm;
+final class RTBCB_LLM_ResponseParserTest extends TestCase {
+       /**
+       * Parser instance.
+       *
+       * @var RTBCB_LLM_Response_Parser
+       */
+       private $parser;
 	
 	protected function setUp(): void {
-		require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
-		$this->llm = new RTBCB_LLM();
+               require_once __DIR__ . '/../inc/class-rtbcb-llm-response-parser.php';
+               $this->parser = new RTBCB_LLM_Response_Parser();
 	}
 
 	public function test_handles_valid_utf8() {
-		$json    = '{"message":"Hello"}';
-		$decoded = $this->llm->process_openai_response( $json );
+               $json    = '{"message":"Hello"}';
+               $decoded = $this->parser->process_openai_response( $json );
 		$this->assertSame( 'Hello', $decoded['message'] );
 	}
 
 	public function test_converts_iso_8859_1_to_utf8() {
-		$json    = '{"text":"' . mb_convert_encoding( 'café', 'ISO-8859-1', 'UTF-8' ) . '"}';
-		$decoded = $this->llm->process_openai_response( $json );
+               $json    = '{"text":"' . mb_convert_encoding( 'café', 'ISO-8859-1', 'UTF-8' ) . '"}';
+               $decoded = $this->parser->process_openai_response( $json );
 		$this->assertSame( 'café', $decoded['text'] );
 	}
 
@@ -44,14 +44,14 @@ final class RTBCB_Z_ProcessOpenAIResponseTest extends TestCase {
 		$json = '{"text":"missing end"';
 		$orig = ini_get( 'error_log' );
 		ini_set( 'error_log', '/tmp/phpunit.log' );
-		$this->assertFalse( $this->llm->process_openai_response( $json ) );
+               $this->assertFalse( $this->parser->process_openai_response( $json ) );
 		ini_set( 'error_log', $orig );
 	}
 
        public function test_handles_large_response() {
                $large   = str_repeat( 'a', 10000 );
                $json    = '{"text":"' . $large . '"}';
-               $decoded = $this->llm->process_openai_response( $json );
+               $decoded = $this->parser->process_openai_response( $json );
                $this->assertSame( $large, $decoded['text'] );
        }
 
@@ -65,7 +65,7 @@ final class RTBCB_Z_ProcessOpenAIResponseTest extends TestCase {
                        ],
                ];
                $json    = json_encode( $payload );
-               $decoded = $this->llm->process_openai_response( $json );
+               $decoded = $this->parser->process_openai_response( $json );
                $this->assertSame( 5, $decoded['usage']['input_tokens'] );
                $this->assertSame( 'ok', $decoded['result'] );
        }

--- a/tests/RTBCB_LLM_TransportTest.php
+++ b/tests/RTBCB_LLM_TransportTest.php
@@ -1,0 +1,25 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/wp-stubs.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for RTBCB_LLM_Transport.
+ */
+final class RTBCB_LLM_TransportTest extends TestCase {
+public function test_requires_api_key() {
+require_once __DIR__ . '/../inc/class-rtbcb-llm-config.php';
+require_once __DIR__ . '/../inc/class-rtbcb-llm-transport.php';
+$config    = new RTBCB_LLM_Config();
+$transport = new RTBCB_LLM_Transport( $config );
+
+$result = $transport->call_openai_with_retry( 'gpt-test', 'prompt' );
+$this->assertTrue( is_wp_error( $result ) );
+$this->assertSame( 'no_api_key', $result->get_error_code() );
+}
+}


### PR DESCRIPTION
## Summary
- split LLM responsibilities into configuration, prompt building, transport, and response parsing helpers
- update main LLM class to compose helpers
- add unit tests covering each new helper class

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-test bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b78345f11883319c6342a1a14b1fd4