### PR TITLE
feat: restore transport streaming and retries

### DIFF
--- a/inc/class-rtbcb-llm-transport.php
+++ b/inc/class-rtbcb-llm-transport.php
@@ -66,49 +66,290 @@ return $this->last_response;
 }
 
 /**
- * Call OpenAI Responses API.
- *
- * @param string       $model             Model name.
- * @param array|string $prompt            Prompt data.
- * @param int|null     $max_output_tokens Optional max output tokens.
- * @param int|null     $max_retries       Optional retries.
- * @param callable|null $chunk_handler    Optional streaming handler.
- * @return array|WP_Error Response array or WP_Error.
- */
-public function call_openai_with_retry( $model, $prompt, $max_output_tokens = null, $max_retries = null, $chunk_handler = null ) {
-if ( rtbcb_heavy_features_disabled() ) {
-return new WP_Error( 'heavy_features_disabled', __( 'AI features temporarily disabled.', 'rtbcb' ) );
-}
+	* Call OpenAI Responses API with retries and optional streaming.
+	*
+	* @param string        $model             Model name.
+	* @param array|string  $prompt            Prompt data.
+	* @param int|null      $max_output_tokens Optional max output tokens.
+	* @param int|null      $max_retries       Optional retries.
+	* @param callable|null $chunk_handler     Optional streaming handler.
+	* @return array|WP_Error Response array or WP_Error.
+	*/
+	public function call_openai_with_retry( $model, $prompt, $max_output_tokens = null, $max_retries = null, $chunk_handler = null ) {
+		if ( rtbcb_heavy_features_disabled() ) {
+			return new WP_Error( 'heavy_features_disabled', __( 'AI features temporarily disabled.', 'rtbcb' ) );
+		}
 
-if ( empty( $this->api_key ) ) {
-return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
-}
+		if ( empty( $this->api_key ) ) {
+			return new WP_Error( 'no_api_key', __( 'OpenAI API key not configured.', 'rtbcb' ) );
+		}
 
-$input = is_array( $prompt ) ? ( $prompt['input'] ?? '' ) : $prompt;
-if ( '' === trim( (string) $input ) ) {
-return new WP_Error( 'empty_prompt', __( 'Prompt cannot be empty.', 'rtbcb' ) );
-}
+		$input = is_array( $prompt ) ? ( $prompt['input'] ?? '' ) : $prompt;
+		if ( '' === trim( (string) $input ) ) {
+			return new WP_Error( 'empty_prompt', __( 'Prompt cannot be empty.', 'rtbcb' ) );
+		}
 
-$endpoint = 'https://api.openai.com/v1/responses';
-$body     = is_array( $prompt ) ? $prompt : [ 'input' => $prompt ];
-$body['model'] = sanitize_text_field( $model ?: 'gpt-5-mini' );
-if ( $max_output_tokens ) {
-$body['max_output_tokens'] = intval( $max_output_tokens );
-}
+		$max_retries     = min( 3, $max_retries ?? intval( $this->gpt5_config['max_retries'] ?? 3 ) );
+		$base_timeout    = intval( $this->gpt5_config['timeout'] ?? 300 );
+		$current_timeout = $base_timeout;
+		$current_tokens  = $max_output_tokens;
+		$max_retry_time  = max( $base_timeout, intval( $this->gpt5_config['max_retry_time'] ?? $base_timeout ) );
+		$start_time      = microtime( true );
 
-$args = [
-'headers' => [
-'Authorization' => 'Bearer ' . $this->api_key,
-'Content-Type'  => 'application/json',
-],
-'body'    => wp_json_encode( $body ),
-'timeout' => intval( $this->gpt5_config['timeout'] ?? 300 ),
-];
+		for ( $attempt = 1; $attempt <= $max_retries; $attempt++ ) {
+			$elapsed = microtime( true ) - $start_time;
+			if ( $elapsed >= $max_retry_time ) {
+				break;
+			}
 
-$this->last_request  = $body;
-$response            = function_exists( 'wp_remote_post' ) ? wp_remote_post( $endpoint, $args ) : new WP_Error( 'http_unavailable', __( 'HTTP transport unavailable.', 'rtbcb' ) );
-$this->last_response = $response;
+			$remaining                    = $max_retry_time - $elapsed;
+			$this->gpt5_config['timeout'] = min( $current_timeout, $remaining );
 
-return $response;
-}
+			$response = $this->call_openai( $model, $prompt, $current_tokens, $chunk_handler );
+
+			if ( ! is_wp_error( $response ) ) {
+				$this->gpt5_config['timeout'] = $base_timeout;
+				return $response;
+			}
+
+			$error_code = $response->get_error_code();
+			if ( 'llm_http_status' === $error_code ) {
+				$data   = $response->get_error_data();
+				$status = isset( $data['status'] ) ? intval( $data['status'] ) : 0;
+				if ( $status >= 400 && $status < 500 && 429 !== $status ) {
+					break;
+				}
+			}
+
+			if ( ! in_array( $error_code, [ 'llm_timeout', 'llm_http_error', 'llm_http_status' ], true ) ) {
+				break;
+			}
+
+			if ( $attempt < $max_retries ) {
+				if ( null !== $current_tokens ) {
+					$min_tokens    = intval( $this->gpt5_config['min_output_tokens'] ?? 1 );
+					$current_tokens = max( $min_tokens, (int) ( $current_tokens * 0.9 ) );
+				}
+
+				$current_timeout = min( $current_timeout + 5, $max_retry_time );
+
+				$delay = min( 5, pow( 2, $attempt - 1 ) );
+				usleep( (int) ( $delay * 1000000 ) );
+			}
+		}
+
+		$this->gpt5_config['timeout'] = $base_timeout;
+
+		return $response; // Return last error.
+	}
+
+	/**
+	 * Perform the actual OpenAI call.
+	 *
+	 * @param string        $model          Model name.
+	 * @param array|string  $prompt         Prompt data.
+	 * @param int|null      $max_tokens     Optional max output tokens.
+	 * @param callable|null $chunk_handler  Optional streaming handler.
+	 * @return array|WP_Error HTTP-like response or WP_Error.
+	 */
+	protected function call_openai( $model, $prompt, $max_tokens = null, $chunk_handler = null ) {
+		if ( ! function_exists( 'curl_init' ) ) {
+			return new WP_Error( 'missing_curl', __( 'The cURL PHP extension is required.', 'rtbcb' ) );
+		}
+
+		$endpoint   = 'https://api.openai.com/v1/responses';
+		$model_name = sanitize_text_field( $model ?: 'gpt-5-mini' );
+		$body       = is_array( $prompt ) ? $prompt : [ 'input' => sanitize_textarea_field( (string) $prompt ) ];
+		$body['model'] = $model_name;
+		if ( $max_tokens ) {
+			$body['max_output_tokens'] = intval( $max_tokens );
+		}
+		if ( is_callable( $chunk_handler ) ) {
+			$body['stream'] = true;
+		}
+
+		$timeout = intval( $this->gpt5_config['timeout'] ?? 300 );
+		$payload = wp_json_encode( $body );
+		$stream  = '';
+
+		$ch = curl_init( $endpoint );
+		curl_setopt( $ch, CURLOPT_HTTPHEADER, [
+			'Authorization: Bearer ' . $this->api_key,
+			'Content-Type: application/json',
+		] );
+		curl_setopt( $ch, CURLOPT_POST, true );
+		curl_setopt( $ch, CURLOPT_POSTFIELDS, $payload );
+		curl_setopt( $ch, CURLOPT_TIMEOUT, $timeout );
+		curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function ( $curl, $data ) use ( &$stream, $chunk_handler ) {
+			if ( is_callable( $chunk_handler ) ) {
+				try {
+					call_user_func( $chunk_handler, $data );
+				} catch ( Exception $e ) {
+					error_log( 'RTBCB: Chunk handler error: ' . $e->getMessage() );
+				}
+			}
+			$stream .= $data;
+			return strlen( $data );
+		} );
+
+		$this->last_request = $body;
+
+		$ok        = curl_exec( $ch );
+		$error     = curl_error( $ch );
+		$http_code = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+		curl_close( $ch );
+
+		if ( false === $ok ) {
+			if ( false !== strpos( strtolower( $error ), 'timed out' ) ) {
+				return new WP_Error(
+					'llm_timeout',
+					__( 'The request took longer than our 5-minute limit. Try Fast Mode or request email delivery.', 'rtbcb' )
+				);
+			}
+
+			return new WP_Error(
+				'llm_http_error',
+				sprintf( __( 'Language model request failed: %s', 'rtbcb' ), sanitize_text_field( $error ) )
+			);
+		}
+
+		$final_response = $this->process_streaming_response( $stream );
+		if ( null === $final_response ) {
+			return new WP_Error(
+				'llm_response_format',
+				__( 'Invalid response format received from language model.', 'rtbcb' )
+			);
+		}
+
+		$response_body = wp_json_encode( $final_response );
+		$response      = [
+			'body'     => $response_body,
+			'response' => [ 'code' => $http_code, 'message' => '' ],
+			'headers'  => [],
+		];
+
+		$this->last_response = $response;
+
+		if ( $http_code >= 400 ) {
+			if ( isset( $final_response['error']['message'] ) ) {
+				$message = $final_response['error']['message'];
+			} elseif ( isset( $final_response['message'] ) ) {
+				$message = $final_response['message'];
+			} else {
+				$message = wp_json_encode( $final_response );
+			}
+
+			$message = sanitize_text_field( $message );
+
+			return new WP_Error( 'llm_http_status', $message, [ 'status' => $http_code ] );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Process streaming response chunks from the OpenAI API.
+	 *
+	 * Splits the raw stream into events and assembles the final response
+	 * structure, handling both modern and legacy formats.
+	 *
+	 * @param string $stream Raw streaming data from cURL.
+	 * @return array|null Structured response array or null on failure.
+	 */
+	protected function process_streaming_response( $stream ) {
+		if ( empty( $stream ) ) {
+			return null;
+		}
+
+		$events        = [];
+		$lines         = preg_split( "/\r?\n/", $stream );
+		$current_event = [];
+
+		foreach ( $lines as $line ) {
+			$line = trim( $line );
+
+			if ( empty( $line ) ) {
+				if ( ! empty( $current_event ) ) {
+					$events[]      = $current_event;
+					$current_event = [];
+				}
+				continue;
+			}
+
+			if ( strpos( $line, ':' ) !== false ) {
+				list( $field, $value ) = explode( ':', $line, 2 );
+				$field = trim( $field );
+				$value = trim( $value );
+
+				if ( 'data' === $field && '[DONE]' !== $value ) {
+					$current_event['data'] = $value;
+				} elseif ( 'event' === $field ) {
+					$current_event['event'] = $value;
+				}
+			}
+		}
+
+		if ( ! empty( $current_event ) ) {
+			$events[] = $current_event;
+		}
+
+		$final_response      = null;
+		$accumulated_content = '';
+
+		foreach ( $events as $event ) {
+			if ( ! isset( $event['data'] ) ) {
+				continue;
+			}
+
+			$event_data = json_decode( $event['data'], true );
+			if ( JSON_ERROR_NONE !== json_last_error() ) {
+				continue;
+			}
+
+			if ( isset( $event_data['type'] ) ) {
+				switch ( $event_data['type'] ) {
+					case 'response.done':
+					case 'response.content_part.done':
+						if ( isset( $event_data['response'] ) ) {
+							$final_response = $event_data['response'];
+						}
+						break;
+					case 'response.content_part.delta':
+						if ( isset( $event_data['delta']['text'] ) ) {
+							$accumulated_content .= $event_data['delta']['text'];
+						}
+						break;
+				}
+			} else {
+				if ( isset( $event_data['choices'][0]['delta']['content'] ) ) {
+					$accumulated_content .= $event_data['choices'][0]['delta']['content'];
+				} elseif ( isset( $event_data['choices'][0]['message'] ) ) {
+					$final_response = $event_data;
+				}
+			}
+		}
+
+		if ( $final_response ) {
+			return $final_response;
+		}
+
+		if ( ! empty( $accumulated_content ) ) {
+			return [
+				'choices' => [
+					[
+						'message' => [
+							'content' => $accumulated_content,
+						],
+					],
+				],
+			];
+		}
+
+		$decoded = json_decode( $stream, true );
+		if ( JSON_ERROR_NONE === json_last_error() ) {
+			return $decoded;
+		}
+
+		return null;
+	}
 }

--- a/tests/RTBCB_LLM_TransportTest.php
+++ b/tests/RTBCB_LLM_TransportTest.php
@@ -1,6 +1,6 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-define( 'ABSPATH', __DIR__ . '/../' );
+	define( 'ABSPATH', __DIR__ . '/../' );
 }
 defined( 'ABSPATH' ) || exit;
 
@@ -12,14 +12,42 @@ use PHPUnit\Framework\TestCase;
  * Tests for RTBCB_LLM_Transport.
  */
 final class RTBCB_LLM_TransportTest extends TestCase {
-public function test_requires_api_key() {
-require_once __DIR__ . '/../inc/class-rtbcb-llm-config.php';
-require_once __DIR__ . '/../inc/class-rtbcb-llm-transport.php';
-$config    = new RTBCB_LLM_Config();
-$transport = new RTBCB_LLM_Transport( $config );
+	public function test_requires_api_key() {
+		require_once __DIR__ . '/../inc/class-rtbcb-llm-config.php';
+		require_once __DIR__ . '/../inc/class-rtbcb-llm-transport.php';
+		$config    = new RTBCB_LLM_Config();
+		$transport = new RTBCB_LLM_Transport( $config );
 
-$result = $transport->call_openai_with_retry( 'gpt-test', 'prompt' );
-$this->assertTrue( is_wp_error( $result ) );
-$this->assertSame( 'no_api_key', $result->get_error_code() );
-}
+		$result = $transport->call_openai_with_retry( 'gpt-test', 'prompt' );
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'no_api_key', $result->get_error_code() );
+	}
+
+	public function test_retries_and_chunk_handler() {
+		require_once __DIR__ . '/../inc/class-rtbcb-llm-config.php';
+		require_once __DIR__ . '/../inc/class-rtbcb-llm-transport.php';
+		$config = new class extends RTBCB_LLM_Config {
+			public function __construct() {}
+			public function get_api_key() { return 'test'; }
+			public function get_gpt5_config() { return [ 'timeout' => 1, 'max_retries' => 2, 'min_output_tokens' => 1 ]; }
+		};
+		$transport = new class( $config ) extends RTBCB_LLM_Transport {
+			public $calls = 0;
+			protected function call_openai( $model, $prompt, $max_tokens = null, $chunk_handler = null ) {
+				$this->calls++;
+				if ( $this->calls < 2 ) {
+					return new WP_Error( 'llm_http_status', 'rate limited', [ 'status' => 429 ] );
+				}
+				if ( is_callable( $chunk_handler ) ) {
+					call_user_func( $chunk_handler, 'partial' );
+				}
+				return [ 'body' => wp_json_encode( [ 'choices' => [ [ 'message' => [ 'content' => 'ok' ] ] ] ] ), 'response' => [ 'code' => 200, 'message' => '' ], 'headers' => [] ];
+			}
+		};
+		$chunks   = '';
+		$response = $transport->call_openai_with_retry( 'gpt-test', 'prompt', null, 2, function ( $data ) use ( &$chunks ) { $chunks .= $data; } );
+		$this->assertSame( 2, $transport->calls );
+		$this->assertNotEmpty( $chunks );
+		$this->assertFalse( is_wp_error( $response ) );
+	}
 }


### PR DESCRIPTION
## Summary
- reinstate retry logic with exponential backoff and streaming chunk handler in transport helper
- add cURL-based OpenAI call and streaming response parser
- cover transport retries and chunk handler with unit test

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b786fa549883319f6b36637fc1e92b