### PR TITLE
Summarize structured operational insights

### DIFF
--- a/tests/RTBCB_StructureReportDataTest.php
+++ b/tests/RTBCB_StructureReportDataTest.php
@@ -163,30 +163,42 @@ $final_analysis  = $analysis_method->invoke( $llm, $analysis_data );
 
 $result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], microtime( true ), [] );
 
-self::assertSame( [ 'Manual process', 'Siloed data' ], $final_analysis['operational_insights']['current_state_assessment'] );
+self::assertSame( [ 'Manual process', 'Siloed data' ], $result['operational_insights']['current_state_assessment'] );
 self::assertSame(
-[
-[
-'process_area'   => 'Reconciliation',
-'current_state'  => 'Manual spreadsheets',
-'improved_state' => 'Automated workflow',
-'impact_level'   => 'High',
-],
-],
-$final_analysis['operational_insights']['process_improvements']
+	[ 'Reconciliation: Manual spreadsheets → Automated workflow (High impact)' ],
+	$result['operational_insights']['process_improvements']
 );
 self::assertSame(
-[
-[
-'opportunity'           => 'Cash Forecasting',
-'complexity'            => 'Medium',
-'time_savings'         => 8.0,
-'implementation_effort' => 'Low',
-],
-],
-$final_analysis['operational_insights']['automation_opportunities']
+	[ 'Cash Forecasting: Medium complexity, Low effort → 8 hours saved' ],
+	$result['operational_insights']['automation_opportunities']
 );
-self::assertSame( $final_analysis['operational_insights'], $result['operational_insights'] );
+}
+
+public function test_empty_operational_arrays_default_to_no_data() {
+	$method = new ReflectionMethod( RTBCB_Ajax::class, 'structure_report_data' );
+	$method->setAccessible( true );
+
+	$user_inputs     = [ 'company_name' => 'Test', 'industry' => 'finance' ];
+	$enriched_profile = [];
+	$roi_scenarios    = [ 'conservative' => [], 'base' => [], 'optimistic' => [] ];
+	$recommendation   = [ 'recommended' => '', 'category_info' => [] ];
+	$analysis_data    = [
+		'operational_insights' => [
+			'process_improvements'     => [ [] ],
+			'automation_opportunities' => [ [] ],
+		],
+	];
+
+	$llm_reflection  = new ReflectionClass( RTBCB_LLM::class );
+	$llm             = $llm_reflection->newInstanceWithoutConstructor();
+	$analysis_method = new ReflectionMethod( RTBCB_LLM::class, 'validate_and_structure_analysis' );
+	$analysis_method->setAccessible( true );
+	$final_analysis  = $analysis_method->invoke( $llm, $analysis_data );
+
+	$result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], microtime( true ), [] );
+
+	self::assertSame( [ 'No data provided' ], $result['operational_insights']['process_improvements'] );
+	self::assertSame( [ 'No data provided' ], $result['operational_insights']['automation_opportunities'] );
 }
 
 public function test_financial_benchmarks_pass_through() {
@@ -209,19 +221,19 @@ self::assertSame( $financial_benchmarks, $result['financial_benchmarks'] );
 }
 
 public function test_rag_context_pass_through() {
-    $method = new ReflectionMethod( RTBCB_Ajax::class, 'structure_report_data' );
-    $method->setAccessible( true );
+	$method = new ReflectionMethod( RTBCB_Ajax::class, 'structure_report_data' );
+	$method->setAccessible( true );
 
-    $user_inputs     = [ 'company_name' => 'Test', 'industry' => 'finance' ];
-    $enriched_profile = [];
-    $roi_scenarios    = [ 'conservative' => [], 'base' => [], 'optimistic' => [] ];
-    $recommendation   = [ 'recommended' => '', 'category_info' => [] ];
-    $final_analysis   = [];
-    $rag_context      = [ 'ctx item' ];
+	$user_inputs     = [ 'company_name' => 'Test', 'industry' => 'finance' ];
+	$enriched_profile = [];
+	$roi_scenarios    = [ 'conservative' => [], 'base' => [], 'optimistic' => [] ];
+	$recommendation   = [ 'recommended' => '', 'category_info' => [] ];
+	$final_analysis   = [];
+	$rag_context      = [ 'ctx item' ];
 
-    $result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $rag_context, [], microtime( true ), [] );
+	$result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $rag_context, [], microtime( true ), [] );
 
-    self::assertSame( $rag_context, $result['rag_context'] );
+	self::assertSame( $rag_context, $result['rag_context'] );
 }
 }
 


### PR DESCRIPTION
## Summary
- Collapse detailed process improvement objects into readable summary strings for report output
- Convert automation opportunity objects to concise descriptions and skip empty entries
- Test operational insight summarization and defaulting when only empty objects are provided

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8cca0015c83319bb0a48acf02eef9