### PR TITLE
Handle action plan array items from API

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -841,15 +841,15 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
        private static function normalize_action_items( $items ) {
                $normalized = array();
                foreach ( (array) $items as $item ) {
-                       if ( is_array( $item ) ) {
-                               $action   = sanitize_text_field( $item['action'] ?? ( $item['step'] ?? ( $item['milestone'] ?? ( $item['objective'] ?? '' ) ) ) );
-                               $owner    = sanitize_text_field( $item['owner'] ?? '' );
-                               $timeline = sanitize_text_field( $item['timeline'] ?? ( $item['timeframe'] ?? '' ) );
-                               $parts    = array_filter( array( $action, $owner, $timeline ) );
-                               $summary  = implode( ' - ', $parts );
-                       } else {
-                               $summary = sanitize_text_field( $item );
-                       }
+if ( is_array( $item ) ) {
+$action   = sanitize_text_field( $item['action'] ?? ( $item['step'] ?? ( $item['milestone'] ?? ( $item['objective'] ?? ( $item['description'] ?? ( $item['task'] ?? '' ) ) ) ) ) );
+$owner    = sanitize_text_field( $item['owner'] ?? '' );
+$timeline = sanitize_text_field( $item['timeline'] ?? ( $item['timeframe'] ?? ( $item['deadline'] ?? '' ) ) );
+$parts    = array_filter( array( $action, $owner, $timeline ) );
+$summary  = implode( ' - ', $parts );
+} else {
+$summary = sanitize_text_field( $item );
+}
 
                        if ( '' !== $summary ) {
                                $normalized[] = $summary;

--- a/inc/class-rtbcb-llm.php
+++ b/inc/class-rtbcb-llm.php
@@ -2509,11 +2509,11 @@ PROMPT;
 		'mitigation_strategies' => array_map( 'sanitize_text_field', (array) ( $analysis_data['risk_analysis']['mitigation_strategies'] ?? [] ) ),
 		'success_factors'      => array_map( 'sanitize_text_field', (array) ( $analysis_data['risk_analysis']['success_factors'] ?? [] ) ),
 		],
-	'action_plan' => [
-		'immediate_steps'       => array_map( 'sanitize_text_field', (array) ( $analysis_data['action_plan']['immediate_steps'] ?? $analysis_data['next_steps']['immediate'] ?? [] ) ),
-		'short_term_milestones' => array_map( 'sanitize_text_field', (array) ( $analysis_data['action_plan']['short_term_milestones'] ?? $analysis_data['next_steps']['short_term'] ?? [] ) ),
-		'long_term_objectives'  => array_map( 'sanitize_text_field', (array) ( $analysis_data['action_plan']['long_term_objectives'] ?? $analysis_data['next_steps']['long_term'] ?? [] ) ),
-		],
+'action_plan' => [
+'immediate_steps'       => function_exists( 'rtbcb_sanitize_recursive' ) ? rtbcb_sanitize_recursive( (array) ( $analysis_data['action_plan']['immediate_steps'] ?? $analysis_data['next_steps']['immediate'] ?? [] ) ) : array(),
+'short_term_milestones' => function_exists( 'rtbcb_sanitize_recursive' ) ? rtbcb_sanitize_recursive( (array) ( $analysis_data['action_plan']['short_term_milestones'] ?? $analysis_data['next_steps']['short_term'] ?? [] ) ) : array(),
+'long_term_objectives'  => function_exists( 'rtbcb_sanitize_recursive' ) ? rtbcb_sanitize_recursive( (array) ( $analysis_data['action_plan']['long_term_objectives'] ?? $analysis_data['next_steps']['long_term'] ?? [] ) ) : array(),
+],
 	'vendor_considerations' => [],
 	];
 	


### PR DESCRIPTION
## Summary
- Preserve nested action plan arrays by sanitizing recursively
- Support additional action item keys (description, task, deadline) when normalizing items

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b91279676083319543e6d15885f80c