### PR TITLE
Handle implementation roadmap fields and render them

### DIFF
--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2550,12 +2550,12 @@ $analysis['operational_insights']['automation_opportunities'][] = [
 
 	foreach ( (array) ( $analysis_data['implementation_roadmap'] ?? [] ) as $phase ) {
 		$analysis['implementation_roadmap'][] = [
-	'phase'          => sanitize_text_field( $phase['phase'] ?? '' ),
-	'duration'       => sanitize_text_field( $phase['duration'] ?? '' ),
-	'key_activities' => array_map( 'sanitize_text_field', $phase['key_activities'] ?? [] ),
-	'success_criteria' => array_map( 'sanitize_text_field', $phase['success_criteria'] ?? [] ),
-	'risks'          => array_map( 'sanitize_text_field', $phase['risks'] ?? [] ),
-	];
+			'phase'            => sanitize_text_field( $phase['phase'] ?? '' ),
+			'timeline'         => sanitize_text_field( $phase['timeline'] ?? ( $phase['duration'] ?? '' ) ),
+			'activities'       => array_map( 'sanitize_text_field', (array) ( $phase['activities'] ?? ( $phase['key_activities'] ?? [] ) ) ),
+			'success_criteria' => array_map( 'sanitize_text_field', (array) ( $phase['success_criteria'] ?? [] ) ),
+			'risks'            => array_map( 'sanitize_text_field', (array) ( $phase['risks'] ?? [] ) ),
+		];
 	}
 
 	return $analysis;

--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -538,7 +538,22 @@ echo '<li>' . esc_html( $label . ': ' . $value ) . '</li>';
 <h3><?php echo esc_html__( 'Implementation Roadmap', 'rtbcb' ); ?></h3>
 <ul>
 <?php foreach ( $technology_strategy['implementation_roadmap'] as $step ) : ?>
-<li><?php echo esc_html( $step ); ?></li>
+	<?php if ( is_array( $step ) ) : ?>
+	<?php
+	$phase      = sanitize_text_field( $step['phase'] ?? '' );
+	$timeline   = sanitize_text_field( $step['timeline'] ?? '' );
+	$activities = array_map( 'sanitize_text_field', (array) ( $step['activities'] ?? [] ) );
+	$parts      = array_filter( [ $phase, $timeline ] );
+	$summary    = implode( ' - ', $parts );
+	if ( ! empty( $activities ) ) {
+	$summary .= $summary ? ': ' : '';
+	$summary .= implode( ', ', $activities );
+	}
+	?>
+	<li><?php echo esc_html( $summary ); ?></li>
+	<?php else : ?>
+	<li><?php echo esc_html( $step ); ?></li>
+	<?php endif; ?>
 <?php endforeach; ?>
 </ul>
 </div>

--- a/tests/render-comprehensive-template.test.php
+++ b/tests/render-comprehensive-template.test.php
@@ -80,6 +80,15 @@ $business_case_data = [
                        ],
                ],
        ],
+       'technology_strategy' => [
+               'implementation_roadmap' => [
+                       [
+                               'phase'      => 'Phase 1',
+                               'timeline'   => 'Q1',
+                               'activities' => [ 'Setup', 'Training' ],
+                       ],
+               ],
+       ],
 ];
 
 $report_data = $business_case_data;
@@ -106,6 +115,11 @@ if ( strpos( $output, 'Operational Insights' ) === false || strpos( $output, 'Re
 if ( strpos( $output, 'No data provided' ) !== false ) {
         echo "Operational insights fallback triggered unexpectedly\n";
         exit( 1 );
+}
+
+if ( strpos( $output, 'Phase 1 - Q1: Setup, Training' ) === false ) {
+       echo "Implementation roadmap not rendered\n";
+       exit( 1 );
 }
 
 echo "Comprehensive template render test passed.\n";


### PR DESCRIPTION
## Summary
- Parse implementation roadmap entries using timeline and activities fields
- Format implementation roadmap steps in the comprehensive report template
- Cover roadmap rendering with a template test

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8eed86e108331a7661c3084a2e818