### PR TITLE
Add tests for API log token tracking and display

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,7 @@
       <file>tests/RTBCB_ValidatorTest.php</file>
       <file>tests/RTBCB_ResponseParserTest.php</file>
           <file>tests/RTBCB_ResponseIntegrityTest.php</file>
+      <file>tests/RTBCB_ApiLogTokensTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/RTBCB_ApiLogTokensTest.php
+++ b/tests/RTBCB_ApiLogTokensTest.php
@@ -1,0 +1,55 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/wp-stubs.php';
+
+if ( ! function_exists( 'current_time' ) ) {
+	function current_time( $type ) {
+	    return '2024-01-01 00:00:00';
+	}
+}
+
+class WPDB_LogStub {
+	public $rows = [];
+
+	public function insert( $table, $data, $format ) {
+	    $this->rows[] = $data;
+	    return 1;
+	}
+}
+
+final class RTBCB_ApiLogTokensTest extends TestCase {
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function test_save_log_stores_token_usage() {
+	    require_once __DIR__ . '/../inc/class-rtbcb-api-log.php';
+	    global $wpdb;
+	    $wpdb = new WPDB_LogStub();
+
+	    $reflect  = new ReflectionClass( RTBCB_API_Log::class );
+	    $property = $reflect->getProperty( 'table_name' );
+	    $property->setAccessible( true );
+	    $property->setValue( null, 'rtbcb_api_logs' );
+
+	    $response = [
+	        'usage' => [
+	            'prompt_tokens'     => 5,
+	            'completion_tokens' => 7,
+	            'total_tokens'      => 12,
+	        ],
+	    ];
+
+	    RTBCB_API_Log::save_log( [], $response, 1 );
+
+	    $this->assertNotEmpty( $wpdb->rows );
+	    $row = $wpdb->rows[0];
+	    $this->assertSame( 5, $row['prompt_tokens'] );
+	    $this->assertSame( 7, $row['completion_tokens'] );
+	    $this->assertSame( 12, $row['total_tokens'] );
+	}
+}

--- a/tests/api-logs-page.test.js
+++ b/tests/api-logs-page.test.js
@@ -1,0 +1,40 @@
+const { execSync } = require('child_process');
+const assert = require('assert');
+const { JSDOM } = require('jsdom');
+
+const php = `<?php
+define('ABSPATH', getcwd() . '/');
+function current_user_can($cap) { return true; }
+function esc_html__($t, $d = null) { return $t; }
+function esc_html_e($t, $d = null) { echo $t; }
+function esc_html($t) { return $t; }
+function esc_attr($t) { return $t; }
+function esc_js($t) { return $t; }
+function wp_trim_words($text, $num_words = 55, $more = null) { return $text; }
+function __($t, $d = null) { return $t; }
+$nonce = 'abc';
+$logs = [
+    [
+        'id' => 1,
+        'lead_id' => 0,
+        'user_email' => 'test@example.com',
+        'company_name' => 'Test Co',
+        'request_json' => '{}',
+        'response_json' => '{}',
+        'total_tokens' => 42,
+        'prompt_tokens' => 40,
+        'completion_tokens' => 2,
+        'is_truncated' => 0,
+        'corruption_detected' => 0,
+        'created_at' => '2024-01-01 00:00:00'
+    ]
+];
+include 'admin/api-logs-page.php';
+?>`;
+
+const output = execSync('php', { input: php }).toString();
+const dom = new JSDOM(output);
+const tokenCell = dom.window.document.querySelector('#rtbcb-api-logs-table tbody tr td:nth-child(6)');
+assert.ok(tokenCell);
+assert.strictEqual(tokenCell.textContent.trim(), '42');
+console.log('api-logs-page.test.js passed');

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -116,6 +116,7 @@ node tests/temperature-model.test.js
 node tests/min-output-tokens.test.js
 node tests/gpt5-config-defaults.test.js
 node tests/export-to-pdf-button.test.js
+node tests/api-logs-page.test.js
 node tests/wizard-report-flow.test.js
 npx --yes jest tests/poll-job-completed.test.js --config '{"testEnvironment":"node"}'
 npx --yes jest tests/poll-job-show-results.test.js --config '{"testEnvironment":"node"}'


### PR DESCRIPTION
## Summary
- add PHPUnit test covering API log token usage persistence
- add JS test ensuring API log admin page shows token counts
- run JS test in test suite

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `vendor/bin/phpunit tests/RTBCB_ApiLogTokensTest.php`
- `node tests/api-logs-page.test.js`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b7a7a2ab448331b0fe4e14c68cc336