### PR TITLE
fix: improve AI highlight toggle accessibility

### DIFF
--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -83,10 +83,10 @@ $processing_time = $metadata['processing_time'] ?? ( $report_data['processing_ti
 										</div>
 </div>
 		<div class="rtbcb-ai-toggle-panel">
-			<span><?php echo esc_html__( 'Highlight AI-Generated Content', 'rtbcb' ); ?></span>
 			<label for="rtbcb-ai-toggle" class="rtbcb-toggle-switch">
 				<input type="checkbox" id="rtbcb-ai-toggle" class="rtbcb-sr-only" />
 				<div class="rtbcb-toggle-track"></div>
+				<span class="rtbcb-toggle-label"><?php echo esc_html__( 'Highlight AI-Generated Content', 'rtbcb' ); ?></span>
 			</label>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary
- move AI highlight toggle's descriptive text inside label for proper association

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: document.querySelector is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a8edf35c8331becbaf16741720c7