### PR TITLE
Bump plugin version to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Real Treasury Business Case Builder - Enhanced Version 1.2
+# Real Treasury Business Case Builder - Enhanced Version 1.3.0
 
 A comprehensive WordPress plugin that helps treasury teams quantify the benefits of modern treasury tools, generate professional business case reports, and track lead engagement with advanced analytics.
 
-## 🚀 What's New in Version 1.2
+## 🚀 What's New in Version 1.3.0
 
 ### ✨ Enhancements
 - Re-minified assets.

--- a/docs/REPOSITORY_STRUCTURE.md
+++ b/docs/REPOSITORY_STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-Documentation reflects repository layout for version 1.2.
+Documentation reflects repository layout for version 1.3.0.
 
 ## Directory Tree
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: realtreasury
 Tags: business, case, builder, roi, treasury
 Requires at least: 6.0
 Tested up to: 6.0
-Stable tag: 1.2
+Stable tag: 1.3.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -164,6 +164,9 @@ Reports are rendered as HTML in the browser. Use your browser's print or save fu
 The analytics dashboard uses Chart.js for its visualizations. The library is bundled with the plugin to reduce blocking by privacy tools, but strict ad blockers may still prevent it from loading. Allow the plugin's scripts in your browser to enable the charts.
 
 == Changelog ==
+= 1.3.0 =
+* Bump version to 1.3.0.
+
 = 1.2 =
 * Re-minified assets.
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2,7 +2,7 @@
 	/**
 	* Plugin Name: Real Treasury - Business Case Builder (Enhanced Pro)
 	* Description: Professional-grade ROI calculator and comprehensive business case generator for treasury technology with advanced analysis and consultant-style reports.
-       * Version: 1.2
+       * Version: 1.3.0
 	* Requires PHP: 7.4
 	* Author: Real Treasury
 	* Text Domain: rtbcb
@@ -12,7 +12,7 @@
 	*/
 defined( 'ABSPATH' ) || exit;
 
-define( 'RTBCB_VERSION', '1.2' );
+define( 'RTBCB_VERSION', '1.3.0' );
 define( 'RTBCB_FILE', __FILE__ );
 define( 'RTBCB_URL', plugin_dir_url( RTBCB_FILE ) );
 define( 'RTBCB_DIR', plugin_dir_path( RTBCB_FILE ) );


### PR DESCRIPTION
## Summary
- update plugin header and constant to version 1.3.0
- set readme stable tag and changelog for 1.3.0
- refresh documentation references to version 1.3.0

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Report iframe not injected, assertion errors)*
- `npx -y markdownlint-cli docs/**/*.md`
- `npx -y markdown-link-check docs/REPOSITORY_STRUCTURE.md`
- `phpcs --standard=WordPress` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba407417c48331b6c62a83ab0e522d