### PR TITLE
Return JSON error for invalid report type

### DIFF
--- a/inc/class-rtbcb-router.php
+++ b/inc/class-rtbcb-router.php
@@ -48,15 +48,22 @@ class RTBCB_Router {
 
                        $form_data = $validated_data;
 
-                       // Determine report type from request if provided.
-                       if ( isset( $_POST['report_type'] ) ) {
-                               $requested_type = sanitize_text_field( wp_unslash( $_POST['report_type'] ) );
-                               if ( ! in_array( $requested_type, $allowed_types, true ) ) {
-                                       return new WP_Error( 'rtbcb_invalid_report_type', __( 'Invalid report type.', 'rtbcb' ) );
-                               }
-                               $report_type = $requested_type;
-                       }
-
+			// Determine report type from request if provided.
+			if ( isset( $_POST['report_type'] ) ) {
+				$requested_type = sanitize_text_field( wp_unslash( $_POST['report_type'] ) );
+				if ( ! in_array( $requested_type, $allowed_types, true ) ) {
+					RTBCB_Logger::log(
+						'invalid_report_type',
+						[ 'requested_type' => $requested_type ]
+					);
+					wp_send_json_error(
+						[ 'message' => __( 'Invalid report type.', 'rtbcb' ) ],
+						400
+					);
+					return;
+				}
+				$report_type = $requested_type;
+			}
                        // Perform ROI calculations.
                        $calculations   = RTBCB_Calculator::calculate_roi( $form_data );
                        $recommendation = RTBCB_Category_Recommender::recommend_category( $form_data );


### PR DESCRIPTION
## Summary
- send structured log and JSON error when report_type is outside the allowlist

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b86a979160833191b85c22692909be