### PR TITLE
Use API report data and full company names

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -523,14 +523,16 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 		],
 	];
 
+	$company_name_meta = sanitize_text_field( $enriched_profile_struct['name'] ?: $user_inputs['company_name'] );
+
 	return [
-			'metadata' => [
-				'company_name'   => $user_inputs['company_name'],
-				'analysis_date'  => current_time( 'Y-m-d' ),
-							'analysis_type'  => rtbcb_get_analysis_type(),
-				'confidence_level' => $final_analysis['confidence_level'] ?? 0.85,
-				'processing_time' => microtime( true ) - $request_start,
-			],
+		'metadata' => [
+			'company_name'   => $company_name_meta,
+			'analysis_date'  => current_time( 'Y-m-d' ),
+			'analysis_type'  => rtbcb_get_analysis_type(),
+			'confidence_level' => $final_analysis['confidence_level'] ?? 0.85,
+			'processing_time' => microtime( true ) - $request_start,
+		],
 			'executive_summary' => [
 				'strategic_positioning'   => $final_analysis['executive_summary']['strategic_positioning'] ?? '',
 				'business_case_strength'  => self::calculate_business_case_strength( $roi_scenarios, $recommendation ),

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -31,7 +31,7 @@ $company_intelligence  = $report_data['company_intelligence'] ?? [];
 	 * @var array $report_data Structured report data from the new workflow
 	 */
 	
-	$company_name    = $metadata['company_name'] ?? __( 'Your Company', 'rtbcb' );
+$company_name    = $metadata['company_name'] ?? ( $company_intelligence['enriched_profile']['name'] ?? __( 'Your Company', 'rtbcb' ) );
 	$analysis_date   = $metadata['analysis_date'] ?? current_time( 'Y-m-d' );
 	$analysis_type   = $metadata['analysis_type'] ?? 'basic';
 	$confidence_level = round( ( $metadata['confidence_level'] ?? 0.85 ) * 100 );


### PR DESCRIPTION
## Summary
- Use company name from comprehensive analysis, preferring enriched profile
- Pass structured API response directly to report builder and response payload
- Populate metadata with enriched company name for background jobs

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b7883983f08331804e08c7d9a3aa22