### PR TITLE
Ensure action plan key consistency and test coverage

### DIFF
--- a/templates/comprehensive-report-template.php
+++ b/templates/comprehensive-report-template.php
@@ -701,7 +701,7 @@ echo '<li>' . esc_html( $label . ': ' . $value ) . '</li>';
 							<span class="rtbcb-timeline-duration"><?php echo esc_html__( 'Next 30 days', 'rtbcb' ); ?></span>
 						</div>
 						<ul class="rtbcb-action-list">
-							<?php foreach ( $action_plan['immediate_steps'] as $step ) : ?>
+							<?php foreach ( (array) $action_plan['immediate_steps'] as $step ) : ?>
 								<li><?php echo esc_html( $step ); ?></li>
 							<?php endforeach; ?>
 						</ul>
@@ -716,7 +716,7 @@ echo '<li>' . esc_html( $label . ': ' . $value ) . '</li>';
 							<span class="rtbcb-timeline-duration"><?php echo esc_html__( '3-6 months', 'rtbcb' ); ?></span>
 						</div>
 						<ul class="rtbcb-action-list">
-							<?php foreach ( $action_plan['short_term_milestones'] as $milestone ) : ?>
+							<?php foreach ( (array) $action_plan['short_term_milestones'] as $milestone ) : ?>
 								<li><?php echo esc_html( $milestone ); ?></li>
 							<?php endforeach; ?>
 						</ul>
@@ -731,7 +731,7 @@ echo '<li>' . esc_html( $label . ': ' . $value ) . '</li>';
 							<span class="rtbcb-timeline-duration"><?php echo esc_html__( '6+ months', 'rtbcb' ); ?></span>
 						</div>
 						<ul class="rtbcb-action-list">
-							<?php foreach ( $action_plan['long_term_objectives'] as $objective ) : ?>
+							<?php foreach ( (array) $action_plan['long_term_objectives'] as $objective ) : ?>
 								<li><?php echo esc_html( $objective ); ?></li>
 							<?php endforeach; ?>
 						</ul>

--- a/tests/RTBCB_ActionPlanKeysTest.php
+++ b/tests/RTBCB_ActionPlanKeysTest.php
@@ -1,0 +1,50 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+	}
+
+defined( 'ABSPATH' ) || exit;
+
+	require_once __DIR__ . '/wp-stubs.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ensure action plan keys are present in comprehensive prompts.
+ */
+final class RTBCB_ActionPlanKeysTest extends TestCase {
+	public function test_build_comprehensive_prompt_includes_action_plan_keys() {
+	require_once __DIR__ . '/../inc/class-rtbcb-llm.php';
+	$llm    = new RTBCB_LLM();
+	$method = new ReflectionMethod( RTBCB_LLM::class, 'build_comprehensive_prompt' );
+	$method->setAccessible( true );
+
+	$user_inputs = [ 'company_name' => 'Acme', 'pain_points' => [] ];
+	$roi_data = [ 'conservative' => [ 'total_annual_benefit' => 0 ], 'base' => [ 'total_annual_benefit' => 0 ], 'optimistic' => [ 'total_annual_benefit' => 0 ] ];
+	$company_research = [ 'company_profile' => [ 'business_stage' => '', 'key_characteristics' => '', 'treasury_priorities' => '', 'common_challenges' => '' ] ];
+	$prompt = $method->invoke( $llm, $user_inputs, $roi_data, $company_research, [], '', [], [] );
+
+	$this->assertStringContainsString( '"action_plan"', $prompt );
+	$this->assertStringContainsString( '"immediate_steps"', $prompt );
+	$this->assertStringContainsString( '"short_term_milestones"', $prompt );
+	$this->assertStringContainsString( '"long_term_objectives"', $prompt );
+	}
+
+	public function test_optimized_prompt_includes_action_plan_keys() {
+	require_once __DIR__ . '/../inc/class-rtbcb-llm-optimized.php';
+	$llm    = new RTBCB_LLM_Optimized();
+	$method = new ReflectionMethod( RTBCB_LLM_Optimized::class, 'build_comprehensive_prompt' );
+	$method->setAccessible( true );
+
+	$user_inputs = [ 'company_name' => 'Acme', 'pain_points' => [], 'business_objective' => '', 'implementation_timeline' => '', 'budget_range' => '' ];
+	$roi_data = [ 'conservative' => [ 'total_annual_benefit' => 0 ], 'base' => [ 'total_annual_benefit' => 0 ], 'optimistic' => [ 'total_annual_benefit' => 0 ] ];
+	$company_research = [ 'company_profile' => [ 'business_stage' => '', 'key_characteristics' => '', 'treasury_priorities' => '', 'common_challenges' => '' ] ];
+	$prompt = $method->invoke( $llm, $user_inputs, $roi_data, $company_research, [], '', [], [] );
+
+	$this->assertStringContainsString( '"action_plan"', $prompt );
+	$this->assertStringContainsString( '"immediate_steps"', $prompt );
+	$this->assertStringContainsString( '"short_term_milestones"', $prompt );
+	$this->assertStringContainsString( '"long_term_objectives"', $prompt );
+	}
+	}
+


### PR DESCRIPTION
## Summary
- Cast action plan loops in comprehensive report template to arrays for consistent key usage
- Add unit tests verifying comprehensive prompt schema includes action plan keys

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b90ce41b6c8331b08546a69a8a0f17