### PR TITLE
Require report type selection in business case form

### DIFF
--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -88,14 +88,14 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
                                         <div class="rtbcb-field rtbcb-field-required">
                                                 <fieldset class="rtbcb-report-type">
                                                         <legend><?php esc_html_e( 'Report Type', 'rtbcb' ); ?></legend>
-                                                        <label>
-                                                                <input type="radio" name="report_type" value="basic" checked />
-                                                                <?php esc_html_e( 'Basic', 'rtbcb' ); ?>
-                                                        </label>
-                                                        <label>
-                                                                <input type="radio" name="report_type" value="enhanced" />
-                                                                <?php esc_html_e( 'Enhanced', 'rtbcb' ); ?>
-                                                        </label>
+                                                       <label>
+                                                               <input type="radio" name="report_type" value="basic" checked required />
+                                                               <?php esc_html_e( 'Basic', 'rtbcb' ); ?>
+                                                       </label>
+                                                       <label>
+                                                               <input type="radio" name="report_type" value="enhanced" required />
+                                                               <?php esc_html_e( 'Enhanced', 'rtbcb' ); ?>
+                                                       </label>
                                                 </fieldset>
                                         </div>
                                 </div>


### PR DESCRIPTION
## Summary
- enforce choosing a report type by adding `required` to both radio options
- keep Basic report pre-selected for default flow

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ba1af1b0a08331969412e04b80c100