### PR TITLE
Ensure operational insights populate without AI data

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -720,17 +720,18 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 		return implode( ' ', array_filter( $query_parts ) );
 	}
 
-	private static function create_fallback_analysis( $enriched_profile, $roi_scenarios ) {
-		return [
-			'executive_summary' => [
-				'strategic_positioning'   => '',
-				'key_value_drivers'       => [],
-				'executive_recommendation' => '',
-				'confidence_level'        => 0.5,
-			],
-			'financial_analysis' => [],
-		];
-	}
+       private static function create_fallback_analysis( $enriched_profile, $roi_scenarios ) {
+               return [
+                       'executive_summary' => [
+                               'strategic_positioning'   => '',
+                               'key_value_drivers'       => [],
+                               'executive_recommendation' => '',
+                               'confidence_level'        => 0.5,
+                       ],
+                       'operational_insights' => rtbcb_generate_operational_fallbacks( array() ),
+                       'financial_analysis'   => [],
+               ];
+       }
 
 		private static function save_lead_data_async( $user_inputs, $structured_report_data ) {
 				if ( class_exists( 'RTBCB_Leads' ) ) {

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -284,6 +284,7 @@ $processing_time = $metadata['processing_time'] ?? ( $report_data['processing_ti
 <?php
 $process_items = 0;
 foreach ( (array) $operational_insights['process_improvements'] as $item ) :
+if ( is_array( $item ) ) {
 $process = $item['process'] ?? ( $item['process_area'] ?? '' );
 $current = $item['current_state'] ?? '';
 $improved = $item['improved_state'] ?? '';
@@ -301,7 +302,19 @@ $details .= $details ? ' (' . $impact . ')' : '(' . $impact . ')';
 $process_items++;
 ?>
 <li><strong><?php echo esc_html( $process ); ?></strong><?php echo $details ? ': ' . esc_html( $details ) : ''; ?></li>
-<?php endforeach; ?>
+<?php
+} else {
+$summary = sanitize_text_field( $item );
+if ( '' === $summary ) {
+continue;
+}
+$process_items++;
+?>
+<li><?php echo esc_html( $summary ); ?></li>
+<?php
+}
+endforeach;
+?>
 <?php if ( 0 === $process_items ) : ?>
 <li><?php esc_html_e( 'No data provided', 'rtbcb' ); ?></li>
 <?php endif; ?>
@@ -314,9 +327,10 @@ $process_items++;
 <?php
 $automation_items = 0;
 foreach ( (array) $operational_insights['automation_opportunities'] as $item ) :
+if ( is_array( $item ) ) {
 $opportunity = $item['opportunity'] ?? '';
-$complexity = $item['complexity'] ?? '';
-$savings    = $item['savings'] ?? ( $item['time_savings'] ?? '' );
+$complexity  = $item['complexity'] ?? '';
+$savings     = $item['savings'] ?? ( $item['time_savings'] ?? '' );
 if ( '' === $opportunity && '' === $complexity && '' === $savings ) {
 continue;
 }
@@ -330,7 +344,19 @@ $parts[] = $savings;
 $automation_items++;
 ?>
 <li><strong><?php echo esc_html( $opportunity ); ?></strong><?php echo $parts ? ': ' . esc_html( implode( ' → ', $parts ) ) : ''; ?></li>
-<?php endforeach; ?>
+<?php
+} else {
+$summary = sanitize_text_field( $item );
+if ( '' === $summary ) {
+continue;
+}
+$automation_items++;
+?>
+<li><?php echo esc_html( $summary ); ?></li>
+<?php
+}
+endforeach;
+?>
 <?php if ( 0 === $automation_items ) : ?>
 <li><?php esc_html_e( 'No data provided', 'rtbcb' ); ?></li>
 <?php endif; ?>

--- a/tests/RTBCB_StructureReportDataTest.php
+++ b/tests/RTBCB_StructureReportDataTest.php
@@ -233,7 +233,18 @@ public function test_rag_context_pass_through() {
 
 	$result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $rag_context, [], microtime( true ), [] );
 
-	self::assertSame( $rag_context, $result['rag_context'] );
+        self::assertSame( $rag_context, $result['rag_context'] );
+}
+
+public function test_create_fallback_analysis_includes_operational_insights() {
+$method = new ReflectionMethod( RTBCB_Ajax::class, 'create_fallback_analysis' );
+$method->setAccessible( true );
+
+$result = $method->invoke( null, [], [] );
+
+self::assertNotEmpty( $result['operational_insights']['current_state_assessment'] );
+self::assertNotEmpty( $result['operational_insights']['process_improvements'] );
+self::assertNotEmpty( $result['operational_insights']['automation_opportunities'] );
 }
 }
 


### PR DESCRIPTION
## Summary
- Provide default operational insights when AI analysis fails, ensuring the report no longer shows empty sections
- Safely render process improvements and automation opportunities whether insights arrive as structured data or plain strings
- Verify fallback analysis includes operational insights with new unit test

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b8d43472b483319b3b5f4285210ca2