### PR TITLE
Ensure comprehensive report sections use OpenAI data

### DIFF
--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -504,6 +504,60 @@ $tech_adoption      = $sector_analysis['technology_adoption'] ?? ( $benchmarking
 </div>
 <?php endif; ?>
 
+<?php if ( ! empty( $technology_strategy['category_details'] ) || ! empty( $technology_strategy['implementation_roadmap'] ) || ! empty( $technology_strategy['vendor_considerations'] ) ) : ?>
+<div class="rtbcb-section-enhanced rtbcb-technology-strategy">
+<div class="rtbcb-section-header-enhanced">
+<h2 class="rtbcb-section-title">
+<span class="rtbcb-section-icon">🛠️</span>
+<?php echo esc_html__( 'Technology Strategy', 'rtbcb' ); ?>
+</h2>
+</div>
+<div class="rtbcb-section-content">
+<?php if ( ! empty( $technology_strategy['category_details'] ) ) : ?>
+<div class="rtbcb-tech-category-details">
+<h3><?php echo esc_html__( 'Solution Details', 'rtbcb' ); ?></h3>
+<ul>
+<?php foreach ( $technology_strategy['category_details'] as $key => $value ) : ?>
+<?php
+$label = ucwords( str_replace( '_', ' ', $key ) );
+if ( is_array( $value ) ) {
+foreach ( $value as $item ) {
+echo '<li>' . esc_html( $label . ': ' . $item ) . '</li>';
+}
+} else {
+echo '<li>' . esc_html( $label . ': ' . $value ) . '</li>';
+}
+?>
+<?php endforeach; ?>
+</ul>
+</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $technology_strategy['implementation_roadmap'] ) ) : ?>
+<div class="rtbcb-tech-roadmap">
+<h3><?php echo esc_html__( 'Implementation Roadmap', 'rtbcb' ); ?></h3>
+<ul>
+<?php foreach ( $technology_strategy['implementation_roadmap'] as $step ) : ?>
+<li><?php echo esc_html( $step ); ?></li>
+<?php endforeach; ?>
+</ul>
+</div>
+<?php endif; ?>
+
+<?php if ( ! empty( $technology_strategy['vendor_considerations'] ) ) : ?>
+<div class="rtbcb-vendor-considerations">
+<h3><?php echo esc_html__( 'Vendor Considerations', 'rtbcb' ); ?></h3>
+<ul>
+<?php foreach ( $technology_strategy['vendor_considerations'] as $consideration ) : ?>
+<li><?php echo esc_html( $consideration ); ?></li>
+<?php endforeach; ?>
+</ul>
+</div>
+<?php endif; ?>
+</div>
+</div>
+<?php endif; ?>
+
 <?php if ( ! empty( $risk_analysis ) ) : ?>
 <div class="rtbcb-section-enhanced rtbcb-risk-analysis">
 <div class="rtbcb-section-header-enhanced">

--- a/tests/RTBCB_ComprehensiveTransformTest.php
+++ b/tests/RTBCB_ComprehensiveTransformTest.php
@@ -1,0 +1,58 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/../' );
+}
+defined( 'ABSPATH' ) || exit;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/wp-stubs.php';
+
+if ( ! function_exists( '__' ) ) {
+        function __( $text, $domain = null ) {
+                return $text;
+        }
+}
+if ( ! function_exists( 'current_time' ) ) {
+        function current_time( $format ) {
+                return '2024-01-01';
+        }
+}
+if ( ! function_exists( 'wp_parse_args' ) ) {
+        function wp_parse_args( $args, $defaults = [] ) {
+                return array_merge( $defaults, $args );
+        }
+}
+if ( ! function_exists( 'wp_kses_post' ) ) {
+        function wp_kses_post( $data ) {
+                return $data;
+        }
+}
+
+require_once __DIR__ . '/../inc/helpers.php';
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+final class RTBCB_ComprehensiveTransformTest extends TestCase {
+        public function test_additional_sections_preserved() {
+                $input = [
+                        'financial_benchmarks' => [
+                                'industry_benchmarks' => [ [ 'metric' => 'EBITDA Margin', 'value' => '20%' ] ],
+                        ],
+                        'rag_context' => [ 'Context A' ],
+                        'technology_strategy' => [
+                                'implementation_roadmap' => [ 'Step 1', 'Step 2' ],
+                                'vendor_considerations' => [ 'Vendor A', 'Vendor B' ],
+                        ],
+                ];
+
+                $result = rtbcb_transform_data_for_template( $input );
+
+                $this->assertSame( 'EBITDA Margin', $result['financial_benchmarks']['industry_benchmarks'][0]['metric'] );
+                $this->assertSame( [ 'Context A' ], $result['rag_context'] );
+                $this->assertSame( [ 'Step 1', 'Step 2' ], $result['technology_strategy']['implementation_roadmap'] );
+                $this->assertSame( [ 'Vendor A', 'Vendor B' ], $result['technology_strategy']['vendor_considerations'] );
+        }
+}
+


### PR DESCRIPTION
## Summary
- Preserve additional OpenAI fields during report data transform, including sanitized category details, financial benchmarks, RAG context, and full technology strategy metadata
- Render a Technology Strategy section in the comprehensive report template to display solution details, roadmap steps, and vendor considerations
- Test that transform retains new sections like financial benchmarks, RAG context, and technology strategy arrays

## Testing
- `bash tests/run-tests.sh`
- `vendor/bin/phpunit tests/RTBCB_ComprehensiveTransformTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8e9195f408331819475cd7178c242