### PR TITLE
feat: expand intake wizard questions

### DIFF
--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -126,8 +126,8 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 					</div>
 
 					<!-- Optional: Add current position field for more personalization -->
-					<div class="rtbcb-field">
-						<label for="job_title"><?php esc_html_e( 'Your Role (Optional)', 'rtbcb' ); ?></label>
+<div class="rtbcb-field">
+<label for="job_title"><?php esc_html_e( 'Your Role (Optional)', 'rtbcb' ); ?></label>
 						<select name="job_title" id="job_title">
 							<option value=""><?php esc_html_e( 'Select your role...', 'rtbcb' ); ?></option>
 							<option value="cfo"><?php esc_html_e( 'CFO', 'rtbcb' ); ?></option>
@@ -138,12 +138,32 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 							<option value="controller"><?php esc_html_e( 'Controller', 'rtbcb' ); ?></option>
 							<option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
 						</select>
-						<div class="rtbcb-field-help">
-							<?php esc_html_e( 'Helps us tailor recommendations to your perspective', 'rtbcb' ); ?>
-						</div>
-					</div>
-				</div>
-			</div>
+                                               <div class="rtbcb-field-help">
+                                                       <?php esc_html_e( 'Helps us tailor recommendations to your perspective', 'rtbcb' ); ?>
+                                               </div>
+                                       </div>
+
+                                       <div class="rtbcb-field rtbcb-field-required">
+                                               <label for="num_entities">
+                                                       <?php esc_html_e( 'Number of Legal Entities', 'rtbcb' ); ?>
+                                               </label>
+                                               <input type="number" name="num_entities" id="num_entities" min="1" step="1" required />
+                                               <div class="rtbcb-field-help">
+                                                       <?php esc_html_e( 'Count of subsidiaries or business units handled by treasury.', 'rtbcb' ); ?>
+                                               </div>
+                                       </div>
+
+                                       <div class="rtbcb-field rtbcb-field-required">
+                                               <label for="num_currencies">
+                                                       <?php esc_html_e( 'Number of Active Currencies', 'rtbcb' ); ?>
+                                               </label>
+                                               <input type="number" name="num_currencies" id="num_currencies" min="1" step="1" required />
+                                               <div class="rtbcb-field-help">
+                                                       <?php esc_html_e( 'How many currencies do you transact in?', 'rtbcb' ); ?>
+                                               </div>
+                                       </div>
+                               </div>
+                       </div>
 
 			<!-- Step 2: Treasury Operations -->
 			<div class="rtbcb-wizard-step" data-step="2">
@@ -190,12 +210,262 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 						<label for="ftes">
 							<?php esc_html_e( 'Treasury Team Size (FTEs)', 'rtbcb' ); ?>
 						</label>
-						<input type="number" name="ftes" id="ftes"
-							min="0.5" max="100" step="0.5" placeholder="0" required inputmode="decimal" />
-						<div class="rtbcb-field-help">
-							<?php esc_html_e( 'Full-time equivalent employees dedicated to treasury functions', 'rtbcb' ); ?>
-						</div>
-					</div>
+<input type="number" name="ftes" id="ftes"
+min="0.5" max="100" step="0.5" placeholder="0" required inputmode="decimal" />
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Full-time equivalent employees dedicated to treasury functions', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="treasury_automation">
+<?php esc_html_e( 'Treasury Workflow Automation Level', 'rtbcb' ); ?>
+</label>
+<select name="treasury_automation" id="treasury_automation" required>
+<option value=""><?php esc_html_e( 'Select automation level...', 'rtbcb' ); ?></option>
+<option value="manual"><?php esc_html_e( 'Mostly manual', 'rtbcb' ); ?></option>
+<option value="some"><?php esc_html_e( 'Some automation', 'rtbcb' ); ?></option>
+<option value="full"><?php esc_html_e( 'Fully automated', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Assess the degree to which treasury tasks rely on spreadsheets versus software.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="primary_systems">
+<?php esc_html_e( 'Primary Treasury Systems in Use', 'rtbcb' ); ?>
+</label>
+<select name="primary_systems[]" id="primary_systems" multiple required>
+<option value="erp"><?php esc_html_e( 'ERP', 'rtbcb' ); ?></option>
+<option value="bank_portals"><?php esc_html_e( 'Bank portals', 'rtbcb' ); ?></option>
+<option value="spreadsheets"><?php esc_html_e( 'Spreadsheets', 'rtbcb' ); ?></option>
+<option value="tms"><?php esc_html_e( 'Dedicated TMS', 'rtbcb' ); ?></option>
+<option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Select all platforms used today for treasury tasks.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="bank_import_frequency">
+<?php esc_html_e( 'Frequency of Bank Statement Imports', 'rtbcb' ); ?>
+</label>
+<select name="bank_import_frequency" id="bank_import_frequency" required>
+<option value=""><?php esc_html_e( 'Select frequency...', 'rtbcb' ); ?></option>
+<option value="manual_daily"><?php esc_html_e( 'Manual daily', 'rtbcb' ); ?></option>
+<option value="manual_weekly"><?php esc_html_e( 'Manual weekly', 'rtbcb' ); ?></option>
+<option value="automated_daily"><?php esc_html_e( 'Automated daily', 'rtbcb' ); ?></option>
+<option value="real_time"><?php esc_html_e( 'Real-time', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'How often are bank statements imported into your systems?', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="reporting_cadence">
+<?php esc_html_e( 'Reporting Cadence to Stakeholders', 'rtbcb' ); ?>
+</label>
+<select name="reporting_cadence" id="reporting_cadence" required>
+<option value=""><?php esc_html_e( 'Select cadence...', 'rtbcb' ); ?></option>
+<option value="ad_hoc"><?php esc_html_e( 'Ad-hoc', 'rtbcb' ); ?></option>
+<option value="monthly"><?php esc_html_e( 'Monthly', 'rtbcb' ); ?></option>
+<option value="weekly"><?php esc_html_e( 'Weekly', 'rtbcb' ); ?></option>
+<option value="daily"><?php esc_html_e( 'Daily', 'rtbcb' ); ?></option>
+<option value="real_time"><?php esc_html_e( 'Real-time dashboard', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Frequency of delivering cash/treasury reports to management.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="annual_payment_volume">
+<?php esc_html_e( 'Annual Payment Volume', 'rtbcb' ); ?>
+</label>
+<input type="number" name="annual_payment_volume" id="annual_payment_volume" min="0" step="1" required />
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Approximate number of payments processed per year.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="payment_approval_workflow">
+<?php esc_html_e( 'Treasury Payment Approval Workflow', 'rtbcb' ); ?>
+</label>
+<select name="payment_approval_workflow" id="payment_approval_workflow" required>
+<option value=""><?php esc_html_e( 'Select workflow...', 'rtbcb' ); ?></option>
+<option value="single"><?php esc_html_e( 'Single approver', 'rtbcb' ); ?></option>
+<option value="dual"><?php esc_html_e( 'Dual approval', 'rtbcb' ); ?></option>
+<option value="tiered"><?php esc_html_e( 'Tiered/role-based', 'rtbcb' ); ?></option>
+<option value="none"><?php esc_html_e( 'No formal workflow', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Describe how payments are authorized.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="reconciliation_method">
+<?php esc_html_e( 'Reconciliation Method', 'rtbcb' ); ?>
+</label>
+<select name="reconciliation_method" id="reconciliation_method" required>
+<option value=""><?php esc_html_e( 'Select method...', 'rtbcb' ); ?></option>
+<option value="manual"><?php esc_html_e( 'Manual matching', 'rtbcb' ); ?></option>
+<option value="rule"><?php esc_html_e( 'Rule-based automation', 'rtbcb' ); ?></option>
+<option value="ai"><?php esc_html_e( 'AI/ML-based automation', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'How are transactions reconciled against statements?', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="cash_update_frequency">
+<?php esc_html_e( 'Cash Position Update Frequency', 'rtbcb' ); ?>
+</label>
+<select name="cash_update_frequency" id="cash_update_frequency" required>
+<option value=""><?php esc_html_e( 'Select frequency...', 'rtbcb' ); ?></option>
+<option value="ad_hoc"><?php esc_html_e( 'Ad-hoc', 'rtbcb' ); ?></option>
+<option value="daily"><?php esc_html_e( 'Daily', 'rtbcb' ); ?></option>
+<option value="multi_daily"><?php esc_html_e( 'Multiple times per day', 'rtbcb' ); ?></option>
+<option value="real_time"><?php esc_html_e( 'Real-time', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'How often do you refresh cash positions?', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field">
+<label for="reg_reporting">
+<?php esc_html_e( 'Regulatory or Compliance Reporting Needs', 'rtbcb' ); ?>
+</label>
+<select name="reg_reporting[]" id="reg_reporting" multiple>
+<option value="sox"><?php esc_html_e( 'SOX', 'rtbcb' ); ?></option>
+<option value="emir"><?php esc_html_e( 'EMIR', 'rtbcb' ); ?></option>
+<option value="dodd_frank"><?php esc_html_e( 'Dodd-Frank', 'rtbcb' ); ?></option>
+<option value="local_tax"><?php esc_html_e( 'Local tax reporting', 'rtbcb' ); ?></option>
+<option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Select any regulatory frameworks your treasury reports must meet.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="integration_requirements">
+<?php esc_html_e( 'Integration Requirements', 'rtbcb' ); ?>
+</label>
+<select name="integration_requirements[]" id="integration_requirements" multiple required>
+<option value="erp"><?php esc_html_e( 'ERP', 'rtbcb' ); ?></option>
+<option value="gl"><?php esc_html_e( 'Accounting/GL', 'rtbcb' ); ?></option>
+<option value="ap_ar"><?php esc_html_e( 'AP/AR system', 'rtbcb' ); ?></option>
+<option value="payroll"><?php esc_html_e( 'Payroll', 'rtbcb' ); ?></option>
+<option value="market_data"><?php esc_html_e( 'Market data', 'rtbcb' ); ?></option>
+<option value="none"><?php esc_html_e( 'None', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Systems you need to connect with treasury tools.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="forecast_horizon">
+<?php esc_html_e( 'Forecasting Horizon', 'rtbcb' ); ?>
+</label>
+<select name="forecast_horizon" id="forecast_horizon" required>
+<option value=""><?php esc_html_e( 'Select horizon...', 'rtbcb' ); ?></option>
+<option value="under_1"><?php esc_html_e( 'Under 1 month', 'rtbcb' ); ?></option>
+<option value="1_3"><?php esc_html_e( '1–3 months', 'rtbcb' ); ?></option>
+<option value="3_12"><?php esc_html_e( '3–12 months', 'rtbcb' ); ?></option>
+<option value="over_12"><?php esc_html_e( 'Over 12 months', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Typical length of cash forecasting.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="fx_management">
+<?php esc_html_e( 'FX Exposure Management', 'rtbcb' ); ?>
+</label>
+<select name="fx_management" id="fx_management" required>
+<option value=""><?php esc_html_e( 'Select approach...', 'rtbcb' ); ?></option>
+<option value="none"><?php esc_html_e( 'None', 'rtbcb' ); ?></option>
+<option value="basic"><?php esc_html_e( 'Basic tracking', 'rtbcb' ); ?></option>
+<option value="manual_hedging"><?php esc_html_e( 'Hedging with manual processes', 'rtbcb' ); ?></option>
+<option value="automated_hedging"><?php esc_html_e( 'Automated hedging program', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Describe your foreign exchange risk approach.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="investment_activities">
+<?php esc_html_e( 'Investment Activities', 'rtbcb' ); ?>
+</label>
+<select name="investment_activities[]" id="investment_activities" multiple required>
+<option value="mmf"><?php esc_html_e( 'MMFs', 'rtbcb' ); ?></option>
+<option value="term_deposits"><?php esc_html_e( 'Term deposits', 'rtbcb' ); ?></option>
+<option value="bonds"><?php esc_html_e( 'Bonds', 'rtbcb' ); ?></option>
+<option value="derivatives"><?php esc_html_e( 'Derivatives', 'rtbcb' ); ?></option>
+<option value="none"><?php esc_html_e( 'None', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Select instruments used for investing excess cash.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="intercompany_lending">
+<?php esc_html_e( 'Intercompany Lending or Netting', 'rtbcb' ); ?>
+</label>
+<select name="intercompany_lending" id="intercompany_lending" required>
+<option value=""><?php esc_html_e( 'Select option...', 'rtbcb' ); ?></option>
+<option value="none"><?php esc_html_e( 'None', 'rtbcb' ); ?></option>
+<option value="manual"><?php esc_html_e( 'Manual tracking', 'rtbcb' ); ?></option>
+<option value="automated_loans"><?php esc_html_e( 'Automated intercompany loans', 'rtbcb' ); ?></option>
+<option value="netting_center"><?php esc_html_e( 'Netting center', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'How do you handle intercompany cash movements?', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field">
+<label for="treasury_kpis">
+<?php esc_html_e( 'Treasury KPIs Tracked', 'rtbcb' ); ?>
+</label>
+<select name="treasury_kpis[]" id="treasury_kpis" multiple>
+<option value="daily_liquidity"><?php esc_html_e( 'Daily liquidity', 'rtbcb' ); ?></option>
+<option value="forecast_accuracy"><?php esc_html_e( 'Forecast accuracy', 'rtbcb' ); ?></option>
+<option value="cost_of_funds"><?php esc_html_e( 'Cost of funds', 'rtbcb' ); ?></option>
+<option value="fx_gain_loss"><?php esc_html_e( 'FX gain/loss', 'rtbcb' ); ?></option>
+<option value="bank_fees"><?php esc_html_e( 'Bank fees', 'rtbcb' ); ?></option>
+<option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Metrics you monitor regularly.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="audit_trail">
+<?php esc_html_e( 'Audit Trail & Control Requirements', 'rtbcb' ); ?>
+</label>
+<select name="audit_trail" id="audit_trail" required>
+<option value=""><?php esc_html_e( 'Select requirement...', 'rtbcb' ); ?></option>
+<option value="none"><?php esc_html_e( 'None', 'rtbcb' ); ?></option>
+<option value="basic"><?php esc_html_e( 'Basic logging', 'rtbcb' ); ?></option>
+<option value="full"><?php esc_html_e( 'Full audit trail with user roles', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Level of traceability needed for treasury actions.', 'rtbcb' ); ?>
+</div>
+</div>
 				</div>
 			</div>
 
@@ -211,78 +481,96 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 						<div class="rtbcb-pain-point-card">
 							<label class="rtbcb-pain-point-label">
 								<input type="checkbox" name="pain_points[]" value="manual_processes" />
-								<div class="rtbcb-pain-point-content">
-									<div class="rtbcb-pain-point-icon">⚙️</div>
-									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Manual Processes', 'rtbcb' ); ?></div>
-									<div class="rtbcb-pain-point-description">
-										<?php esc_html_e( 'Time-consuming manual data entry and reconciliation', 'rtbcb' ); ?>
-									</div>
-								</div>
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">⚙️</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Manual Processes', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Time-consuming manual data entry and reconciliation', 'rtbcb' ); ?>
+</div>
+<div class="rtbcb-pain-point-rank">
+<input type="number" name="pain_point_rank[manual_processes]" min="1" max="10" placeholder="1" />
+</div>
+</div>
 							</label>
 						</div>
 
 						<div class="rtbcb-pain-point-card">
 							<label class="rtbcb-pain-point-label">
 								<input type="checkbox" name="pain_points[]" value="poor_visibility" />
-								<div class="rtbcb-pain-point-content">
-									<div class="rtbcb-pain-point-icon">👁️</div>
-									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Poor Cash Visibility', 'rtbcb' ); ?></div>
-									<div class="rtbcb-pain-point-description">
-										<?php esc_html_e( 'Lack of real-time visibility into cash positions', 'rtbcb' ); ?>
-									</div>
-								</div>
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">👁️</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Poor Cash Visibility', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Lack of real-time visibility into cash positions', 'rtbcb' ); ?>
+</div>
+<div class="rtbcb-pain-point-rank">
+<input type="number" name="pain_point_rank[poor_visibility]" min="1" max="10" placeholder="1" />
+</div>
+</div>
 							</label>
 						</div>
 
 						<div class="rtbcb-pain-point-card">
 							<label class="rtbcb-pain-point-label">
 								<input type="checkbox" name="pain_points[]" value="forecast_accuracy" />
-								<div class="rtbcb-pain-point-content">
-									<div class="rtbcb-pain-point-icon">📊</div>
-									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Forecast Accuracy', 'rtbcb' ); ?></div>
-									<div class="rtbcb-pain-point-description">
-										<?php esc_html_e( 'Inaccurate cash forecasting and planning', 'rtbcb' ); ?>
-									</div>
-								</div>
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">📊</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Forecast Accuracy', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Inaccurate cash forecasting and planning', 'rtbcb' ); ?>
+</div>
+<div class="rtbcb-pain-point-rank">
+<input type="number" name="pain_point_rank[forecast_accuracy]" min="1" max="10" placeholder="1" />
+</div>
+</div>
 							</label>
 						</div>
 
 						<div class="rtbcb-pain-point-card">
 							<label class="rtbcb-pain-point-label">
 								<input type="checkbox" name="pain_points[]" value="compliance_risk" />
-								<div class="rtbcb-pain-point-content">
-									<div class="rtbcb-pain-point-icon">🛡️</div>
-									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Compliance & Risk', 'rtbcb' ); ?></div>
-									<div class="rtbcb-pain-point-description">
-										<?php esc_html_e( 'Regulatory compliance and risk management concerns', 'rtbcb' ); ?>
-									</div>
-								</div>
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">🛡️</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Compliance & Risk', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Regulatory compliance and risk management concerns', 'rtbcb' ); ?>
+</div>
+<div class="rtbcb-pain-point-rank">
+<input type="number" name="pain_point_rank[compliance_risk]" min="1" max="10" placeholder="1" />
+</div>
+</div>
 							</label>
 						</div>
 
 						<div class="rtbcb-pain-point-card">
 							<label class="rtbcb-pain-point-label">
 								<input type="checkbox" name="pain_points[]" value="bank_fees" />
-								<div class="rtbcb-pain-point-content">
-									<div class="rtbcb-pain-point-icon">💰</div>
-									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'High Bank Fees', 'rtbcb' ); ?></div>
-									<div class="rtbcb-pain-point-description">
-										<?php esc_html_e( 'Excessive banking fees and suboptimal cash positioning', 'rtbcb' ); ?>
-									</div>
-								</div>
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">💰</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'High Bank Fees', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Excessive banking fees and suboptimal cash positioning', 'rtbcb' ); ?>
+</div>
+<div class="rtbcb-pain-point-rank">
+<input type="number" name="pain_point_rank[bank_fees]" min="1" max="10" placeholder="1" />
+</div>
+</div>
 							</label>
 						</div>
 
 						<div class="rtbcb-pain-point-card">
 							<label class="rtbcb-pain-point-label">
 								<input type="checkbox" name="pain_points[]" value="integration_issues" />
-								<div class="rtbcb-pain-point-content">
-									<div class="rtbcb-pain-point-icon">🔗</div>
-									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'System Integration', 'rtbcb' ); ?></div>
-									<div class="rtbcb-pain-point-description">
-										<?php esc_html_e( 'Disconnected systems and data silos', 'rtbcb' ); ?>
-									</div>
-								</div>
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">🔗</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'System Integration', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Disconnected systems and data silos', 'rtbcb' ); ?>
+</div>
+<div class="rtbcb-pain-point-rank">
+<input type="number" name="pain_point_rank[integration_issues]" min="1" max="10" placeholder="1" />
+</div>
+</div>
 							</label>
 						</div>
 					</div>
@@ -322,15 +610,16 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 					</div>
 
 					<div class="rtbcb-field rtbcb-field-required">
-						<label for="implementation_timeline">
-							<?php esc_html_e( 'Implementation Timeline', 'rtbcb' ); ?>
-						</label>
-						<select name="implementation_timeline" id="implementation_timeline" required>
-							<option value=""><?php esc_html_e( 'Select a timeline...', 'rtbcb' ); ?></option>
-							<option value="3-6"><?php esc_html_e( '3-6 months', 'rtbcb' ); ?></option>
-							<option value="6-12"><?php esc_html_e( '6-12 months', 'rtbcb' ); ?></option>
-							<option value="12+"><?php esc_html_e( '12+ months', 'rtbcb' ); ?></option>
-						</select>
+<label for="implementation_timeline">
+<?php esc_html_e( 'Implementation Timeline', 'rtbcb' ); ?>
+</label>
+<select name="implementation_timeline" id="implementation_timeline" required>
+<option value=""><?php esc_html_e( 'Select a timeline...', 'rtbcb' ); ?></option>
+<option value="under_3"><?php esc_html_e( '<3 months', 'rtbcb' ); ?></option>
+<option value="3_6"><?php esc_html_e( '3–6 months', 'rtbcb' ); ?></option>
+<option value="6_12"><?php esc_html_e( '6–12 months', 'rtbcb' ); ?></option>
+<option value="over_12"><?php esc_html_e( '>12 months', 'rtbcb' ); ?></option>
+</select>
 					</div>
 
 					<div class="rtbcb-field">
@@ -459,6 +748,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 </form>
 <div id="rtbcbSuccessMessage" class="rtbcb-success-message" style="display:none"></div>
 </div>
+
 </div>
 </div>
 


### PR DESCRIPTION
## Summary
- extend wizard form with fields for treasury automation, systems in use, bank reporting cadence, payment volume, approval workflows and more
- capture company structure details including number of entities and currencies
- allow ranking treasury challenges and update implementation timeline options

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b9bf7d900483318ae0b603e6a4f155