### PR TITLE
Enable delete-all action for reports

### DIFF
--- a/admin/reports-page.php
+++ b/admin/reports-page.php
@@ -16,9 +16,33 @@ defined( 'ABSPATH' ) || exit;
         <?php submit_button( __( 'Delete Old Reports', 'rtbcb' ), 'secondary', 'rtbcb_delete_old_reports', false ); ?>
     </form>
 
-    <form method="post">
+    <form method="post" id="rtbcb-reports-form">
         <?php wp_nonce_field( 'rtbcb_reports_action' ); ?>
         <input type="hidden" name="page" value="rtbcb-reports" />
         <?php $table->display(); ?>
     </form>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+var form = document.getElementById('rtbcb-reports-form');
+if (!form) {
+return;
+}
+var selects = form.querySelectorAll('select[name="action"], select[name="action2"]');
+var applyButtons = form.querySelectorAll('input#doaction, input#doaction2');
+function maybeSelectAll() {
+var deleteAll = Array.from(selects).some(function(sel) {
+return 'delete_all' === sel.value;
+});
+if (deleteAll) {
+form.querySelectorAll('input[name="files[]"]').forEach(function(cb) {
+cb.checked = true;
+});
+}
+}
+applyButtons.forEach(function(btn) {
+btn.addEventListener('click', maybeSelectAll);
+});
+});
+</script>


### PR DESCRIPTION
## Summary
- ensure `Delete All` bulk action selects all report files so the action submits

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `php tests/reports-bulk-delete.test.php`
- `timeout 120 bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8b0fca7248331b01c0e6b7b98190e