### PR TITLE
Add risk and financial research handling

### DIFF
--- a/inc/class-rtbcb-llm-optimized.php
+++ b/inc/class-rtbcb-llm-optimized.php
@@ -70,6 +70,8 @@ Provide deep, actionable insights to support:
 2. **Technology Category Selection**: Solution complexity and feature requirements
 3. **Implementation Planning**: Timeline, resource requirements, and risk factors
 4. **Strategic Positioning**: Competitive context and business value alignment
+5. **Risk Baseline**: Key operational and strategic risk considerations
+6. **Financial Benchmarking**: Relevant industry metrics and valuation references
 
 Focus on treasury-specific challenges and opportunities within the {$user_inputs['industry']} industry for a {$user_inputs['company_size']} organization.
 
@@ -125,6 +127,36 @@ Focus on treasury-specific challenges and opportunities within the {$user_inputs
     },
     "critical_success_factors": ["array of 4-5 key implementation success factors"],
     "potential_obstacles": ["array of 4-5 likely implementation challenges"]
+  },
+  "risk": {
+    "risk_matrix": [
+      {
+        "risk": "string - risk description",
+        "likelihood": "low|medium|high",
+        "impact": "low|medium|high"
+      }
+    ],
+    "mitigations": [
+      {
+        "risk": "string - risk addressed",
+        "strategy": "string - mitigation approach"
+      }
+    ]
+  },
+  "financial": {
+    "industry_benchmarks": [
+      {
+        "metric": "string - benchmark metric",
+        "value": "string - benchmark value",
+        "source": "string - data source"
+      }
+    ],
+    "valuation_multiples": [
+      {
+        "metric": "string - multiple name",
+        "range": "string - typical range"
+      }
+    ]
   },
   "enrichment_metadata": {
     "confidence_level": "number between 0.7 and 0.95",
@@ -234,13 +266,14 @@ PROMPT;
 	// Required Comprehensive Analysis - instructs LLM to use all data.
 	$prompt .= "## Required Comprehensive Analysis\n\n";
 	$prompt .= "Return a complete JSON business case covering:\n\n";
-	$prompt .= "1. **Executive Summary**: Strategic positioning, value drivers, and executive recommendation\n";
-	$prompt .= "2. **Company Intelligence**: Enhanced company profile and industry context analysis\n";
-	$prompt .= "3. **Operational Insights**: Current state assessment and improvement opportunities\n";
-	$prompt .= "4. **Financial Analysis**: Detailed ROI scenarios, investment breakdown, and payback analysis\n";
-	$prompt .= "5. **Technology Strategy**: Recommended solutions and implementation roadmap\n";
-	$prompt .= "6. **Risk Analysis**: Implementation risks and comprehensive mitigation strategies\n";
-	$prompt .= "7. **Action Plan**: Immediate steps, short-term milestones, and long-term objectives\n\n";
+        $prompt .= "1. **Executive Summary**: Strategic positioning, value drivers, and executive recommendation\n";
+        $prompt .= "2. **Company Intelligence**: Enhanced company profile and industry context analysis\n";
+        $prompt .= "3. **Operational Insights**: Current state assessment and improvement opportunities\n";
+        $prompt .= "4. **Financial Analysis**: Detailed ROI scenarios, investment breakdown, and payback analysis\n";
+        $prompt .= "5. **Technology Strategy**: Recommended solutions and implementation roadmap\n";
+        $prompt .= "6. **Risk Analysis**: Implementation risks and comprehensive mitigation strategies\n";
+        $prompt .= "7. **Financial Benchmarks**: Industry metrics and valuation references\n";
+        $prompt .= "8. **Action Plan**: Immediate steps, short-term milestones, and long-term objectives\n\n";
 	
 	// Complete schema definition for the LLM output.
 	$prompt .= <<<SCHEMA
@@ -356,24 +389,39 @@ PROMPT;
 	    ],
 	    "vendor_considerations": ["array of 4-5 vendor evaluation factors"]
 	  },
-	  "industry_insights": {
-	    "sector_trends": ["array of 3-4 industry trends affecting treasury"],
-	    "competitive_benchmarks": ["array of 2-3 competitive benchmarking insights"],
-	    "regulatory_considerations": ["array of 2-3 regulatory factors"]
-	  },
-	  "risk_analysis": {
-	    "implementation_risks": ["array of 5-6 key implementation risks"],
-	    "mitigation_strategies": ["array of 5-6 specific risk mitigation approaches"],
-	    "success_factors": ["array of 5-6 critical success factors"]
-	  },
-	  "action_plan": {
-	    "immediate_steps": ["array of immediate actions for next 30 days"],
-	    "short_term_milestones": ["array of milestones for 3-6 months"],
-	    "long_term_objectives": ["array of objectives for 6+ months"]
-	  }
+          "industry_insights": {
+            "sector_trends": ["array of 3-4 industry trends affecting treasury"],
+            "competitive_benchmarks": ["array of 2-3 competitive benchmarking insights"],
+            "regulatory_considerations": ["array of 2-3 regulatory factors"]
+          },
+          "risk_analysis": {
+            "implementation_risks": ["array of 5-6 key implementation risks"],
+            "mitigation_strategies": ["array of 5-6 specific risk mitigation approaches"],
+            "success_factors": ["array of 5-6 critical success factors"]
+          },
+          "financial_benchmarks": {
+            "industry_benchmarks": [
+              {
+                "metric": "string - benchmark metric",
+                "value": "string - benchmark value",
+                "source": "string - data source"
+              }
+            ],
+            "valuation_multiples": [
+              {
+                "metric": "string - multiple name",
+                "range": "string - typical range"
+              }
+            ]
+          },
+          "action_plan": {
+            "immediate_steps": ["array of immediate actions for next 30 days"],
+            "short_term_milestones": ["array of milestones for 3-6 months"],
+            "long_term_objectives": ["array of objectives for 6+ months"]
+          }
 	}
-	```
-	SCHEMA;
+        ```
+SCHEMA;
 	
 	return $prompt;
 	}

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -6,13 +6,14 @@ $report_data           = $report_data ?? [];
 $metadata              = $report_data['metadata'] ?? [];
 $executive_summary     = $report_data['executive_summary'] ?? [];
 $company_intelligence  = $report_data['company_intelligence'] ?? [];
-	$financial_analysis    = $report_data['financial_analysis'] ?? [];
-	$technology_strategy   = $report_data['technology_strategy'] ?? [];
-	$industry_insights     = $report_data['industry_insights'] ?? [];
-	$operational_insights  = $report_data['operational_insights'] ?? [];
-	$risk_analysis         = $report_data['risk_analysis'] ?? [];
-	$action_plan           = $report_data['action_plan'] ?? [];
-	$rag_context           = $report_data['rag_context'] ?? [];
+$financial_analysis    = $report_data['financial_analysis'] ?? [];
+$technology_strategy   = $report_data['technology_strategy'] ?? [];
+$industry_insights     = $report_data['industry_insights'] ?? [];
+$operational_insights  = $report_data['operational_insights'] ?? [];
+$risk_analysis         = $report_data['risk_analysis'] ?? [];
+$financial_benchmarks  = $report_data['financial_benchmarks'] ?? [];
+$action_plan           = $report_data['action_plan'] ?? [];
+$rag_context           = $report_data['rag_context'] ?? [];
 	
 	// Ensure classes exist.
 	$enable_charts         = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_setting( 'enable_charts', true ) : true;
@@ -506,7 +507,94 @@ $processing_time = $metadata['processing_time'] ?? ( $report_data['processing_ti
 	<?php endif; ?>
 	</div>
 	</div>
-	<?php endif; ?>
+<?php endif; ?>
+
+<?php if ( ! empty( $financial_benchmarks ) ) : ?>
+<div class="rtbcb-section-enhanced rtbcb-financial-benchmarks">
+<div class="rtbcb-section-header-enhanced">
+<h2 class="rtbcb-section-title">
+<span class="rtbcb-section-icon">💹</span>
+<?php echo esc_html__( 'Industry & Financial Benchmarks', 'rtbcb' ); ?>
+</h2>
+</div>
+<div class="rtbcb-section-content">
+<?php if ( ! empty( $financial_benchmarks['industry_benchmarks'] ) ) : ?>
+<div class="rtbcb-benchmark-block">
+<h3><?php echo esc_html__( 'Industry Benchmarks', 'rtbcb' ); ?></h3>
+<ul>
+<?php foreach ( $financial_benchmarks['industry_benchmarks'] as $bench ) : ?>
+<li>
+<?php echo esc_html( $bench['metric'] . ': ' . $bench['value'] ); ?>
+<?php if ( ! empty( $bench['source'] ) ) : ?>
+<span class="rtbcb-benchmark-source">(<?php echo esc_html( $bench['source'] ); ?>)</span>
+<?php endif; ?>
+</li>
+<?php endforeach; ?>
+</ul>
+</div>
+<?php endif; ?>
+<?php if ( ! empty( $financial_benchmarks['valuation_multiples'] ) ) : ?>
+<div class="rtbcb-benchmark-block">
+<h3><?php echo esc_html__( 'Valuation Multiples', 'rtbcb' ); ?></h3>
+<ul>
+<?php foreach ( $financial_benchmarks['valuation_multiples'] as $mult ) : ?>
+<li><?php echo esc_html( $mult['metric'] . ': ' . $mult['range'] ); ?></li>
+<?php endforeach; ?>
+</ul>
+</div>
+<?php endif; ?>
+</div>
+</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $risk_analysis ) ) : ?>
+<div class="rtbcb-section-enhanced rtbcb-risk-analysis">
+<div class="rtbcb-section-header-enhanced">
+<h2 class="rtbcb-section-title">
+<span class="rtbcb-section-icon">⚠️</span>
+<?php echo esc_html__( 'Risk Assessment', 'rtbcb' ); ?>
+</h2>
+</div>
+<div class="rtbcb-section-content">
+<?php if ( ! empty( $risk_analysis['risk_matrix'] ) ) : ?>
+<table class="rtbcb-risk-matrix">
+<thead>
+<tr>
+<th><?php esc_html_e( 'Risk', 'rtbcb' ); ?></th>
+<th><?php esc_html_e( 'Likelihood', 'rtbcb' ); ?></th>
+<th><?php esc_html_e( 'Impact', 'rtbcb' ); ?></th>
+</tr>
+</thead>
+<tbody>
+<?php foreach ( $risk_analysis['risk_matrix'] as $risk ) : ?>
+<tr>
+<td><?php echo esc_html( $risk['risk'] ); ?></td>
+<td><?php echo esc_html( $risk['likelihood'] ); ?></td>
+<td><?php echo esc_html( $risk['impact'] ); ?></td>
+</tr>
+<?php endforeach; ?>
+</tbody>
+</table>
+<?php endif; ?>
+<?php if ( ! empty( $risk_analysis['implementation_risks'] ) ) : ?>
+<h3><?php echo esc_html__( 'Key Risks', 'rtbcb' ); ?></h3>
+<ul>
+<?php foreach ( $risk_analysis['implementation_risks'] as $risk ) : ?>
+<li><?php echo esc_html( $risk ); ?></li>
+<?php endforeach; ?>
+</ul>
+<?php endif; ?>
+<?php if ( ! empty( $risk_analysis['mitigation_strategies'] ) ) : ?>
+<h3><?php echo esc_html__( 'Mitigation Strategies', 'rtbcb' ); ?></h3>
+<ul>
+<?php foreach ( $risk_analysis['mitigation_strategies'] as $mitigation ) : ?>
+<li><?php echo esc_html( $mitigation ); ?></li>
+<?php endforeach; ?>
+</ul>
+<?php endif; ?>
+</div>
+</div>
+<?php endif; ?>
 
 <!-- Action Plan Section with Timeline -->
 <?php if ( ! empty( $action_plan ) ) : ?>


### PR DESCRIPTION
## Summary
- extend enrichment and comprehensive prompts to include risk and financial benchmark research
- add risk assessment and financial benchmark sections to comprehensive report template

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*
- `phpcs --standard=WordPress` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b81ae60d5083318065e66bc67bdd42