### PR TITLE
Preserve executive summary on partial analysis

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -402,7 +402,7 @@ $json = $this->response_parser->process_openai_response( $content );
 		}
 
 		// Validate required fields
-		$required_fields = [ 'analysis', 'recommendations', 'references', 'metrics' ];
+			$required_fields = [ 'analysis', 'recommendations', 'references', 'metrics' ];
 		$missing_fields  = array_diff( $required_fields, array_keys( $json ) );
 
 		if ( ! empty( $missing_fields ) ) {
@@ -2231,15 +2231,18 @@ PROMPT;
                        return false;
                }
 
-               $required = [
-                       'executive_summary',
-                       'operational_insights',
-                       'financial_analysis',
-                       'implementation_roadmap',
-                       'risk_analysis',
-                       'action_plan',
-                       'vendor_considerations',
-               ];
+			$required = [
+'executive_summary',
+];
+
+			$optional = [
+'operational_insights',
+'financial_analysis',
+'implementation_roadmap',
+'risk_analysis',
+'action_plan',
+'vendor_considerations',
+];
 
                foreach ( $required as $key ) {
                        if ( ! array_key_exists( $key, $data ) ) {


### PR DESCRIPTION
## Summary
- Relax LLM strategic response validation so only an executive summary is required, allowing other sections to be optional
- Salvage partial strategic analysis results in AJAX workflow instead of always falling back to a generated analysis
- Confirm comprehensive report template displays the executive summary when present

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8de3923688331ae39da156ed241c0