### PR TITLE
Handle new streaming response events

### DIFF
--- a/tests/RTBCB_ResponseParserProcessTest.php
+++ b/tests/RTBCB_ResponseParserProcessTest.php
@@ -72,12 +72,12 @@ final class RTBCB_ResponseParserProcessTest extends TestCase {
        }
 
 	public function test_parses_streaming_response() {
-		$stream  = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n";
-		$stream .= "data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n";
-		$stream .= "data: {\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"Hello world\"}}]}\n\n";
-		$stream .= "data: [DONE]\n\n";
-		$decoded = $this->parser->process_openai_response( $stream );
-		$this->assertSame( 'Hello world', $decoded );
-       }
+                $stream  = "data: {\"type\":\"response.output_text.delta\",\"delta\":{\"text\":\"Hello\"}}\n\n";
+                $stream .= "data: {\"type\":\"response.output_text.delta\",\"delta\":{\"text\":\" world\"}}\n\n";
+                $stream .= "data: {\"type\":\"response.output_text.done\",\"response\":{\"output_text\":\"Hello world\"}}\n\n";
+                $stream .= "data: [DONE]\n\n";
+                $decoded = $this->parser->process_openai_response( $stream );
+                $this->assertSame( 'Hello world', $decoded['output_text'] );
+        }
 }
 

--- a/tests/wpcom-streaming-response.test.php
+++ b/tests/wpcom-streaming-response.test.php
@@ -8,17 +8,19 @@ require_once __DIR__ . '/../inc/class-rtbcb-response-parser.php';
 
 $parser = new RTBCB_Response_Parser();
 
-$stream  = "for (;;);\n";
-$stream .= "for (;;); event: ping\n";
-$stream .= "for (;;); data: {invalid json}\n\n";
-$stream .= "   for (;;); data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n";
-$stream .= "for (;;); data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n";
-$stream .= "for (;;); data: {\"choices\":[{\"message\":{\"content\":\"Hello world\"}}]}\n\n";
+$stream  = "for (;;); data: {\"type\":\"response.reasoning.delta\",\"delta\":{\"text\":\"thinking\"}}\n\n";
+$stream .= "for (;;); data: {\"type\":\"response.output_text.delta\",\"delta\":{\"text\":\"Hello\"}}\n\n";
+$stream .= "for (;;); data: {\"type\":\"response.output_text.delta\",\"delta\":{\"text\":\" world\"}}\n\n";
+$stream .= "for (;;); data: {\"type\":\"response.output_text.done\",\"response\":{\"output_text\":\"Hello world\"}}\n\n";
 $stream .= "for (;;); data: [DONE]\n\n";
 
 $result = $parser->process_openai_response( $stream );
-if ( 'Hello world' !== $result ) {
-    echo "wpcom-streaming-response.test.php failed\n";
+if ( 'Hello world' !== $result['output_text'] ) {
+    echo "wpcom-streaming-response.test.php failed: output_text\n";
+    exit( 1 );
+}
+if ( [ 'thinking' ] !== $result['reasoning'] ) {
+    echo "wpcom-streaming-response.test.php failed: reasoning\n";
     exit( 1 );
 }
 


### PR DESCRIPTION
## Summary
- Parse new `response.output_text.delta`, `response.output_text.done`, and `response.reasoning.delta` events in streaming responses
- Capture streamed output text and reasoning segments for downstream consumption
- Extend tests to cover new event types and reasoning capture

## Testing
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b8bb3b549c8331aee17b145388b267