### PR TITLE
Ensure AJAX handlers verify action before sending headers

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -63,17 +63,17 @@ rtbcb_increase_memory_limit();
 		* @return void
 		*/
 
-	public static function stream_analysis() {
-		if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
-			wp_die( 'Invalid request' );
-		}
+       public static function stream_analysis() {
+               $action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : '';
+               if ( 'rtbcb_stream_analysis' !== $action ) {
+                       // Jetpack also routes requests through admin-ajax.php; avoid sending
+                       // streaming headers for unrelated actions.
+                       return;
+               }
 
-		$action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : '';
-		if ( 'rtbcb_stream_analysis' !== $action ) {
-			// Jetpack also routes requests through admin-ajax.php; avoid sending
-			// streaming headers for unrelated actions.
-			return;
-		}
+               if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
+                       wp_die( 'Invalid request' );
+               }
 
 		if ( ! function_exists( 'check_ajax_referer' ) ) {
 			wp_die( 'WordPress not ready' );

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1630,12 +1630,12 @@ function rtbcb_parse_gpt5_response( $response, $store_raw = false ) {
 	*/
 
 function rtbcb_proxy_openai_responses() {
-	$action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : '';
-	if ( 'rtbcb_openai_responses' !== $action ) {
-		// Jetpack also routes requests through admin-ajax.php; avoid sending
-		// streaming headers for unrelated actions.
-		return;
-	}
+        // Only handle our specific AJAX action; bail early for others.
+        if ( ! isset( $_REQUEST['action'] ) || 'rtbcb_openai_responses' !== sanitize_key( wp_unslash( $_REQUEST['action'] ) ) ) {
+                // Jetpack also routes requests through admin-ajax.php; avoid sending
+                // streaming headers for unrelated actions.
+                return;
+        }
 
 	$api_key = rtbcb_get_openai_api_key();
 	if ( ! rtbcb_has_openai_api_key() ) {

--- a/tests/non-rtbcb-ajax.test.php
+++ b/tests/non-rtbcb-ajax.test.php
@@ -4,8 +4,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 defined( 'ABSPATH' ) || exit;
 
-define( 'DOING_AJAX', true );
-
 if ( ! function_exists( 'sanitize_key' ) ) {
     function sanitize_key( $key ) {
         return $key;
@@ -16,11 +14,15 @@ if ( ! function_exists( 'wp_unslash' ) ) {
         return $value;
     }
 }
-if ( ! function_exists( 'wp_die' ) ) {
-    function wp_die( $msg = '' ) {}
-}
-
+// Track calls to wp_die and nocache_headers to ensure early returns.
+$wp_die_count   = 0;
 $nocache_count = 0;
+if ( ! function_exists( 'wp_die' ) ) {
+    function wp_die( $msg = '' ) {
+        global $wp_die_count;
+        $wp_die_count++;
+    }
+}
 if ( ! function_exists( 'nocache_headers' ) ) {
     function nocache_headers() {
         global $nocache_count;
@@ -31,22 +33,47 @@ if ( ! function_exists( 'nocache_headers' ) ) {
 require_once __DIR__ . '/../inc/helpers.php';
 require_once __DIR__ . '/../inc/class-rtbcb-ajax.php';
 
+// Mismatched action should not trigger headers or wp_die.
 ob_start();
 $_REQUEST = [ 'action' => 'other_action' ];
 rtbcb_proxy_openai_responses();
 $output = ob_get_clean();
-if ( 0 !== $nocache_count || '' !== $output ) {
+if ( 0 !== $nocache_count || 0 !== $wp_die_count || '' !== $output ) {
     echo "rtbcb_proxy_openai_responses interfered with other actions\n";
     exit( 1 );
 }
 
 $nocache_count = 0;
+$wp_die_count  = 0;
 ob_start();
 $_REQUEST = [ 'action' => 'other_action' ];
 RTBCB_Ajax::stream_analysis();
 $output = ob_get_clean();
-if ( 0 !== $nocache_count || '' !== $output ) {
+if ( 0 !== $nocache_count || 0 !== $wp_die_count || '' !== $output ) {
     echo "stream_analysis interfered with other actions\n";
+    exit( 1 );
+}
+
+// Missing action should also be ignored.
+$nocache_count = 0;
+$wp_die_count  = 0;
+ob_start();
+$_REQUEST = [];
+rtbcb_proxy_openai_responses();
+$output = ob_get_clean();
+if ( 0 !== $nocache_count || 0 !== $wp_die_count || '' !== $output ) {
+    echo "rtbcb_proxy_openai_responses interfered with missing action\n";
+    exit( 1 );
+}
+
+$nocache_count = 0;
+$wp_die_count  = 0;
+ob_start();
+$_REQUEST = [];
+RTBCB_Ajax::stream_analysis();
+$output = ob_get_clean();
+if ( 0 !== $nocache_count || 0 !== $wp_die_count || '' !== $output ) {
+    echo "stream_analysis interfered with missing action\n";
     exit( 1 );
 }
 


### PR DESCRIPTION
## Summary
- Avoid emitting headers in `rtbcb_proxy_openai_responses` when the request action doesn't match
- Guard `RTBCB_Ajax::stream_analysis` by checking the AJAX action before `DOING_AJAX`
- Extend non-RTBCB AJAX regression test to cover missing and mismatched actions

## Testing
- `composer install`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b88cc66018833196cf41fde191b22e