### PR TITLE
Handle operational insight objects

### DIFF
--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -272,25 +272,68 @@ $processing_time = $metadata['processing_time'] ?? ( $report_data['processing_ti
 <?php if ( ! empty( $operational_insights['current_state_assessment'] ) ) : ?>
 <h3><?php echo esc_html__( 'Current State Assessment', 'rtbcb' ); ?></h3>
 <ul>
-<?php foreach ( $operational_insights['current_state_assessment'] as $item ) : ?>
+<?php foreach ( (array) $operational_insights['current_state_assessment'] as $item ) : ?>
 <li><?php echo esc_html( $item ); ?></li>
 <?php endforeach; ?>
 </ul>
 <?php endif; ?>
-<?php if ( ! empty( $operational_insights['process_improvements'] ) ) : ?>
+
+<?php if ( array_key_exists( 'process_improvements', $operational_insights ) ) : ?>
 <h3><?php echo esc_html__( 'Process Improvements', 'rtbcb' ); ?></h3>
 <ul>
-<?php foreach ( $operational_insights['process_improvements'] as $item ) : ?>
-<li><?php echo esc_html( $item ); ?></li>
+<?php
+$process_items = 0;
+foreach ( (array) $operational_insights['process_improvements'] as $item ) :
+$process = $item['process'] ?? ( $item['process_area'] ?? '' );
+$current = $item['current_state'] ?? '';
+$improved = $item['improved_state'] ?? '';
+$impact = $item['impact'] ?? ( $item['impact_level'] ?? '' );
+if ( '' === $process && '' === $current && '' === $improved && '' === $impact ) {
+continue;
+}
+$details = '';
+if ( $current || $improved ) {
+$details .= trim( $current . ' → ' . $improved );
+}
+if ( $impact ) {
+$details .= $details ? ' (' . $impact . ')' : '(' . $impact . ')';
+}
+$process_items++;
+?>
+<li><strong><?php echo esc_html( $process ); ?></strong><?php echo $details ? ': ' . esc_html( $details ) : ''; ?></li>
 <?php endforeach; ?>
+<?php if ( 0 === $process_items ) : ?>
+<li><?php esc_html_e( 'No data provided', 'rtbcb' ); ?></li>
+<?php endif; ?>
 </ul>
 <?php endif; ?>
-<?php if ( ! empty( $operational_insights['automation_opportunities'] ) ) : ?>
+
+<?php if ( array_key_exists( 'automation_opportunities', $operational_insights ) ) : ?>
 <h3><?php echo esc_html__( 'Automation Opportunities', 'rtbcb' ); ?></h3>
 <ul>
-<?php foreach ( $operational_insights['automation_opportunities'] as $item ) : ?>
-<li><?php echo esc_html( $item ); ?></li>
+<?php
+$automation_items = 0;
+foreach ( (array) $operational_insights['automation_opportunities'] as $item ) :
+$opportunity = $item['opportunity'] ?? '';
+$complexity = $item['complexity'] ?? '';
+$savings    = $item['savings'] ?? ( $item['time_savings'] ?? '' );
+if ( '' === $opportunity && '' === $complexity && '' === $savings ) {
+continue;
+}
+$parts = [];
+if ( $complexity ) {
+$parts[] = sprintf( __( '%s complexity', 'rtbcb' ), $complexity );
+}
+if ( $savings ) {
+$parts[] = $savings;
+}
+$automation_items++;
+?>
+<li><strong><?php echo esc_html( $opportunity ); ?></strong><?php echo $parts ? ': ' . esc_html( implode( ' → ', $parts ) ) : ''; ?></li>
 <?php endforeach; ?>
+<?php if ( 0 === $automation_items ) : ?>
+<li><?php esc_html_e( 'No data provided', 'rtbcb' ); ?></li>
+<?php endif; ?>
 </ul>
 <?php endif; ?>
 </div>

--- a/tests/RTBCB_ReportTypeTest.php
+++ b/tests/RTBCB_ReportTypeTest.php
@@ -210,17 +210,34 @@ if ( 'error' === self::$mode ) {
 return new WP_Error( 'missing_sections', 'Required sections missing.', [ 'status' => 500 ] );
 }
 return [
-'report_data' => [
-'action_plan'         => [ 'immediate_steps' => [ 'Step 1' ] ],
-'operational_insights' => [ 'Insight' ],
-'risk_analysis'       => [ 'Risk' ],
-'company_intelligence'=> [],
-'executive_summary'   => [],
-'financial_analysis'  => [],
-'technology_strategy' => [],
-'financial_benchmarks'=> [],
-'metadata'            => [],
-],
+    'report_data' => [
+    'action_plan'         => [ 'immediate_steps' => [ 'Step 1' ] ],
+    'operational_insights' => [
+        'current_state_assessment' => [ 'Manual process' ],
+        'process_improvements'     => [
+            [
+                'process'        => 'Reconciliation',
+                'current_state'  => 'Manual spreadsheets',
+                'improved_state' => 'Automated workflow',
+                'impact'         => 'High',
+            ],
+        ],
+        'automation_opportunities' => [
+            [
+                'opportunity' => 'Cash Forecasting',
+                'complexity'  => 'Medium',
+                'savings'     => '10 hours',
+            ],
+        ],
+    ],
+    'risk_analysis'       => [ 'Risk' ],
+    'company_intelligence'=> [],
+    'executive_summary'   => [],
+    'financial_analysis'  => [],
+    'technology_strategy' => [],
+    'financial_benchmarks'=> [],
+    'metadata'            => [],
+    ],
 ];
 }
 public function generate_business_case( $form_data, $calculations, $rag_context, $model ) {
@@ -249,16 +266,27 @@ $_POST         = [
 RTBCB_LLM_Optimized::$mode = 'success';
 }
 
-public function test_comprehensive_includes_sections() {
-$router = new RTBCB_Router();
-$router->handle_form_submission( 'comprehensive' );
-global $last_response;
-$this->assertTrue( $last_response['success'] );
-$html = $last_response['data']['report_html'] ?? '';
-$this->assertStringContainsString( 'Implementation Action Plan', $html );
-$this->assertStringContainsString( 'Operational Insights', $html );
-$this->assertStringContainsString( 'Risk Assessment', $html );
-}
+    public function test_comprehensive_includes_sections() {
+        $router = new RTBCB_Router();
+        $router->handle_form_submission( 'comprehensive' );
+        global $last_response;
+        $this->assertTrue( $last_response['success'] );
+        $html = $last_response['data']['report_html'] ?? '';
+        $this->assertStringContainsString( 'Implementation Action Plan', $html );
+        $this->assertStringContainsString( 'Operational Insights', $html );
+        $this->assertStringContainsString( 'Risk Assessment', $html );
+    }
+
+    public function test_operational_insights_section_populates() {
+        $router = new RTBCB_Router();
+        $router->handle_form_submission( 'comprehensive' );
+        global $last_response;
+        $this->assertTrue( $last_response['success'] );
+        $html = $last_response['data']['report_html'] ?? '';
+        $this->assertStringContainsString( 'Reconciliation', $html );
+        $this->assertStringContainsString( 'Cash Forecasting', $html );
+        $this->assertStringNotContainsString( 'No data provided', $html );
+    }
 
 public function test_basic_omits_sections() {
 $router = new RTBCB_Router();

--- a/tests/operational-insights-render.test.js
+++ b/tests/operational-insights-render.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Minimal stubs for browser globals used in rtbcb-wizard.js
+global.window = {};
+global.document = {
+addEventListener: () => {},
+getElementById: () => null,
+};
+
+const originalRequire = global.require;
+global.require = undefined;
+const wizardCode = fs.readFileSync('public/js/rtbcb-wizard.js', 'utf8');
+vm.runInThisContext(wizardCode);
+global.require = originalRequire;
+
+const renderOperationalAnalysis = BusinessCaseBuilder.prototype.renderOperationalAnalysis;
+const context = { escapeHTML: (s) => s };
+const html = renderOperationalAnalysis.call(context, {
+current_state_assessment: 'Assessment',
+process_improvements: [
+{
+process: 'Reconciliation',
+current_state: 'Manual',
+improved_state: 'Automated',
+impact: 'High',
+},
+],
+automation_opportunities: [
+{
+opportunity: 'Cash Forecasting',
+complexity: 'Medium',
+savings: '10 hours',
+},
+],
+});
+
+assert.ok(html.includes('Reconciliation'), 'Process name missing');
+assert.ok(html.includes('Manual'), 'Current state missing');
+assert.ok(html.includes('Automated'), 'Improved state missing');
+assert.ok(html.includes('High'), 'Impact missing');
+assert.ok(html.includes('Cash Forecasting'), 'Opportunity missing');
+assert.ok(html.includes('Medium'), 'Complexity missing');
+assert.ok(html.includes('10 hours'), 'Savings missing');
+console.log('Operational analysis render test passed.');

--- a/tests/render-comprehensive-template.test.php
+++ b/tests/render-comprehensive-template.test.php
@@ -33,8 +33,8 @@ if ( ! function_exists( 'current_time' ) ) {
 }
 
 $business_case_data = [
-        'company_name'      => 'Demo Corp',
-        'executive_summary' => [
+       'company_name'      => 'Demo Corp',
+       'executive_summary' => [
                 'strategic_positioning'   => 'Positioned well.',
                 'business_case_strength'  => 'Strong',
                 'key_value_drivers'       => [ 'Efficiency', 'Compliance' ],
@@ -62,6 +62,24 @@ $business_case_data = [
                ],
        ],
        'rag_context' => [ 'Example RAG item' ],
+       'operational_insights' => [
+               'current_state_assessment' => [ 'Manual process' ],
+               'process_improvements'     => [
+                       [
+                               'process'        => 'Reconciliation',
+                               'current_state'  => 'Manual spreadsheets',
+                               'improved_state' => 'Automated workflow',
+                               'impact'         => 'High',
+                       ],
+               ],
+               'automation_opportunities' => [
+                       [
+                               'opportunity' => 'Cash Forecasting',
+                               'complexity'  => 'Medium',
+                               'savings'     => '10 hours',
+                       ],
+               ],
+       ],
 ];
 
 $report_data = $business_case_data;
@@ -77,6 +95,16 @@ if ( strpos( $output, 'rtbcb-executive-summary' ) === false || strpos( $output, 
 
 if ( strpos( $output, 'Example RAG item' ) === false ) {
         echo "RAG context not rendered\n";
+        exit( 1 );
+}
+
+if ( strpos( $output, 'Operational Insights' ) === false || strpos( $output, 'Reconciliation' ) === false || strpos( $output, 'Cash Forecasting' ) === false ) {
+        echo "Operational insights not rendered\n";
+        exit( 1 );
+}
+
+if ( strpos( $output, 'No data provided' ) !== false ) {
+        echo "Operational insights fallback triggered unexpectedly\n";
         exit( 1 );
 }
 

--- a/tests/report-interactivity.test.js
+++ b/tests/report-interactivity.test.js
@@ -30,6 +30,7 @@ global.document = {
             tagName: tag,
             style: {},
             appendChild() {},
+            addEventListener() {},
             set srcdoc(v) { this.srcdoc = v; },
             srcdoc: '',
             className: '',

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -103,6 +103,8 @@ echo "14d. Running Jetpack compatibility test..."
 php tests/jetpack-compatibility.test.php
 echo "14e. Running reports bulk delete test..."
 php tests/reports-bulk-delete.test.php
+echo "14f. Running report type test..."
+vendor/bin/phpunit tests/RTBCB_ReportTypeTest.php
 
 # JavaScript tests
 echo "16. Running JavaScript tests..."
@@ -122,6 +124,7 @@ node tests/min-output-tokens.test.js
 node tests/gpt5-config-defaults.test.js
 node tests/api-logs-page.test.js
 node tests/wizard-report-flow.test.js
+node tests/operational-insights-render.test.js
 npx --yes jest tests/poll-job-completed.test.js --config '{"testEnvironment":"node"}'
 npx --yes jest tests/poll-job-show-results.test.js --config '{"testEnvironment":"node"}'
 npx --yes jest tests/poll-job-progress-text.test.js --config '{"testEnvironment":"node"}'


### PR DESCRIPTION
## Summary
- Render structured operational insights with detailed process and automation info
- Adapt report template to show process details, automation complexity and savings with fallbacks
- Add integration tests for operational insights rendering in PHP and JS

## Testing
- `composer install`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8cee4c3348331a4cb0f766f8df193