### PR TITLE
Refactor to OpenAI responses API

### DIFF
--- a/admin/api-logs-page.php
+++ b/admin/api-logs-page.php
@@ -44,8 +44,8 @@ if ( ! current_user_can( 'manage_options' ) ) {
 						$request  = json_decode( $log['request_json'], true );
 						$response = json_decode( $log['response_json'], true );
 						$summary  = '';
-						if ( isset( $request['messages'][0]['content'] ) ) {
-							$summary = wp_trim_words( $request['messages'][0]['content'], 10, '...' );
+						if ( isset( $request['input'][0]['content'] ) ) {
+							$summary = wp_trim_words( $request['input'][0]['content'], 10, '...' );
 						} else {
 							$summary = wp_trim_words( $log['request_json'], 10, '...' );
 						}


### PR DESCRIPTION
## Summary
- remove legacy `messages` handling from OpenAI client
- generate strategic analysis through the `/v1/responses` API
- show request summaries from the new `input` field on API log page

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b9a399cf708331bf3c4e64c2ffb301