### PR TITLE
Use central logging utilities in core classes

### DIFF
--- a/inc/class-rtbcb-api-log.php
+++ b/inc/class-rtbcb-api-log.php
@@ -1,5 +1,6 @@
 <?php
 defined( 'ABSPATH' ) || exit;
+require_once __DIR__ . '/helpers.php';
 
 /**
 	* API log management class.
@@ -73,26 +74,26 @@ class RTBCB_API_Log {
 				)
 			);
 
-			if ( ! $table_exists ) {
-				error_log( 'RTBCB: Failed to create table ' . self::$table_name );
+if ( ! $table_exists ) {
+rtbcb_log_error( 'Failed to create API log table', [ 'table' => self::$table_name ] );
 
-                               $simple_sql = 'CREATE TABLE IF NOT EXISTS ' . self::$table_name . " (
-                                       id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-                                       user_id bigint(20) unsigned DEFAULT 0,
-                                       user_email varchar(255) DEFAULT '',
-                                       lead_id bigint(20) unsigned DEFAULT 0,
-                                       company_name varchar(255) DEFAULT '',
-                                       request_json longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-                                       response_json longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-                                       is_truncated tinyint(1) DEFAULT 0,
-                                       original_size bigint(20) unsigned DEFAULT 0,
-                                       corruption_detected tinyint(1) DEFAULT 0,
-                                       prompt_tokens int(11) DEFAULT 0,
-                                       completion_tokens int(11) DEFAULT 0,
-                                       total_tokens int(11) DEFAULT 0,
-                                       created_at datetime DEFAULT CURRENT_TIMESTAMP,
-                                       PRIMARY KEY (id)
-                               ) $charset_collate;";
+$simple_sql = 'CREATE TABLE IF NOT EXISTS ' . self::$table_name . " (
+id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+user_id bigint(20) unsigned DEFAULT 0,
+user_email varchar(255) DEFAULT '',
+lead_id bigint(20) unsigned DEFAULT 0,
+company_name varchar(255) DEFAULT '',
+request_json longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+response_json longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+is_truncated tinyint(1) DEFAULT 0,
+original_size bigint(20) unsigned DEFAULT 0,
+corruption_detected tinyint(1) DEFAULT 0,
+prompt_tokens int(11) DEFAULT 0,
+completion_tokens int(11) DEFAULT 0,
+total_tokens int(11) DEFAULT 0,
+created_at datetime DEFAULT CURRENT_TIMESTAMP,
+PRIMARY KEY (id)
+) $charset_collate;";
 
 				$wpdb->query( $simple_sql );
 
@@ -104,20 +105,20 @@ class RTBCB_API_Log {
 					)
 				);
 
-				if ( ! $table_exists ) {
-					error_log( 'RTBCB: Failed to create API log table even with simple structure' );
-					return false;
-                }
-        }
+if ( ! $table_exists ) {
+rtbcb_log_error( 'Failed to create API log table even with simple structure', [ 'table' => self::$table_name ] );
+return false;
+}
+}
 
-                       return true;
-               } catch ( Exception $e ) {
-                       error_log( 'RTBCB: Exception creating API log table: ' . $e->getMessage() );
-                       return false;
-               } catch ( Error $e ) {
-                       error_log( 'RTBCB: Fatal error creating API log table: ' . $e->getMessage() );
-                       return false;
-               }
+return true;
+} catch ( Exception $e ) {
+rtbcb_log_error( 'Exception creating API log table', [ 'table' => self::$table_name, 'error' => $e->getMessage() ] );
+return false;
+} catch ( Error $e ) {
+rtbcb_log_error( 'Fatal error creating API log table', [ 'table' => self::$table_name, 'error' => $e->getMessage() ] );
+return false;
+}
        }
 
        /**

--- a/inc/class-rtbcb-db.php
+++ b/inc/class-rtbcb-db.php
@@ -1,8 +1,9 @@
 <?php
 defined( 'ABSPATH' ) || exit;
+require_once __DIR__ . '/helpers.php';
 
 /**
-	* Database management and migration handling.
+* Database management and migration handling.
 	*
 	* @package RealTreasuryBusinessCaseBuilder
 	*/
@@ -25,10 +26,10 @@ class RTBCB_DB {
 	public static function init() {
 		global $wpdb;
 
-		if ( ! $wpdb ) {
-			error_log( 'RTBCB: WordPress database not available' );
-			return false;
-		}
+if ( ! $wpdb ) {
+rtbcb_log_error( 'WordPress database not available', [ 'source' => 'db_init' ] );
+return false;
+}
 
 		try {
 			$current = function_exists( 'get_option' ) ? get_option( 'rtbcb_db_version', '1.0.0' ) : '1.0.0';
@@ -49,10 +50,10 @@ class RTBCB_DB {
 			self::seed_rag_sample_data();
 
 			return true;
-		} catch ( Throwable $e ) {
-			error_log( 'RTBCB: Database initialization failed: ' . $e->getMessage() );
-			return false;
-		}
+} catch ( Throwable $e ) {
+rtbcb_log_error( 'Database initialization failed', [ 'error' => $e->getMessage() ] );
+return false;
+}
 	}
 
 
@@ -96,8 +97,10 @@ class RTBCB_DB {
 
        // Future migrations can be handled here.
 
-		// Log the upgrade.
-		error_log( 'RTBCB: Database upgraded from version ' . $from_version . ' to ' . self::DB_VERSION );
+// Log the upgrade.
+if ( class_exists( 'RTBCB_Logger' ) ) {
+RTBCB_Logger::log( 'database_upgraded', [ 'from' => $from_version, 'to' => self::DB_VERSION ] );
+}
 	}
 
 	/**

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -1,5 +1,6 @@
 <?php
 defined( 'ABSPATH' ) || exit;
+require_once __DIR__ . '/helpers.php';
 
 /**
 	* Enhanced leads management for tracking form submissions.
@@ -81,10 +82,10 @@ class RTBCB_Leads {
 				self::$table_name
 			) );
 
-			if ( ! $table_exists ) {
-				error_log( 'RTBCB: Failed to create table ' . self::$table_name );
+if ( ! $table_exists ) {
+rtbcb_log_error( 'Failed to create leads table', [ 'table' => self::$table_name ] );
 
-				// Try to create table with simpler structure as fallback
+// Try to create table with simpler structure as fallback
 				$simple_sql = "CREATE TABLE IF NOT EXISTS " . self::$table_name . " (
 					id mediumint(9) NOT NULL AUTO_INCREMENT,
 					email varchar(255) NOT NULL,
@@ -122,23 +123,25 @@ class RTBCB_Leads {
 					self::$table_name
 				) );
 
-				if ( ! $table_exists ) {
-					error_log( 'RTBCB: Failed to create table even with simple structure' );
-					return false;
-				}
-			}
+if ( ! $table_exists ) {
+rtbcb_log_error( 'Failed to create leads table with fallback', [ 'table' => self::$table_name ] );
+return false;
+}
+}
 
-			error_log( 'RTBCB: Successfully created/updated table ' . self::$table_name );
-			return true;
+if ( class_exists( 'RTBCB_Logger' ) ) {
+RTBCB_Logger::log( 'leads_table_created', [ 'table' => self::$table_name ] );
+}
+return true;
 
-		} catch ( Exception $e ) {
-			error_log( 'RTBCB: Exception creating table: ' . $e->getMessage() );
-			return false;
-		} catch ( Error $e ) {
-			error_log( 'RTBCB: Fatal error creating table: ' . $e->getMessage() );
-			return false;
-		}
-	}
+} catch ( Exception $e ) {
+rtbcb_log_error( 'Exception creating leads table', [ 'table' => self::$table_name, 'error' => $e->getMessage() ] );
+return false;
+} catch ( Error $e ) {
+rtbcb_log_error( 'Fatal error creating leads table', [ 'table' => self::$table_name, 'error' => $e->getMessage() ] );
+return false;
+}
+}
 
 	/**
 	* Initialize the class with better error handling.
@@ -150,8 +153,8 @@ class RTBCB_Leads {
 		// Try to create table and log results
 		$table_created = self::create_table();
 
-		if ( ! $table_created ) {
-			error_log( 'RTBCB: Warning - leads table creation failed, plugin may not function correctly' );
+if ( ! $table_created ) {
+rtbcb_log_error( 'Leads table creation failed, plugin may not function correctly', [ 'table' => self::$table_name ] );
 
 			// Add admin notice for database issues
 			add_action( 'admin_notices', function() {
@@ -253,10 +256,10 @@ class RTBCB_Leads {
 		global $wpdb;
 
 		// Validate required fields
-		if ( empty( $lead_data['email'] ) || ! is_email( $lead_data['email'] ) ) {
-			error_log( 'RTBCB: Invalid email provided to save_lead' );
-			return false;
-		}
+if ( empty( $lead_data['email'] ) || ! is_email( $lead_data['email'] ) ) {
+rtbcb_log_error( 'Invalid email provided to save_lead', [ 'email' => $lead_data['email'] ?? '' ] );
+return false;
+}
 
 		// Sanitize data with proper validation
 		$sanitized_data = [
@@ -322,10 +325,10 @@ class RTBCB_Leads {
 					[ '%s' ]
 				);
 
-				if ( false === $result ) {
-					error_log( 'RTBCB: Database update failed: ' . $wpdb->last_error );
-					return false;
-				}
+if ( false === $result ) {
+rtbcb_log_error( 'Database update failed', [ 'table' => self::$table_name, 'error' => $wpdb->last_error ] );
+return false;
+}
 
                                self::update_cached_statistics();
                                if ( function_exists( 'rtbcb_clear_report_cache' ) ) {
@@ -346,10 +349,10 @@ class RTBCB_Leads {
 					$formats
 				);
 
-				if ( false === $result ) {
-					error_log( 'RTBCB: Database insert failed: ' . $wpdb->last_error );
-					return false;
-				}
+if ( false === $result ) {
+rtbcb_log_error( 'Database insert failed', [ 'table' => self::$table_name, 'error' => $wpdb->last_error ] );
+return false;
+}
 
                                $lead_id = $wpdb->insert_id;
                                self::update_cached_statistics();
@@ -364,13 +367,13 @@ class RTBCB_Leads {
                                }
                                return $lead_id;
                        }
-		} catch ( Exception $e ) {
-			error_log( 'RTBCB: Exception in save_lead: ' . $e->getMessage() );
-			return false;
-		} catch ( Error $e ) {
-			error_log( 'RTBCB: Fatal error in save_lead: ' . $e->getMessage() );
-			return false;
-		}
+} catch ( Exception $e ) {
+rtbcb_log_error( 'Exception in save_lead', [ 'table' => self::$table_name, 'error' => $e->getMessage() ] );
+return false;
+} catch ( Error $e ) {
+rtbcb_log_error( 'Fatal error in save_lead', [ 'table' => self::$table_name, 'error' => $e->getMessage() ] );
+return false;
+}
 	}
 
 	/**

--- a/inc/class-rtbcb-llm-optimized.php
+++ b/inc/class-rtbcb-llm-optimized.php
@@ -415,7 +415,15 @@ PROMPT;
 
                $total_complexity = array_sum( $complexity_factors );
 
-               error_log( sprintf( 'RTBCB: Complexity calculation - Total: %.2f, Factors: %s', $total_complexity, wp_json_encode( $complexity_factors ) ) );
+if ( class_exists( 'RTBCB_Logger' ) ) {
+RTBCB_Logger::log(
+'complexity_calculation',
+[
+'total'   => $total_complexity,
+'factors' => $complexity_factors,
+]
+);
+}
 
                if ( $total_complexity >= 0.8 ) {
                        $selected_model = $this->get_model( 'premium' );
@@ -428,7 +436,16 @@ PROMPT;
                        $reasoning      = 'Standard complexity suitable for mini model';
                }
 
-               error_log( sprintf( 'RTBCB: Model selected - %s (Complexity: %.2f, Reason: %s)', $selected_model, $total_complexity, $reasoning ) );
+if ( class_exists( 'RTBCB_Logger' ) ) {
+RTBCB_Logger::log(
+'model_selected',
+[
+'model'      => $selected_model,
+'complexity' => $total_complexity,
+'reason'     => $reasoning,
+]
+);
+}
 
                return $selected_model;
        }

--- a/inc/class-rtbcb-llm-transport.php
+++ b/inc/class-rtbcb-llm-transport.php
@@ -217,11 +217,11 @@ return $response; // Return last error.
 		curl_setopt( $ch, CURLOPT_TIMEOUT, $timeout );
 		curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function ( $curl, $data ) use ( &$stream, $chunk_handler ) {
 			if ( is_callable( $chunk_handler ) ) {
-				try {
-					call_user_func( $chunk_handler, $data );
-				} catch ( Exception $e ) {
-					error_log( 'RTBCB: Chunk handler error: ' . $e->getMessage() );
-				}
+try {
+call_user_func( $chunk_handler, $data );
+} catch ( Exception $e ) {
+rtbcb_log_error( 'Chunk handler error', [ 'error' => $e->getMessage() ] );
+}
 			}
 			$stream .= $data;
 			return strlen( $data );

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -59,9 +59,9 @@ class RTBCB_LLM {
                $this->transport       = new RTBCB_LLM_Transport( $this->config );
                $this->response_parser = new RTBCB_LLM_Response_Parser();
 
-               if ( empty( $this->config->get_api_key() ) ) {
-                       error_log( 'RTBCB: OpenAI API key not configured' );
-               }
+if ( empty( $this->config->get_api_key() ) ) {
+rtbcb_log_error( 'OpenAI API key not configured', [ 'source' => 'llm' ] );
+}
        }
 
 	/**
@@ -2307,9 +2307,11 @@ PROMPT;
                $response_body = $response['body'] ?? '';
                $response_data = $this->response_parser->process_openai_response( $response_body );
 
-               if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                       error_log( 'OpenAI Response (clean): ' . wp_json_encode( $response_data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) );
-               }
+if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+if ( class_exists( 'RTBCB_Logger' ) ) {
+RTBCB_Logger::log( 'openai_response_clean', $response_data );
+}
+}
 
                return $response_data;
        }

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -188,8 +188,8 @@ class RTBCB_Router {
                } catch ( RTBCB_JSON_Error $e ) {
                        throw $e;
                } catch ( Exception $e ) {
-                       // Log the detailed error to debug.log.
-                       error_log( 'RTBCB Form Submission Error: ' . $e->getMessage() );
+// Log the detailed error.
+rtbcb_log_error( 'Form submission error', [ 'error' => $e->getMessage() ] );
 
                        // Send a generic error response to the client.
                        wp_send_json_error(
@@ -237,11 +237,21 @@ $premium_model = function_exists( 'get_option' ) ? get_option( 'rtbcb_premium_mo
 				'rtbcb_missing_model',
 				__( 'No language model configured. Please review the plugin settings.', 'rtbcb' )
 			);
-			error_log( 'RTBCB: ' . $error->get_error_message() );
-			return $error;
+rtbcb_log_error( 'Model routing error', [ 'message' => $error->get_error_message() ] );
+return $error;
 		}
 
-		error_log( "RTBCB: Model selected: {$model} (Complexity: {$complexity}, Category: {$category}, Reason: {$reasoning})" );
+if ( class_exists( 'RTBCB_Logger' ) ) {
+RTBCB_Logger::log(
+'model_selected',
+[
+'model'      => $model,
+'complexity' => $complexity,
+'category'   => $category,
+'reason'     => $reasoning,
+]
+);
+}
 
 		return $model;
 	}

--- a/inc/class-rtbcb-workflow-tracker.php
+++ b/inc/class-rtbcb-workflow-tracker.php
@@ -1,8 +1,9 @@
 <?php
 defined( 'ABSPATH' ) || exit;
+require_once __DIR__ . '/helpers.php';
 
 /**
-	* Workflow Tracker for monitoring and debugging the report generation process.
+        * Workflow Tracker for monitoring and debugging the report generation process.
 	*
 	* @package RealTreasuryBusinessCaseBuilder
 	*/
@@ -86,7 +87,9 @@ $this->current_step = [
 'status'     => 'running',
 ];
 
-error_log( "RTBCB Workflow: Starting step '{$step_name}'" );
+if ( class_exists( 'RTBCB_Logger' ) ) {
+RTBCB_Logger::log( 'workflow_step_start', [ 'step' => $step_name ] );
+}
 }
 
 /**
@@ -113,7 +116,15 @@ $this->current_step = null;
 
 do_action( 'rtbcb_workflow_step_completed', $step_name );
 
-error_log( 'RTBCB Workflow: Completed step ' . $step_name . ' in ' . round( $this->steps[ count( $this->steps ) - 1 ]['duration'], 2 ) . 's' );
+if ( class_exists( 'RTBCB_Logger' ) ) {
+RTBCB_Logger::log(
+'workflow_step_complete',
+[
+'step'     => $step_name,
+'duration' => round( $this->steps[ count( $this->steps ) - 1 ]['duration'], 2 ),
+]
+);
+}
 }
 }
 
@@ -134,7 +145,9 @@ public function add_warning( $code, $message ) {
 	];
 
 	$this->warnings[] = $warning;
-	error_log( "RTBCB Workflow Warning [{$code}]: {$message}" );
+if ( class_exists( 'RTBCB_Logger' ) ) {
+RTBCB_Logger::log( 'workflow_warning', [ 'code' => $code, 'message' => $message, 'step' => $step_name ] );
+}
 	do_action( 'rtbcb_workflow_warning', $warning );
 }
 
@@ -155,7 +168,7 @@ public function add_error( $code, $message ) {
 	];
 
 	$this->errors[] = $error;
-	error_log( "RTBCB Workflow Error [{$code}]: {$message}" );
+rtbcb_log_error( 'Workflow error', [ 'code' => $code, 'message' => $message, 'step' => $step_name ] );
 	do_action( 'rtbcb_workflow_error', $error );
 }
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -960,9 +960,11 @@ error_log( $log_message );
 }
 
 function rtbcb_log_error( $message, $context = null ) {
-		$lead = rtbcb_get_current_lead();
-	if ( $lead ) {
-	$message .= ' [Lead ID: ' . $lead['id'] . ' Email: ' . $lead['email'] . ']';
+if ( function_exists( 'rtbcb_get_current_lead' ) && function_exists( 'wp_cache_get' ) ) {
+$lead = rtbcb_get_current_lead();
+if ( $lead ) {
+$message .= ' [Lead ID: ' . $lead['id'] . ' Email: ' . $lead['email'] . ']';
+}
 }
 $log_message = 'RTBCB Error: ' . $message;
 if ( $context ) {


### PR DESCRIPTION
## Summary
- replace `error_log` calls with `rtbcb_log_error()` or `RTBCB_Logger::log()`
- include context (table name, operation, etc.) for clearer diagnostics
- guard logging helper against missing WP functions

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b797d1a104833196ef340d3d2758c7