### PR TITLE
Add mitigation and success arrays to risk analysis

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1953,23 +1953,23 @@ $results = [
 'market_analysis' => [
 'summary'	=> $vendor_list,
 'stored_in' => 'rtbcb_rag_market_analysis',
-],
+                          ],
 'implementation_roadmap' => [
 'summary'	=> $analysis['implementation_roadmap'],
 'stored_in' => 'rtbcb_roadmap_plan',
-],
+                          ],
 'value_proposition' => [
 'summary'	=> $analysis['executive_summary'],
 'stored_in' => 'rtbcb_value_proposition',
-],
+                          ],
 'financial_analysis' => [
 'summary'	=> $analysis['financial_analysis'],
 'stored_in' => 'rtbcb_estimated_benefits',
-],
+                          ],
 'executive_summary' => [
 'summary'	=> $analysis['executive_summary'],
 'stored_in' => 'rtbcb_executive_summary',
-],
+                          ],
 	];
 
 	$usage_map = [
@@ -2121,7 +2121,7 @@ $allowed['script'] = [
 'type' => [
 'application/json'	 => true,
 'application/ld+json' => true,
-],
+                          ],
 ];
 
 return $allowed;
@@ -2365,17 +2365,27 @@ function rtbcb_transform_data_for_template( $business_case_data ) {
 			];
 	}
 
-	// Prepare risk analysis.
-	if ( ! empty( $business_case_data['risk_analysis']['implementation_risks'] ) ) {
-			$implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risk_analysis']['implementation_risks'] );
-	} elseif ( ! empty( $business_case_data['risks'] ) ) {
-			$implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
-	} else {
-			$implementation_risks = [
-				    __( 'Integration complexity with existing systems', 'rtbcb' ),
-				    __( 'Change management and user adoption challenges', 'rtbcb' ),
-			];
-	}
+ // Prepare risk analysis.
+if ( ! empty( $business_case_data['risk_analysis']['implementation_risks'] ) ) {
+$implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risk_analysis']['implementation_risks'] );
+} elseif ( ! empty( $business_case_data['risks'] ) ) {
+$implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risks'] );
+} else {
+$implementation_risks = [
+__( 'Integration complexity with existing systems', 'rtbcb' ),
+__( 'Change management and user adoption challenges', 'rtbcb' ),
+];
+}
+
+$mitigation_strategies = [];
+if ( ! empty( $business_case_data['risk_analysis']['mitigation_strategies'] ) ) {
+$mitigation_strategies = array_map( 'sanitize_text_field', (array) $business_case_data['risk_analysis']['mitigation_strategies'] );
+}
+
+$success_factors = [];
+if ( ! empty( $business_case_data['risk_analysis']['success_factors'] ) ) {
+$success_factors = array_map( 'sanitize_text_field', (array) $business_case_data['risk_analysis']['success_factors'] );
+}
 
 	// Create structured data format expected by template.
 	$report_data = [
@@ -2418,10 +2428,12 @@ function rtbcb_transform_data_for_template( $business_case_data ) {
 				    'recommended_category' => $recommended_category,
 				    'category_details'     => $category_details,
 			],
-			'operational_insights' => $operational_insights,
-			'risk_analysis'        => [
-				    'implementation_risks' => $implementation_risks,
-			],
+                        'operational_insights' => $operational_insights,
+                          'risk_analysis'        => [
+				'implementation_risks' => $implementation_risks,
+				'mitigation_strategies' => $mitigation_strategies,
+				'success_factors'      => $success_factors,
+                          ],
 			'action_plan'          => $action_plan,
 	];
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,8 +4,9 @@
     <testsuite name="rtbcb">
       <file>tests/RTBCB_ValidatorTest.php</file>
       <file>tests/RTBCB_ResponseParserTest.php</file>
-          <file>tests/RTBCB_ResponseIntegrityTest.php</file>
+      <file>tests/RTBCB_ResponseIntegrityTest.php</file>
       <file>tests/RTBCB_ApiLogTokensTest.php</file>
+      <file>tests/RTBCB_RiskAnalysisTransformTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/RTBCB_RiskAnalysisTransformTest.php
+++ b/tests/RTBCB_RiskAnalysisTransformTest.php
@@ -1,0 +1,61 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/wp-stubs.php';
+
+if ( ! function_exists( '__' ) ) {
+    function __( $text, $domain = null ) {
+        return $text;
+    }
+}
+if ( ! function_exists( 'current_time' ) ) {
+    function current_time( $format ) {
+        return '2024-01-01';
+    }
+}
+if ( ! function_exists( 'rtbcb_get_current_company' ) ) {
+    function rtbcb_get_current_company() {
+        return [];
+    }
+}
+if ( ! function_exists( 'rtbcb_get_analysis_type' ) ) {
+    function rtbcb_get_analysis_type() {
+        return 'test';
+    }
+}
+if ( ! function_exists( 'wp_parse_args' ) ) {
+    function wp_parse_args( $args, $defaults = [] ) {
+        return array_merge( $defaults, $args );
+    }
+}
+if ( ! function_exists( 'wp_kses_post' ) ) {
+    function wp_kses_post( $data ) {
+        return $data;
+    }
+}
+
+require_once __DIR__ . '/../inc/helpers.php';
+
+final class RTBCB_RiskAnalysisTransformTest extends TestCase {
+    public function test_risk_analysis_arrays_present() {
+        $input  = [
+            'risk_analysis' => [
+                'implementation_risks' => [ ' Risk A ', 'Risk B' ],
+                'mitigation_strategies' => [ ' Strategy A ', 'Strategy B' ],
+                'success_factors'      => [ ' Factor A ', 'Factor B' ],
+            ],
+        ];
+
+        $result = rtbcb_transform_data_for_template( $input );
+        $risk   = $result['risk_analysis'];
+
+        $this->assertSame( [ 'Risk A', 'Risk B' ], $risk['implementation_risks'] );
+        $this->assertSame( [ 'Strategy A', 'Strategy B' ], $risk['mitigation_strategies'] );
+        $this->assertSame( [ 'Factor A', 'Factor B' ], $risk['success_factors'] );
+    }
+}


### PR DESCRIPTION
## Summary
- extend `rtbcb_transform_data_for_template()` to include sanitized `mitigation_strategies` and `success_factors`
- add PHPUnit test confirming all risk analysis arrays appear in API output
- register new test in phpunit configuration

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8d685bc1083319b8387e841f79141