### PR TITLE
Detect WP.com hosting and disable SSE

### DIFF
--- a/docs/LLM_WPCOM_PARSING.md
+++ b/docs/LLM_WPCOM_PARSING.md
@@ -34,6 +34,9 @@ overall report generation process.
     keys to the repository.
 - WordPress.com uses a shared hosting model. Ensure outbound HTTP requests to OpenAI are
     allowed and that the site’s plan includes external API access.
+- Server-sent events are blocked on WordPress.com. `RTBCB_Ajax::stream_analysis` and
+    `rtbcb_proxy_openai_responses` detect this hosting and return a
+    `streaming_unsupported` error so clients can fall back to polling.
 - Responses may include unexpected prefixes or truncated streaming data. Monitor logs for
     `RTBCB` entries to catch parsing warnings or errors.
 

--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -17,9 +17,9 @@ class RTBCB_Ajax {
 		       wp_die( 'WordPress not ready' );
 	       }
 
-	       $params = self::get_sanitized_params();
+$params = self::get_sanitized_params();
 
-	       rtbcb_increase_memory_limit();
+rtbcb_increase_memory_limit();
 	       $timeout = absint( rtbcb_get_api_timeout() );
 	       if ( ! ini_get( 'safe_mode' ) && $timeout > 0 ) {
 		       set_time_limit( $timeout );
@@ -62,7 +62,7 @@ class RTBCB_Ajax {
 		*
 		* @return void
 		*/
-       public static function stream_analysis() {
+public static function stream_analysis() {
 
 	       if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
 		       wp_die( 'Invalid request' );
@@ -72,9 +72,15 @@ class RTBCB_Ajax {
 		       wp_die( 'WordPress not ready' );
 	       }
 
-	       $params = self::get_sanitized_params();
-
-	       rtbcb_increase_memory_limit();
+	$params = self::get_sanitized_params();
+	
+	if ( function_exists( 'rtbcb_is_wpcom' ) && rtbcb_is_wpcom() ) {
+		self::log_request( __FUNCTION__, $params, 'error', [ 'code' => 'streaming_unsupported' ] );
+		wp_send_json_error( [ 'code' => 'streaming_unsupported', 'message' => __( 'Streaming is not supported on this hosting environment.', 'rtbcb' ) ], 400 );
+		return;
+	}
+	
+	rtbcb_increase_memory_limit();
 	       $timeout = absint( rtbcb_get_api_timeout() );
 	       if ( ! ini_get( 'safe_mode' ) && $timeout > 0 ) {
 		       set_time_limit( $timeout );

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -144,6 +144,9 @@ php tests/company-research-cache.test.php
 echo "18c. Running Jetpack cron test..."
 php tests/jetpack-cron.test.php
 
+echo "18d. Running WordPress.com streaming fallback test..."
+php tests/wpcom-sse-fallback.test.php
+
 echo "19. Running validator tests..."
 vendor/bin/phpunit -c phpunit.xml
 

--- a/tests/wpcom-sse-fallback.test.php
+++ b/tests/wpcom-sse-fallback.test.php
@@ -1,0 +1,93 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+define( 'DOING_AJAX', true );
+define( 'IS_WPCOM', true );
+
+if ( ! function_exists( 'check_ajax_referer' ) ) {
+function check_ajax_referer( $action, $query_arg = false, $die = true ) {
+return true;
+}
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+function sanitize_key( $key ) {
+return $key;
+}
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+function sanitize_text_field( $text ) {
+return $text;
+}
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+function wp_unslash( $value ) {
+return $value;
+}
+}
+if ( ! function_exists( '__' ) ) {
+function __( $text, $domain = null ) {
+return $text;
+}
+}
+if ( ! function_exists( 'wp_die' ) ) {
+function wp_die( $msg = '' ) {}
+}
+if ( ! function_exists( 'sanitize_email' ) ) {
+function sanitize_email( $email ) {
+return $email;
+}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+function wp_json_encode( $data ) {
+return json_encode( $data );
+}
+}
+if ( ! function_exists( 'nocache_headers' ) ) {
+function nocache_headers() {}
+}
+if ( ! function_exists( 'header' ) ) {
+function header( $str ) {}
+}
+if ( ! function_exists( 'get_option' ) ) {
+function get_option( $name, $default = null ) {
+return $default;
+}
+}
+
+require_once __DIR__ . '/../inc/helpers.php';
+require_once __DIR__ . '/../inc/class-rtbcb-ajax.php';
+
+$sent_error = null;
+if ( ! function_exists( 'wp_send_json_error' ) ) {
+function wp_send_json_error( $data = null, $status = null ) {
+global $sent_error;
+$sent_error = [
+'data'   => $data,
+'status' => $status,
+];
+}
+}
+if ( ! function_exists( 'wp_send_json_success' ) ) {
+function wp_send_json_success( $data = null ) {}
+}
+
+$_REQUEST = [ 'action' => 'rtbcb_stream_analysis', 'rtbcb_nonce' => 'nonce' ];
+RTBCB_Ajax::stream_analysis();
+if ( 'streaming_unsupported' !== ( $sent_error['data']['code'] ?? '' ) ) {
+echo "stream_analysis fallback not triggered\n";
+exit( 1 );
+}
+
+$sent_error = null;
+$_POST    = [ 'body' => json_encode( [ 'foo' => 'bar' ] ), 'nonce' => 'nonce' ];
+$_REQUEST = [ 'action' => 'rtbcb_openai_responses' ];
+rtbcb_proxy_openai_responses();
+if ( 'streaming_unsupported' !== ( $sent_error['data']['code'] ?? '' ) ) {
+echo "proxy fallback not triggered\n";
+exit( 1 );
+}
+
+echo "wpcom-sse-fallback.test.php passed\n";


### PR DESCRIPTION
## Summary
- detect WordPress.com hosting and return `streaming_unsupported` to avoid SSE
- document WP.com streaming fallback
- add integration test and wire into test runner

## Testing
- `npx --yes markdownlint-cli docs/**/*.md`
- `npx --yes markdown-link-check docs/LLM_WPCOM_PARSING.md`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b88137945c8331af4c4193ba09f471