### PR TITLE
Integrate risk and financial research into business case builder

### DIFF
--- a/inc/class-rtbcb-llm-optimized.php
+++ b/inc/class-rtbcb-llm-optimized.php
@@ -238,7 +238,8 @@ Return a complete JSON business case covering:
 4. **Financial Analysis**: Detailed ROI scenarios, investment breakdown, and payback analysis
 5. **Technology Strategy**: Recommended solutions and implementation roadmap
 6. **Risk Analysis**: Implementation risks and comprehensive mitigation strategies
-7. **Action Plan**: Immediate steps, short-term milestones, and long-term objectives
+7. **Research Context**: Risk profile and financial benchmark summaries
+8. **Action Plan**: Immediate steps, short-term milestones, and long-term objectives
 
 ### Complete Business Case Schema
 ```json
@@ -356,6 +357,38 @@ Return a complete JSON business case covering:
     "sector_trends": ["array of 3-4 industry trends affecting treasury"],
     "competitive_benchmarks": ["array of 2-3 competitive benchmarking insights"],
     "regulatory_considerations": ["array of 2-3 regulatory factors"]
+  },
+  "research_context": {
+    "risk_profile": {
+      "risk_matrix": [
+        {
+          "risk": "string - risk description",
+          "likelihood": "low|medium|high",
+          "impact": "low|medium|high"
+        }
+      ],
+      "mitigations": [
+        {
+          "risk": "string - risk description",
+          "strategy": "string - mitigation approach"
+        }
+      ]
+    },
+    "financial_benchmarks": {
+      "industry_benchmarks": [
+        {
+          "metric": "string - benchmark metric",
+          "value": "string - benchmark value",
+          "source": "string - data source"
+        }
+      ],
+      "valuation_multiples": [
+        {
+          "metric": "string - valuation metric",
+          "range": "string - industry range"
+        }
+      ]
+    }
   },
   "risk_analysis": {
     "implementation_risks": ["array of 5-6 key implementation risks"],

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -6,13 +6,16 @@ $report_data           = $report_data ?? [];
 $metadata              = $report_data['metadata'] ?? [];
 $executive_summary     = $report_data['executive_summary'] ?? [];
 $company_intelligence  = $report_data['company_intelligence'] ?? [];
-	$financial_analysis    = $report_data['financial_analysis'] ?? [];
-	$technology_strategy   = $report_data['technology_strategy'] ?? [];
-	$industry_insights     = $report_data['industry_insights'] ?? [];
-	$operational_insights  = $report_data['operational_insights'] ?? [];
-	$risk_analysis         = $report_data['risk_analysis'] ?? [];
-	$action_plan           = $report_data['action_plan'] ?? [];
-	$rag_context           = $report_data['rag_context'] ?? [];
+$financial_analysis    = $report_data['financial_analysis'] ?? [];
+$technology_strategy   = $report_data['technology_strategy'] ?? [];
+$industry_insights     = $report_data['industry_insights'] ?? [];
+$operational_insights  = $report_data['operational_insights'] ?? [];
+$risk_analysis         = $report_data['risk_analysis'] ?? [];
+$action_plan           = $report_data['action_plan'] ?? [];
+$rag_context           = $report_data['rag_context'] ?? [];
+$research              = $report_data['research'] ?? [];
+$risk_research         = $research['risk'] ?? [];
+$financial_research    = $research['financial'] ?? [];
 	
 	// Ensure classes exist.
 	$enable_charts         = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_setting( 'enable_charts', true ) : true;
@@ -463,7 +466,7 @@ $processing_time = $metadata['processing_time'] ?? ( $report_data['processing_ti
 </div>
 <?php endif; ?>
 
-	<?php if ( ! empty( $industry_insights ) ) : ?>
+<?php if ( ! empty( $industry_insights ) ) : ?>
 	<div class="rtbcb-section-enhanced rtbcb-industry-insights">
 	<div class="rtbcb-section-header-enhanced">
 	<h2 class="rtbcb-section-title">
@@ -506,7 +509,90 @@ $processing_time = $metadata['processing_time'] ?? ( $report_data['processing_ti
 	<?php endif; ?>
 	</div>
 	</div>
-	<?php endif; ?>
+<?php endif; ?>
+
+<?php if ( ! empty( $financial_research ) ) : ?>
+<div class="rtbcb-section-enhanced rtbcb-financial-benchmarks">
+<div class="rtbcb-section-header-enhanced">
+<h2 class="rtbcb-section-title">
+<span class="rtbcb-section-icon">💹</span>
+<?php echo esc_html__( 'Industry Benchmarks', 'rtbcb' ); ?>
+</h2>
+</div>
+<div class="rtbcb-section-content">
+<?php if ( ! empty( $financial_research['industry_benchmarks'] ) ) : ?>
+<div class="rtbcb-benchmark-block">
+<h3><?php echo esc_html__( 'Operational Benchmarks', 'rtbcb' ); ?></h3>
+<ul>
+<?php foreach ( $financial_research['industry_benchmarks'] as $bench ) : ?>
+<li>
+<?php echo esc_html( $bench['metric'] . ': ' . $bench['value'] ); ?>
+<?php if ( ! empty( $bench['source'] ) ) : ?>
+<?php echo esc_html( ' (' . $bench['source'] . ')' ); ?>
+<?php endif; ?>
+</li>
+<?php endforeach; ?>
+</ul>
+</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $financial_research['valuation_multiples'] ) ) : ?>
+<div class="rtbcb-benchmark-block">
+<h3><?php echo esc_html__( 'Valuation Multiples', 'rtbcb' ); ?></h3>
+<ul>
+<?php foreach ( $financial_research['valuation_multiples'] as $mult ) : ?>
+<li><?php echo esc_html( $mult['metric'] . ': ' . $mult['range'] ); ?></li>
+<?php endforeach; ?>
+</ul>
+</div>
+<?php endif; ?>
+</div>
+</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $risk_research ) ) : ?>
+<div class="rtbcb-section-enhanced rtbcb-risk-assessment">
+<div class="rtbcb-section-header-enhanced">
+<h2 class="rtbcb-section-title">
+<span class="rtbcb-section-icon">⚠️</span>
+<?php echo esc_html__( 'Risk Assessment', 'rtbcb' ); ?>
+</h2>
+</div>
+<div class="rtbcb-section-content">
+<?php if ( ! empty( $risk_research['risk_matrix'] ) ) : ?>
+<table class="rtbcb-table">
+<thead>
+<tr>
+<th><?php esc_html_e( 'Risk', 'rtbcb' ); ?></th>
+<th><?php esc_html_e( 'Likelihood', 'rtbcb' ); ?></th>
+<th><?php esc_html_e( 'Impact', 'rtbcb' ); ?></th>
+</tr>
+</thead>
+<tbody>
+<?php foreach ( $risk_research['risk_matrix'] as $risk ) : ?>
+<tr>
+<td><?php echo esc_html( $risk['risk'] ?? '' ); ?></td>
+<td><?php echo esc_html( $risk['likelihood'] ?? '' ); ?></td>
+<td><?php echo esc_html( $risk['impact'] ?? '' ); ?></td>
+</tr>
+<?php endforeach; ?>
+</tbody>
+</table>
+<?php endif; ?>
+
+<?php if ( ! empty( $risk_research['mitigations'] ) ) : ?>
+<div class="rtbcb-risk-mitigations">
+<h3><?php echo esc_html__( 'Mitigation Strategies', 'rtbcb' ); ?></h3>
+<ul>
+<?php foreach ( $risk_research['mitigations'] as $mitigation ) : ?>
+<li><?php echo esc_html( $mitigation['risk'] . ': ' . $mitigation['strategy'] ); ?></li>
+<?php endforeach; ?>
+</ul>
+</div>
+<?php endif; ?>
+</div>
+</div>
+<?php endif; ?>
 
 <!-- Action Plan Section with Timeline -->
 <?php if ( ! empty( $action_plan ) ) : ?>


### PR DESCRIPTION
## Summary
- extend comprehensive prompt builder to include risk and financial research context and JSON schema
- render risk assessment and industry benchmark sections in comprehensive report template

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(requires composer install)*
- `phpcs --standard=WordPress` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bf1da9e0833198e282e786ae723d