### PR TITLE
Link API logs to workflow history and record LLM model

### DIFF
--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -27,14 +27,15 @@ if ( ! current_user_can( 'manage_options' ) ) {
                                        <th><?php esc_html_e( 'ID', 'rtbcb' ); ?></th>
                                        <th><?php esc_html_e( 'Lead ID', 'rtbcb' ); ?></th>
                                        <th><?php esc_html_e( 'Email', 'rtbcb' ); ?></th>
-                                        <th><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></th>
-                                        <th><?php esc_html_e( 'Request', 'rtbcb' ); ?></th>
-                                        <th><?php esc_html_e( 'Prompt Tokens', 'rtbcb' ); ?></th>
-                                        <th><?php esc_html_e( 'Completion Tokens', 'rtbcb' ); ?></th>
-                                        <th><?php esc_html_e( 'Tokens', 'rtbcb' ); ?></th>
-                                        <th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
-                                        <th><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
-                                        <th><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'Company Name', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'Model', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'Request', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'Prompt Tokens', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'Completion Tokens', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'Tokens', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'Status', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'Timestamp', 'rtbcb' ); ?></th>
+                                       <th><?php esc_html_e( 'Actions', 'rtbcb' ); ?></th>
                                 </tr>
                         </thead>
                         <tbody>
@@ -59,8 +60,9 @@ if ( ! current_user_can( 'manage_options' ) ) {
 	                                       <td><?php echo esc_html( $log['id'] ); ?></td>
 	                                       <td><?php echo esc_html( $log['lead_id'] ); ?></td>
 	                                       <td><?php echo esc_html( $log['user_email'] ); ?></td>
-						<td><?php echo esc_html( $log['company_name'] ); ?></td>
-						<td><?php echo esc_html( $summary ); ?></td>
+                                               <td><?php echo esc_html( $log['company_name'] ); ?></td>
+                                               <td><?php echo esc_html( $log['llm_model'] ); ?></td>
+                                               <td><?php echo esc_html( $summary ); ?></td>
                                                <td><?php echo esc_html( $log['prompt_tokens'] ); ?></td>
                                                <td><?php echo esc_html( $log['completion_tokens'] ); ?></td>
                                                <td><?php echo esc_html( $log['total_tokens'] ); ?></td>
@@ -90,28 +92,29 @@ if ( ! current_user_can( 'manage_options' ) ) {
 </div>
 <script type="text/javascript">
         jQuery(function($){
-var table = $('#rtbcb-api-logs-table').DataTable({
-pageLength: 20,
-order: [[0, 'desc']],
-scrollX: true,
-autoWidth: false,
-language: {
-emptyTable: '<?php echo esc_js( __( 'No logs found.', 'rtbcb' ) ); ?>'
-},
-columns: [
-null,
-null,
-null,
-null,
-null,
-null,
-null,
-null,
-null,
-null,
-{ orderable: false }
-]
-});
+        var table = $('#rtbcb-api-logs-table').DataTable({
+        pageLength: 20,
+        order: [[0, 'desc']],
+        scrollX: true,
+        autoWidth: false,
+        language: {
+        emptyTable: '<?php echo esc_js( __( 'No logs found.', 'rtbcb' ) ); ?>'
+        },
+        columns: [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        { orderable: false }
+        ]
+        });
 var search = new URLSearchParams(window.location.search).get('search');
 if (search) {
 table.search(search).draw();

--- a/admin/class-rtbcb-admin.php
+++ b/admin/class-rtbcb-admin.php
@@ -2034,11 +2034,15 @@ wp_localize_script(
 					$entry['started_at']     = isset( $entry['started_at'] ) ? sanitize_text_field( $entry['started_at'] ) : '';
 					$entry['report_template'] = isset( $entry['report_template'] ) ? sanitize_text_field( $entry['report_template'] ) : '';
 
-					$log_ids = RTBCB_API_Log::get_log_ids_for_contact( $entry['lead_id'], $entry['lead_email'] );
-					if ( ! empty( $log_ids ) ) {
-						$search            = $entry['lead_email'] ? $entry['lead_email'] : $entry['lead_id'];
-						$entry['logs_url'] = admin_url( 'admin.php?page=rtbcb-api-logs&search=' . rawurlencode( $search ) );
-					}
+                                        $entry['log_ids'] = isset( $entry['log_ids'] ) && is_array( $entry['log_ids'] ) ? array_map( 'intval', $entry['log_ids'] ) : [];
+                                        $log_ids          = $entry['log_ids'];
+                                        if ( empty( $log_ids ) && class_exists( 'RTBCB_API_Log' ) ) {
+                                                $log_ids = RTBCB_API_Log::get_log_ids_for_contact( $entry['lead_id'], $entry['lead_email'] );
+                                        }
+                                        if ( ! empty( $log_ids ) ) {
+                                                $entry['log_ids'] = array_map( 'intval', $log_ids );
+                                                $entry['logs_url'] = admin_url( 'admin.php?page=rtbcb-api-logs&search=' . rawurlencode( (string) $log_ids[0] ) );
+                                        }
 
 					return $entry;
 				},

--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -893,13 +893,20 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 		   if ( ! empty( $company_name ) ) {
 			$debug_info['company_name'] = sanitize_text_field( $company_name );
 		   }
-		   $history[] = $debug_info;
-		   if ( count( $history ) > 20 ) {
-			   $history = array_slice( $history, -20 );
-		   }
-		   if ( function_exists( 'update_option' ) ) {
-			   update_option( 'rtbcb_workflow_history', $history, false );
-		   }
-	   }
+                   if ( class_exists( 'RTBCB_API_Log' ) ) {
+                           $log_ids = RTBCB_API_Log::get_log_ids_for_contact( $debug_info['lead_id'] ?? 0, $debug_info['lead_email'] ?? '' );
+                           if ( ! empty( $log_ids ) ) {
+                                   $debug_info['log_ids'] = array_map( 'intval', $log_ids );
+                           }
+                   }
+
+                   $history[] = $debug_info;
+                   if ( count( $history ) > 20 ) {
+                           $history = array_slice( $history, -20 );
+                   }
+                   if ( function_exists( 'update_option' ) ) {
+                           update_option( 'rtbcb_workflow_history', $history, false );
+                   }
+           }
 }
 

--- a/inc/class-rtbcb-llm-transport.php
+++ b/inc/class-rtbcb-llm-transport.php
@@ -95,7 +95,8 @@ $user_id      = function_exists( 'get_current_user_id' ) ? get_current_user_id()
 $user_email   = $request['email'] ?? '';
 $company_name = $request['company_name'] ?? '';
 
-RTBCB_API_Log::save_log( $request, $response, $user_id, $user_email, $company_name );
+       $model = $request['model'] ?? '';
+       RTBCB_API_Log::save_log( $request, $response, $user_id, $user_email, $company_name, 0, $model );
 }
 
 /**

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -1503,7 +1503,8 @@ $parsed = $this->response_parser->parse( $response );
 			if ( class_exists( 'RTBCB_API_Log' ) ) {
 				$user_email   = $this->current_inputs['email'] ?? '';
 				$company_name = $this->current_inputs['company_name'] ?? '';
-				RTBCB_API_Log::save_log( $body, [ 'error' => $response->get_error_message() ], get_current_user_id(), $user_email, $company_name );
+                               $model = $body['model'] ?? '';
+                               RTBCB_API_Log::save_log( $body, [ 'error' => $response->get_error_message() ], get_current_user_id(), $user_email, $company_name, 0, $model );
 			}
 			return $response;
 		}
@@ -2200,7 +2201,8 @@ PROMPT;
                        if ( class_exists( 'RTBCB_API_Log' ) ) {
                                $user_email   = $this->current_inputs['email'] ?? '';
                                $company_name = $this->current_inputs['company_name'] ?? '';
-                               RTBCB_API_Log::save_log( $payload, $decoded, get_current_user_id(), $user_email, $company_name );
+                               $model = $payload['model'] ?? '';
+                               RTBCB_API_Log::save_log( $payload, $decoded, get_current_user_id(), $user_email, $company_name, 0, $model );
                        }
 
                        return $this->validate_and_structure_analysis( $data );

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1798,7 +1798,8 @@ function rtbcb_handle_openai_responses_job( $job_id, $user_id ) {
 
 	if ( is_wp_error( $response ) ) {
 				if ( class_exists( 'RTBCB_API_Log' ) ) {
-					RTBCB_API_Log::save_log( $body_array, [ 'error' => $response->get_error_message() ], $user_id, $user_email, $company_name );
+                                        $model = $body_array['model'] ?? '';
+                                        RTBCB_API_Log::save_log( $body_array, [ 'error' => $response->get_error_message() ], $user_id, $user_email, $company_name, 0, $model );
 				}
 		set_transient(
 			'rtbcb_openai_job_' . $job_id,
@@ -1819,7 +1820,8 @@ function rtbcb_handle_openai_responses_job( $job_id, $user_id ) {
 	}
 
 		if ( class_exists( 'RTBCB_API_Log' ) ) {
-				RTBCB_API_Log::save_log( $body_array, $decoded, $user_id, $user_email, $company_name );
+                                $model = $body_array['model'] ?? '';
+                                RTBCB_API_Log::save_log( $body_array, $decoded, $user_id, $user_email, $company_name, 0, $model );
 		}
 
 	set_transient(

--- a/tests/RTBCB_ApiLogFieldsTest.php
+++ b/tests/RTBCB_ApiLogFieldsTest.php
@@ -41,12 +41,13 @@ final class RTBCB_ApiLogFieldsTest extends TestCase {
                         'company_name' => 'Example Co',
                 ];
 
-                RTBCB_API_Log::save_log( $request, [], 1, '', '', 7 );
+               RTBCB_API_Log::save_log( $request, [], 1, '', '', 7, 'gpt-5' );
 
                 $this->assertNotEmpty( $wpdb->rows );
                 $row = $wpdb->rows[0];
                 $this->assertSame( 'user@example.com', $row['user_email'] );
                 $this->assertSame( 'Example Co', $row['company_name'] );
-                $this->assertSame( 7, $row['lead_id'] );
+               $this->assertSame( 7, $row['lead_id'] );
+               $this->assertSame( 'gpt-5', $row['llm_model'] );
         }
 }

--- a/tests/RTBCB_ApiLogTokensTest.php
+++ b/tests/RTBCB_ApiLogTokensTest.php
@@ -44,7 +44,7 @@ final class RTBCB_ApiLogTokensTest extends TestCase {
 	        ],
 	    ];
 
-	    RTBCB_API_Log::save_log( [], $response, 1 );
+            RTBCB_API_Log::save_log( [], $response, 1, '', '', 0, 'gpt-5' );
 
 	    $this->assertNotEmpty( $wpdb->rows );
 	    $row = $wpdb->rows[0];

--- a/tests/api-logs-page.test.js
+++ b/tests/api-logs-page.test.js
@@ -19,6 +19,7 @@ $logs = [
         'lead_id' => 0,
         'user_email' => 'test@example.com',
         'company_name' => 'Test Co',
+        'llm_model' => 'gpt-5',
         'request_json' => '{}',
         'response_json' => '{}',
         'total_tokens' => 42,
@@ -34,9 +35,9 @@ include 'admin/api-logs-page.php';
 
 const output = execSync('php', { input: php }).toString();
 const dom = new JSDOM(output);
-const promptCell = dom.window.document.querySelector('#rtbcb-api-logs-table tbody tr td:nth-child(6)');
-const completionCell = dom.window.document.querySelector('#rtbcb-api-logs-table tbody tr td:nth-child(7)');
-const totalCell = dom.window.document.querySelector('#rtbcb-api-logs-table tbody tr td:nth-child(8)');
+const promptCell = dom.window.document.querySelector('#rtbcb-api-logs-table tbody tr td:nth-child(7)');
+const completionCell = dom.window.document.querySelector('#rtbcb-api-logs-table tbody tr td:nth-child(8)');
+const totalCell = dom.window.document.querySelector('#rtbcb-api-logs-table tbody tr td:nth-child(9)');
 assert.ok(promptCell && completionCell && totalCell);
 assert.strictEqual(promptCell.textContent.trim(), '40');
 assert.strictEqual(completionCell.textContent.trim(), '2');


### PR DESCRIPTION
## Summary
- track log IDs with workflow history entries to link recent executions to API logs
- record the LLM model used for each API call and display it in the logs page

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=test RTBCB_TEST_MODEL=gpt-5 bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b8d5f16ff08331bc909b00fae91c58