### PR TITLE
Validate potential obstacles count

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -993,7 +993,7 @@ $tech_prompt .= '\nContext: ' . implode( '\n', array_map( 'sanitize_text_field',
 	private function parse_comprehensive_response( $response ) {
 	$parser = new RTBCB_Response_Parser();
 	return $parser->parse_business_case( $response );
-    }
+	}
 
 
 	/**
@@ -2063,65 +2063,65 @@ Focus on treasury-specific challenges and opportunities within the {$user_inputs
 ```json
 {
   "company_profile": {
-    "enhanced_description": "string - comprehensive company description",
-    "business_model": "string - primary business model and revenue streams",
-    "market_position": "string - competitive position and market standing",
-    "maturity_level": "basic|developing|strategic|optimized",
-    "financial_indicators": {
+	"enhanced_description": "string - comprehensive company description",
+	"business_model": "string - primary business model and revenue streams",
+	"market_position": "string - competitive position and market standing",
+	"maturity_level": "basic|developing|strategic|optimized",
+	"financial_indicators": {
 	"estimated_revenue": "number - best estimate in USD",
 	"growth_stage": "startup|growth|mature|decline",
 	"financial_health": "strong|stable|concerning|unknown"
-    },
-    "treasury_maturity": {
+	},
+	"treasury_maturity": {
 	"current_state": "string - assessment of current treasury operations",
 	"sophistication_level": "manual|semi_automated|automated|strategic",
 	"key_gaps": ["array of identified gaps"],
 	"automation_readiness": "low|medium|high"
-    },
-    "strategic_context": {
+	},
+	"strategic_context": {
 	"primary_challenges": ["array of business challenges"],
 	"growth_objectives": ["array of growth objectives"],
 	"competitive_pressures": ["array of competitive factors"],
 	"regulatory_environment": "string - regulatory considerations"
-    }
+	}
   },
   "industry_context": {
-    "sector_analysis": {
+	"sector_analysis": {
 	"market_dynamics": "string - current market conditions",
 	"growth_trends": "string - industry growth patterns",
 	"disruption_factors": ["array of disruptive forces"],
 	"technology_adoption": "laggard|follower|mainstream|leader"
-    },
-    "benchmarking": {
+	},
+	"benchmarking": {
 	"typical_treasury_setup": "string - industry norm for treasury operations",
 	"common_pain_points": ["array of industry-wide challenges"],
 	"technology_penetration": "low|medium|high",
 	"investment_patterns": "string - typical technology investment patterns"
-    },
-    "regulatory_landscape": {
+	},
+	"regulatory_landscape": {
 	"key_regulations": ["array of relevant regulations"],
 	"compliance_complexity": "low|medium|high|very_high",
 	"upcoming_changes": ["array of anticipated regulatory changes"]
-    }
+	}
   },
   "strategic_insights": {
-    "technology_readiness": "not_ready|ready|urgent_need",
-    "investment_justification": "weak|moderate|strong|compelling",
-    "implementation_complexity": "low|medium|high|very_high",
-    "expected_benefits": {
+	"technology_readiness": "not_ready|ready|urgent_need",
+	"investment_justification": "weak|moderate|strong|compelling",
+	"implementation_complexity": "low|medium|high|very_high",
+	"expected_benefits": {
 	"efficiency_gains": "string - expected efficiency improvements",
 	"risk_reduction": "string - risk mitigation benefits",
 	"strategic_value": "string - strategic business value",
 	"competitive_advantage": "string - competitive positioning benefits"
-    },
-    "critical_success_factors": ["array of key success factors"],
-    "potential_obstacles": ["array of implementation challenges"]
+	},
+	"critical_success_factors": ["array of key success factors"],
+	"potential_obstacles": ["array of 4-5 likely implementation challenges"]
   },
   "enrichment_metadata": {
-    "confidence_level": "number - 0.0 to 1.0",
-    "data_sources": ["array of information sources considered"],
-    "analysis_depth": "surface|moderate|comprehensive",
-    "recommendations_priority": "low|medium|high|urgent"
+	"confidence_level": "number - 0.0 to 1.0",
+	"data_sources": ["array of information sources considered"],
+	"analysis_depth": "surface|moderate|comprehensive",
+	"recommendations_priority": "low|medium|high|urgent"
   }
 	}
 ```
@@ -2315,19 +2315,40 @@ return $this->validate_and_structure_analysis( $analysis_data );
 	* @return array Validated insights.
 	*/
 	private function validate_strategic_insights( $insights ) {
-	return [
-	'technology_readiness'     => sanitize_text_field( $insights['technology_readiness'] ?? 'not_ready' ),
-	'investment_justification' => sanitize_text_field( $insights['investment_justification'] ?? 'weak' ),
-	'implementation_complexity' => sanitize_text_field( $insights['implementation_complexity'] ?? 'medium' ),
-	'expected_benefits'        => [
-	'efficiency_gains'     => wp_kses_post( $insights['expected_benefits']['efficiency_gains'] ?? '' ),
-	'risk_reduction'       => wp_kses_post( $insights['expected_benefits']['risk_reduction'] ?? '' ),
-	'strategic_value'      => wp_kses_post( $insights['expected_benefits']['strategic_value'] ?? '' ),
-	'competitive_advantage' => wp_kses_post( $insights['expected_benefits']['competitive_advantage'] ?? '' ),
-	],
-	'critical_success_factors' => array_map( 'sanitize_text_field', $insights['critical_success_factors'] ?? [] ),
-	'potential_obstacles'      => array_map( 'sanitize_text_field', $insights['potential_obstacles'] ?? [] ),
-	];
+		$obstacles = array_map( 'sanitize_text_field', $insights['potential_obstacles'] ?? [] );
+		$count     = count( $obstacles );
+
+		if ( $count < 4 ) {
+			while ( count( $obstacles ) < 4 ) {
+				$obstacles[] = __( 'unspecified challenge', 'rtbcb' );
+			}
+			return new WP_Error(
+				'insufficient_potential_obstacles',
+				__( 'At least four potential obstacles are required.', 'rtbcb' ),
+				$obstacles
+			);
+		}
+
+		if ( $count > 5 ) {
+			return new WP_Error(
+				'too_many_potential_obstacles',
+				__( 'No more than five potential obstacles allowed.', 'rtbcb' )
+			);
+		}
+
+		return [
+			'technology_readiness'     => sanitize_text_field( $insights['technology_readiness'] ?? 'not_ready' ),
+			'investment_justification' => sanitize_text_field( $insights['investment_justification'] ?? 'weak' ),
+			'implementation_complexity' => sanitize_text_field( $insights['implementation_complexity'] ?? 'medium' ),
+			'expected_benefits'        => [
+				'efficiency_gains'     => wp_kses_post( $insights['expected_benefits']['efficiency_gains'] ?? '' ),
+				'risk_reduction'       => wp_kses_post( $insights['expected_benefits']['risk_reduction'] ?? '' ),
+				'strategic_value'      => wp_kses_post( $insights['expected_benefits']['strategic_value'] ?? '' ),
+				'competitive_advantage' => wp_kses_post( $insights['expected_benefits']['competitive_advantage'] ?? '' ),
+			],
+			'critical_success_factors' => array_map( 'sanitize_text_field', $insights['critical_success_factors'] ?? [] ),
+			'potential_obstacles'      => $obstacles,
+		];
 	}
 
 	/**
@@ -2476,7 +2497,7 @@ return $this->validate_and_structure_analysis( $analysis_data );
 	private function call_openai_with_retry( $model, $prompt, $max_output_tokens = null, $max_retries = null, $chunk_handler = null ) {
 	       return $this->transport->call_openai_with_retry( $model, $prompt, $max_output_tokens, $max_retries, $chunk_handler );
 	}
-    private function calculate_efficiency_rating( $user_inputs ) {
+	private function calculate_efficiency_rating( $user_inputs ) {
 		$total_hours = ($user_inputs['hours_reconciliation'] ?? 0) + ($user_inputs['hours_cash_positioning'] ?? 0);
 		$team_size = $user_inputs['ftes'] ?? 1;
 		$hours_per_fte = $team_size > 0 ? $total_hours / $team_size : $total_hours;

--- a/tests/RTBCB_ResponseParserTest.php
+++ b/tests/RTBCB_ResponseParserTest.php
@@ -1,6 +1,6 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-        define( 'ABSPATH', __DIR__ . '/../' );
+		define( 'ABSPATH', __DIR__ . '/../' );
 }
 defined( 'ABSPATH' ) || exit;
 
@@ -9,107 +9,139 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/wp-stubs.php';
 
 if ( ! function_exists( 'get_option' ) ) {
-        function get_option( $name, $default = '' ) {
-                return $default;
-        }
+		function get_option( $name, $default = '' ) {
+				return $default;
+		}
 }
 
 if ( ! class_exists( 'WP_Error' ) ) {
-        class WP_Error {
-                public $errors = [];
-                public function __construct( $code = '', $message = '' ) {
-                        $this->errors[ $code ] = [ $message ];
-                }
-        }
+	   class WP_Error {
+			   public $errors = [];
+			   public $data   = [];
+			   public function __construct( $code = '', $message = '', $data = null ) {
+					   $this->errors[ $code ] = [ $message ];
+					   $this->data           = $data;
+			   }
+	   }
 }
 
 if ( ! function_exists( '__' ) ) {
-        function __( $text, $domain = null ) {
-                return $text;
-        }
+		function __( $text, $domain = null ) {
+				return $text;
+		}
 }
 
 if ( ! function_exists( 'is_wp_error' ) ) {
-        function is_wp_error( $thing ) {
-                return $thing instanceof WP_Error;
-        }
+		function is_wp_error( $thing ) {
+				return $thing instanceof WP_Error;
+		}
 }
 
 if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
-        function wp_remote_retrieve_body( $response ) {
-                return $response['body'] ?? '';
-        }
+		function wp_remote_retrieve_body( $response ) {
+				return $response['body'] ?? '';
+		}
 }
 
 if ( ! function_exists( 'sanitize_text_field' ) ) {
-        function sanitize_text_field( $text ) {
-                $text = is_scalar( $text ) ? (string) $text : '';
-                $text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
-                return trim( $text );
-        }
+	   function sanitize_text_field( $text ) {
+			   $text = is_scalar( $text ) ? (string) $text : '';
+			   $text = preg_replace( '/[\r\n\t\0\x0B]/', '', $text );
+			   return trim( $text );
+	   }
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	   function sanitize_key( $key ) {
+			   $key = strtolower( $key );
+			   return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	   }
+}
+
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	   function wp_kses_post( $text ) {
+			   return $text;
+	   }
 }
 
 require_once __DIR__ . '/../inc/class-rtbcb-response-parser.php';
+require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
 
 final class RTBCB_ResponseParserTest extends TestCase {
-        public function test_parse_business_case_success() {
-                $valid = [
-                        'executive_summary'    => [],
-                        'company_intelligence' => [],
-                        'operational_insights' => [],
-                        'risk_analysis'        => [],
-                        'action_plan'          => [],
-                        'industry_insights'    => [],
-                        'technology_strategy'  => [],
-                        'financial_analysis'   => [],
-                ];
-                $response = [ 'body' => json_encode( [ 'output_text' => json_encode( $valid ) ] ) ];
-                $parser  = new RTBCB_Response_Parser();
-                $result  = $parser->parse_business_case( $response );
-                $this->assertIsArray( $result );
-                $this->assertArrayHasKey( 'executive_summary', $result );
-        }
+		public function test_parse_business_case_success() {
+				$valid = [
+						'executive_summary'    => [],
+						'company_intelligence' => [],
+						'operational_insights' => [],
+						'risk_analysis'        => [],
+						'action_plan'          => [],
+						'industry_insights'    => [],
+						'technology_strategy'  => [],
+						'financial_analysis'   => [],
+				];
+				$response = [ 'body' => json_encode( [ 'output_text' => json_encode( $valid ) ] ) ];
+				$parser  = new RTBCB_Response_Parser();
+				$result  = $parser->parse_business_case( $response );
+				$this->assertIsArray( $result );
+				$this->assertArrayHasKey( 'executive_summary', $result );
+		}
 
-        public function test_parse_business_case_malformed_json() {
-                $response = [ 'body' => 'not json' ];
-                $parser   = new RTBCB_Response_Parser();
-                $result   = $parser->parse_business_case( $response );
-                $this->assertTrue( is_wp_error( $result ) );
-        }
+		public function test_parse_business_case_malformed_json() {
+				$response = [ 'body' => 'not json' ];
+				$parser   = new RTBCB_Response_Parser();
+				$result   = $parser->parse_business_case( $response );
+				$this->assertTrue( is_wp_error( $result ) );
+		}
 
-        public function test_parse_business_case_missing_section() {
-                $invalid  = [ 'executive_summary' => [] ];
-                $response = [ 'body' => json_encode( [ 'output_text' => json_encode( $invalid ) ] ) ];
-                $parser   = new RTBCB_Response_Parser();
-                $result   = $parser->parse_business_case( $response );
-                $this->assertTrue( is_wp_error( $result ) );
-        }
+		public function test_parse_business_case_missing_section() {
+				$invalid  = [ 'executive_summary' => [] ];
+				$response = [ 'body' => json_encode( [ 'output_text' => json_encode( $invalid ) ] ) ];
+				$parser   = new RTBCB_Response_Parser();
+				$result   = $parser->parse_business_case( $response );
+				$this->assertTrue( is_wp_error( $result ) );
+		}
 
-        public function test_parse_marks_truncated_output() {
-                $payload = [
-                        'status'      => 'incomplete',
-                        'output_text' => str_repeat( 'a', 25 ),
-                        'usage'       => [ 'output_tokens' => 15 ],
-                ];
-                $response = [ 'body' => json_encode( $payload ) ];
-                $parser   = new RTBCB_Response_Parser();
-                $result   = $parser->parse( $response );
-                $this->assertTrue( $result['truncated'] );
-        }
+		public function test_parse_marks_truncated_output() {
+				$payload = [
+						'status'      => 'incomplete',
+						'output_text' => str_repeat( 'a', 25 ),
+						'usage'       => [ 'output_tokens' => 15 ],
+				];
+				$response = [ 'body' => json_encode( $payload ) ];
+				$parser   = new RTBCB_Response_Parser();
+				$result   = $parser->parse( $response );
+				$this->assertTrue( $result['truncated'] );
+		}
 
-        public function test_extracts_function_calls() {
-                $payload = [
-                        'output' => [
-                                [
-                                        'type' => 'function_call',
-                                        'name' => 'test',
-                                        'arguments' => '{}',
-                                ],
-                        ],
-                ];
-                $response = [ 'body' => json_encode( $payload ) ];
-                $parser   = new RTBCB_Response_Parser();
-                $result   = $parser->parse( $response );
-                $this->assertCount( 1, $result['function_calls'] );
-        }
+		public function test_extracts_function_calls() {
+				$payload = [
+						'output' => [
+								[
+										'type' => 'function_call',
+										'name' => 'test',
+										'arguments' => '{}',
+								],
+						],
+				];
+				$response = [ 'body' => json_encode( $payload ) ];
+				$parser   = new RTBCB_Response_Parser();
+				$result   = $parser->parse( $response );
+				$this->assertCount( 1, $result['function_calls'] );
+		}
+
+	   public function test_validate_strategic_insights_requires_four_obstacles() {
+			   $ref    = new ReflectionClass( RTBCB_LLM::class );
+			   $llm    = $ref->newInstanceWithoutConstructor();
+			   $method = $ref->getMethod( 'validate_strategic_insights' );
+			   $method->setAccessible( true );
+
+			   $input  = [ 'potential_obstacles' => [ 'a', 'b', 'c' ] ];
+			   $result = $method->invoke( $llm, $input );
+			   $this->assertTrue( is_wp_error( $result ) );
+
+			   $input['potential_obstacles'][] = 'd';
+			   $result = $method->invoke( $llm, $input );
+			   $this->assertFalse( is_wp_error( $result ) );
+			   $this->assertCount( 4, $result['potential_obstacles'] );
+	   }
 }


### PR DESCRIPTION
## Summary
- clarify `potential_obstacles` schema hint to require 4–5 items
- validate strategic insights and flag obstacle lists under four or above five entries
- test potential obstacles count enforcement

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4o-mini bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b835e33fb08331bd5404ec95a21788