### PR TITLE
refactor: remove unused response parsers

### DIFF
--- a/docs/MEMORY_USAGE.md
+++ b/docs/MEMORY_USAGE.md
@@ -1,9 +1,9 @@
 # MEMORY_USAGE
 
 The plugin reduces memory usage during LLM calls by streaming chunks directly to handlers and
-discarding processed data. Additionally, `rtbcb_parse_gpt5_response()` can skip storing the full raw
+discarding processed data. Additionally, `RTBCB_Response_Parser::parse()` can skip storing the full raw
 payload unless requested, lowering peak memory.
 
 - The LLM client now processes stream chunks incrementally and logs peak memory after each call.
-- Pass `true` as the second argument to `rtbcb_parse_gpt5_response()` when raw response details are needed.
+- Pass `true` as the second argument to `RTBCB_Response_Parser::parse()` when raw response details are needed.
 - Run `tests/report-memory-usage.test.php` and `tests/parse-gpt5-response-raw-option.test.php` to monitor for regressions.

--- a/inc/class-rtbcb-settings.php
+++ b/inc/class-rtbcb-settings.php
@@ -57,14 +57,6 @@ class RTBCB_Settings {
        * @return void
        */
        public static function register_settings() {
-               register_setting(
-                       'rtbcb_settings',
-                       'rtbcb_clean_json_responses',
-                       [
-                               'type'              => 'boolean',
-                               'default'           => true,
-                               'sanitize_callback' => 'rest_sanitize_boolean',
-                       ]
-               );
+               // Placeholder for future settings.
        }
 }


### PR DESCRIPTION
## Summary
- remove obsolete helper functions for parsing responses
- drop unused `rtbcb_clean_json_responses` setting
- document `RTBCB_Response_Parser::parse()` for memory options

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `OPENAI_API_KEY=dummy RTBCB_TEST_MODEL=dummy bash tests/run-tests.sh`
- `phpcs --standard=WordPress inc/class-rtbcb-settings.php inc/helpers.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99580a37c83319def19489dfaa96e