### PR TITLE
Log errors through RTBCB_Logger

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -960,14 +960,23 @@ error_log( $log_message );
 }
 
 function rtbcb_log_error( $message, $context = null ) {
-		$lead = rtbcb_get_current_lead();
-	if ( $lead ) {
-	$message .= ' [Lead ID: ' . $lead['id'] . ' Email: ' . $lead['email'] . ']';
+$lead = rtbcb_get_current_lead();
+if ( $lead ) {
+$message .= ' [Lead ID: ' . $lead['id'] . ' Email: ' . $lead['email'] . ']';
 }
 $log_message = 'RTBCB Error: ' . $message;
 if ( $context ) {
 $log_message .= ' - Context: ' . wp_json_encode( $context );
 }
+
+if ( class_exists( 'RTBCB_Logger' ) ) {
+$logger_context = [ 'message' => $log_message ];
+if ( null !== $context ) {
+$logger_context['context'] = $context;
+}
+RTBCB_Logger::log( 'error', $logger_context );
+}
+
 error_log( $log_message );
 }
 


### PR DESCRIPTION
## Summary
- Route `rtbcb_log_error` through `RTBCB_Logger` while keeping existing `error_log` for backwards compatibility

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b797c22dbc8331ad1e756d0daf3e48