### PR TITLE
docs: describe wp.com LLM parsing

### DIFF
--- a/docs/LLM_WPCOM_PARSING.md
+++ b/docs/LLM_WPCOM_PARSING.md
@@ -1,0 +1,53 @@
+# LLM Response Handling on WordPress.com
+
+`RTBCB_LLM` generates model responses and `RTBCB_LLM_Response_Parser` validates the
+returned content. When deploying this plugin on WordPress.com, developers must account for
+platform-specific credential storage and hosting constraints.
+
+## Generating Responses with RTBCB_LLM
+
+- `RTBCB_LLM` boots with configuration, prompt, transport, and parser helpers.
+- The constructor fetches the OpenAI key from `RTBCB_LLM_Config`, which pulls from the
+    `RTBCB_OPENAI_API_KEY` environment variable or the `rtbcb_openai_api_key` option.
+- Prompts are assembled by `RTBCB_LLM_Prompt` and sent via `RTBCB_LLM_Transport` to the
+    OpenAI API.
+- Raw responses pass to `RTBCB_LLM_Response_Parser::process_openai_response()` for
+    cleanup and JSON extraction.
+
+See [End-to-End Workflow](END_TO_END_WORKFLOW.md) and
+[Wizard Form & API Flow](WIZARD_FORM_API_FLOW.md) for how these calls fit into the
+overall report generation process.
+
+## Parsing Responses on WordPress.com
+
+- `RTBCB_LLM_Response_Parser` strips BOM characters, normalizes encoding, and attempts
+    a standard `json_decode()`.
+- If decoding fails, the parser searches for fenced JSON blocks, mixed content, or
+    streaming chunks before giving up.
+- The parser returns arrays when valid JSON is found or a raw string otherwise, enabling
+    the calling code to handle partial failures gracefully.
+
+## WordPress.com Deployment Notes
+
+- Store the OpenAI API key as a secret environment variable (`RTBCB_OPENAI_API_KEY`) in
+    your WordPress.com dashboard or via the `rtbcb_openai_api_key` option. Avoid committing
+    keys to the repository.
+- WordPress.com uses a shared hosting model. Ensure outbound HTTP requests to OpenAI are
+    allowed and that the site’s plan includes external API access.
+- Responses may include unexpected prefixes or truncated streaming data. Monitor logs for
+    `RTBCB` entries to catch parsing warnings or errors.
+
+## Common Pitfalls
+
+- Missing API credentials will cause `RTBCB_LLM` to log an error and return failures.
+- Non‑UTF‑8 responses or leading BOM markers can break parsing if the parser’s cleanup
+    steps are bypassed.
+- Overly long outputs might exceed the configured token limit, producing incomplete JSON
+    that the parser cannot recover.
+
+## References
+
+- [`RTBCB_LLM`](../inc/class-rtbcb-llm.php)
+- [`RTBCB_LLM_Response_Parser`](../inc/class-rtbcb-llm-response-parser.php)
+- [End-to-End Workflow](END_TO_END_WORKFLOW.md)
+- [Wizard Form & API Flow](WIZARD_FORM_API_FLOW.md)


### PR DESCRIPTION
## Summary
- document WordPress.com deployment considerations for LLM response generation and parsing
- cover API credential storage, hosting nuances, and common parsing pitfalls

## Testing
- `npx markdownlint docs/**/*.md` *(fails: could not determine executable to run)*
- `npx --yes markdownlint-cli docs/**/*.md`
- `npx --yes markdown-link-check docs/LLM_WPCOM_PARSING.md`


------
https://chatgpt.com/codex/tasks/task_e_68b787bf8fdc83318cda069038ae41b4