### PR TITLE
Handle missing progress steps in wizard

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -289,16 +289,17 @@ this.lastValidationErrors = [];
 			        this.form.querySelector('.rtbcb-wizard-step[data-step="7"]')
 			];
 			this.getStepFields = this.getEnhancedFields.bind(this);
-			this.progressSteps = Array.from(this.form.querySelectorAll('.rtbcb-progress-step')).filter(Boolean);
-			 this.progressSteps.forEach((step, index) => {
-			         if (step) {
-			                 step.style.display = 'flex';
-			                 const num = step.querySelector('.rtbcb-progress-number');
-			                 if (num) {
-			                         num.textContent = index + 1;
-			                 }
-			         }
-			 });
+                        this.progressSteps = Array.from(this.form.querySelectorAll('.rtbcb-progress-step')).filter(Boolean);
+                        this.progressSteps.forEach((step, index) => {
+                                if (step) {
+                                        step.style.display = 'flex';
+                                        step.dataset.step = index + 1;
+                                        const num = step.querySelector('.rtbcb-progress-number');
+                                        if (num) {
+                                                num.textContent = index + 1;
+                                        }
+                                }
+                        });
 
 			 this.totalSteps = 7;
 		 } else {
@@ -325,19 +326,20 @@ this.lastValidationErrors = [];
 			         this.form.querySelector('.rtbcb-progress-step[data-step="7"]')
 			 ].filter(Boolean);
 
-			 // Hide unused progress steps and renumber
-			 this.form.querySelectorAll('.rtbcb-progress-step').forEach(step => {
-			         if (step) {
-			                 step.style.display = 'none';
-			         }
-			 });
-			 this.progressSteps.forEach((step, index) => {
-			         step.style.display = 'flex';
-			         const num = step.querySelector('.rtbcb-progress-number');
-			         if (num) {
-			                 num.textContent = index + 1;
-			         }
-			 });
+                        // Hide unused progress steps and renumber
+                        this.form.querySelectorAll('.rtbcb-progress-step').forEach(step => {
+                                if (step) {
+                                        step.style.display = 'none';
+                                }
+                        });
+                        this.progressSteps.forEach((step, index) => {
+                                step.style.display = 'flex';
+                                step.dataset.step = index + 1;
+                                const num = step.querySelector('.rtbcb-progress-number');
+                                if (num) {
+                                        num.textContent = index + 1;
+                                }
+                        });
 
 			 this.totalSteps = 3;
 		 }
@@ -754,23 +756,23 @@ this.lastValidationErrors = [];
 		}
 	}
 
-	updateProgressIndicator() {
-		this.progressSteps.forEach((step, index) => {
-			if ( ! step ) {
-				return;
-			}
-			const stepNum = index + 1;
+        updateProgressIndicator() {
+                this.progressSteps.forEach((step, index) => {
+                        if (!step) {
+                                return;
+                        }
+                        const stepNum = parseInt(step.dataset.step, 10) || index + 1;
 
-			if (stepNum < this.currentStep) {
-				step.classList.add('completed');
-				step.classList.remove('active');
-			} else if (stepNum === this.currentStep) {
-				step.classList.add('active');
-				step.classList.remove('completed');
-			} else {
-				step.classList.remove('active', 'completed');
-			}
-		});
+                        if (stepNum < this.currentStep) {
+                                step.classList.add('completed');
+                                step.classList.remove('active');
+                        } else if (stepNum === this.currentStep) {
+                                step.classList.add('active');
+                                step.classList.remove('completed');
+                        } else {
+                                step.classList.remove('active', 'completed');
+                        }
+                });
 
 		if (this.progressLine) {
 			const progress = (this.currentStep / this.totalSteps) * 100;

--- a/tests/wizard-missing-progress-step.test.js
+++ b/tests/wizard-missing-progress-step.test.js
@@ -47,5 +47,8 @@ vm.runInThisContext(wizardCode);
 const builder = new BusinessCaseBuilder();
 
 builder.nextBtn.click();
+const activeStep = dom.window.document.querySelector('.rtbcb-progress-step.active');
+assert.ok(activeStep, 'Active progress step should exist');
+assert.strictEqual(activeStep.dataset.step, '2', 'Active progress indicator should match current step');
 assert.strictEqual(builder.currentStep, 2, 'Wizard should advance to step 2 even with missing progress steps');
 console.log('Wizard missing progress step test passed.');


### PR DESCRIPTION
## Summary
- Ensure progress indicators are renumbered sequentially and store their step in `data-step`
- Read `data-step` in `updateProgressIndicator` to avoid DOM mismatches
- Expand missing-progress-step test to verify active indicator matches wizard step

## Testing
- `node tests/wizard-missing-progress-step.test.js`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Form with ID rtbcbForm not found / assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2b0b4134833193affbc1d8ce19d8