### PR TITLE
Make job title optional in enhanced wizard

### DIFF
--- a/inc/class-rtbcb-validator.php
+++ b/inc/class-rtbcb-validator.php
@@ -38,7 +38,6 @@ $required_fields,
 [
 'company_size'         => __( 'Company size is required.', 'rtbcb' ),
 'industry'             => __( 'Industry is required.', 'rtbcb' ),
-'job_title'            => __( 'Job title is required.', 'rtbcb' ),
 'num_entities'         => __( 'Number of legal entities is required.', 'rtbcb' ),
 'num_currencies'       => __( 'Number of active currencies is required.', 'rtbcb' ),
 'num_banks'            => __( 'Number of banking relationships is required.', 'rtbcb' ),

--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -516,6 +516,12 @@ class BusinessCaseBuilder {
                        return [];
                }
                const requiredFields = Array.from(step.querySelectorAll('[name][required]')).map(field => field.name);
+               if (stepNumber === 2) {
+                       const index = requiredFields.indexOf('job_title');
+                       if (index !== -1) {
+                               requiredFields.splice(index, 1);
+                       }
+               }
                if (stepNumber === 5 && !requiredFields.includes('pain_points')) {
                        requiredFields.push('pain_points');
                }
@@ -975,23 +981,22 @@ class BusinessCaseBuilder {
 		}
 	}
 
-	collectFormData() {
-		const rawData = new FormData(this.form);
-		const formData = new FormData();
-		const numericFields = ['hours_reconciliation', 'hours_cash_positioning', 'num_banks', 'ftes'];
-
-		const skipFields = ['report_type'];
-		for (const [key, value] of rawData.entries()) {
-			if (skipFields.includes(key)) {
-				continue;
-			}
-			if (numericFields.includes(key)) {
-				const num = parseFloat(value);
-				formData.append(key, Number.isFinite(num) ? num : 0);
-			} else {
-				formData.append(key, value);
-			}
-		}
+       collectFormData() {
+               const rawData = new FormData(this.form);
+               const formData = new FormData();
+               const numericFields = ['hours_reconciliation', 'hours_cash_positioning', 'num_banks', 'ftes'];
+               const skipFields = ['report_type'];
+               for (const [key, value] of rawData.entries()) {
+                       if (skipFields.includes(key) || (key === 'job_title' && value === '')) {
+                               continue;
+                       }
+                       if (numericFields.includes(key)) {
+                               const num = parseFloat(value);
+                               formData.append(key, Number.isFinite(num) ? num : 0);
+                       } else {
+                               formData.append(key, value);
+                       }
+               }
 
 		formData.append('action', 'rtbcb_generate_case');
 		if (typeof rtbcb_ajax !== 'undefined' && rtbcb_ajax.nonce) {

--- a/tests/RTBCB_ValidatorTest.php
+++ b/tests/RTBCB_ValidatorTest.php
@@ -53,13 +53,9 @@ $base['company_size'] = '100-500';
 $result               = $validator->validate( $base, 'enhanced' );
 $this->assertSame( 'Industry is required.', $result['error'] );
 
-$base['industry'] = 'finance';
-$result           = $validator->validate( $base, 'enhanced' );
-$this->assertSame( 'Job title is required.', $result['error'] );
-
-$base['job_title'] = 'cfo';
-$result            = $validator->validate( $base, 'enhanced' );
-$this->assertSame( 'Number of legal entities is required.', $result['error'] );
+       $base['industry'] = 'finance';
+       $result           = $validator->validate( $base, 'enhanced' );
+       $this->assertSame( 'Number of legal entities is required.', $result['error'] );
 
 $base['num_entities'] = 1;
 $result               = $validator->validate( $base, 'enhanced' );


### PR DESCRIPTION
## Summary
- remove `job_title` from enhanced required fields and skip when empty
- allow validator to omit job title
- update validator tests

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ba1332438c8331bd43352a15127bd2