### PR TITLE
Expose RAG context in report data

### DIFF
--- a/tests/RTBCB_StructureReportDataTest.php
+++ b/tests/RTBCB_StructureReportDataTest.php
@@ -74,7 +74,7 @@ $final_analysis = [
 ],
 ];
 
-$result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], microtime( true ), [] );
+$result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], [], microtime( true ), [] );
 
 $profile   = $result['company_intelligence']['enriched_profile'];
 $company   = $result['company_intelligence'];
@@ -114,7 +114,7 @@ $final_analysis   = [
 ],
 ];
 
-$result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], microtime( true ), [] );
+$result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], [], microtime( true ), [] );
 
 self::assertSame( $final_analysis['industry_insights'], $result['industry_insights'] );
 }
@@ -133,9 +133,25 @@ $financial_benchmarks = [
 ];
 $final_analysis   = [ 'financial_benchmarks' => $financial_benchmarks ];
 
-$result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], microtime( true ), $financial_benchmarks );
+$result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], [], microtime( true ), $financial_benchmarks );
 
 self::assertSame( $financial_benchmarks, $result['financial_benchmarks'] );
+}
+
+public function test_rag_context_included() {
+$method = new ReflectionMethod( RTBCB_Ajax::class, 'structure_report_data' );
+$method->setAccessible( true );
+
+$user_inputs     = [ 'company_name' => 'Test', 'industry' => 'finance' ];
+$enriched_profile = [];
+$roi_scenarios    = [ 'conservative' => [], 'base' => [], 'optimistic' => [] ];
+$recommendation   = [ 'recommended' => '', 'category_info' => [] ];
+$final_analysis   = [];
+$rag_context      = [ 'ctx' ];
+
+$result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $rag_context, [], microtime( true ), [] );
+
+self::assertSame( $rag_context, $result['rag_context'] );
 }
 }
 

--- a/tests/financial-benchmarks-template.test.php
+++ b/tests/financial-benchmarks-template.test.php
@@ -55,7 +55,7 @@ $final_analysis   = [ 'financial_benchmarks' => $financial_benchmarks ];
 
 $method = new ReflectionMethod( RTBCB_Ajax::class, 'structure_report_data' );
 $method->setAccessible( true );
-$report_data = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], microtime( true ), $financial_benchmarks );
+$report_data = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], [], microtime( true ), $financial_benchmarks );
 
 ob_start();
 include __DIR__ . '/../templates/comprehensive-report-template.php';


### PR DESCRIPTION
## Summary
- capture RAG search results as `rag_context` and pass them to report assembly
- expose `rag_context` in `structure_report_data`
- test that report data includes `rag_context` when present

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b8468dd7cc8331b33ada34eba9fdb2