### PR TITLE
Avoid duplicate API logs and ensure model info

### DIFF
--- a/inc/class-rtbcb-llm-unified.php
+++ b/inc/class-rtbcb-llm-unified.php
@@ -2298,13 +2298,6 @@ PROMPT;
                $data    = json_decode( $parsed['output_text'], true );
 
                if ( $this->is_valid_strategic_response( $data ) ) {
-                       if ( class_exists( 'RTBCB_API_Log' ) ) {
-                               $user_email   = $this->current_inputs['email'] ?? '';
-                               $company_name = $this->current_inputs['company_name'] ?? '';
-                               $model = $payload['model'] ?? '';
-                               RTBCB_API_Log::save_log( $payload, $decoded, get_current_user_id(), $user_email, $company_name, 0, $model );
-                       }
-
                        return $this->validate_and_structure_analysis( $data );
                }
 
@@ -3137,9 +3130,9 @@ return $analysis;
                         return;
                 }
 
-                $user_id      = function_exists( 'get_current_user_id' ) ? get_current_user_id() : 0;
-                $user_email   = $request['email'] ?? '';
-                $company_name = $request['company_name'] ?? '';
+               $user_id      = function_exists( 'get_current_user_id' ) ? get_current_user_id() : 0;
+               $user_email   = $request['email'] ?? ( $this->current_inputs['email'] ?? '' );
+               $company_name = $request['company_name'] ?? ( $this->current_inputs['company_name'] ?? '' );
 
                 $model = $request['model'] ?? '';
                 RTBCB_API_Log::save_log( $request, $response, $user_id, $user_email, $company_name, 0, $model );


### PR DESCRIPTION
## Summary
- Prevent duplicate API log entries by removing extra `save_log` call after strategic analysis generation.
- Populate API log context with current user email and company name when not provided.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: AssertionError in render-results-no-narrative.test.js)*
- `vendor/bin/phpcs --standard=WordPress inc/class-rtbcb-llm-unified.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b33ea6308331be786cdcc2ee60f6