### PR TITLE
refactor: replace error_log with structured logging

### DIFF
--- a/inc/class-rtbcb-api-log.php
+++ b/inc/class-rtbcb-api-log.php
@@ -73,8 +73,14 @@ class RTBCB_API_Log {
 				)
 			);
 
-			if ( ! $table_exists ) {
-				error_log( 'RTBCB: Failed to create table ' . self::$table_name );
+                       if ( ! $table_exists ) {
+                               rtbcb_log_error(
+                                       'Failed to create API log table',
+                                       [
+                                               'table'     => self::$table_name,
+                                               'operation' => 'create_table',
+                                       ]
+                               );
 
                                $simple_sql = 'CREATE TABLE IF NOT EXISTS ' . self::$table_name . " (
                                        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -104,20 +110,40 @@ class RTBCB_API_Log {
 					)
 				);
 
-				if ( ! $table_exists ) {
-					error_log( 'RTBCB: Failed to create API log table even with simple structure' );
-					return false;
-                }
-        }
+                               if ( ! $table_exists ) {
+                                       rtbcb_log_error(
+                                               'Failed to create API log table even with simple structure',
+                                               [
+                                                       'table'     => self::$table_name,
+                                                       'operation' => 'create_table_fallback',
+                                               ]
+                                       );
+                                       return false;
+               }
+       }
 
                        return true;
-               } catch ( Exception $e ) {
-                       error_log( 'RTBCB: Exception creating API log table: ' . $e->getMessage() );
-                       return false;
-               } catch ( Error $e ) {
-                       error_log( 'RTBCB: Fatal error creating API log table: ' . $e->getMessage() );
-                       return false;
-               }
+              } catch ( Exception $e ) {
+                      rtbcb_log_error(
+                              'Exception creating API log table',
+                              [
+                                      'table'     => self::$table_name,
+                                      'operation' => 'create_table',
+                                      'error'     => $e->getMessage(),
+                              ]
+                      );
+                      return false;
+              } catch ( Error $e ) {
+                      rtbcb_log_error(
+                              'Fatal error creating API log table',
+                              [
+                                      'table'     => self::$table_name,
+                                      'operation' => 'create_table',
+                                      'error'     => $e->getMessage(),
+                              ]
+                      );
+                      return false;
+              }
        }
 
        /**

--- a/inc/class-rtbcb-db.php
+++ b/inc/class-rtbcb-db.php
@@ -25,10 +25,13 @@ class RTBCB_DB {
 	public static function init() {
 		global $wpdb;
 
-		if ( ! $wpdb ) {
-			error_log( 'RTBCB: WordPress database not available' );
-			return false;
-		}
+               if ( ! $wpdb ) {
+                       rtbcb_log_error(
+                               'WordPress database not available',
+                               [ 'operation' => 'db_init' ]
+                       );
+                       return false;
+               }
 
 		try {
 			$current = function_exists( 'get_option' ) ? get_option( 'rtbcb_db_version', '1.0.0' ) : '1.0.0';
@@ -49,10 +52,16 @@ class RTBCB_DB {
 			self::seed_rag_sample_data();
 
 			return true;
-		} catch ( Throwable $e ) {
-			error_log( 'RTBCB: Database initialization failed: ' . $e->getMessage() );
-			return false;
-		}
+               } catch ( Throwable $e ) {
+                       rtbcb_log_error(
+                               'Database initialization failed',
+                               [
+                                       'operation' => 'db_init',
+                                       'error'     => $e->getMessage(),
+                               ]
+                       );
+                       return false;
+               }
 	}
 
 
@@ -96,9 +105,15 @@ class RTBCB_DB {
 
        // Future migrations can be handled here.
 
-		// Log the upgrade.
-		error_log( 'RTBCB: Database upgraded from version ' . $from_version . ' to ' . self::DB_VERSION );
-	}
+               // Log the upgrade.
+               RTBCB_Logger::log(
+                       'database_upgraded',
+                       [
+                               'from_version' => $from_version,
+                               'to_version'   => self::DB_VERSION,
+                       ]
+               );
+       }
 
 	/**
 	* Create the RAG index table if it does not exist.

--- a/inc/class-rtbcb-llm-optimized.php
+++ b/inc/class-rtbcb-llm-optimized.php
@@ -415,7 +415,13 @@ PROMPT;
 
                $total_complexity = array_sum( $complexity_factors );
 
-               error_log( sprintf( 'RTBCB: Complexity calculation - Total: %.2f, Factors: %s', $total_complexity, wp_json_encode( $complexity_factors ) ) );
+               RTBCB_Logger::log(
+                       'complexity_calculation',
+                       [
+                               'total'   => $total_complexity,
+                               'factors' => $complexity_factors,
+                       ]
+               );
 
                if ( $total_complexity >= 0.8 ) {
                        $selected_model = $this->get_model( 'premium' );
@@ -428,7 +434,14 @@ PROMPT;
                        $reasoning      = 'Standard complexity suitable for mini model';
                }
 
-               error_log( sprintf( 'RTBCB: Model selected - %s (Complexity: %.2f, Reason: %s)', $selected_model, $total_complexity, $reasoning ) );
+               RTBCB_Logger::log(
+                       'model_selected',
+                       [
+                               'model'      => $selected_model,
+                               'complexity' => $total_complexity,
+                               'reason'     => $reasoning,
+                       ]
+               );
 
                return $selected_model;
        }

--- a/inc/class-rtbcb-llm-transport.php
+++ b/inc/class-rtbcb-llm-transport.php
@@ -217,11 +217,17 @@ return $response; // Return last error.
 		curl_setopt( $ch, CURLOPT_TIMEOUT, $timeout );
 		curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function ( $curl, $data ) use ( &$stream, $chunk_handler ) {
 			if ( is_callable( $chunk_handler ) ) {
-				try {
-					call_user_func( $chunk_handler, $data );
-				} catch ( Exception $e ) {
-					error_log( 'RTBCB: Chunk handler error: ' . $e->getMessage() );
-				}
+                               try {
+                                       call_user_func( $chunk_handler, $data );
+                               } catch ( Exception $e ) {
+                                       rtbcb_log_error(
+                                               'Chunk handler error',
+                                               [
+                                                       'operation' => 'call_openai_with_retry',
+                                                       'error'     => $e->getMessage(),
+                                               ]
+                                       );
+                               }
 			}
 			$stream .= $data;
 			return strlen( $data );

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -60,7 +60,10 @@ class RTBCB_LLM {
                $this->response_parser = new RTBCB_LLM_Response_Parser();
 
                if ( empty( $this->config->get_api_key() ) ) {
-                       error_log( 'RTBCB: OpenAI API key not configured' );
+                       rtbcb_log_error(
+                               'OpenAI API key not configured',
+                               [ 'operation' => '__construct' ]
+                       );
                }
        }
 
@@ -2308,7 +2311,10 @@ PROMPT;
                $response_data = $this->response_parser->process_openai_response( $response_body );
 
                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                       error_log( 'OpenAI Response (clean): ' . wp_json_encode( $response_data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) );
+                       RTBCB_Logger::log(
+                               'openai_response_clean',
+                               [ 'response' => $response_data ]
+                       );
                }
 
                return $response_data;

--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -189,7 +189,13 @@ class RTBCB_Router {
                        throw $e;
                } catch ( Exception $e ) {
                        // Log the detailed error to debug.log.
-                       error_log( 'RTBCB Form Submission Error: ' . $e->getMessage() );
+                       rtbcb_log_error(
+                               'Form submission error',
+                               [
+                                       'operation' => 'generate_case',
+                                       'error'     => $e->getMessage(),
+                               ]
+                       );
 
                        // Send a generic error response to the client.
                        wp_send_json_error(
@@ -233,15 +239,26 @@ $premium_model = function_exists( 'get_option' ) ? get_option( 'rtbcb_premium_mo
 
 		// Validate selected model
 		if ( empty( $model ) ) {
-			$error = new WP_Error(
-				'rtbcb_missing_model',
-				__( 'No language model configured. Please review the plugin settings.', 'rtbcb' )
-			);
-			error_log( 'RTBCB: ' . $error->get_error_message() );
-			return $error;
+                       $error = new WP_Error(
+                               'rtbcb_missing_model',
+                               __( 'No language model configured. Please review the plugin settings.', 'rtbcb' )
+                       );
+                       rtbcb_log_error(
+                               $error->get_error_message(),
+                               [ 'operation' => 'route_model' ]
+                       );
+                       return $error;
 		}
 
-		error_log( "RTBCB: Model selected: {$model} (Complexity: {$complexity}, Category: {$category}, Reason: {$reasoning})" );
+               RTBCB_Logger::log(
+                       'model_selected',
+                       [
+                               'model'      => $model,
+                               'complexity' => $complexity,
+                               'category'   => $category,
+                               'reason'     => $reasoning,
+                       ]
+               );
 
 		return $model;
 	}

--- a/inc/class-rtbcb-workflow-tracker.php
+++ b/inc/class-rtbcb-workflow-tracker.php
@@ -86,7 +86,12 @@ $this->current_step = [
 'status'     => 'running',
 ];
 
-error_log( "RTBCB Workflow: Starting step '{$step_name}'" );
+       RTBCB_Logger::log(
+               'workflow_start',
+               [
+                       'step' => $step_name,
+               ]
+       );
 }
 
 /**
@@ -113,7 +118,13 @@ $this->current_step = null;
 
 do_action( 'rtbcb_workflow_step_completed', $step_name );
 
-error_log( 'RTBCB Workflow: Completed step ' . $step_name . ' in ' . round( $this->steps[ count( $this->steps ) - 1 ]['duration'], 2 ) . 's' );
+       RTBCB_Logger::log(
+               'workflow_step_completed',
+               [
+                       'step'     => $step_name,
+                       'duration' => round( $this->steps[ count( $this->steps ) - 1 ]['duration'], 2 ),
+               ]
+       );
 }
 }
 
@@ -134,7 +145,14 @@ public function add_warning( $code, $message ) {
 	];
 
 	$this->warnings[] = $warning;
-	error_log( "RTBCB Workflow Warning [{$code}]: {$message}" );
+       rtbcb_log_error(
+               'Workflow warning',
+               [
+                       'code'    => $code,
+                       'message' => $message,
+                       'step'    => $step_name,
+               ]
+       );
 	do_action( 'rtbcb_workflow_warning', $warning );
 }
 
@@ -155,7 +173,14 @@ public function add_error( $code, $message ) {
 	];
 
 	$this->errors[] = $error;
-	error_log( "RTBCB Workflow Error [{$code}]: {$message}" );
+       rtbcb_log_error(
+               'Workflow error',
+               [
+                       'code'    => $code,
+                       'message' => $message,
+                       'step'    => $step_name,
+               ]
+       );
 	do_action( 'rtbcb_workflow_error', $error );
 }
 


### PR DESCRIPTION
## Summary
- refactor leads and API log classes to use rtbcb_log_error and RTBCB_Logger::log
- replace remaining error_log calls across `inc/` with structured logging helpers
- ensure `inc/` now relies exclusively on dedicated logging utilities

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b79b1489f88331bc62d3c7da6c069c