### PR TITLE
Add Delete All Reports control

### DIFF
--- a/admin/class-rtbcb-reports-table.php
+++ b/admin/class-rtbcb-reports-table.php
@@ -198,19 +198,23 @@ class RTBCB_Reports_Table extends WP_List_Table {
 		    return;
 		}
 
-		if ( 'delete_all' === $action ) {
-		    $files = glob( trailingslashit( $this->reports_dir ) . '*.{html,pdf}', GLOB_BRACE );
-		    $files = $files ? $files : [];
+                if ( 'delete_all' === $action ) {
+                    $files = glob( trailingslashit( $this->reports_dir ) . '*.{html,pdf}', GLOB_BRACE );
+                    $files = $files ? $files : [];
 
-		    foreach ( $files as $file_path ) {
-		        if ( file_exists( $file_path ) ) {
-		            unlink( $file_path );
-		        }
-		    }
+                    foreach ( $files as $file_path ) {
+                        if ( file_exists( $file_path ) ) {
+                            unlink( $file_path );
+                        }
+                    }
 
-		    rtbcb_clear_report_cache();
-		    return;
-		}
+                    rtbcb_clear_report_cache();
+                    wp_safe_redirect( admin_url( 'admin.php?page=rtbcb-reports' ) );
+                    if ( ! defined( 'RTBCB_TESTS' ) ) {
+                        exit;
+                    }
+                    return;
+                }
 
 		$files = isset( $_POST['files'] ) ? (array) wp_unslash( $_POST['files'] ) : [];
 		$files = array_map( 'sanitize_file_name', $files );

--- a/tests/reports-bulk-delete.test.php
+++ b/tests/reports-bulk-delete.test.php
@@ -3,6 +3,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'ABSPATH', __DIR__ . '/../' );
 }
 
+define( 'RTBCB_TESTS', true );
+
+if ( ! function_exists( 'admin_url' ) ) {
+function admin_url( $path = '' ) {
+return 'http://example.com/wp-admin/' . ltrim( $path, '/' );
+}
+}
+
+if ( ! function_exists( 'wp_safe_redirect' ) ) {
+function wp_safe_redirect( $location ) {
+global $redirect_location;
+$redirect_location = $location;
+}
+}
+
 if ( ! class_exists( 'WP_List_Table' ) ) {
 class WP_List_Table {
 public function __construct( $args = [] ) {}
@@ -69,6 +84,8 @@ return true;
 }
 }
 
+$redirect_location = '';
+
 $clear_called = 0;
 function rtbcb_clear_report_cache() {
 global $clear_called;
@@ -117,6 +134,11 @@ $_REQUEST['action'] = 'delete_all';
 $_POST              = [ '_wpnonce' => 'nonce' ];
 
 $table->prepare_items();
+
+if ( admin_url( 'admin.php?page=rtbcb-reports' ) !== $redirect_location ) {
+echo "No redirect after delete all\n";
+exit( 1 );
+}
 
 if ( glob( $reports_dir . '/*' ) ) {
 echo "Delete all failed\n";


### PR DESCRIPTION
## Summary
- add Delete All Reports button to admin list for easier cleanup
- remove unused delete_all bulk action
- redirect after Delete All action to clear query

## Testing
- `composer install`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`
- `phpcs --standard=WordPress admin/class-rtbcb-reports-table.php tests/reports-bulk-delete.test.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b90a66148331adc6a30df35a75a6