### PR TITLE
Handle industry insights in analysis structuring

### DIFF
--- a/tests/RTBCB_StructureReportDataTest.php
+++ b/tests/RTBCB_StructureReportDataTest.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || exit;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../inc/class-rtbcb-ajax.php';
+require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
 
 if ( ! function_exists( '__' ) ) {
 function __( $text, $domain = null ) {


### PR DESCRIPTION
## Summary
- sanitize industry insight lists element-wise to preserve array data
- extend structure report test to verify sanitized array handling
- load LLM class in structure report data test

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Call to undefined function esc_html_e)*
- `vendor/bin/phpcs --standard=WordPress` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68b84a4a246c8331a9df90b9c27ba2e4