### PR TITLE
Handle industry insights in analysis structuring

### DIFF
--- a/tests/RTBCB_StructureReportDataTest.php
+++ b/tests/RTBCB_StructureReportDataTest.php
@@ -6,17 +6,13 @@ defined( 'ABSPATH' ) || exit;
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/wp-stubs.php';
 require_once __DIR__ . '/../inc/class-rtbcb-ajax.php';
 require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
 
 if ( ! function_exists( '__' ) ) {
 function __( $text, $domain = null ) {
 return $text;
-}
-}
-if ( ! function_exists( 'sanitize_text_field' ) ) {
-function sanitize_text_field( $text ) {
-return is_string( $text ) ? trim( $text ) : '';
 }
 }
 if ( ! function_exists( 'current_time' ) ) {


### PR DESCRIPTION
## Summary
- sanitize industry insight lists element-wise to preserve array data
- extend structure report test to verify sanitized array handling
- load LLM class in structure report data test
- bootstrap WordPress stubs before loading LLM in structure report test

## Testing
- `composer install`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b84dfc1ea08331a6ba5dfd86c9d322