### PR TITLE
Document report type options

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,28 @@ If testing the template outside WordPress, manually include:
 
 before the closing `</body>` tag.
 
+## Report Types
+
+The `report_type` parameter determines the depth of the generated report:
+
+- `basic` - summary results with minimal narrative.
+- `comprehensive` - full report with ROI analysis and detailed sections.
+- `fast` - quick preview that skips heavy calculations.
+
+`action_plan`, `operational_insights`, and `risk_analysis` are returned only when
+`report_type` is `comprehensive` and `fast_mode` is `false`.
+
+### Example Request
+
+```json
+{
+    "action": "rtbcb_generate_case",
+    "report_type": "comprehensive",
+    "fast_mode": false,
+    "company_name": "Acme Corp"
+}
+```
+
 ## 🗂️ Repository Structure
 
 - `admin/` – WordPress dashboard pages, settings, and nonces.

--- a/docs/WIZARD_FORM_API_FLOW.md
+++ b/docs/WIZARD_FORM_API_FLOW.md
@@ -29,6 +29,28 @@ Field definitions come from `templates/business-case-form.php` and the field reg
 
 `public/js/rtbcb-wizard.js` serializes the form and posts it to WordPress’s AJAX endpoint with the action `rtbcb_generate_case`. On success, the returned report data is rendered in the page; otherwise an error overlay is displayed.
 
+## Report Types
+
+The API accepts a `report_type` parameter:
+
+- `basic` - summary results with minimal narrative.
+- `comprehensive` - full report with ROI analysis and detailed sections.
+- `fast` - quick preview that skips heavy calculations.
+
+`action_plan`, `operational_insights`, and `risk_analysis` are returned only when
+`report_type` is `comprehensive` and `fast_mode` is `false`.
+
+### Example Request
+
+```json
+{
+    "action": "rtbcb_generate_case",
+    "report_type": "comprehensive",
+    "fast_mode": false,
+    "company_name": "Acme Corp"
+}
+```
+
 ## Server-side Processing
 
 `RTBCB_Main::ajax_generate_comprehensive_case()` validates the request and orchestrates report generation:


### PR DESCRIPTION
## Summary
- document available `report_type` values and when extra sections are returned
- add example request payload for comprehensive reports

## Testing
- `npx markdownlint README.md docs/WIZARD_FORM_API_FLOW.md` *(fails: multiple existing style warnings)*
- `npx markdownlint docs/**/*.md`
- `npx markdown-link-check docs/WIZARD_FORM_API_FLOW.md`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*
- `phpcs --standard=WordPress` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ad958f88331b3bac614b4977a37