### PR TITLE
Expand industry context in comprehensive report

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -514,14 +514,25 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 		'key_challenges'      => $company_profile['key_challenges'] ?? [],
 		'strategic_priorities'=> $company_profile['strategic_priorities'] ?? [],
 	];
-	$industry_context_struct = [
-		'sector_analysis' => [
-			'market_dynamics' => $industry_context_raw['sector_trends'] ?? ( $industry_context_raw['market_dynamics'] ?? '' ),
-		],
-		'benchmarking'    => [
-			'technology_penetration' => $industry_context_raw['technology_penetration'] ?? ( $industry_context_raw['technology_adoption'] ?? '' ),
-		],
-	];
+$industry_context_struct = [
+'sector_analysis' => [
+'market_dynamics'    => $industry_context_raw['sector_analysis']['market_dynamics'] ?? ( $industry_context_raw['sector_trends'] ?? ( $industry_context_raw['market_dynamics'] ?? '' ) ),
+'growth_trends'      => $industry_context_raw['sector_analysis']['growth_trends'] ?? '',
+'disruption_factors' => (array) ( $industry_context_raw['sector_analysis']['disruption_factors'] ?? [] ),
+'technology_adoption'=> $industry_context_raw['sector_analysis']['technology_adoption'] ?? ( $industry_context_raw['technology_adoption'] ?? '' ),
+],
+'benchmarking'    => [
+'typical_treasury_setup' => $industry_context_raw['benchmarking']['typical_treasury_setup'] ?? '',
+'common_pain_points'     => (array) ( $industry_context_raw['benchmarking']['common_pain_points'] ?? [] ),
+'technology_penetration' => $industry_context_raw['benchmarking']['technology_penetration'] ?? ( $industry_context_raw['technology_penetration'] ?? '' ),
+'investment_patterns'    => $industry_context_raw['benchmarking']['investment_patterns'] ?? '',
+],
+'regulatory_landscape' => [
+'key_regulations'      => (array) ( $industry_context_raw['regulatory_landscape']['key_regulations'] ?? [] ),
+'compliance_complexity'=> $industry_context_raw['regulatory_landscape']['compliance_complexity'] ?? '',
+'upcoming_changes'     => (array) ( $industry_context_raw['regulatory_landscape']['upcoming_changes'] ?? [] ),
+],
+];
 
 	$company_name_meta = sanitize_text_field( $enriched_profile_struct['name'] ?: $user_inputs['company_name'] );
 

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -386,23 +386,99 @@ $processing_time = $metadata['processing_time'] ?? ( $report_data['processing_ti
 </div>
 <?php endif; ?>
 
-<?php if ( ! empty( $company_intelligence['industry_context'] ) ) : ?>
+<?php if ( ! empty( $company_intelligence['industry_context'] ) ) :
+$industry_context   = $company_intelligence['industry_context'];
+$sector_analysis    = $industry_context['sector_analysis'] ?? [];
+$benchmarking       = $industry_context['benchmarking'] ?? [];
+$regulatory_land    = $industry_context['regulatory_landscape'] ?? [];
+$tech_adoption      = $sector_analysis['technology_adoption'] ?? ( $benchmarking['technology_penetration'] ?? '' );
+?>
 <div class="rtbcb-intelligence-card">
 <h3><?php echo esc_html__( 'Industry Context', 'rtbcb' ); ?></h3>
 <div class="rtbcb-industry-insights">
-<?php if ( ! empty( $company_intelligence['industry_context']['sector_analysis']['market_dynamics'] ) ) : ?>
+<?php if ( ! empty( $sector_analysis['market_dynamics'] ) ) : ?>
 <div class="rtbcb-insight-item">
 <strong><?php echo esc_html__( 'Market Dynamics:', 'rtbcb' ); ?></strong>
-<span><?php echo esc_html( $company_intelligence['industry_context']['sector_analysis']['market_dynamics'] ); ?></span>
+<span><?php echo esc_html( $sector_analysis['market_dynamics'] ); ?></span>
 </div>
 <?php endif; ?>
 
-<?php if ( ! empty( $company_intelligence['industry_context']['benchmarking']['technology_penetration'] ) ) : ?>
+<?php if ( ! empty( $sector_analysis['growth_trends'] ) ) : ?>
+<div class="rtbcb-insight-item">
+<strong><?php echo esc_html__( 'Growth Trends:', 'rtbcb' ); ?></strong>
+<span><?php echo esc_html( $sector_analysis['growth_trends'] ); ?></span>
+</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $sector_analysis['disruption_factors'] ) ) : ?>
+<div class="rtbcb-insight-item">
+<strong><?php echo esc_html__( 'Disruption Factors:', 'rtbcb' ); ?></strong>
+<ul>
+<?php foreach ( $sector_analysis['disruption_factors'] as $factor ) : ?>
+<li><?php echo esc_html( $factor ); ?></li>
+<?php endforeach; ?>
+</ul>
+</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $tech_adoption ) ) : ?>
 <div class="rtbcb-insight-item">
 <strong><?php echo esc_html__( 'Technology Adoption:', 'rtbcb' ); ?></strong>
-<span class="rtbcb-adoption-level <?php echo esc_attr( $company_intelligence['industry_context']['benchmarking']['technology_penetration'] ); ?>">
-<?php echo esc_html( ucfirst( $company_intelligence['industry_context']['benchmarking']['technology_penetration'] ) ); ?>
-</span>
+<span class="rtbcb-adoption-level <?php echo esc_attr( $tech_adoption ); ?>"><?php echo esc_html( ucfirst( $tech_adoption ) ); ?></span>
+</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $benchmarking['typical_treasury_setup'] ) ) : ?>
+<div class="rtbcb-insight-item">
+<strong><?php echo esc_html__( 'Typical Treasury Setup:', 'rtbcb' ); ?></strong>
+<span><?php echo esc_html( $benchmarking['typical_treasury_setup'] ); ?></span>
+</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $benchmarking['common_pain_points'] ) ) : ?>
+<div class="rtbcb-insight-item">
+<strong><?php echo esc_html__( 'Common Pain Points:', 'rtbcb' ); ?></strong>
+<ul>
+<?php foreach ( $benchmarking['common_pain_points'] as $pain ) : ?>
+<li><?php echo esc_html( $pain ); ?></li>
+<?php endforeach; ?>
+</ul>
+</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $benchmarking['investment_patterns'] ) ) : ?>
+<div class="rtbcb-insight-item">
+<strong><?php echo esc_html__( 'Investment Patterns:', 'rtbcb' ); ?></strong>
+<span><?php echo esc_html( $benchmarking['investment_patterns'] ); ?></span>
+</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $regulatory_land['key_regulations'] ) ) : ?>
+<div class="rtbcb-insight-item">
+<strong><?php echo esc_html__( 'Key Regulations:', 'rtbcb' ); ?></strong>
+<ul>
+<?php foreach ( $regulatory_land['key_regulations'] as $reg ) : ?>
+<li><?php echo esc_html( $reg ); ?></li>
+<?php endforeach; ?>
+</ul>
+</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $regulatory_land['compliance_complexity'] ) ) : ?>
+<div class="rtbcb-insight-item">
+<strong><?php echo esc_html__( 'Compliance Complexity:', 'rtbcb' ); ?></strong>
+<span><?php echo esc_html( $regulatory_land['compliance_complexity'] ); ?></span>
+</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $regulatory_land['upcoming_changes'] ) ) : ?>
+<div class="rtbcb-insight-item">
+<strong><?php echo esc_html__( 'Upcoming Changes:', 'rtbcb' ); ?></strong>
+<ul>
+<?php foreach ( $regulatory_land['upcoming_changes'] as $change ) : ?>
+<li><?php echo esc_html( $change ); ?></li>
+<?php endforeach; ?>
+</ul>
 </div>
 <?php endif; ?>
 </div>

--- a/tests/render-comprehensive-template.test.php
+++ b/tests/render-comprehensive-template.test.php
@@ -40,6 +40,27 @@ $business_case_data = [
                 'key_value_drivers'       => [ 'Efficiency', 'Compliance' ],
                 'executive_recommendation'=> 'Proceed',
         ],
+       'company_intelligence' => [
+               'industry_context' => [
+                       'sector_analysis' => [
+                               'market_dynamics'   => 'Volatile market',
+                               'growth_trends'     => '5% annual growth',
+                               'disruption_factors'=> [ 'Fintech competitors' ],
+                               'technology_adoption'=> 'mainstream',
+                       ],
+                       'benchmarking' => [
+                               'typical_treasury_setup' => 'Centralized',
+                               'common_pain_points'     => [ 'Manual processes' ],
+                               'technology_penetration' => 'high',
+                               'investment_patterns'    => 'Aggressive',
+                       ],
+                       'regulatory_landscape' => [
+                               'key_regulations'      => [ 'Regulation X' ],
+                               'compliance_complexity'=> 'high',
+                               'upcoming_changes'     => [ 'New tax rules' ],
+                       ],
+               ],
+       ],
        'industry_insights' => [
                'sector_trends'          => [ 'Growth' ],
                'competitive_benchmarks' => [ 'Benchmark' ],
@@ -53,7 +74,7 @@ ob_start();
 include __DIR__ . '/../templates/comprehensive-report-template.php';
 $output = ob_get_clean();
 
-if ( strpos( $output, 'rtbcb-executive-summary' ) === false || strpos( $output, 'Industry Insights' ) === false ) {
+if ( strpos( $output, 'rtbcb-executive-summary' ) === false || strpos( $output, 'Industry Insights' ) === false || strpos( $output, 'Volatile market' ) === false || strpos( $output, 'Regulation X' ) === false ) {
         echo "Executive summary not found\n";
         exit( 1 );
 }


### PR DESCRIPTION
## Summary
- Map additional industry context fields from API responses
- Render full industry context section in comprehensive report template
- Test industry context rendering for comprehensive report

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b7c01ce7348331aa90a27a9b37e6d4