### PR TITLE
feat: store new intake fields

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -777,10 +777,16 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
 	}
 
 		private static function save_lead_data_async( $user_inputs, $structured_report_data ) {
-				if ( class_exists( 'RTBCB_Leads' ) ) {
-						$lead_data = array_merge( $user_inputs, [ 'report_data' => $structured_report_data ] );
-						return RTBCB_Leads::save_lead( $lead_data );
-				}
+               if ( class_exists( 'RTBCB_Leads' ) ) {
+                               $lead_data = array_merge(
+                                       $user_inputs,
+                                       [
+                                               'report_data' => $structured_report_data,
+                                               'form_data'   => $user_inputs,
+                                       ]
+                               );
+                               return RTBCB_Leads::save_lead( $lead_data );
+               }
 				return null;
 		}
 

--- a/inc/class-rtbcb-leads.php
+++ b/inc/class-rtbcb-leads.php
@@ -53,6 +53,7 @@ class RTBCB_Leads {
                         roi_high decimal(12,2) DEFAULT 0,
                         report_html longtext DEFAULT '',
                         api_response longtext DEFAULT '',
+                        form_data longtext DEFAULT '',
                         ip_address varchar(45) DEFAULT '',
                         user_agent text DEFAULT '',
                         utm_source varchar(100) DEFAULT '',
@@ -108,6 +109,7 @@ class RTBCB_Leads {
                                         roi_high decimal(12,2) DEFAULT 0,
                                         report_html text DEFAULT '',
                                         api_response longtext DEFAULT '',
+                                        form_data longtext DEFAULT '',
                                         ip_address varchar(45) DEFAULT '',
                                         user_agent text DEFAULT '',
                                         utm_source varchar(100) DEFAULT '',
@@ -317,8 +319,9 @@ class RTBCB_Leads {
 			'roi_low'                 => floatval( $lead_data['roi_low'] ?? 0 ),
 			'roi_base'                => floatval( $lead_data['roi_base'] ?? 0 ),
 			'roi_high'                => floatval( $lead_data['roi_high'] ?? 0 ),
-			'report_html'             => wp_kses_post( $lead_data['report_html'] ?? '' ),
-			'ip_address'              => self::get_client_ip(),
+                       'report_html'             => wp_kses_post( $lead_data['report_html'] ?? '' ),
+                       'form_data'              => maybe_serialize( $lead_data['form_data'] ?? [] ),
+                       'ip_address'              => self::get_client_ip(),
 			'user_agent'              => sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ?? '' ),
 			'utm_source'              => sanitize_text_field( $_GET['utm_source'] ?? '' ),
 			'utm_medium'              => sanitize_text_field( $_GET['utm_medium'] ?? '' ),
@@ -343,10 +346,11 @@ class RTBCB_Leads {
 			'%s', // recommended_category
 			'%f', // roi_low
 			'%f', // roi_base
-			'%f', // roi_high
-			'%s', // report_html
-			'%s', // ip_address
-			'%s', // user_agent
+                       '%f', // roi_high
+                       '%s', // report_html
+                       '%s', // form_data
+                       '%s', // ip_address
+                       '%s', // user_agent
 			'%s', // utm_source
 			'%s', // utm_medium
 			'%s', // utm_campaign

--- a/inc/class-rtbcb-llm-unified.php
+++ b/inc/class-rtbcb-llm-unified.php
@@ -243,7 +243,7 @@ class RTBCB_LLM_Unified {
 	* @return array|WP_Error Simplified analysis array or error object.
 	*/
 	public function generate_business_case( $user_inputs, $roi_data, $context_chunks = [], $model = null ) {
-	       $inputs = [
+               $inputs = [
                        'company_name'           => sanitize_text_field( $user_inputs['company_name'] ?? '' ),
                        'company_size'           => sanitize_text_field( $user_inputs['company_size'] ?? '' ),
                        'industry'               => '',
@@ -253,6 +253,24 @@ class RTBCB_LLM_Unified {
                        'ftes'                   => floatval( $user_inputs['ftes'] ?? 0 ),
                        'pain_points'            => array_map( 'sanitize_text_field', (array) ( $user_inputs['pain_points'] ?? [] ) ),
                        'email'                  => sanitize_email( $user_inputs['email'] ?? '' ),
+                       'num_entities'           => intval( $user_inputs['num_entities'] ?? 0 ),
+                       'num_currencies'         => intval( $user_inputs['num_currencies'] ?? 0 ),
+                       'treasury_automation'    => sanitize_text_field( $user_inputs['treasury_automation'] ?? '' ),
+                       'primary_systems'        => array_map( 'sanitize_text_field', (array) ( $user_inputs['primary_systems'] ?? [] ) ),
+                       'bank_import_frequency'  => sanitize_text_field( $user_inputs['bank_import_frequency'] ?? '' ),
+                       'reporting_cadence'      => sanitize_text_field( $user_inputs['reporting_cadence'] ?? '' ),
+                       'annual_payment_volume'  => intval( $user_inputs['annual_payment_volume'] ?? 0 ),
+                       'payment_approval_workflow' => sanitize_text_field( $user_inputs['payment_approval_workflow'] ?? '' ),
+                       'reconciliation_method'  => sanitize_text_field( $user_inputs['reconciliation_method'] ?? '' ),
+                       'cash_update_frequency'  => sanitize_text_field( $user_inputs['cash_update_frequency'] ?? '' ),
+                       'reg_reporting'          => array_map( 'sanitize_text_field', (array) ( $user_inputs['reg_reporting'] ?? [] ) ),
+                       'integration_requirements' => array_map( 'sanitize_text_field', (array) ( $user_inputs['integration_requirements'] ?? [] ) ),
+                       'forecast_horizon'       => sanitize_text_field( $user_inputs['forecast_horizon'] ?? '' ),
+                       'fx_management'          => sanitize_text_field( $user_inputs['fx_management'] ?? '' ),
+                       'investment_activities'  => array_map( 'sanitize_text_field', (array) ( $user_inputs['investment_activities'] ?? [] ) ),
+                       'intercompany_lending'   => sanitize_text_field( $user_inputs['intercompany_lending'] ?? '' ),
+                       'treasury_kpis'          => array_map( 'sanitize_text_field', (array) ( $user_inputs['treasury_kpis'] ?? [] ) ),
+                       'audit_trail'            => sanitize_text_field( $user_inputs['audit_trail'] ?? '' ),
                ];
 
                $company          = function_exists( 'rtbcb_get_current_company' ) ? rtbcb_get_current_company() : [];
@@ -276,6 +294,23 @@ class RTBCB_LLM_Unified {
                }
 
                $prompt .= '\nSize: ' . $inputs['company_size']
+                        . '\nEntities: ' . $inputs['num_entities']
+                        . '\nCurrencies: ' . $inputs['num_currencies']
+                        . '\nAutomation: ' . $inputs['treasury_automation']
+                        . '\nSystems: ' . implode( ', ', $inputs['primary_systems'] )
+                        . '\nBank Imports: ' . $inputs['bank_import_frequency']
+                        . '\nReporting: ' . $inputs['reporting_cadence']
+                        . '\nAnnual Payments: ' . $inputs['annual_payment_volume']
+                        . '\nApproval Workflow: ' . $inputs['payment_approval_workflow']
+                        . '\nReconciliation: ' . $inputs['reconciliation_method']
+                        . '\nCash Updates: ' . $inputs['cash_update_frequency']
+                        . '\nIntegrations: ' . implode( ', ', $inputs['integration_requirements'] )
+                        . '\nForecast Horizon: ' . $inputs['forecast_horizon']
+                        . '\nFX Management: ' . $inputs['fx_management']
+                        . '\nInvestments: ' . implode( ', ', $inputs['investment_activities'] )
+                        . '\nIntercompany: ' . $inputs['intercompany_lending']
+                        . '\nKPIs: ' . implode( ', ', $inputs['treasury_kpis'] )
+                        . '\nAudit Trail: ' . $inputs['audit_trail']
                         . '\nPain Points: ' . implode( ', ', $inputs['pain_points'] );
 
 		if ( ! empty( $context_chunks ) ) {

--- a/inc/class-rtbcb-validator.php
+++ b/inc/class-rtbcb-validator.php
@@ -18,17 +18,90 @@ class RTBCB_Validator {
 	* @return array Sanitized data or array with 'error' key.
 	*/
 	public function validate( array $data ): array {
-		$sanitized = rtbcb_sanitize_form_data( wp_unslash( $data ) );
+               $sanitized = rtbcb_sanitize_form_data( wp_unslash( $data ) );
+
+               $text_fields = [
+                       'job_title',
+                       'treasury_automation',
+                       'bank_import_frequency',
+                       'reporting_cadence',
+                       'payment_approval_workflow',
+                       'reconciliation_method',
+                       'cash_update_frequency',
+                       'forecast_horizon',
+                       'fx_management',
+                       'intercompany_lending',
+                       'audit_trail',
+                       'current_tech',
+                       'business_objective',
+                       'implementation_timeline',
+                       'budget_range',
+               ];
+               foreach ( $text_fields as $field ) {
+                       if ( isset( $data[ $field ] ) ) {
+                               $sanitized[ $field ] = sanitize_text_field( wp_unslash( $data[ $field ] ) );
+                       }
+               }
+
+               $numeric_fields_extra = [
+                       'annual_payment_volume',
+                       'num_entities',
+                       'num_currencies',
+               ];
+               foreach ( $numeric_fields_extra as $field ) {
+                       if ( isset( $data[ $field ] ) && is_numeric( $data[ $field ] ) ) {
+                               $sanitized[ $field ] = floatval( $data[ $field ] );
+                       }
+               }
+
+               $array_fields = [
+                       'primary_systems',
+                       'reg_reporting',
+                       'integration_requirements',
+                       'investment_activities',
+                       'treasury_kpis',
+                       'decision_makers',
+               ];
+               foreach ( $array_fields as $field ) {
+                       if ( isset( $data[ $field ] ) && is_array( $data[ $field ] ) ) {
+                               $sanitized[ $field ] = array_map( 'sanitize_text_field', wp_unslash( $data[ $field ] ) );
+                       }
+               }
+
+               if ( isset( $data['pain_point_rank'] ) && is_array( $data['pain_point_rank'] ) ) {
+                       $sanitized['pain_point_rank'] = [];
+                       foreach ( $data['pain_point_rank'] as $key => $value ) {
+                               $sanitized['pain_point_rank'][ sanitize_key( $key ) ] = absint( $value );
+                       }
+               }
 
 		if ( isset( $data['company_name'] ) ) {
 			$sanitized['company_name'] = sanitize_text_field( wp_unslash( $data['company_name'] ) );
 		}
 
-		$required_fields = [
-			'company_name' => __( 'Company name is required.', 'rtbcb' ),
-			'email'        => __( 'Email is required.', 'rtbcb' ),
-			'company_size' => __( 'Company size is required.', 'rtbcb' ),
-		];
+               $required_fields = [
+                        'company_name'           => __( 'Company name is required.', 'rtbcb' ),
+                        'email'                  => __( 'Email is required.', 'rtbcb' ),
+                        'company_size'           => __( 'Company size is required.', 'rtbcb' ),
+                        'num_entities'           => __( 'Number of legal entities is required.', 'rtbcb' ),
+                        'num_currencies'         => __( 'Number of active currencies is required.', 'rtbcb' ),
+                        'treasury_automation'    => __( 'Treasury automation level is required.', 'rtbcb' ),
+                        'primary_systems'        => __( 'Primary treasury systems are required.', 'rtbcb' ),
+                        'bank_import_frequency'  => __( 'Bank statement import frequency is required.', 'rtbcb' ),
+                        'reporting_cadence'      => __( 'Reporting cadence is required.', 'rtbcb' ),
+                        'annual_payment_volume'  => __( 'Annual payment volume is required.', 'rtbcb' ),
+                        'payment_approval_workflow' => __( 'Payment approval workflow is required.', 'rtbcb' ),
+                        'reconciliation_method'  => __( 'Reconciliation method is required.', 'rtbcb' ),
+                        'cash_update_frequency'  => __( 'Cash position update frequency is required.', 'rtbcb' ),
+                        'integration_requirements' => __( 'Integration requirements are required.', 'rtbcb' ),
+                        'forecast_horizon'       => __( 'Forecasting horizon is required.', 'rtbcb' ),
+                        'fx_management'          => __( 'FX exposure management is required.', 'rtbcb' ),
+                        'investment_activities'  => __( 'Investment activities are required.', 'rtbcb' ),
+                        'intercompany_lending'   => __( 'Intercompany lending or netting is required.', 'rtbcb' ),
+                        'audit_trail'            => __( 'Audit trail requirement is required.', 'rtbcb' ),
+                        'implementation_timeline' => __( 'Implementation timeline is required.', 'rtbcb' ),
+                        'budget_range'           => __( 'Budget range is required.', 'rtbcb' ),
+               ];
 
 		foreach ( $required_fields as $field => $message ) {
 			if ( empty( $sanitized[ $field ] ) ) {
@@ -38,12 +111,15 @@ class RTBCB_Validator {
 			}
 		}
 
-	$numeric_fields = [
-			'hours_reconciliation',
-			'hours_cash_positioning',
-			'num_banks',
-			'ftes',
-	];
+       $numeric_fields = [
+                        'hours_reconciliation',
+                        'hours_cash_positioning',
+                        'num_banks',
+                        'ftes',
+                        'annual_payment_volume',
+                        'num_entities',
+                        'num_currencies',
+       ];
 
 	foreach ( $numeric_fields as $field ) {
 			if ( isset( $data[ $field ] ) && '' !== $data[ $field ] && ! is_numeric( $data[ $field ] ) ) {

--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -961,6 +961,10 @@ html {
     box-sizing: border-box;
 }
 
+.rtbcb-form select[multiple] {
+min-height: 120px;
+}
+
 
 .rtbcb-form input:focus,
 .rtbcb-form select:focus {

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -126,8 +126,8 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 					</div>
 
 					<!-- Optional: Add current position field for more personalization -->
-					<div class="rtbcb-field">
-						<label for="job_title"><?php esc_html_e( 'Your Role (Optional)', 'rtbcb' ); ?></label>
+<div class="rtbcb-field">
+<label for="job_title"><?php esc_html_e( 'Your Role (Optional)', 'rtbcb' ); ?></label>
 						<select name="job_title" id="job_title">
 							<option value=""><?php esc_html_e( 'Select your role...', 'rtbcb' ); ?></option>
 							<option value="cfo"><?php esc_html_e( 'CFO', 'rtbcb' ); ?></option>
@@ -138,12 +138,32 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 							<option value="controller"><?php esc_html_e( 'Controller', 'rtbcb' ); ?></option>
 							<option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
 						</select>
-						<div class="rtbcb-field-help">
-							<?php esc_html_e( 'Helps us tailor recommendations to your perspective', 'rtbcb' ); ?>
-						</div>
-					</div>
-				</div>
-			</div>
+                                               <div class="rtbcb-field-help">
+                                                       <?php esc_html_e( 'Helps us tailor recommendations to your perspective', 'rtbcb' ); ?>
+                                               </div>
+                                       </div>
+
+                                       <div class="rtbcb-field rtbcb-field-required">
+                                               <label for="num_entities">
+                                                       <?php esc_html_e( 'Number of Legal Entities', 'rtbcb' ); ?>
+                                               </label>
+                                               <input type="number" name="num_entities" id="num_entities" min="1" step="1" required />
+                                               <div class="rtbcb-field-help">
+                                                       <?php esc_html_e( 'Count of subsidiaries or business units handled by treasury.', 'rtbcb' ); ?>
+                                               </div>
+                                       </div>
+
+                                       <div class="rtbcb-field rtbcb-field-required">
+                                               <label for="num_currencies">
+                                                       <?php esc_html_e( 'Number of Active Currencies', 'rtbcb' ); ?>
+                                               </label>
+                                               <input type="number" name="num_currencies" id="num_currencies" min="1" step="1" required />
+                                               <div class="rtbcb-field-help">
+                                                       <?php esc_html_e( 'How many currencies do you transact in?', 'rtbcb' ); ?>
+                                               </div>
+                                       </div>
+                               </div>
+                       </div>
 
 			<!-- Step 2: Treasury Operations -->
 			<div class="rtbcb-wizard-step" data-step="2">
@@ -190,12 +210,262 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 						<label for="ftes">
 							<?php esc_html_e( 'Treasury Team Size (FTEs)', 'rtbcb' ); ?>
 						</label>
-						<input type="number" name="ftes" id="ftes"
-							min="0.5" max="100" step="0.5" placeholder="0" required inputmode="decimal" />
-						<div class="rtbcb-field-help">
-							<?php esc_html_e( 'Full-time equivalent employees dedicated to treasury functions', 'rtbcb' ); ?>
-						</div>
-					</div>
+<input type="number" name="ftes" id="ftes"
+min="0.5" max="100" step="0.5" placeholder="0" required inputmode="decimal" />
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Full-time equivalent employees dedicated to treasury functions', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="treasury_automation">
+<?php esc_html_e( 'Treasury Workflow Automation Level', 'rtbcb' ); ?>
+</label>
+<select name="treasury_automation" id="treasury_automation" required>
+<option value=""><?php esc_html_e( 'Select automation level...', 'rtbcb' ); ?></option>
+<option value="manual"><?php esc_html_e( 'Mostly manual', 'rtbcb' ); ?></option>
+<option value="some"><?php esc_html_e( 'Some automation', 'rtbcb' ); ?></option>
+<option value="full"><?php esc_html_e( 'Fully automated', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Assess the degree to which treasury tasks rely on spreadsheets versus software.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="primary_systems">
+<?php esc_html_e( 'Primary Treasury Systems in Use', 'rtbcb' ); ?>
+</label>
+<select name="primary_systems[]" id="primary_systems" multiple required>
+<option value="erp"><?php esc_html_e( 'ERP', 'rtbcb' ); ?></option>
+<option value="bank_portals"><?php esc_html_e( 'Bank portals', 'rtbcb' ); ?></option>
+<option value="spreadsheets"><?php esc_html_e( 'Spreadsheets', 'rtbcb' ); ?></option>
+<option value="tms"><?php esc_html_e( 'Dedicated TMS', 'rtbcb' ); ?></option>
+<option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Select all platforms used today for treasury tasks.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="bank_import_frequency">
+<?php esc_html_e( 'Frequency of Bank Statement Imports', 'rtbcb' ); ?>
+</label>
+<select name="bank_import_frequency" id="bank_import_frequency" required>
+<option value=""><?php esc_html_e( 'Select frequency...', 'rtbcb' ); ?></option>
+<option value="manual_daily"><?php esc_html_e( 'Manual daily', 'rtbcb' ); ?></option>
+<option value="manual_weekly"><?php esc_html_e( 'Manual weekly', 'rtbcb' ); ?></option>
+<option value="automated_daily"><?php esc_html_e( 'Automated daily', 'rtbcb' ); ?></option>
+<option value="real_time"><?php esc_html_e( 'Real-time', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'How often are bank statements imported into your systems?', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="reporting_cadence">
+<?php esc_html_e( 'Reporting Cadence to Stakeholders', 'rtbcb' ); ?>
+</label>
+<select name="reporting_cadence" id="reporting_cadence" required>
+<option value=""><?php esc_html_e( 'Select cadence...', 'rtbcb' ); ?></option>
+<option value="ad_hoc"><?php esc_html_e( 'Ad-hoc', 'rtbcb' ); ?></option>
+<option value="monthly"><?php esc_html_e( 'Monthly', 'rtbcb' ); ?></option>
+<option value="weekly"><?php esc_html_e( 'Weekly', 'rtbcb' ); ?></option>
+<option value="daily"><?php esc_html_e( 'Daily', 'rtbcb' ); ?></option>
+<option value="real_time"><?php esc_html_e( 'Real-time dashboard', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Frequency of delivering cash/treasury reports to management.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="annual_payment_volume">
+<?php esc_html_e( 'Annual Payment Volume', 'rtbcb' ); ?>
+</label>
+<input type="number" name="annual_payment_volume" id="annual_payment_volume" min="0" step="1" required />
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Approximate number of payments processed per year.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="payment_approval_workflow">
+<?php esc_html_e( 'Treasury Payment Approval Workflow', 'rtbcb' ); ?>
+</label>
+<select name="payment_approval_workflow" id="payment_approval_workflow" required>
+<option value=""><?php esc_html_e( 'Select workflow...', 'rtbcb' ); ?></option>
+<option value="single"><?php esc_html_e( 'Single approver', 'rtbcb' ); ?></option>
+<option value="dual"><?php esc_html_e( 'Dual approval', 'rtbcb' ); ?></option>
+<option value="tiered"><?php esc_html_e( 'Tiered/role-based', 'rtbcb' ); ?></option>
+<option value="none"><?php esc_html_e( 'No formal workflow', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Describe how payments are authorized.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="reconciliation_method">
+<?php esc_html_e( 'Reconciliation Method', 'rtbcb' ); ?>
+</label>
+<select name="reconciliation_method" id="reconciliation_method" required>
+<option value=""><?php esc_html_e( 'Select method...', 'rtbcb' ); ?></option>
+<option value="manual"><?php esc_html_e( 'Manual matching', 'rtbcb' ); ?></option>
+<option value="rule"><?php esc_html_e( 'Rule-based automation', 'rtbcb' ); ?></option>
+<option value="ai"><?php esc_html_e( 'AI/ML-based automation', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'How are transactions reconciled against statements?', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="cash_update_frequency">
+<?php esc_html_e( 'Cash Position Update Frequency', 'rtbcb' ); ?>
+</label>
+<select name="cash_update_frequency" id="cash_update_frequency" required>
+<option value=""><?php esc_html_e( 'Select frequency...', 'rtbcb' ); ?></option>
+<option value="ad_hoc"><?php esc_html_e( 'Ad-hoc', 'rtbcb' ); ?></option>
+<option value="daily"><?php esc_html_e( 'Daily', 'rtbcb' ); ?></option>
+<option value="multi_daily"><?php esc_html_e( 'Multiple times per day', 'rtbcb' ); ?></option>
+<option value="real_time"><?php esc_html_e( 'Real-time', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'How often do you refresh cash positions?', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field">
+<label for="reg_reporting">
+<?php esc_html_e( 'Regulatory or Compliance Reporting Needs', 'rtbcb' ); ?>
+</label>
+<select name="reg_reporting[]" id="reg_reporting" multiple>
+<option value="sox"><?php esc_html_e( 'SOX', 'rtbcb' ); ?></option>
+<option value="emir"><?php esc_html_e( 'EMIR', 'rtbcb' ); ?></option>
+<option value="dodd_frank"><?php esc_html_e( 'Dodd-Frank', 'rtbcb' ); ?></option>
+<option value="local_tax"><?php esc_html_e( 'Local tax reporting', 'rtbcb' ); ?></option>
+<option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Select any regulatory frameworks your treasury reports must meet.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="integration_requirements">
+<?php esc_html_e( 'Integration Requirements', 'rtbcb' ); ?>
+</label>
+<select name="integration_requirements[]" id="integration_requirements" multiple required>
+<option value="erp"><?php esc_html_e( 'ERP', 'rtbcb' ); ?></option>
+<option value="gl"><?php esc_html_e( 'Accounting/GL', 'rtbcb' ); ?></option>
+<option value="ap_ar"><?php esc_html_e( 'AP/AR system', 'rtbcb' ); ?></option>
+<option value="payroll"><?php esc_html_e( 'Payroll', 'rtbcb' ); ?></option>
+<option value="market_data"><?php esc_html_e( 'Market data', 'rtbcb' ); ?></option>
+<option value="none"><?php esc_html_e( 'None', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Systems you need to connect with treasury tools.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="forecast_horizon">
+<?php esc_html_e( 'Forecasting Horizon', 'rtbcb' ); ?>
+</label>
+<select name="forecast_horizon" id="forecast_horizon" required>
+<option value=""><?php esc_html_e( 'Select horizon...', 'rtbcb' ); ?></option>
+<option value="under_1"><?php esc_html_e( 'Under 1 month', 'rtbcb' ); ?></option>
+<option value="1_3"><?php esc_html_e( '1–3 months', 'rtbcb' ); ?></option>
+<option value="3_12"><?php esc_html_e( '3–12 months', 'rtbcb' ); ?></option>
+<option value="over_12"><?php esc_html_e( 'Over 12 months', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Typical length of cash forecasting.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="fx_management">
+<?php esc_html_e( 'FX Exposure Management', 'rtbcb' ); ?>
+</label>
+<select name="fx_management" id="fx_management" required>
+<option value=""><?php esc_html_e( 'Select approach...', 'rtbcb' ); ?></option>
+<option value="none"><?php esc_html_e( 'None', 'rtbcb' ); ?></option>
+<option value="basic"><?php esc_html_e( 'Basic tracking', 'rtbcb' ); ?></option>
+<option value="manual_hedging"><?php esc_html_e( 'Hedging with manual processes', 'rtbcb' ); ?></option>
+<option value="automated_hedging"><?php esc_html_e( 'Automated hedging program', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Describe your foreign exchange risk approach.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="investment_activities">
+<?php esc_html_e( 'Investment Activities', 'rtbcb' ); ?>
+</label>
+<select name="investment_activities[]" id="investment_activities" multiple required>
+<option value="mmf"><?php esc_html_e( 'MMFs', 'rtbcb' ); ?></option>
+<option value="term_deposits"><?php esc_html_e( 'Term deposits', 'rtbcb' ); ?></option>
+<option value="bonds"><?php esc_html_e( 'Bonds', 'rtbcb' ); ?></option>
+<option value="derivatives"><?php esc_html_e( 'Derivatives', 'rtbcb' ); ?></option>
+<option value="none"><?php esc_html_e( 'None', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Select instruments used for investing excess cash.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="intercompany_lending">
+<?php esc_html_e( 'Intercompany Lending or Netting', 'rtbcb' ); ?>
+</label>
+<select name="intercompany_lending" id="intercompany_lending" required>
+<option value=""><?php esc_html_e( 'Select option...', 'rtbcb' ); ?></option>
+<option value="none"><?php esc_html_e( 'None', 'rtbcb' ); ?></option>
+<option value="manual"><?php esc_html_e( 'Manual tracking', 'rtbcb' ); ?></option>
+<option value="automated_loans"><?php esc_html_e( 'Automated intercompany loans', 'rtbcb' ); ?></option>
+<option value="netting_center"><?php esc_html_e( 'Netting center', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'How do you handle intercompany cash movements?', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field">
+<label for="treasury_kpis">
+<?php esc_html_e( 'Treasury KPIs Tracked', 'rtbcb' ); ?>
+</label>
+<select name="treasury_kpis[]" id="treasury_kpis" multiple>
+<option value="daily_liquidity"><?php esc_html_e( 'Daily liquidity', 'rtbcb' ); ?></option>
+<option value="forecast_accuracy"><?php esc_html_e( 'Forecast accuracy', 'rtbcb' ); ?></option>
+<option value="cost_of_funds"><?php esc_html_e( 'Cost of funds', 'rtbcb' ); ?></option>
+<option value="fx_gain_loss"><?php esc_html_e( 'FX gain/loss', 'rtbcb' ); ?></option>
+<option value="bank_fees"><?php esc_html_e( 'Bank fees', 'rtbcb' ); ?></option>
+<option value="other"><?php esc_html_e( 'Other', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Metrics you monitor regularly.', 'rtbcb' ); ?>
+</div>
+</div>
+
+<div class="rtbcb-field rtbcb-field-required">
+<label for="audit_trail">
+<?php esc_html_e( 'Audit Trail & Control Requirements', 'rtbcb' ); ?>
+</label>
+<select name="audit_trail" id="audit_trail" required>
+<option value=""><?php esc_html_e( 'Select requirement...', 'rtbcb' ); ?></option>
+<option value="none"><?php esc_html_e( 'None', 'rtbcb' ); ?></option>
+<option value="basic"><?php esc_html_e( 'Basic logging', 'rtbcb' ); ?></option>
+<option value="full"><?php esc_html_e( 'Full audit trail with user roles', 'rtbcb' ); ?></option>
+</select>
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'Level of traceability needed for treasury actions.', 'rtbcb' ); ?>
+</div>
+</div>
 				</div>
 			</div>
 
@@ -211,78 +481,96 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 						<div class="rtbcb-pain-point-card">
 							<label class="rtbcb-pain-point-label">
 								<input type="checkbox" name="pain_points[]" value="manual_processes" />
-								<div class="rtbcb-pain-point-content">
-									<div class="rtbcb-pain-point-icon">⚙️</div>
-									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Manual Processes', 'rtbcb' ); ?></div>
-									<div class="rtbcb-pain-point-description">
-										<?php esc_html_e( 'Time-consuming manual data entry and reconciliation', 'rtbcb' ); ?>
-									</div>
-								</div>
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">⚙️</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Manual Processes', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Time-consuming manual data entry and reconciliation', 'rtbcb' ); ?>
+</div>
+<div class="rtbcb-pain-point-rank">
+<input type="number" name="pain_point_rank[manual_processes]" min="1" max="10" placeholder="1" />
+</div>
+</div>
 							</label>
 						</div>
 
 						<div class="rtbcb-pain-point-card">
 							<label class="rtbcb-pain-point-label">
 								<input type="checkbox" name="pain_points[]" value="poor_visibility" />
-								<div class="rtbcb-pain-point-content">
-									<div class="rtbcb-pain-point-icon">👁️</div>
-									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Poor Cash Visibility', 'rtbcb' ); ?></div>
-									<div class="rtbcb-pain-point-description">
-										<?php esc_html_e( 'Lack of real-time visibility into cash positions', 'rtbcb' ); ?>
-									</div>
-								</div>
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">👁️</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Poor Cash Visibility', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Lack of real-time visibility into cash positions', 'rtbcb' ); ?>
+</div>
+<div class="rtbcb-pain-point-rank">
+<input type="number" name="pain_point_rank[poor_visibility]" min="1" max="10" placeholder="1" />
+</div>
+</div>
 							</label>
 						</div>
 
 						<div class="rtbcb-pain-point-card">
 							<label class="rtbcb-pain-point-label">
 								<input type="checkbox" name="pain_points[]" value="forecast_accuracy" />
-								<div class="rtbcb-pain-point-content">
-									<div class="rtbcb-pain-point-icon">📊</div>
-									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Forecast Accuracy', 'rtbcb' ); ?></div>
-									<div class="rtbcb-pain-point-description">
-										<?php esc_html_e( 'Inaccurate cash forecasting and planning', 'rtbcb' ); ?>
-									</div>
-								</div>
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">📊</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Forecast Accuracy', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Inaccurate cash forecasting and planning', 'rtbcb' ); ?>
+</div>
+<div class="rtbcb-pain-point-rank">
+<input type="number" name="pain_point_rank[forecast_accuracy]" min="1" max="10" placeholder="1" />
+</div>
+</div>
 							</label>
 						</div>
 
 						<div class="rtbcb-pain-point-card">
 							<label class="rtbcb-pain-point-label">
 								<input type="checkbox" name="pain_points[]" value="compliance_risk" />
-								<div class="rtbcb-pain-point-content">
-									<div class="rtbcb-pain-point-icon">🛡️</div>
-									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Compliance & Risk', 'rtbcb' ); ?></div>
-									<div class="rtbcb-pain-point-description">
-										<?php esc_html_e( 'Regulatory compliance and risk management concerns', 'rtbcb' ); ?>
-									</div>
-								</div>
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">🛡️</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Compliance & Risk', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Regulatory compliance and risk management concerns', 'rtbcb' ); ?>
+</div>
+<div class="rtbcb-pain-point-rank">
+<input type="number" name="pain_point_rank[compliance_risk]" min="1" max="10" placeholder="1" />
+</div>
+</div>
 							</label>
 						</div>
 
 						<div class="rtbcb-pain-point-card">
 							<label class="rtbcb-pain-point-label">
 								<input type="checkbox" name="pain_points[]" value="bank_fees" />
-								<div class="rtbcb-pain-point-content">
-									<div class="rtbcb-pain-point-icon">💰</div>
-									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'High Bank Fees', 'rtbcb' ); ?></div>
-									<div class="rtbcb-pain-point-description">
-										<?php esc_html_e( 'Excessive banking fees and suboptimal cash positioning', 'rtbcb' ); ?>
-									</div>
-								</div>
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">💰</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'High Bank Fees', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Excessive banking fees and suboptimal cash positioning', 'rtbcb' ); ?>
+</div>
+<div class="rtbcb-pain-point-rank">
+<input type="number" name="pain_point_rank[bank_fees]" min="1" max="10" placeholder="1" />
+</div>
+</div>
 							</label>
 						</div>
 
 						<div class="rtbcb-pain-point-card">
 							<label class="rtbcb-pain-point-label">
 								<input type="checkbox" name="pain_points[]" value="integration_issues" />
-								<div class="rtbcb-pain-point-content">
-									<div class="rtbcb-pain-point-icon">🔗</div>
-									<div class="rtbcb-pain-point-title"><?php esc_html_e( 'System Integration', 'rtbcb' ); ?></div>
-									<div class="rtbcb-pain-point-description">
-										<?php esc_html_e( 'Disconnected systems and data silos', 'rtbcb' ); ?>
-									</div>
-								</div>
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">🔗</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'System Integration', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Disconnected systems and data silos', 'rtbcb' ); ?>
+</div>
+<div class="rtbcb-pain-point-rank">
+<input type="number" name="pain_point_rank[integration_issues]" min="1" max="10" placeholder="1" />
+</div>
+</div>
 							</label>
 						</div>
 					</div>
@@ -322,15 +610,16 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 					</div>
 
 					<div class="rtbcb-field rtbcb-field-required">
-						<label for="implementation_timeline">
-							<?php esc_html_e( 'Implementation Timeline', 'rtbcb' ); ?>
-						</label>
-						<select name="implementation_timeline" id="implementation_timeline" required>
-							<option value=""><?php esc_html_e( 'Select a timeline...', 'rtbcb' ); ?></option>
-							<option value="3-6"><?php esc_html_e( '3-6 months', 'rtbcb' ); ?></option>
-							<option value="6-12"><?php esc_html_e( '6-12 months', 'rtbcb' ); ?></option>
-							<option value="12+"><?php esc_html_e( '12+ months', 'rtbcb' ); ?></option>
-						</select>
+<label for="implementation_timeline">
+<?php esc_html_e( 'Implementation Timeline', 'rtbcb' ); ?>
+</label>
+<select name="implementation_timeline" id="implementation_timeline" required>
+<option value=""><?php esc_html_e( 'Select a timeline...', 'rtbcb' ); ?></option>
+<option value="under_3"><?php esc_html_e( '<3 months', 'rtbcb' ); ?></option>
+<option value="3_6"><?php esc_html_e( '3–6 months', 'rtbcb' ); ?></option>
+<option value="6_12"><?php esc_html_e( '6–12 months', 'rtbcb' ); ?></option>
+<option value="over_12"><?php esc_html_e( '>12 months', 'rtbcb' ); ?></option>
+</select>
 					</div>
 
 					<div class="rtbcb-field">
@@ -459,6 +748,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 </form>
 <div id="rtbcbSuccessMessage" class="rtbcb-success-message" style="display:none"></div>
 </div>
+
 </div>
 </div>
 


### PR DESCRIPTION
## Summary
- capture extended intake fields on the server with validation and required checks
- persist full form payloads for each lead and forward them to LLM prompts
- improve multi-select styling for a cleaner wizard UI

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bf7d900483318ae0b603e6a4f155