### PR TITLE
Handle wrapped analysis in response parser

### DIFF
--- a/inc/class-rtbcb-response-parser.php
+++ b/inc/class-rtbcb-response-parser.php
@@ -459,12 +459,21 @@ if ( is_wp_error( $parsed ) ) {
 return $parsed;
 }
 
-$content = $parsed['output_text'];
-$json    = is_string( $content ) ? json_decode( $content, true ) : ( is_array( $content ) ? $content : [] );
+	$content = $parsed['output_text'];
+	$json    = is_string( $content ) ? json_decode( $content, true ) : ( is_array( $content ) ? $content : [] );
 
-if ( ! is_array( $json ) ) {
-return new WP_Error( 'llm_response_parse_error', __( 'Invalid JSON from language model.', 'rtbcb' ) );
-}
+	if ( is_array( $json ) ) {
+		foreach ( [ 'analysis', 'report_data' ] as $wrapper ) {
+			if ( isset( $json[ $wrapper ] ) && is_array( $json[ $wrapper ] ) ) {
+				$json = $json[ $wrapper ];
+				break;
+			}
+		}
+	}
+
+	if ( ! is_array( $json ) ) {
+		return new WP_Error( 'llm_response_parse_error', __( 'Invalid JSON from language model.', 'rtbcb' ) );
+	}
 
 $required = [
 'executive_summary',

--- a/tests/RTBCB_ResponseParserTest.php
+++ b/tests/RTBCB_ResponseParserTest.php
@@ -100,6 +100,26 @@ final class RTBCB_ResponseParserTest extends TestCase {
 				$result   = $parser->parse_business_case( $response );
 				$this->assertTrue( is_wp_error( $result ) );
 		}
+		public function test_parse_business_case_wrapped_analysis() {
+			$wrapped = [
+				'analysis' => [
+					'executive_summary'    => [],
+					'company_intelligence' => [],
+					'operational_insights' => [],
+					'risk_analysis'        => [],
+					'action_plan'          => [],
+					'industry_insights'    => [],
+					'technology_strategy'  => [],
+					'financial_analysis'   => [],
+				],
+			];
+			$response = [ 'body' => json_encode( [ 'output_text' => json_encode( $wrapped ) ] ) ];
+			$parser   = new RTBCB_Response_Parser();
+			$result   = $parser->parse_business_case( $response );
+			$this->assertIsArray( $result );
+			$this->assertArrayHasKey( 'executive_summary', $result );
+		}
+
 
 		public function test_parse_marks_truncated_output() {
 				$payload = [


### PR DESCRIPTION
## Summary
- unwrap `analysis`/`report_data` keys before validating OpenAI responses
- add regression test for wrapped analysis payload

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8e620cda483318d7ce8aea9a08a7f