### PR TITLE
Align analysis keys across sections

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -526,7 +526,7 @@ $final_analysis['financial_benchmarks'] ?? ( $final_analysis['research']['financ
  * @return array Structured report data.
  */
 private static function structure_report_data( $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, $rag_context, $chart_data, $request_start, $financial_benchmarks = array() ) {
-	$operational_insights     = (array) ( $final_analysis['operational_insights'] ?? $final_analysis['operational_analysis'] ?? [] );
+$operational_insights     = (array) ( $final_analysis['operational_insights'] ?? [] );
 	$current_state_assessment = (array) ( $operational_insights['current_state_assessment'] ?? [] );
 	if ( empty( $current_state_assessment ) ) {
 		$current_state_assessment = [ __( 'No data provided', 'rtbcb' ) ];
@@ -611,7 +611,7 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 		$automation_opportunities = [ __( 'No data provided', 'rtbcb' ) ];
 	}
 
-	$risk_analysis        = (array) ( $final_analysis['risk_analysis'] ?? $final_analysis['risk_mitigation'] ?? [] );
+$risk_analysis        = (array) ( $final_analysis['risk_analysis'] ?? [] );
 	$implementation_risks = (array) ( $risk_analysis['implementation_risks'] ?? [] );
 	if ( empty( $implementation_risks ) ) {
 		$implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -230,9 +230,9 @@ $parsed = $this->response_parser->parse( $response );
 				'key_value_drivers'       => array_map( 'sanitize_text_field', $json['executive_summary']['key_value_drivers'] ?? [] ),
 				'executive_recommendation'=> sanitize_text_field( $json['executive_summary']['executive_recommendation'] ?? '' ),
 			],
-	               'operational_insights' => [
-	                       'current_state_assessment' => sanitize_text_field( $json['operational_insights']['current_state_assessment'] ?? ( $json['operational_analysis']['current_state_assessment'] ?? '' ) ),
-	               ],
+'operational_insights' => [
+'current_state_assessment' => sanitize_text_field( $json['operational_insights']['current_state_assessment'] ?? '' ),
+],
 			'industry_insights'   => [
 				'sector_trends'          => sanitize_text_field( $json['industry_insights']['sector_trends'] ?? '' ),
 				'competitive_benchmarks' => sanitize_text_field( $json['industry_insights']['competitive_benchmarks'] ?? '' ),
@@ -2462,8 +2462,7 @@ PROMPT;
 'operational_insights' => [
 'current_state_assessment' => array_map(
 'sanitize_textarea_field',
-(array) ( $analysis_data['operational_insights']['current_state_assessment'] ??
-( $analysis_data['operational_analysis']['current_state_assessment'] ?? [] ) )
+(array) ( $analysis_data['operational_insights']['current_state_assessment'] ?? [] )
 ),
 'process_improvements'     => [],
 'automation_opportunities' => [],
@@ -2488,11 +2487,11 @@ PROMPT;
 	],
 	],
 	'implementation_roadmap' => [],
-	'risk_analysis' => [
-	'implementation_risks'  => array_map( 'sanitize_text_field', (array) ( $analysis_data['risk_analysis']['implementation_risks'] ?? $analysis_data['risk_mitigation']['implementation_risks'] ?? [] ) ),
-	'mitigation_strategies' => array_map( 'sanitize_text_field', (array) ( $analysis_data['risk_analysis']['mitigation_strategies'] ?? $analysis_data['risk_mitigation']['mitigation_strategies'] ?? [] ) ),
-	'success_factors'      => array_map( 'sanitize_text_field', (array) ( $analysis_data['risk_analysis']['success_factors'] ?? $analysis_data['risk_mitigation']['success_factors'] ?? [] ) ),
-	],
+'risk_analysis' => [
+'implementation_risks'  => array_map( 'sanitize_text_field', (array) ( $analysis_data['risk_analysis']['implementation_risks'] ?? [] ) ),
+'mitigation_strategies' => array_map( 'sanitize_text_field', (array) ( $analysis_data['risk_analysis']['mitigation_strategies'] ?? [] ) ),
+'success_factors'      => array_map( 'sanitize_text_field', (array) ( $analysis_data['risk_analysis']['success_factors'] ?? [] ) ),
+],
 	'action_plan' => [
 	'immediate_steps'       => array_map( 'sanitize_text_field', (array) ( $analysis_data['action_plan']['immediate_steps'] ?? $analysis_data['next_steps']['immediate'] ?? [] ) ),
 	'short_term_milestones' => array_map( 'sanitize_text_field', (array) ( $analysis_data['action_plan']['short_term_milestones'] ?? $analysis_data['next_steps']['short_term'] ?? [] ) ),
@@ -2530,7 +2529,7 @@ $financial_benchmarks['valuation_multiples'] ?? []
 ];
 }
 
-foreach ( (array) ( $analysis_data['operational_insights']['process_improvements'] ?? $analysis_data['operational_analysis']['process_improvements'] ?? [] ) as $item ) {
+foreach ( (array) ( $analysis_data['operational_insights']['process_improvements'] ?? [] ) as $item ) {
 $analysis['operational_insights']['process_improvements'][] = [
 'process_area'   => sanitize_text_field( $item['process'] ?? ( $item['process_area'] ?? '' ) ),
 'current_state'  => sanitize_textarea_field( $item['current_state'] ?? '' ),
@@ -2539,7 +2538,7 @@ $analysis['operational_insights']['process_improvements'][] = [
 ];
 }
 
-foreach ( (array) ( $analysis_data['operational_insights']['automation_opportunities'] ?? $analysis_data['operational_analysis']['automation_opportunities'] ?? [] ) as $item ) {
+foreach ( (array) ( $analysis_data['operational_insights']['automation_opportunities'] ?? [] ) as $item ) {
 $analysis['operational_insights']['automation_opportunities'][] = [
 'opportunity'          => sanitize_text_field( $item['opportunity'] ?? '' ),
 'complexity'           => sanitize_text_field( $item['complexity'] ?? '' ),


### PR DESCRIPTION
## Summary
- remove fallback keys for operational insights in LLM parsing
- use `risk_analysis` consistently
- drop legacy fallbacks when structuring report data

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b9006a761483318d68edaca5fec77c