### PR TITLE
Check AJAX action before sending headers

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -62,11 +62,17 @@ class RTBCB_Ajax {
 		*
 		* @return void
 		*/
-       public static function stream_analysis() {
+	public static function stream_analysis() {
 
-	       if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
-		       wp_die( 'Invalid request' );
-	       }
+		$action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : '';
+		if ( 'rtbcb_stream_analysis' !== $action ) {
+			// Jetpack also routes requests through admin-ajax.php; avoid processing unrelated actions.
+			return;
+	}
+
+               if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
+                       wp_die( 'Invalid request' );
+               }
 
 	       if ( ! function_exists( 'check_ajax_referer' ) ) {
 		       wp_die( 'WordPress not ready' );
@@ -94,17 +100,10 @@ class RTBCB_Ajax {
 		       return;
 	       }
 
-	       $action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : '';
-			       if ( 'rtbcb_stream_analysis' !== $action ) {
-			       // Jetpack also routes requests through admin-ajax.php; avoid sending
-			       // streaming headers for unrelated actions.
-			       return;
-			       }
-
-				nocache_headers();
-				header( 'Content-Type: text/event-stream' );
-				header( 'Cache-Control: no-cache' );
-				header( 'Connection: keep-alive' );
+                               nocache_headers();
+                                header( 'Content-Type: text/event-stream' );
+                                header( 'Cache-Control: no-cache' );
+                                header( 'Connection: keep-alive' );
 
 				$scenarios      = RTBCB_Calculator::calculate_roi( $user_inputs );
 				$recommendation = RTBCB_Category_Recommender::recommend_category( $user_inputs );

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1,4 +1,4 @@
-<?php
+	<?php
 defined( 'ABSPATH' ) || exit;
 require_once __DIR__ . '/class-rtbcb-response-parser.php';
 
@@ -1601,7 +1601,13 @@ function rtbcb_parse_gpt5_response( $response, $store_raw = false ) {
 	* @return void
 	*/
 function rtbcb_proxy_openai_responses() {
-		$api_key = rtbcb_get_openai_api_key();
+	$action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : '';
+	if ( 'rtbcb_openai_responses' !== $action ) {
+		// Jetpack also routes requests through admin-ajax.php; avoid processing unrelated actions.
+		return;
+	}
+
+	$api_key = rtbcb_get_openai_api_key();
 		if ( ! rtbcb_has_openai_api_key() ) {
 			wp_send_json_error( [ 'message' => __( 'OpenAI API key not configured.', 'rtbcb' ) ], 500 );
 		}
@@ -1635,14 +1641,7 @@ function rtbcb_proxy_openai_responses() {
 	$body_array['stream']			 = true;
 	$payload						 = wp_json_encode( $body_array );
 
-	$action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : '';
-	if ( 'rtbcb_openai_responses' !== $action ) {
-		// Jetpack also routes requests through admin-ajax.php; avoid sending
-		// streaming headers for unrelated actions.
-		return;
-	}
-
-	nocache_headers();
+       nocache_headers();
 	header( 'Content-Type: text/event-stream' );
 	header( 'Cache-Control: no-cache' );
 	header( 'Connection: keep-alive' );

--- a/tests/non-rtbcb-ajax.test.php
+++ b/tests/non-rtbcb-ajax.test.php
@@ -1,0 +1,40 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+require_once __DIR__ . '/wp-stubs.php';
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		return preg_replace( '/[^a-z0-9_]/', '', strtolower( $key ) );
+	}
+}
+ob_start();
+require_once __DIR__ . '/../inc/helpers.php';
+require_once __DIR__ . '/../inc/class-rtbcb-ajax.php';
+ob_end_clean();
+
+// Ensure non-RTBCB actions produce no output or headers.
+header_remove();
+$_REQUEST['action'] = 'unrelated_action';
+ob_start();
+rtbcb_proxy_openai_responses();
+$output = ob_get_clean();
+$headers = headers_list();
+if ( '' !== $output || ! empty( $headers ) ) {
+	echo "rtbcb_proxy_openai_responses affected non-RTBCB action\n";
+	exit( 1 );
+}
+
+header_remove();
+$_REQUEST['action'] = 'unrelated_action';
+ob_start();
+RTBCB_Ajax::stream_analysis();
+$output = ob_get_clean();
+$headers = headers_list();
+if ( '' !== $output || ! empty( $headers ) ) {
+	echo "RTBCB_Ajax::stream_analysis affected non-RTBCB action\n";
+	exit( 1 );
+}
+
+echo "non-rtbcb-ajax.test.php passed\n";

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -104,6 +104,9 @@ php tests/jetpack-compatibility.test.php
 echo "14e. Running reports bulk delete test..."
 php tests/reports-bulk-delete.test.php
 
+echo "14f. Running non-RTBCB AJAX test..."
+php tests/non-rtbcb-ajax.test.php
+
 # JavaScript tests
 echo "16. Running JavaScript tests..."
 node tests/handle-submit-error.test.js


### PR DESCRIPTION
## Summary
- Verify `$_REQUEST['action']` before sending headers in OpenAI proxy and stream analysis handlers.
- Early-return for unrelated AJAX actions so headers aren't emitted.
- Add regression test ensuring non-RTBCB actions remain unaffected and run in test script.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`
- `php tests/non-rtbcb-ajax.test.php`


------
https://chatgpt.com/codex/tasks/task_e_68b881609a6c83318e4ec344998f707b