### PR TITLE
Add Report Preview submenu page

### DIFF
--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -245,7 +245,6 @@ wp_localize_script(
 				'all_sections_done'   => __( 'All sections completed', 'rtbcb' ),
 			],
 		] );
-
 	}
 
 	/**
@@ -343,6 +342,15 @@ wp_localize_script(
 			'manage_options',
 			'rtbcb-workflow-visualizer',
 			[ $this, 'render_workflow_visualizer' ]
+		);
+
+		add_submenu_page(
+			'rtbcb-dashboard',
+			__( 'Report Preview', 'rtbcb' ),
+			__( 'Report Preview', 'rtbcb' ),
+			'manage_options',
+			'rtbcb-report-preview',
+			[ $this, 'report_preview_page' ]
 		);
 
 	}
@@ -914,7 +922,6 @@ wp_localize_script(
 					],
 				]
 			);
-
 		} catch ( Exception $e ) {
 			error_log( 'RTBCB Company Overview Error: ' . $e->getMessage() );
 			wp_send_json_error( [


### PR DESCRIPTION
## Summary
- expose a new **Report Preview** page in the admin dashboard menu for quick access

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b82908b4f08331b9f6b2d882a36dec