### PR TITLE
Handle industry insights in analysis structuring

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -566,11 +566,7 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
                                'maturity_assessment' => (array) ( is_array( $enriched_profile['maturity_assessment'] ?? null ) ? $enriched_profile['maturity_assessment'] : [] ),
                                'competitive_position'=> (array) ( is_array( $enriched_profile['competitive_position'] ?? null ) ? $enriched_profile['competitive_position'] : [] ),
 			],
-		       'industry_insights' => [
-			       'sector_trends'          => (array) ( $final_analysis['industry_insights']['sector_trends'] ?? [] ),
-			       'competitive_benchmarks' => (array) ( $final_analysis['industry_insights']['competitive_benchmarks'] ?? [] ),
-			       'regulatory_considerations' => (array) ( $final_analysis['industry_insights']['regulatory_considerations'] ?? [] ),
-		       ],
+'industry_insights' => $final_analysis['industry_insights'] ?? [],
                                        'financial_analysis' => [
                                                        'roi_scenarios'        => self::format_roi_scenarios( $roi_scenarios ),
                                                        'investment_breakdown' => (array) ( is_array( $final_analysis['financial_analysis']['investment_breakdown'] ?? null ) ? $final_analysis['financial_analysis']['investment_breakdown'] : [] ),

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2382,20 +2382,25 @@ return $this->validate_and_structure_analysis( $analysis_data );
 	'executive_recommendation' => sanitize_textarea_field( $analysis_data['executive_summary']['executive_recommendation'] ?? '' ),
 	'confidence_level'        => floatval( $analysis_data['executive_summary']['confidence_level'] ?? 0 ),
 	],
-	'operational_insights' => [
-	'current_state_assessment' => [
-	'efficiency_rating'   => sanitize_text_field( $analysis_data['operational_insights']['current_state_assessment']['efficiency_rating'] ?? ( $analysis_data['operational_analysis']['current_state_assessment']['efficiency_rating'] ?? '' ) ),
-	'benchmark_comparison' => sanitize_textarea_field( $analysis_data['operational_insights']['current_state_assessment']['benchmark_comparison'] ?? ( $analysis_data['operational_analysis']['current_state_assessment']['benchmark_comparison'] ?? '' ) ),
-	'capacity_utilization' => sanitize_textarea_field( $analysis_data['operational_insights']['current_state_assessment']['capacity_utilization'] ?? ( $analysis_data['operational_analysis']['current_state_assessment']['capacity_utilization'] ?? '' ) ),
-	],
-	'process_improvements'     => [],
-	'automation_opportunities' => [],
-	],
-	'financial_analysis' => [
-	'investment_breakdown' => [
-	'software_licensing'        => sanitize_textarea_field( $analysis_data['financial_analysis']['investment_breakdown']['software_licensing'] ?? '' ),
-	'implementation_services'   => sanitize_textarea_field( $analysis_data['financial_analysis']['investment_breakdown']['implementation_services'] ?? '' ),
-	'training_change_management' => sanitize_textarea_field( $analysis_data['financial_analysis']['investment_breakdown']['training_change_management'] ?? '' ),
+'operational_insights' => [
+'current_state_assessment' => [
+'efficiency_rating'   => sanitize_text_field( $analysis_data['operational_insights']['current_state_assessment']['efficiency_rating'] ?? ( $analysis_data['operational_analysis']['current_state_assessment']['efficiency_rating'] ?? '' ) ),
+'benchmark_comparison' => sanitize_textarea_field( $analysis_data['operational_insights']['current_state_assessment']['benchmark_comparison'] ?? ( $analysis_data['operational_analysis']['current_state_assessment']['benchmark_comparison'] ?? '' ) ),
+'capacity_utilization' => sanitize_textarea_field( $analysis_data['operational_insights']['current_state_assessment']['capacity_utilization'] ?? ( $analysis_data['operational_analysis']['current_state_assessment']['capacity_utilization'] ?? '' ) ),
+],
+'process_improvements'     => [],
+'automation_opportunities' => [],
+],
+'industry_insights'   => [
+'sector_trends'          => sanitize_textarea_field( $analysis_data['industry_insights']['sector_trends'] ?? '' ),
+'competitive_benchmarks' => sanitize_textarea_field( $analysis_data['industry_insights']['competitive_benchmarks'] ?? '' ),
+'regulatory_considerations' => sanitize_textarea_field( $analysis_data['industry_insights']['regulatory_considerations'] ?? '' ),
+],
+'financial_analysis' => [
+'investment_breakdown' => [
+'software_licensing'        => sanitize_textarea_field( $analysis_data['financial_analysis']['investment_breakdown']['software_licensing'] ?? '' ),
+'implementation_services'   => sanitize_textarea_field( $analysis_data['financial_analysis']['investment_breakdown']['implementation_services'] ?? '' ),
+'training_change_management' => sanitize_textarea_field( $analysis_data['financial_analysis']['investment_breakdown']['training_change_management'] ?? '' ),
 	'ongoing_support'           => sanitize_textarea_field( $analysis_data['financial_analysis']['investment_breakdown']['ongoing_support'] ?? '' ),
 	],
 	'payback_analysis' => [

--- a/tests/RTBCB_StructureReportDataTest.php
+++ b/tests/RTBCB_StructureReportDataTest.php
@@ -97,5 +97,26 @@ self::assertSame( [], $tech['vendor_considerations'] );
 self::assertSame( [], $risk['mitigation_strategies'] );
 self::assertSame( [], $risk['success_factors'] );
 }
+
+public function test_industry_insights_preserved() {
+$method = new ReflectionMethod( RTBCB_Ajax::class, 'structure_report_data' );
+$method->setAccessible( true );
+
+$user_inputs     = [ 'company_name' => 'Test', 'industry' => 'finance' ];
+$enriched_profile = [];
+$roi_scenarios    = [ 'conservative' => [], 'base' => [], 'optimistic' => [] ];
+$recommendation   = [ 'recommended' => '', 'category_info' => [] ];
+$final_analysis   = [
+'industry_insights' => [
+'sector_trends'            => 'trend',
+'competitive_benchmarks'   => 'benchmark',
+'regulatory_considerations' => 'regulation',
+],
+];
+
+$result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], microtime( true ) );
+
+self::assertSame( $final_analysis['industry_insights'], $result['industry_insights'] );
+}
 }
 

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -54,9 +54,14 @@ if ( ! function_exists( 'update_option' ) ) {
 	}
 }
 if ( ! function_exists( 'sanitize_text_field' ) ) {
-	function sanitize_text_field( $text ) {
-		return is_string( $text ) ? trim( $text ) : '';
-	}
+        function sanitize_text_field( $text ) {
+                return is_string( $text ) ? trim( $text ) : '';
+        }
+}
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+function sanitize_textarea_field( $text ) {
+return is_string( $text ) ? trim( $text ) : '';
+}
 }
 if ( ! function_exists( 'sanitize_email' ) ) {
 	function sanitize_email( $email ) {


### PR DESCRIPTION
## Summary
- include industry_insights data in `validate_and_structure_analysis`
- forward `industry_insights` untouched in `structure_report_data`
- test that industry insights survive structuring and add test stub for `sanitize_textarea_field`

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b840fc0b148331807eb356b7279ba4