### PR TITLE
Add risk matrix support to comprehensive prompts

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -611,11 +611,25 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 		$automation_opportunities = [ __( 'No data provided', 'rtbcb' ) ];
 	}
 
-	$risk_analysis        = (array) ( is_array( $final_analysis['risk_analysis'] ?? null ) ? $final_analysis['risk_analysis'] : [] );
-	$implementation_risks = (array) ( $risk_analysis['implementation_risks'] ?? [] );
-	if ( empty( $implementation_risks ) ) {
-		$implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
-	}
+       $risk_analysis        = (array) ( is_array( $final_analysis['risk_analysis'] ?? null ) ? $final_analysis['risk_analysis'] : [] );
+       $risk_matrix_raw      = (array) ( $risk_analysis['risk_matrix'] ?? [] );
+       $risk_matrix          = [];
+       foreach ( $risk_matrix_raw as $risk_item ) {
+               if ( is_array( $risk_item ) ) {
+                       $sanitized = [
+                               'risk'       => sanitize_text_field( $risk_item['risk'] ?? '' ),
+                               'likelihood' => sanitize_text_field( $risk_item['likelihood'] ?? '' ),
+                               'impact'     => sanitize_text_field( $risk_item['impact'] ?? '' ),
+                       ];
+                       if ( array_filter( $sanitized ) ) {
+                               $risk_matrix[] = $sanitized;
+                       }
+               }
+       }
+       $implementation_risks = (array) ( $risk_analysis['implementation_risks'] ?? [] );
+       if ( empty( $implementation_risks ) ) {
+               $implementation_risks = [ __( 'No data provided', 'rtbcb' ) ];
+       }
        $action_plan             = (array) ( $final_analysis['action_plan'] ?? [] );
        $immediate_steps_raw     = $action_plan['immediate_steps'] ?? ( $final_analysis['next_steps']['immediate'] ?? [] );
        $immediate_steps         = self::normalize_action_items( $immediate_steps_raw );
@@ -712,11 +726,12 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 				                                        'process_improvements'     => $process_improvements,
 				                                        'automation_opportunities' => $automation_opportunities,
 				        ],
-				        'risk_analysis' => [
-				                                        'implementation_risks' => $implementation_risks,
-				                                       'mitigation_strategies' => (array) ( is_array( $risk_analysis['mitigation_strategies'] ?? null ) ? $risk_analysis['mitigation_strategies'] : [] ),
-				                                       'success_factors'      => (array) ( is_array( $risk_analysis['success_factors'] ?? null ) ? $risk_analysis['success_factors'] : [] ),
-				        ],
+                                       'risk_analysis' => [
+                                                                       'risk_matrix'          => $risk_matrix,
+                                                                       'implementation_risks' => $implementation_risks,
+                                                                       'mitigation_strategies' => (array) ( is_array( $risk_analysis['mitigation_strategies'] ?? null ) ? $risk_analysis['mitigation_strategies'] : [] ),
+                                                                       'success_factors'      => (array) ( is_array( $risk_analysis['success_factors'] ?? null ) ? $risk_analysis['success_factors'] : [] ),
+                                       ],
 				        'action_plan' => [
 				                'immediate_steps'       => $immediate_steps,
 				                'short_term_milestones' => $short_term_milestones,

--- a/inc/class-rtbcb-llm-optimized.php
+++ b/inc/class-rtbcb-llm-optimized.php
@@ -395,6 +395,13 @@ PROMPT;
             "regulatory_considerations": ["array of 2-3 regulatory factors"]
           },
           "risk_analysis": {
+            "risk_matrix": [
+              {
+                "risk": "string - risk description",
+                "likelihood": "low|medium|high",
+                "impact": "low|medium|high"
+              }
+            ],
             "implementation_risks": ["array of 5-6 key implementation risks"],
             "mitigation_strategies": ["array of 5-6 specific risk mitigation approaches"],
             "success_factors": ["array of 5-6 critical success factors"]

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -1940,10 +1940,17 @@ $parsed  = $this->response_parser->parse( $response );
 		'competitive_benchmarks' => [ 'benchmark 1 for treasury efficiency', 'benchmark 2 for technology adoption' ],
 		'regulatory_considerations' => [ 'regulatory requirement 1', 'regulatory requirement 2' ],
 ],
-'risk_analysis' => [
-'implementation_risks' => [ 'risk 1: description and likelihood', 'risk 2: description and impact' ],
-'mitigation_strategies' => [ 'mitigation approach 1', 'mitigation approach 2' ],
-'success_factors'       => [ 'critical success factor 1', 'critical success factor 2' ],
+        'risk_analysis' => [
+        'risk_matrix' => [
+        [
+        'risk'       => 'risk description',
+        'likelihood' => 'low|medium|high',
+        'impact'     => 'low|medium|high',
+        ],
+        ],
+        'implementation_risks' => [ 'risk 1: description and likelihood', 'risk 2: description and impact' ],
+        'mitigation_strategies' => [ 'mitigation approach 1', 'mitigation approach 2' ],
+        'success_factors'       => [ 'critical success factor 1', 'critical success factor 2' ],
 ],
 'action_plan' => [
 'immediate_steps'      => [ 'immediate action 1 (next 30 days)', 'immediate action 2 (next 30 days)' ],

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -2365,7 +2365,21 @@ function rtbcb_transform_data_for_template( $business_case_data ) {
 			];
 	}
 
- // Prepare risk analysis.
+// Prepare risk analysis.
+$risk_matrix = [];
+if ( ! empty( $business_case_data['risk_analysis']['risk_matrix'] ) ) {
+$risk_matrix = array_map(
+function ( $risk ) {
+return [
+'risk'       => sanitize_text_field( $risk['risk'] ?? '' ),
+'likelihood' => sanitize_text_field( $risk['likelihood'] ?? '' ),
+'impact'     => sanitize_text_field( $risk['impact'] ?? '' ),
+];
+},
+(array) $business_case_data['risk_analysis']['risk_matrix']
+);
+}
+
 if ( ! empty( $business_case_data['risk_analysis']['implementation_risks'] ) ) {
 $implementation_risks = array_map( 'sanitize_text_field', (array) $business_case_data['risk_analysis']['implementation_risks'] );
 } elseif ( ! empty( $business_case_data['risks'] ) ) {
@@ -2432,6 +2446,7 @@ $success_factors = array_map( 'sanitize_text_field', (array) $business_case_data
                         ],
                         'operational_insights' => $operational_insights,
                           'risk_analysis'        => [
+                                'risk_matrix'          => $risk_matrix,
                                 'implementation_risks' => $implementation_risks,
                                 'mitigation_strategies' => $mitigation_strategies,
                                 'success_factors'      => $success_factors,

--- a/tests/RTBCB_RiskAnalysisTransformTest.php
+++ b/tests/RTBCB_RiskAnalysisTransformTest.php
@@ -36,19 +36,30 @@ require_once __DIR__ . '/../inc/helpers.php';
  */
 final class RTBCB_RiskAnalysisTransformTest extends TestCase {
 	public function test_risk_analysis_arrays_present() {
-		$input  = [
-			'risk_analysis' => [
-				'implementation_risks' => [ ' Risk A ', 'Risk B' ],
-				'mitigation_strategies' => [ ' Strategy A ', 'Strategy B' ],
-				'success_factors'      => [ ' Factor A ', 'Factor B' ],
-			],
-		];
+               $input  = [
+                       'risk_analysis' => [
+                               'risk_matrix' => [
+                                       [ 'risk' => ' Risk X ', 'likelihood' => ' High ', 'impact' => ' Low ' ],
+                                       [ 'risk' => 'Risk Y', 'likelihood' => 'Low', 'impact' => 'High' ],
+                               ],
+                               'implementation_risks' => [ ' Risk A ', 'Risk B' ],
+                               'mitigation_strategies' => [ ' Strategy A ', 'Strategy B' ],
+                               'success_factors'      => [ ' Factor A ', 'Factor B' ],
+                       ],
+               ];
 
-		$result = rtbcb_transform_data_for_template( $input );
-		$risk   = $result['risk_analysis'];
+               $result = rtbcb_transform_data_for_template( $input );
+               $risk   = $result['risk_analysis'];
 
-		$this->assertSame( [ 'Risk A', 'Risk B' ], $risk['implementation_risks'] );
-		$this->assertSame( [ 'Strategy A', 'Strategy B' ], $risk['mitigation_strategies'] );
-		$this->assertSame( [ 'Factor A', 'Factor B' ], $risk['success_factors'] );
-	}
+               $this->assertSame(
+                       [
+                               [ 'risk' => 'Risk X', 'likelihood' => 'High', 'impact' => 'Low' ],
+                               [ 'risk' => 'Risk Y', 'likelihood' => 'Low', 'impact' => 'High' ],
+                       ],
+                       $risk['risk_matrix']
+               );
+               $this->assertSame( [ 'Risk A', 'Risk B' ], $risk['implementation_risks'] );
+               $this->assertSame( [ 'Strategy A', 'Strategy B' ], $risk['mitigation_strategies'] );
+               $this->assertSame( [ 'Factor A', 'Factor B' ], $risk['success_factors'] );
+       }
 }

--- a/tests/RTBCB_StructureReportDataTest.php
+++ b/tests/RTBCB_StructureReportDataTest.php
@@ -91,6 +91,7 @@ self::assertSame( [], $financial['confidence_metrics'] );
 self::assertSame( [], $tech['category_details'] );
 self::assertSame( [], $tech['implementation_roadmap'] );
 self::assertSame( [], $tech['vendor_considerations'] );
+self::assertSame( [], $risk['risk_matrix'] );
 self::assertSame( [], $risk['mitigation_strategies'] );
 self::assertSame( [], $risk['success_factors'] );
 }
@@ -211,11 +212,12 @@ public function test_missing_risk_analysis_defaults_to_no_data() {
 	$recommendation   = [ 'recommended' => '', 'category_info' => [] ];
 	$final_analysis   = [];
 
-	$result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], microtime( true ), [] );
+        $result = $method->invoke( null, $user_inputs, $enriched_profile, $roi_scenarios, $recommendation, $final_analysis, [], microtime( true ), [] );
 
-	self::assertSame( [ 'No data provided' ], $result['risk_analysis']['implementation_risks'] );
-	self::assertSame( [], $result['risk_analysis']['mitigation_strategies'] );
-	self::assertSame( [], $result['risk_analysis']['success_factors'] );
+        self::assertSame( [], $result['risk_analysis']['risk_matrix'] );
+        self::assertSame( [ 'No data provided' ], $result['risk_analysis']['implementation_risks'] );
+        self::assertSame( [], $result['risk_analysis']['mitigation_strategies'] );
+        self::assertSame( [], $result['risk_analysis']['success_factors'] );
 }
 
 public function test_financial_benchmarks_pass_through() {


### PR DESCRIPTION
## Summary
- extend comprehensive business case prompt schema with structured `risk_matrix`
- sanitize and return `risk_matrix` data in AJAX and helper routines
- update tests for new risk analysis schema and ensure optimized prompt matches

## Testing
- `bash tests/run-tests.sh`
- `php /tmp/prompt_check.php`

------
https://chatgpt.com/codex/tasks/task_e_68b90cb1403c8331aab1bfa275371d5e