### PR TITLE
docs: explain how to view JSON responses

### DIFF
--- a/docs/DEBUGGING_JSON_RESPONSES.md
+++ b/docs/DEBUGGING_JSON_RESPONSES.md
@@ -1,0 +1,14 @@
+# Debugging JSON Responses
+
+When the wizard submits data, WordPress handles the request at `admin-ajax.php` and returns a JSON response dynamically. No JSON file is saved to disk.
+
+To inspect the response and verify fields like the analysis date:
+
+- **Browser DevTools**
+    - Open the Network tab, submit the form, and select the `admin-ajax.php` request.
+    - The **Response** panel displays the raw JSON returned by the server.
+- **API Logs Page**
+    - In the WordPress admin dashboard, go to **Business Case Builder → API Logs**.
+    - Each log entry stores the request and response payloads. Click **View** to inspect the saved JSON.
+
+These are the only locations where the JSON exists. If a field such as the analysis date is missing, review the response in one of the above locations to determine whether the server omitted it or if the frontend failed to display it.


### PR DESCRIPTION
## Summary
- Document how the plugin's AJAX responses are generated and where to inspect them

## Testing
- `npx --yes markdownlint-cli docs/**/*.md`
- `npx --yes markdown-link-check docs/DEBUGGING_JSON_RESPONSES.md`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8bd4dada48331accee48907a2b301