### PR TITLE
Handle vendor metadata fallback in supporting context

### DIFF
--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -629,7 +629,10 @@ $tech_adoption      = $sector_analysis['technology_adoption'] ?? ( $benchmarking
 						if ( isset( $context_item['metadata'] ) ) {
 						       if ( is_array( $context_item['metadata'] ) ) {
 							       $context_text = $context_item['metadata']['content'] ?? '';
-						       } else {
+							       if ( 'vendor' === $source_type && '' === $context_text ) {
+								       $context_text = $context_item['metadata']['description'] ?? $context_item['metadata']['name'] ?? '';
+							}
+						} else {
 							       $context_text = $context_item['metadata'];
 						       }
 						}


### PR DESCRIPTION
## Summary
- Use vendor description or name when context content is missing in the Supporting Context list

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`
- `vendor/bin/phpcs --standard=WordPress templates/comprehensive-report-template.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bfa1221c8331a981bca83332cdcd