### PR TITLE
Refine operational insights generation

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2462,9 +2462,6 @@ $html = rtbcb_sanitize_report_html( $html );
                        return array_map( 'wp_kses_post', $data['operational_insights'] );
                }
 
-               if ( ! empty( $data['operational_analysis'] ) && is_array( $data['operational_analysis'] ) ) {
-                       return array_map( 'wp_kses_post', $data['operational_analysis'] );
-               }
 
 		$insights    = [];
 		$pain_points = (array) ( $data['pain_points'] ?? [] );
@@ -2489,7 +2486,8 @@ $html = rtbcb_sanitize_report_html( $html );
 			);
 		}
 
-		return $insights ?: [ __( 'Treasury operations show opportunities for process optimization and technology enhancement', 'rtbcb' ) ];
+		$insights = $insights ?: [ __( 'Treasury operations show opportunities for process optimization and technology enhancement', 'rtbcb' ) ];
+		return array_map( 'wp_kses_post', $insights );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- simplify `generate_operational_insights` by removing unused `operational_analysis` branch
- sanitize computed default insights before returning

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b9030b1f1083318ec590d3302bff00