### PR TITLE
Use verified company industry for AI prompts

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -494,9 +494,9 @@ $final_analysis['financial_benchmarks'] ?? ( $final_analysis['research']['financ
 	private static function create_fallback_profile( $user_inputs ) {
 		return [
 			'company_profile' => [
-				'name'               => $user_inputs['company_name'],
-				'size'               => $user_inputs['company_size'],
-				'industry'           => $user_inputs['industry'],
+                               'name'               => $user_inputs['company_name'],
+                               'size'               => $user_inputs['company_size'],
+                               'industry'           => ( function_exists( 'rtbcb_get_current_company' ) ? ( rtbcb_get_current_company()['industry'] ?? '' ) : '' ),
 				'maturity_level'     => 'basic',
 				'key_challenges'     => $user_inputs['pain_points'],
 				'strategic_priorities'=> [ $user_inputs['business_objective'] ],
@@ -639,7 +639,7 @@ $current_state_assessment = (array) ( $operational_insights['current_state_asses
 	$regulatory_landscape_raw = (array) ( $industry_context_raw['regulatory_landscape'] ?? [] );
 	$enriched_profile_struct = [
 		'name'                => $company_profile['name'] ?? '',
-		'industry'           => $company_profile['industry'] ?? sanitize_text_field( $user_inputs['industry'] ?? '' ),
+               'industry'           => $company_profile['industry'] ?? '',
 		'enhanced_description'=> $company_profile['enhanced_description'] ?? ( $company_profile['description'] ?? '' ),
 		'maturity_level'      => $company_profile['maturity_level'] ?? '',
 		'treasury_maturity'   => (array) ( is_array( $company_profile['treasury_maturity'] ?? null ) ? $company_profile['treasury_maturity'] : [] ),
@@ -726,13 +726,13 @@ $current_state_assessment = (array) ( $operational_insights['current_state_asses
 	}
 
 	private static function build_rag_search_query( $user_inputs, $enriched_profile ) {
-		$query_parts = [
-			$user_inputs['company_name'],
-			$user_inputs['industry'],
-			$enriched_profile['company_profile']['maturity_level'] ?? '',
-			implode( ' ', $user_inputs['pain_points'] ),
-			$user_inputs['business_objective'],
-		];
+               $query_parts = [
+                       $user_inputs['company_name'],
+                       $enriched_profile['company_profile']['industry'] ?? '',
+                       $enriched_profile['company_profile']['maturity_level'] ?? '',
+                       implode( ' ', $user_inputs['pain_points'] ),
+                       $user_inputs['business_objective'],
+               ];
 
 		return implode( ' ', array_filter( $query_parts ) );
 	}

--- a/inc/class-rtbcb-calculator.php
+++ b/inc/class-rtbcb-calculator.php
@@ -22,7 +22,8 @@ class RTBCB_Calculator {
 	*/
 	public static function calculate_roi( $user_inputs, $category = [] ) {
                $settings      = class_exists( 'RTBCB_Settings' ) ? RTBCB_Settings::get_all() : [];
-		$industry_mult = self::get_industry_benchmark( $user_inputs['industry'] ?? '' );
+               $company       = function_exists( 'rtbcb_get_current_company' ) ? rtbcb_get_current_company() : [];
+               $industry_mult = self::get_industry_benchmark( $company['industry'] ?? '' );
 
 		$scenarios = [];
 		foreach ( [ 'conservative', 'base', 'optimistic' ] as $scenario ) {

--- a/inc/class-rtbcb-llm-optimized.php
+++ b/inc/class-rtbcb-llm-optimized.php
@@ -51,7 +51,6 @@ SYSTEM;
 
 ### Company Profile
 - **Company Name**: {$user_inputs['company_name']}
-- **Industry Sector**: {$user_inputs['industry']}
 - **Revenue Size**: {$user_inputs['company_size']}
 - **Business Objective**: {$user_inputs['business_objective']}
 - **Implementation Timeline**: {$user_inputs['implementation_timeline']}
@@ -73,12 +72,13 @@ Provide deep, actionable insights to support:
 5. **Risk Baseline**: Key operational and strategic risk considerations
 6. **Financial Benchmarking**: Relevant industry metrics and valuation references
 
-Focus on treasury-specific challenges and opportunities within the {$user_inputs['industry']} industry for a {$user_inputs['company_size']} organization.
+Focus on treasury-specific challenges and opportunities relevant to the company's industry for a {$user_inputs['company_size']} organization.
 
 ### Required JSON Output Schema
 ```json
 {
   "company_profile": {
+    "industry": "string - primary industry sector",
     "enhanced_description": "string - 2-3 sentence business model and market position summary",
     "business_model": "string - primary revenue streams and operational model",
     "market_position": "string - competitive standing and differentiators",
@@ -225,9 +225,11 @@ PROMPT;
 	// Company Intelligence - uses company_research.
 	$prompt .= "## Company Intelligence\n\n";
 	$prompt .= "### Company Profile\n";
-	$prompt .= "- **Name**: {$company_name}\n";
-	$prompt .= "- **Industry**: {$user_inputs['industry']}\n";
-	$prompt .= "- **Revenue Size**: {$user_inputs['company_size']}\n";
+       $prompt .= "- **Name**: {$company_name}\n";
+       $company_data = function_exists( 'rtbcb_get_current_company' ) ? rtbcb_get_current_company() : [];
+       $industry = $company_data['industry'] ?? '';
+       $prompt .= "- **Industry**: {$industry}\n";
+       $prompt .= "- **Revenue Size**: {$user_inputs['company_size']}\n";
 	$prompt .= "- **Business Stage**: {$business_stage}\n";
 	$prompt .= "- **Key Characteristics**: {$key_characteristics}\n";
 	$prompt .= "- **Treasury Priorities**: {$treasury_priorities}\n\n";
@@ -547,7 +549,7 @@ SCHEMA;
 	               'pain_points_factor' => count( $user_inputs['pain_points'] ?? [] ) * 0.1,
 	               'context_factor' => count( $context_chunks ) * 0.15,
 	               'analysis_type_factor' => $this->get_analysis_type_complexity( $analysis_type ),
-	               'industry_factor' => $this->get_industry_complexity( $user_inputs['industry'] ?? '' ),
+                       'industry_factor' => $this->get_industry_complexity( ( function_exists( 'rtbcb_get_current_company' ) ? ( rtbcb_get_current_company()['industry'] ?? '' ) : '' ) ),
 	       ];
 
 	       $total_complexity = array_sum( $complexity_factors );

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -1240,7 +1240,7 @@ $lead_id = $this->save_lead_data( $user_inputs, $scenarios, $recommendation, $re
 		$search_query = implode(
 		' ',
 		array_merge(
-			[ $user_inputs['company_name'], $user_inputs['industry'] ],
+                       [ $user_inputs['company_name'], ( function_exists( 'rtbcb_get_current_company' ) ? ( rtbcb_get_current_company()['industry'] ?? '' ) : '' ) ],
 			$user_inputs['pain_points'],
 			[ $recommendation['recommended'] ?? '' ]
 		)
@@ -1442,7 +1442,7 @@ $required_keys = [
 	'email'			 => $user_inputs['email'],
 	'company_name'           => $company_name,
 	'company_size'		 => $user_inputs['company_size'],
-	'industry'		 => $user_inputs['industry'],
+	'industry'		 => ( function_exists( 'rtbcb_get_current_company' ) ? ( rtbcb_get_current_company()['industry'] ?? '' ) : '' ),
 	'hours_reconciliation'	 => $user_inputs['hours_reconciliation'],
 	'hours_cash_positioning' => $user_inputs['hours_cash_positioning'],
 	'num_banks'		 => $user_inputs['num_banks'],
@@ -1700,12 +1700,6 @@ $required_keys = [
 			return;
 		}
 
-		if ( empty( $user_inputs['industry'] ) ) {
-			rtbcb_log_error( 'Missing industry', $user_inputs );
-			wp_send_json_error( __( 'Please select your industry.', 'rtbcb' ), 400 );
-			return;
-		}
-
 		if ( $user_inputs['hours_reconciliation'] < 0 ) {
 			rtbcb_log_error( 'Invalid reconciliation hours', $user_inputs );
 			wp_send_json_error( __( 'Please enter your weekly reconciliation hours.', 'rtbcb' ), 400 );
@@ -1783,12 +1777,12 @@ $required_keys = [
 				$rag = new RTBCB_RAG();
 				$search_query = implode(
 					' ',
-					array_merge(
-						[ $user_inputs['company_name'], $user_inputs['industry'] ],
-						$user_inputs['pain_points'],
-						[ $recommendation['recommended'] ?? '' ]
-					)
-				);
+                                       array_merge(
+                                               [ $user_inputs['company_name'], ( function_exists( 'rtbcb_get_current_company' ) ? ( rtbcb_get_current_company()['industry'] ?? '' ) : '' ) ],
+                                               $user_inputs['pain_points'],
+                                               [ $recommendation['recommended'] ?? '' ]
+                                       )
+                               );
 				rtbcb_log_api_debug( 'Performing RAG search', [ 'query' => $search_query ] );
 				$rag_context = $rag->search_similar( $search_query, 3 );
 				rtbcb_log_api_debug( 'RAG search results', $rag_context );
@@ -2049,7 +2043,7 @@ $missing_sections  = array_diff( $required_sections, array_keys( $comprehensive_
 				$lead_data = [
 					'email'			 => $user_inputs['email'],
 					'company_size'		 => $user_inputs['company_size'],
-					'industry'		 => $user_inputs['industry'],
+					'industry'		 => ( function_exists( 'rtbcb_get_current_company' ) ? ( rtbcb_get_current_company()['industry'] ?? '' ) : '' ),
 					'hours_reconciliation'	 => $user_inputs['hours_reconciliation'],
 					'hours_cash_positioning' => $user_inputs['hours_cash_positioning'],
 					'num_banks'		 => $user_inputs['num_banks'],


### PR DESCRIPTION
## Summary
- Derive industry from stored company data instead of relying on form input when generating prompts
- Include company industry in enrichment JSON schema and validate it from LLM responses
- Feed company profile industry into ROI calculations, fallback profiles, and RAG searches

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b983b9791083319ec0b89c1ad7dd0f