### PR TITLE
Add API log field coverage tests

### DIFF
--- a/tests/RTBCB_ApiLogFieldsTest.php
+++ b/tests/RTBCB_ApiLogFieldsTest.php
@@ -1,0 +1,52 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/wp-stubs.php';
+
+if ( ! function_exists( 'current_time' ) ) {
+        function current_time( $type ) {
+                return '2024-01-01 00:00:00';
+        }
+}
+
+class WPDB_LogStub {
+        public $rows = [];
+
+        public function insert( $table, $data, $format ) {
+                $this->rows[] = $data;
+                return 1;
+        }
+}
+
+final class RTBCB_ApiLogFieldsTest extends TestCase {
+        /**
+         * @runInSeparateProcess
+         */
+        public function test_save_log_stores_basic_fields() {
+                require_once __DIR__ . '/../inc/class-rtbcb-api-log.php';
+                global $wpdb;
+                $wpdb = new WPDB_LogStub();
+
+                $reflect  = new ReflectionClass( RTBCB_API_Log::class );
+                $property = $reflect->getProperty( 'table_name' );
+                $property->setAccessible( true );
+                $property->setValue( null, 'rtbcb_api_logs' );
+
+                $request = [
+                        'email'        => 'user@example.com',
+                        'company_name' => 'Example Co',
+                ];
+
+                RTBCB_API_Log::save_log( $request, [], 1, '', '', 7 );
+
+                $this->assertNotEmpty( $wpdb->rows );
+                $row = $wpdb->rows[0];
+                $this->assertSame( 'user@example.com', $row['user_email'] );
+                $this->assertSame( 'Example Co', $row['company_name'] );
+                $this->assertSame( 7, $row['lead_id'] );
+        }
+}

--- a/tests/api-logs-page.test.js
+++ b/tests/api-logs-page.test.js
@@ -34,7 +34,11 @@ include 'admin/api-logs-page.php';
 
 const output = execSync('php', { input: php }).toString();
 const dom = new JSDOM(output);
-const tokenCell = dom.window.document.querySelector('#rtbcb-api-logs-table tbody tr td:nth-child(6)');
-assert.ok(tokenCell);
-assert.strictEqual(tokenCell.textContent.trim(), '42');
+const promptCell = dom.window.document.querySelector('#rtbcb-api-logs-table tbody tr td:nth-child(6)');
+const completionCell = dom.window.document.querySelector('#rtbcb-api-logs-table tbody tr td:nth-child(7)');
+const totalCell = dom.window.document.querySelector('#rtbcb-api-logs-table tbody tr td:nth-child(8)');
+assert.ok(promptCell && completionCell && totalCell);
+assert.strictEqual(promptCell.textContent.trim(), '40');
+assert.strictEqual(completionCell.textContent.trim(), '2');
+assert.strictEqual(totalCell.textContent.trim(), '42');
 console.log('api-logs-page.test.js passed');


### PR DESCRIPTION
## Summary
- test that `RTBCB_API_Log::save_log` records user email, company name, and lead ID
- expand API log page test to check prompt, completion, and total token columns

## Testing
- `composer install`
- `bash tests/run-tests.sh`
- `vendor/bin/phpunit tests/RTBCB_ApiLogTokensTest.php`
- `vendor/bin/phpunit tests/RTBCB_ApiLogFieldsTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7b1bef1b883318f2c81122b187ece