### PR TITLE
Replace industry insights section with financial benchmarks

### DIFF
--- a/inc/class-rtbcb-response-parser.php
+++ b/inc/class-rtbcb-response-parser.php
@@ -481,7 +481,7 @@ $required = [
 'operational_insights',
 'risk_analysis',
 'action_plan',
-'industry_insights',
+'financial_benchmarks',
 'technology_strategy',
 'financial_analysis',
 ];

--- a/tests/RTBCB_ResponseParserTest.php
+++ b/tests/RTBCB_ResponseParserTest.php
@@ -72,12 +72,12 @@ final class RTBCB_ResponseParserTest extends TestCase {
 				$valid = [
 						'executive_summary'    => [],
 						'company_intelligence' => [],
-						'operational_insights' => [],
-						'risk_analysis'        => [],
-						'action_plan'          => [],
-						'industry_insights'    => [],
-						'technology_strategy'  => [],
-						'financial_analysis'   => [],
+'operational_insights' => [],
+'risk_analysis'        => [],
+'action_plan'          => [],
+'financial_benchmarks' => [],
+'technology_strategy'  => [],
+'financial_analysis'   => [],
 				];
 				$response = [ 'body' => json_encode( [ 'output_text' => json_encode( $valid ) ] ) ];
 				$parser  = new RTBCB_Response_Parser();
@@ -105,12 +105,12 @@ final class RTBCB_ResponseParserTest extends TestCase {
 				'analysis' => [
 					'executive_summary'    => [],
 					'company_intelligence' => [],
-					'operational_insights' => [],
-					'risk_analysis'        => [],
-					'action_plan'          => [],
-					'industry_insights'    => [],
-					'technology_strategy'  => [],
-					'financial_analysis'   => [],
+'operational_insights' => [],
+'risk_analysis'        => [],
+'action_plan'          => [],
+'financial_benchmarks' => [],
+'technology_strategy'  => [],
+'financial_analysis'   => [],
 				],
 			];
 			$response = [ 'body' => json_encode( [ 'output_text' => json_encode( $wrapped ) ] ) ];

--- a/tests/logged-prompt.test.php
+++ b/tests/logged-prompt.test.php
@@ -98,7 +98,7 @@ return [ 'body' => wp_json_encode( [ 'output_text' => wp_json_encode( [
 'operational_insights' => [],
 'risk_analysis'        => [],
 'action_plan'          => [],
-'industry_insights'    => [],
+'financial_benchmarks' => [],
 'technology_strategy'  => [ 'implementation_roadmap' => [] ],
 'financial_analysis'   => [],
 ] ) ] ) ];
@@ -113,7 +113,7 @@ return [
 'operational_insights' => [],
 'risk_analysis'        => [],
 'action_plan'          => [],
-'industry_insights'    => [],
+'financial_benchmarks' => [],
 'technology_strategy'  => [],
 'financial_analysis'   => [],
 ];

--- a/tests/parse-comprehensive-response.test.php
+++ b/tests/parse-comprehensive-response.test.php
@@ -59,12 +59,12 @@ $parser = new RTBCB_Response_Parser();
 $valid_json = [
         'executive_summary' => [ 'strategic_positioning' => 'pos' ],
         'company_intelligence' => [],
-        'operational_insights' => [],
-        'risk_analysis' => [],
-        'action_plan' => [],
-        'industry_insights' => [],
-        'technology_strategy' => [],
-        'financial_analysis' => [],
+'operational_insights' => [],
+'risk_analysis' => [],
+'action_plan' => [],
+'financial_benchmarks' => [],
+'technology_strategy' => [],
+'financial_analysis' => [],
 ];
 
 $response = [
@@ -86,7 +86,7 @@ $required = [
         'operational_insights',
         'risk_analysis',
         'action_plan',
-        'industry_insights',
+'financial_benchmarks',
         'technology_strategy',
         'financial_analysis',
 ];


### PR DESCRIPTION
## Summary
- Require `financial_benchmarks` instead of `industry_insights` when parsing business case responses
- Update tests for new required section and keep missing-section error handling

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=test RTBCB_TEST_MODEL=gpt-4o-mini bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b9932c086c83319d7880728a5f97bf