### PR TITLE
Handle industry insights in analysis structuring

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -991,7 +991,7 @@ $tech_prompt .= '\nContext: ' . implode( '\n', array_map( 'sanitize_text_field',
 'operational_insights'   => $analysis['operational_insights'] ?? [],
 'risk_analysis'          => $analysis['risk_analysis'] ?? [],
 'action_plan'            => $analysis['action_plan'] ?? [],
-'industry_insights'      => $analysis['industry_insights'] ?? [],
+	'industry_insights'      => $analysis['industry_insights'] ?? [],
 'technology_strategy'    => $analysis['technology_strategy'] ?? [],
 'financial_analysis'     => $analysis['financial_analysis'] ?? [],
 'implementation_roadmap' => $analysis['implementation_roadmap'] ?? [],
@@ -1873,7 +1873,7 @@ $json            = $this->response_parser->process_openai_response( $parsed_resp
 'complexity'            => 'low|medium|high',
 'potential_savings'     => 'time/cost savings',
 'implementation_effort' => 'effort required',
-],
+	],
 ],
 ],
 'financial_analysis' => [
@@ -1938,9 +1938,9 @@ $json            = $this->response_parser->process_openai_response( $parsed_resp
 'vendor_considerations' => [ 'vendor selection criteria', 'implementation considerations' ],
 ],
 'industry_insights' => [
-'sector_trends' => [ 'trend 1 affecting treasury operations', 'trend 2 driving technology adoption' ],
-'competitive_benchmarks' => [ 'benchmark 1 for treasury efficiency', 'benchmark 2 for technology adoption' ],
-'regulatory_considerations' => [ 'regulatory requirement 1', 'regulatory requirement 2' ],
+		'sector_trends' => [ 'trend 1 affecting treasury operations', 'trend 2 driving technology adoption' ],
+		'competitive_benchmarks' => [ 'benchmark 1 for treasury efficiency', 'benchmark 2 for technology adoption' ],
+		'regulatory_considerations' => [ 'regulatory requirement 1', 'regulatory requirement 2' ],
 ],
 'risk_analysis' => [
 'implementation_risks' => [ 'risk 1: description and likelihood', 'risk 2: description and impact' ],
@@ -2407,11 +2407,11 @@ return $this->validate_and_structure_analysis( $analysis_data );
 'process_improvements'     => [],
 'automation_opportunities' => [],
 ],
-'industry_insights'   => [
-'sector_trends'          => sanitize_textarea_field( $analysis_data['industry_insights']['sector_trends'] ?? '' ),
-'competitive_benchmarks' => sanitize_textarea_field( $analysis_data['industry_insights']['competitive_benchmarks'] ?? '' ),
-'regulatory_considerations' => sanitize_textarea_field( $analysis_data['industry_insights']['regulatory_considerations'] ?? '' ),
-],
+	'industry_insights'   => [
+		'sector_trends'          => array_map( 'sanitize_textarea_field', (array) ( $analysis_data['industry_insights']['sector_trends'] ?? [] ) ),
+		'competitive_benchmarks' => array_map( 'sanitize_textarea_field', (array) ( $analysis_data['industry_insights']['competitive_benchmarks'] ?? [] ) ),
+		'regulatory_considerations' => array_map( 'sanitize_textarea_field', (array) ( $analysis_data['industry_insights']['regulatory_considerations'] ?? [] ) ),
+	],
 'financial_analysis' => [
 'investment_breakdown' => [
 'software_licensing'        => sanitize_textarea_field( $analysis_data['financial_analysis']['investment_breakdown']['software_licensing'] ?? '' ),

--- a/tests/RTBCB_StructureReportDataTest.php
+++ b/tests/RTBCB_StructureReportDataTest.php
@@ -106,16 +106,25 @@ $user_inputs     = [ 'company_name' => 'Test', 'industry' => 'finance' ];
 $enriched_profile = [];
 $roi_scenarios    = [ 'conservative' => [], 'base' => [], 'optimistic' => [] ];
 $recommendation   = [ 'recommended' => '', 'category_info' => [] ];
-$final_analysis   = [
+$analysis_data    = [
+'executive_summary' => [],
+'operational_insights' => [],
 'industry_insights' => [
-'sector_trends'            => 'trend',
-'competitive_benchmarks'   => 'benchmark',
-'regulatory_considerations' => 'regulation',
+'sector_trends'            => [ 'trend' ],
+'competitive_benchmarks'   => [ 'benchmark' ],
+'regulatory_considerations' => [ 'regulation' ],
 ],
 ];
 
+$llm_reflection  = new ReflectionClass( RTBCB_LLM::class );
+$llm             = $llm_reflection->newInstanceWithoutConstructor();
+$analysis_method = new ReflectionMethod( RTBCB_LLM::class, 'validate_and_structure_analysis' );
+$analysis_method->setAccessible( true );
+$final_analysis  = $analysis_method->invoke( $llm, $analysis_data );
+
 $result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], microtime( true ), [] );
 
+self::assertSame( [ 'trend' ], $final_analysis['industry_insights']['sector_trends'] );
 self::assertSame( $final_analysis['industry_insights'], $result['industry_insights'] );
 }
 


### PR DESCRIPTION
## Summary
- sanitize industry insight lists element-wise to preserve array data
- extend structure report test to verify sanitized array handling

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b846be47808331a27f49cdc3d9c581