### PR TITLE
Align operational insight fields for comprehensive reports

### DIFF
--- a/inc/class-rtbcb-llm-optimized.php
+++ b/inc/class-rtbcb-llm-optimized.php
@@ -311,23 +311,23 @@ PROMPT;
 	  },
 	  "operational_insights": {
 	    "current_state_assessment": ["array of 3-4 key current state observations"],
-	    "process_improvements": [
-	      {
-	        "process": "string - specific process name",
-	        "current_state": "string - how process works today",
-	        "improved_state": "string - how process will work post-implementation",
-	        "impact": "string - quantified business impact where possible"
-	      }
-	    ],
-	    "automation_opportunities": [
-	      {
-	        "opportunity": "string - specific automation opportunity",
-	        "complexity": "low|medium|high",
-	        "potential_savings": "string - time and cost savings description",
-	        "implementation_effort": "string - effort and resources required"
-	      }
-	    ]
-	  },
+            "process_improvements": [
+              {
+                "process_area": "string - specific process name",
+                "current_state": "string - how process works today",
+                "improved_state": "string - how process will work post-implementation",
+                "impact_level": "string - quantified business impact where possible"
+              }
+            ],
+            "automation_opportunities": [
+              {
+                "opportunity": "string - specific automation opportunity",
+                "complexity": "low|medium|high",
+                "time_savings": "number - hours saved",
+                "implementation_effort": "string - effort and resources required"
+              }
+            ]
+          },
 	  "financial_analysis": {
 	    "roi_scenarios": {
 	      "conservative": {

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -1857,21 +1857,21 @@ $parsed  = $this->response_parser->parse( $response );
 	],
 	'operational_insights' => [
 	'current_state_assessment' => [ 'assessment point 1', 'assessment point 2', 'assessment point 3' ],
-	'process_improvements' => [
-	[
-	'process'        => 'process name',
-	'current_state'  => 'current approach',
-	'improved_state' => 'future approach',
-	'impact'         => 'expected impact',
-	],
-	],
-	'automation_opportunities' => [
-	[
+        'process_improvements' => [
+        [
+        'process_area'   => 'process name',
+        'current_state'  => 'current approach',
+        'improved_state' => 'future approach',
+        'impact_level'   => 'expected impact',
+        ],
+        ],
+        'automation_opportunities' => [
+        [
 'opportunity'           => 'automation area',
 'complexity'            => 'low|medium|high',
-'potential_savings'     => 'time/cost savings',
+'time_savings'         => 8,
 'implementation_effort' => 'effort required',
-	],
+        ],
 ],
 ],
 'financial_analysis' => [
@@ -2543,7 +2543,7 @@ foreach ( (array) ( $analysis_data['operational_insights']['automation_opportuni
 $analysis['operational_insights']['automation_opportunities'][] = [
 'opportunity'          => sanitize_text_field( $item['opportunity'] ?? '' ),
 'complexity'           => sanitize_text_field( $item['complexity'] ?? '' ),
-'time_savings'         => floatval( $item['potential_savings'] ?? ( $item['time_savings'] ?? 0 ) ),
+'time_savings'         => floatval( $item['time_savings'] ?? ( $item['potential_savings'] ?? 0 ) ),
 'implementation_effort' => sanitize_text_field( $item['implementation_effort'] ?? '' ),
 ];
 }

--- a/tests/RTBCB_ReportTypeTest.php
+++ b/tests/RTBCB_ReportTypeTest.php
@@ -216,17 +216,17 @@ return [
         'current_state_assessment' => [ 'Manual process' ],
         'process_improvements'     => [
             [
-                'process'        => 'Reconciliation',
+                'process_area'   => 'Reconciliation',
                 'current_state'  => 'Manual spreadsheets',
                 'improved_state' => 'Automated workflow',
-                'impact'         => 'High',
+                'impact_level'   => 'High',
             ],
         ],
         'automation_opportunities' => [
             [
-                'opportunity' => 'Cash Forecasting',
-                'complexity'  => 'Medium',
-                'savings'     => '10 hours',
+                'opportunity'   => 'Cash Forecasting',
+                'complexity'    => 'Medium',
+                'time_savings'  => '10 hours',
             ],
         ],
     ],

--- a/tests/RTBCB_StructureReportDataTest.php
+++ b/tests/RTBCB_StructureReportDataTest.php
@@ -138,17 +138,17 @@ $analysis_data    = [
 'current_state_assessment' => [ 'Manual process', 'Siloed data' ],
 'process_improvements'     => [
 [
-'process'        => 'Reconciliation',
+'process_area'   => 'Reconciliation',
 'current_state'  => 'Manual spreadsheets',
 'improved_state' => 'Automated workflow',
-'impact'         => 'High',
+'impact_level'   => 'High',
 ],
 ],
 'automation_opportunities' => [
 [
 'opportunity'           => 'Cash Forecasting',
 'complexity'            => 'Medium',
-'potential_savings'     => 8,
+'time_savings'          => 8,
 'implementation_effort' => 'Low',
 ],
 ],

--- a/tests/operational-insights-render.test.js
+++ b/tests/operational-insights-render.test.js
@@ -21,17 +21,17 @@ const html = renderOperationalAnalysis.call(context, {
 current_state_assessment: ['Assessment'],
 process_improvements: [
 {
-process: 'Reconciliation',
+process_area: 'Reconciliation',
 current_state: 'Manual',
 improved_state: 'Automated',
-impact: 'High',
+impact_level: 'High',
 },
 ],
 automation_opportunities: [
 {
 opportunity: 'Cash Forecasting',
 complexity: 'Medium',
-savings: '10 hours',
+time_savings: '10 hours',
 },
 ],
 });

--- a/tests/render-comprehensive-template.test.php
+++ b/tests/render-comprehensive-template.test.php
@@ -66,17 +66,17 @@ $business_case_data = [
                'current_state_assessment' => [ 'Manual process' ],
                'process_improvements'     => [
                        [
-                               'process'        => 'Reconciliation',
+                               'process_area'   => 'Reconciliation',
                                'current_state'  => 'Manual spreadsheets',
                                'improved_state' => 'Automated workflow',
-                               'impact'         => 'High',
+                               'impact_level'   => 'High',
                        ],
                ],
                'automation_opportunities' => [
                        [
-                               'opportunity' => 'Cash Forecasting',
-                               'complexity'  => 'Medium',
-                               'savings'     => '10 hours',
+                               'opportunity'       => 'Cash Forecasting',
+                               'complexity'        => 'Medium',
+                               'time_savings'      => '10 hours',
                        ],
                ],
        ],


### PR DESCRIPTION
## Summary
- Update AI prompt schema to use `process_area`, `impact_level`, and `time_savings` under `operational_insights`
- Adjust optimized LLM schema and sanitization logic for the new operational insight keys
- Refresh tests to cover revised field names in comprehensive report rendering

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8eac197b88331b94e6e9a37232f5d