### PR TITLE
Improve API logs table mobile responsiveness

### DIFF
--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -93,6 +93,8 @@ if ( ! current_user_can( 'manage_options' ) ) {
 var table = $('#rtbcb-api-logs-table').DataTable({
 pageLength: 20,
 order: [[0, 'desc']],
+scrollX: true,
+autoWidth: false,
 language: {
 emptyTable: '<?php echo esc_js( __( 'No logs found.', 'rtbcb' ) ); ?>'
 },

--- a/admin/css/rtbcb-admin.css
+++ b/admin/css/rtbcb-admin.css
@@ -292,7 +292,7 @@ html {
 }
 
 .rtbcb-log-table-wrapper table {
-	min-width: 600px;
+	min-width: 1200px;
 }
 
 #rtbcb-log-modal {


### PR DESCRIPTION
## Summary
- widen API log table for better mobile usability
- enable horizontal scrolling and natural column widths in logs table

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Fatal error: Class "RTBCB_Logger" not found; AssertionError in api-logs-page.test.js)*
- `phpcs --standard=WordPress admin/api-logs-page.php admin/css/rtbcb-admin.css` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ae9e9ba4833195916289e035fb7b