### PR TITLE
Validate potential obstacles count

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2322,17 +2322,15 @@ return $this->validate_and_structure_analysis( $analysis_data );
 			while ( count( $obstacles ) < 4 ) {
 				$obstacles[] = __( 'unspecified challenge', 'rtbcb' );
 			}
-			return new WP_Error(
+			RTBCB_Logger::log(
 				'insufficient_potential_obstacles',
-				__( 'At least four potential obstacles are required.', 'rtbcb' ),
-				$obstacles
+				[ 'count' => $count ]
 			);
-		}
-
-		if ( $count > 5 ) {
-			return new WP_Error(
+		} elseif ( $count > 5 ) {
+			$obstacles = array_slice( $obstacles, 0, 5 );
+			RTBCB_Logger::log(
 				'too_many_potential_obstacles',
-				__( 'No more than five potential obstacles allowed.', 'rtbcb' )
+				[ 'count' => $count ]
 			);
 		}
 

--- a/tests/RTBCB_ResponseParserTest.php
+++ b/tests/RTBCB_ResponseParserTest.php
@@ -129,19 +129,21 @@ final class RTBCB_ResponseParserTest extends TestCase {
 				$this->assertCount( 1, $result['function_calls'] );
 		}
 
-	   public function test_validate_strategic_insights_requires_four_obstacles() {
-			   $ref    = new ReflectionClass( RTBCB_LLM::class );
-			   $llm    = $ref->newInstanceWithoutConstructor();
-			   $method = $ref->getMethod( 'validate_strategic_insights' );
-			   $method->setAccessible( true );
-
-			   $input  = [ 'potential_obstacles' => [ 'a', 'b', 'c' ] ];
-			   $result = $method->invoke( $llm, $input );
-			   $this->assertTrue( is_wp_error( $result ) );
-
-			   $input['potential_obstacles'][] = 'd';
-			   $result = $method->invoke( $llm, $input );
-			   $this->assertFalse( is_wp_error( $result ) );
-			   $this->assertCount( 4, $result['potential_obstacles'] );
-	   }
+		public function test_validate_strategic_insights_normalizes_obstacle_count() {
+				$ref    = new ReflectionClass( RTBCB_LLM::class );
+				$llm    = $ref->newInstanceWithoutConstructor();
+				$method = $ref->getMethod( 'validate_strategic_insights' );
+				$method->setAccessible( true );
+				
+				$input  = [ 'potential_obstacles' => [ 'a', 'b', 'c' ] ];
+				$result = $method->invoke( $llm, $input );
+				$this->assertIsArray( $result );
+				$this->assertCount( 4, $result['potential_obstacles'] );
+				
+				$input['potential_obstacles'][] = 'd';
+				$input['potential_obstacles'][] = 'e';
+				$input['potential_obstacles'][] = 'f';
+				$result = $method->invoke( $llm, $input );
+				$this->assertCount( 5, $result['potential_obstacles'] );
+		}
 }


### PR DESCRIPTION
## Summary
- sanitize strategic insights obstacle lists and log size issues instead of returning WP_Error
- update tests for padded and truncated obstacle lists

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=gpt-4o-mini bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b83970fa3c8331961c2b87e95c1833