### PR TITLE
Organize wizard steps and add treasury scope

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -110,7 +110,7 @@ document.addEventListener('DOMContentLoaded', function() {
 class BusinessCaseBuilder {
     constructor() {
         this.currentStep = 1;
-        this.totalSteps = 6;
+        this.totalSteps = 7;
         this.form = document.getElementById('rtbcbForm');
         this.overlay = document.getElementById('rtbcbModalOverlay');
         this.ajaxUrl = ( typeof rtbcb_ajax !== 'undefined' && isValidUrl( rtbcb_ajax.ajax_url ) ) ? rtbcb_ajax.ajax_url : '';
@@ -156,11 +156,12 @@ class BusinessCaseBuilder {
         // Form fields by step
         this.enhancedStepFields = {
             1: ['report_type'],
-            2: ['company_name', 'company_size', 'industry', 'job_title', 'num_entities', 'num_currencies'],
-            3: ['hours_reconciliation', 'hours_cash_positioning', 'num_banks', 'ftes', 'treasury_automation'],
-            4: ['pain_points'],
-            5: ['business_objective', 'implementation_timeline', 'budget_range'],
-            6: ['email']
+            2: ['company_name', 'company_size', 'industry', 'job_title'],
+            3: ['num_entities', 'num_currencies', 'num_banks'],
+            4: ['hours_reconciliation', 'hours_cash_positioning', 'ftes', 'treasury_automation', 'primary_systems', 'bank_import_frequency', 'reporting_cadence', 'annual_payment_volume', 'forecast_horizon', 'fx_management', 'investment_activities', 'intercompany_lending', 'treasury_kpis', 'audit_trail'],
+            5: ['pain_points'],
+            6: ['business_objective', 'implementation_timeline', 'budget_range'],
+            7: ['email']
         };
 
         this.basicStepFields = {
@@ -195,7 +196,7 @@ class BusinessCaseBuilder {
                 }
                 const checkedBoxes = this.form.querySelectorAll('input[name="pain_points[]"]:checked');
                 if (checkedBoxes.length > 0) {
-                    this.clearStepError(4);
+                    this.clearStepError(5);
                 }
             }
         });
@@ -230,13 +231,13 @@ class BusinessCaseBuilder {
             this.steps = [
                 this.form.querySelector( '.rtbcb-wizard-step[data-step="1"]' ),
                 this.form.querySelector( '.rtbcb-wizard-step[data-step="2"]' ),
-                this.form.querySelector( '.rtbcb-wizard-step[data-step="6"]' )
+                this.form.querySelector( '.rtbcb-wizard-step[data-step="7"]' )
             ];
 
             this.progressSteps = [
                 this.form.querySelector( '.rtbcb-progress-step[data-step="1"]' ),
                 this.form.querySelector( '.rtbcb-progress-step[data-step="2"]' ),
-                this.form.querySelector( '.rtbcb-progress-step[data-step="6"]' )
+                this.form.querySelector( '.rtbcb-progress-step[data-step="7"]' )
             ];
 
             // Hide unused progress steps and renumber
@@ -272,7 +273,7 @@ class BusinessCaseBuilder {
             } );
 
             this.stepFields = this.enhancedStepFields;
-            this.totalSteps = 6;
+            this.totalSteps = 7;
         }
 
         this.updateStepVisibility();
@@ -432,14 +433,14 @@ class BusinessCaseBuilder {
         let isValid = true;
         const fieldsToValidate = this.stepFields[stepNumber];
 
-        if (this.reportType !== 'basic' && stepNumber === 4) {
+        if (this.reportType !== 'basic' && stepNumber === 5) {
             // Special validation for pain points
             const checkedBoxes = this.form.querySelectorAll('input[name="pain_points[]"]:checked');
             if (checkedBoxes.length === 0) {
-                this.showStepError(4, __( 'Please select at least one challenge', 'rtbcb' ) );
+                this.showStepError(5, __( 'Please select at least one challenge', 'rtbcb' ) );
                 return false;
             }
-            this.clearStepError(4);
+            this.clearStepError(5);
         } else {
             // Standard field validation
             fieldsToValidate.forEach(fieldName => {

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -52,22 +52,26 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
                                                                 <div class="rtbcb-progress-number">2</div>
                                                                 <div class="rtbcb-progress-label"><?php esc_html_e( 'Company', 'rtbcb' ); ?></div>
                                                         </div>
-                                                        <div class="rtbcb-progress-step" data-step="3">
-                                                                <div class="rtbcb-progress-number">3</div>
-                                                                <div class="rtbcb-progress-label"><?php esc_html_e( 'Operations', 'rtbcb' ); ?></div>
-                                                        </div>
-                                                        <div class="rtbcb-progress-step" data-step="4">
-                                                                <div class="rtbcb-progress-number">4</div>
-                                                                <div class="rtbcb-progress-label"><?php esc_html_e( 'Challenges', 'rtbcb' ); ?></div>
-                                                        </div>
-                                                        <div class="rtbcb-progress-step" data-step="5">
-                                                                <div class="rtbcb-progress-number">5</div>
-                                                                <div class="rtbcb-progress-label"><?php esc_html_e( 'Strategy', 'rtbcb' ); ?></div>
-                                                        </div>
-                                                        <div class="rtbcb-progress-step" data-step="6">
-                                                                <div class="rtbcb-progress-number">6</div>
-                                                                <div class="rtbcb-progress-label"><?php esc_html_e( 'Contact', 'rtbcb' ); ?></div>
-                                                        </div>
+                                                       <div class="rtbcb-progress-step" data-step="3">
+                                                               <div class="rtbcb-progress-number">3</div>
+                                                               <div class="rtbcb-progress-label"><?php esc_html_e( 'Scope', 'rtbcb' ); ?></div>
+                                                       </div>
+                                                       <div class="rtbcb-progress-step" data-step="4">
+                                                               <div class="rtbcb-progress-number">4</div>
+                                                               <div class="rtbcb-progress-label"><?php esc_html_e( 'Operations', 'rtbcb' ); ?></div>
+                                                       </div>
+                                                       <div class="rtbcb-progress-step" data-step="5">
+                                                               <div class="rtbcb-progress-number">5</div>
+                                                               <div class="rtbcb-progress-label"><?php esc_html_e( 'Challenges', 'rtbcb' ); ?></div>
+                                                       </div>
+                                                       <div class="rtbcb-progress-step" data-step="6">
+                                                               <div class="rtbcb-progress-number">6</div>
+                                                               <div class="rtbcb-progress-label"><?php esc_html_e( 'Strategy', 'rtbcb' ); ?></div>
+                                                       </div>
+                                                       <div class="rtbcb-progress-step" data-step="7">
+                                                               <div class="rtbcb-progress-number">7</div>
+                                                               <div class="rtbcb-progress-label"><?php esc_html_e( 'Contact', 'rtbcb' ); ?></div>
+                                                       </div>
                                                 </div>
                                         </div>
 
@@ -171,10 +175,19 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
                                                </div>
                                        </div>
 
+                               </div>
+                       </div>
+
+                       <!-- Step 3: Treasury Footprint -->
+                       <div class="rtbcb-wizard-step" data-step="3">
+                               <div class="rtbcb-step-header">
+                                       <h3><?php esc_html_e( 'Outline your treasury footprint', 'rtbcb' ); ?></h3>
+                                       <p><?php esc_html_e( 'Tell us about your organizational and banking structure.', 'rtbcb' ); ?></p>
+                               </div>
+
+                               <div class="rtbcb-step-content">
                                        <div class="rtbcb-field rtbcb-field-required rtbcb-enhanced-only">
-                                               <label for="num_entities">
-                                                       <?php esc_html_e( 'Number of Legal Entities', 'rtbcb' ); ?>
-                                               </label>
+                                               <label for="num_entities"><?php esc_html_e( 'Number of Legal Entities', 'rtbcb' ); ?></label>
                                                <input type="number" name="num_entities" id="num_entities" min="1" step="1" required />
                                                <div class="rtbcb-field-help">
                                                        <?php esc_html_e( 'Count of subsidiaries or business units handled by treasury.', 'rtbcb' ); ?>
@@ -182,19 +195,25 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
                                        </div>
 
                                        <div class="rtbcb-field rtbcb-field-required rtbcb-enhanced-only">
-                                               <label for="num_currencies">
-                                                       <?php esc_html_e( 'Number of Active Currencies', 'rtbcb' ); ?>
-                                               </label>
+                                               <label for="num_currencies"><?php esc_html_e( 'Number of Active Currencies', 'rtbcb' ); ?></label>
                                                <input type="number" name="num_currencies" id="num_currencies" min="1" step="1" required />
                                                <div class="rtbcb-field-help">
                                                        <?php esc_html_e( 'How many currencies do you transact in?', 'rtbcb' ); ?>
                                                </div>
                                        </div>
+
+                                       <div class="rtbcb-field rtbcb-field-required">
+                                               <label for="num_banks"><?php esc_html_e( 'Number of Banking Relationships', 'rtbcb' ); ?></label>
+                                               <input type="number" name="num_banks" id="num_banks" min="1" max="50" placeholder="0" required inputmode="decimal" />
+                                               <div class="rtbcb-field-help">
+                                                       <?php esc_html_e( 'Total number of banks where your company maintains accounts', 'rtbcb' ); ?>
+                                               </div>
+                                       </div>
                                </div>
                        </div>
 
-                        <!-- Step 3: Treasury Operations -->
-                        <div class="rtbcb-wizard-step" data-step="3">
+                        <!-- Step 4: Treasury Operations -->
+                        <div class="rtbcb-wizard-step" data-step="4">
 				<div class="rtbcb-step-header">
 					<h3><?php esc_html_e( 'Your current treasury operations', 'rtbcb' ); ?></h3>
 					<p><?php esc_html_e( 'Help us understand your current workload and banking relationships.', 'rtbcb' ); ?></p>
@@ -223,16 +242,6 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 						</div>
 					</div>
 
-					<div class="rtbcb-field rtbcb-field-required">
-						<label for="num_banks">
-							<?php esc_html_e( 'Number of Banking Relationships', 'rtbcb' ); ?>
-						</label>
-						<input type="number" name="num_banks" id="num_banks"
-							min="1" max="50" placeholder="0" required inputmode="decimal" />
-						<div class="rtbcb-field-help">
-							<?php esc_html_e( 'Total number of banks where your company maintains accounts', 'rtbcb' ); ?>
-						</div>
-					</div>
 
 					<div class="rtbcb-field rtbcb-field-required">
 						<label for="ftes">
@@ -497,8 +506,8 @@ min="0.5" max="100" step="0.5" placeholder="0" required inputmode="decimal" />
 				</div>
 			</div>
 
-                        <!-- Step 4: Treasury Challenges -->
-                        <div class="rtbcb-wizard-step" data-step="4">
+                        <!-- Step 5: Treasury Challenges -->
+                        <div class="rtbcb-wizard-step" data-step="5">
 				<div class="rtbcb-step-header">
 					<h3><?php esc_html_e( 'What are your biggest challenges?', 'rtbcb' ); ?></h3>
 					<p><?php esc_html_e( 'Select the pain points that best describe your current treasury challenges.', 'rtbcb' ); ?></p>
@@ -611,8 +620,8 @@ min="0.5" max="100" step="0.5" placeholder="0" required inputmode="decimal" />
 				</div>
 			</div>
 
-                        <!-- Step 5: Strategic Context -->
-                        <div class="rtbcb-wizard-step" data-step="5">
+                        <!-- Step 6: Strategic Context -->
+                        <div class="rtbcb-wizard-step" data-step="6">
 				<div class="rtbcb-step-header">
 					<h3><?php esc_html_e( 'Strategic context for your initiative', 'rtbcb' ); ?></h3>
 					<p><?php esc_html_e( 'Help us understand the goals and constraints for your project.', 'rtbcb' ); ?></p>
@@ -675,8 +684,8 @@ min="0.5" max="100" step="0.5" placeholder="0" required inputmode="decimal" />
 				</div>
 			</div>
 
-                        <!-- Step 6: Contact Information -->
-                        <div class="rtbcb-wizard-step" data-step="6">
+                        <!-- Step 7: Contact Information -->
+                        <div class="rtbcb-wizard-step" data-step="7">
 				<div class="rtbcb-step-header">
 					<h3><?php esc_html_e( 'Get your business case', 'rtbcb' ); ?></h3>
 					<p><?php esc_html_e( 'Enter your email to receive your personalized ROI analysis and recommendations.', 'rtbcb' ); ?></p>

--- a/tests/wizard-basic-flow.test.js
+++ b/tests/wizard-basic-flow.test.js
@@ -19,6 +19,7 @@ const html = `<!DOCTYPE html><html><body>
         <div class="rtbcb-progress-step" data-step="4"></div>
         <div class="rtbcb-progress-step" data-step="5"></div>
         <div class="rtbcb-progress-step" data-step="6"></div>
+        <div class="rtbcb-progress-step" data-step="7"></div>
       </div>
     </div>
     <div class="rtbcb-wizard-steps">
@@ -31,16 +32,19 @@ const html = `<!DOCTYPE html><html><body>
         <div class="rtbcb-field rtbcb-enhanced-only"><select id="company_size" name="company_size"><option value="small">Small</option></select></div>
       </div>
       <div class="rtbcb-wizard-step" data-step="3">
-        <div class="rtbcb-field"><input id="hours_reconciliation" name="hours_reconciliation" type="number" /></div>
+        <div class="rtbcb-field"><input id="num_entities" name="num_entities" type="number" /></div>
       </div>
       <div class="rtbcb-wizard-step" data-step="4">
+        <div class="rtbcb-field"><input id="hours_reconciliation" name="hours_reconciliation" type="number" /></div>
+      </div>
+      <div class="rtbcb-wizard-step" data-step="5">
         <div class="rtbcb-pain-points-validation"><div class="rtbcb-validation-message"></div></div>
         <label class="rtbcb-pain-point-card"><input type="checkbox" name="pain_points[]" value="manual" /></label>
       </div>
-      <div class="rtbcb-wizard-step" data-step="5">
+      <div class="rtbcb-wizard-step" data-step="6">
         <div class="rtbcb-field"><input id="business_objective" name="business_objective" /></div>
       </div>
-      <div class="rtbcb-wizard-step" data-step="6">
+      <div class="rtbcb-wizard-step" data-step="7">
         <div class="rtbcb-field"><input id="email" name="email" type="email" /></div>
       </div>
     </div>

--- a/tests/wizard-report-flow.test.js
+++ b/tests/wizard-report-flow.test.js
@@ -21,6 +21,7 @@ const html = `<!DOCTYPE html><html><body>
         <div class="rtbcb-progress-step" data-step="4"></div>
         <div class="rtbcb-progress-step" data-step="5"></div>
         <div class="rtbcb-progress-step" data-step="6"></div>
+        <div class="rtbcb-progress-step" data-step="7"></div>
       </div>
     </div>
     <div class="rtbcb-wizard-steps">
@@ -34,21 +35,25 @@ const html = `<!DOCTYPE html><html><body>
         <div class="rtbcb-field"><select id="industry" name="industry"><option value="tech">Tech</option></select></div>
       </div>
       <div class="rtbcb-wizard-step" data-step="3">
-        <div class="rtbcb-field"><input id="hours_reconciliation" name="hours_reconciliation" type="number" /></div>
-        <div class="rtbcb-field"><input id="hours_cash_positioning" name="hours_cash_positioning" type="number" /></div>
+        <div class="rtbcb-field"><input id="num_entities" name="num_entities" type="number" /></div>
+        <div class="rtbcb-field"><input id="num_currencies" name="num_currencies" type="number" /></div>
         <div class="rtbcb-field"><input id="num_banks" name="num_banks" type="number" /></div>
-        <div class="rtbcb-field"><input id="ftes" name="ftes" type="number" /></div>
       </div>
       <div class="rtbcb-wizard-step" data-step="4">
+        <div class="rtbcb-field"><input id="hours_reconciliation" name="hours_reconciliation" type="number" /></div>
+        <div class="rtbcb-field"><input id="hours_cash_positioning" name="hours_cash_positioning" type="number" /></div>
+        <div class="rtbcb-field"><input id="ftes" name="ftes" type="number" /></div>
+      </div>
+      <div class="rtbcb-wizard-step" data-step="5">
         <div class="rtbcb-pain-points-validation"><div class="rtbcb-validation-message"></div></div>
         <label class="rtbcb-pain-point-card"><input type="checkbox" name="pain_points[]" value="manual" /></label>
       </div>
-      <div class="rtbcb-wizard-step" data-step="5">
+      <div class="rtbcb-wizard-step" data-step="6">
         <div class="rtbcb-field"><input id="business_objective" name="business_objective" /></div>
         <div class="rtbcb-field"><input id="implementation_timeline" name="implementation_timeline" /></div>
         <div class="rtbcb-field"><input id="budget_range" name="budget_range" /></div>
       </div>
-      <div class="rtbcb-wizard-step" data-step="6">
+      <div class="rtbcb-wizard-step" data-step="7">
         <div class="rtbcb-field"><input id="email" name="email" type="email" /></div>
       </div>
     </div>
@@ -108,23 +113,28 @@ vm.runInThisContext(wizardCode);
   await builder.handleNext();
 
   // Step 3
-  document.getElementById('hours_reconciliation').value = '1';
-  document.getElementById('hours_cash_positioning').value = '1';
+  document.getElementById('num_entities').value = '1';
+  document.getElementById('num_currencies').value = '1';
   document.getElementById('num_banks').value = '1';
-  document.getElementById('ftes').value = '1';
   await builder.handleNext();
 
   // Step 4
-  document.querySelector('input[name="pain_points[]"]').checked = true;
+  document.getElementById('hours_reconciliation').value = '1';
+  document.getElementById('hours_cash_positioning').value = '1';
+  document.getElementById('ftes').value = '1';
   await builder.handleNext();
 
   // Step 5
+  document.querySelector('input[name="pain_points[]"]').checked = true;
+  await builder.handleNext();
+
+  // Step 6
   document.getElementById('business_objective').value = 'growth';
   document.getElementById('implementation_timeline').value = 'Q4';
   document.getElementById('budget_range').value = '1000';
   await builder.handleNext();
 
-  // Step 6
+  // Step 7
   document.getElementById('email').value = 'test@example.com';
   await builder.handleSubmit();
 


### PR DESCRIPTION
## Summary
- Add dedicated Treasury Footprint step and update step navigation
- Adjust wizard logic for 7-step enhanced flow and re-map basic flow
- Extend tests for new step sequence

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b9d1282b248331b3d9194b71dba188