### PR TITLE
Use company API industry for context

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -443,13 +443,18 @@ class RTBCB_Ajax {
 	public static function collect_and_validate_user_inputs() {
 		$validator = new RTBCB_Validator();
 		$validated = $validator->validate( $_POST );
-
+		
 		if ( isset( $validated['error'] ) ) {
-			return new WP_Error( 'validation_error', $validated['error'] );
-}
-
+		return new WP_Error( 'validation_error', $validated['error'] );
+		}
+		
+		$company = function_exists( 'rtbcb_get_current_company' ) ? rtbcb_get_current_company() : [];
+		if ( ! empty( $company['industry'] ) ) {
+		$validated['industry'] = sanitize_text_field( $company['industry'] );
+		}
+		
 		return $validated;
-}
+	}
 
 	private static function create_fallback_profile( $user_inputs ) {
 		return [
@@ -511,11 +516,12 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 	$regulatory_landscape_raw = (array) ( $industry_context_raw['regulatory_landscape'] ?? [] );
 	$enriched_profile_struct = [
 		'name'                => $company_profile['name'] ?? '',
+		'industry'           => $company_profile['industry'] ?? sanitize_text_field( $user_inputs['industry'] ?? '' ),
 		'enhanced_description'=> $company_profile['enhanced_description'] ?? ( $company_profile['description'] ?? '' ),
 		'maturity_level'      => $company_profile['maturity_level'] ?? '',
-               'treasury_maturity'   => (array) ( is_array( $company_profile['treasury_maturity'] ?? null ) ? $company_profile['treasury_maturity'] : [] ),
-               'key_challenges'      => (array) ( is_array( $company_profile['key_challenges'] ?? null ) ? $company_profile['key_challenges'] : [] ),
-               'strategic_priorities'=> (array) ( is_array( $company_profile['strategic_priorities'] ?? null ) ? $company_profile['strategic_priorities'] : [] ),
+		'treasury_maturity'   => (array) ( is_array( $company_profile['treasury_maturity'] ?? null ) ? $company_profile['treasury_maturity'] : [] ),
+		'key_challenges'      => (array) ( is_array( $company_profile['key_challenges'] ?? null ) ? $company_profile['key_challenges'] : [] ),
+		'strategic_priorities'=> (array) ( is_array( $company_profile['strategic_priorities'] ?? null ) ? $company_profile['strategic_priorities'] : [] ),
 	];
 	$industry_context_struct = [
 		'sector_analysis' => [

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2235,8 +2235,9 @@ return $this->validate_and_structure_analysis( $analysis_data );
 	*/
 	private function validate_company_profile( $profile, $user_inputs ) {
 	return [
-	'name'                => $user_inputs['company_name'],
-	'enhanced_description' => wp_kses_post( $profile['enhanced_description'] ?? '' ),
+		'name'                => $user_inputs['company_name'],
+		'industry'            => sanitize_text_field( $user_inputs['industry'] ?? '' ),
+		'enhanced_description' => wp_kses_post( $profile['enhanced_description'] ?? '' ),
 	'business_model'      => wp_kses_post( $profile['business_model'] ?? '' ),
 	'market_position'     => wp_kses_post( $profile['market_position'] ?? '' ),
 	'maturity_level'      => in_array( $profile['maturity_level'] ?? '', [ 'basic', 'developing', 'strategic', 'optimized' ], true )


### PR DESCRIPTION
## Summary
- Prefer company API industry over user selection when building analysis inputs
- Include industry in enriched profile and validated company data

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b82e1818948331992a69221f39ab20