### PR TITLE
Refactor OpenAI client to return usage metadata

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2027,12 +2027,20 @@ PROMPT;
        ],
        ];
 
-       $analysis_data = $client->request( $payload, $this->config->estimate_tokens( 2000 ) );
-       if ( is_wp_error( $analysis_data ) ) {
-       return $analysis_data;
-       }
-       return $this->validate_and_structure_analysis( $analysis_data );
-       }
+$response = $client->request( $payload, $this->config->estimate_tokens( 2000 ) );
+if ( is_wp_error( $response ) ) {
+return $response;
+}
+
+if ( class_exists( 'RTBCB_API_Log' ) ) {
+$user_email   = $this->current_inputs['email'] ?? '';
+$company_name = $this->current_inputs['company_name'] ?? '';
+RTBCB_API_Log::save_log( $payload, $response, get_current_user_id(), $user_email, $company_name );
+}
+
+$analysis_data = $response['choices'] ?? [];
+return $this->validate_and_structure_analysis( $analysis_data );
+}
 
        /**
        * Validate enrichment response JSON structure.


### PR DESCRIPTION
## Summary
- Decode full OpenAI response in client and return `choices` with `usage`
- Ensure strategic analysis handler forwards usage metrics to API logs
- Tighten CLI test to expect populated choices

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b7a783316083319c11311f204f2961