### PR TITLE
Add token usage columns to API logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A comprehensive WordPress plugin that helps treasury teams quantify the benefits
 ### ✨ Enhancements
 - Regenerated minified assets.
 - Introduced RTBCB_Response_Parser for unified OpenAI response parsing and validation.
+- Added prompt and completion token columns to the API Logs page.
 
 
 ## 📋 Installation & Setup

--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -19,22 +19,25 @@ if ( ! current_user_can( 'manage_options' ) ) {
 			<?php esc_html_e( 'Clear All Logs', 'rtbcb' ); ?>
 		</button>
 	</p>
+       <p><?php esc_html_e( 'Logs include prompt, completion, and total token usage.', 'rtbcb' ); ?></p>
        <div class="rtbcb-log-table-wrapper">
 <table id="rtbcb-api-logs-table" class="widefat fixed striped">
-			<thead>
-				<tr>
-	                               <th><?php esc_html_e( 'ID', 'rtbcb' ); ?></th>
-	                               <th><?php esc_html_e( 'Lead ID', 'rtbcb' ); ?></th>
-	                               <th><?php esc_html_e( 'Email', 'rtbcb' ); ?></th>
-					<th><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></th>
-					<th><?php esc_html_e( 'Request', 'rtbcb' ); ?></th>
-					<th><?php esc_html_e( 'Tokens', 'rtbcb' ); ?></th>
-					<th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
-					<th><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
-					<th><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
-				</tr>
-			</thead>
-			<tbody>
+                        <thead>
+                                <tr>
+                                       <th><?php esc_html_e( 'ID', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'Lead ID', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'Email', 'rtbcb' ); ?></th>
+                                        <th><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></th>
+                                        <th><?php esc_html_e( 'Request', 'rtbcb' ); ?></th>
+                                        <th><?php esc_html_e( 'Prompt Tokens', 'rtbcb' ); ?></th>
+                                        <th><?php esc_html_e( 'Completion Tokens', 'rtbcb' ); ?></th>
+                                        <th><?php esc_html_e( 'Tokens', 'rtbcb' ); ?></th>
+                                        <th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
+                                        <th><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
+                                        <th><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
+                                </tr>
+                        </thead>
+                        <tbody>
 <?php if ( ! empty( $logs ) ) : ?>
 <?php foreach ( $logs as $log ) :
 						$request  = json_decode( $log['request_json'], true );
@@ -58,10 +61,12 @@ if ( ! current_user_can( 'manage_options' ) ) {
 	                                       <td><?php echo esc_html( $log['user_email'] ); ?></td>
 						<td><?php echo esc_html( $log['company_name'] ); ?></td>
 						<td><?php echo esc_html( $summary ); ?></td>
-						<td><?php echo esc_html( $log['total_tokens'] ); ?></td>
-						<td><?php echo esc_html( $status ); ?></td>
-						<td><?php echo esc_html( $log['created_at'] ); ?></td>
-						<td>
+                                               <td><?php echo esc_html( $log['prompt_tokens'] ); ?></td>
+                                               <td><?php echo esc_html( $log['completion_tokens'] ); ?></td>
+                                               <td><?php echo esc_html( $log['total_tokens'] ); ?></td>
+                                               <td><?php echo esc_html( $status ); ?></td>
+                                               <td><?php echo esc_html( $log['created_at'] ); ?></td>
+                                               <td>
 							<button class="button rtbcb-view-log">
 								<?php esc_html_e( 'View', 'rtbcb' ); ?>
 							</button>
@@ -90,7 +95,20 @@ pageLength: 20,
 order: [[0, 'desc']],
 language: {
 emptyTable: '<?php echo esc_js( __( 'No logs found.', 'rtbcb' ) ); ?>'
-}
+},
+columns: [
+null,
+null,
+null,
+null,
+null,
+null,
+null,
+null,
+null,
+null,
+{ orderable: false }
+]
 });
 var search = new URLSearchParams(window.location.search).get('search');
 if (search) {

--- a/readme.txt
+++ b/readme.txt
@@ -167,6 +167,7 @@ The analytics dashboard uses Chart.js for its visualizations. The library is bun
 == Changelog ==
 = 2.1.13 =
 * Regenerated minified assets.
+* Added prompt and completion token columns to API Logs page.
 
 = 2.1.12 =
 * Refined wizard form styling and improved mobile responsiveness.


### PR DESCRIPTION
## Summary
- show prompt and completion token usage on API Logs page
- initialize DataTable with new token columns
- document token columns in README and changelog

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b7a7aa742083319efadaa962ba9c03