### PR TITLE
docs: bump version references to 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# Real Treasury Business Case Builder - Enhanced Version 1.2.1
+# Real Treasury Business Case Builder - Enhanced Version 1.3.1
 
 A comprehensive WordPress plugin that helps treasury teams quantify the benefits of modern treasury tools, generate professional business case reports, and track lead engagement with advanced analytics.
 
-## 🚀 What's New in Version 1.2.1
+## 🚀 What's New in Version 1.3.1
 
 ### ✨ Enhancements
-- Re-minified assets and updated documentation.
+- Re-minified assets and refreshed documentation.
+- Updated repository structure references.
 
 ## 🧠 How It Works
 

--- a/docs/REPOSITORY_STRUCTURE.md
+++ b/docs/REPOSITORY_STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-Documentation reflects repository layout for version 1.2.1.
+Documentation reflects repository layout for version 1.3.1.
 
 ## Directory Tree
 
@@ -102,4 +102,8 @@ The repository uses `AGENTS.md` files to outline coding rules for each directory
 
 - Third-party libraries.
 - Do not modify files in this directory.
+
+## Changelog
+
+- 1.3.1 – Updated version references and re-minified assets.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: realtreasury
 Tags: business, case, builder, roi, treasury
 Requires at least: 6.0
 Tested up to: 6.0
-Stable tag: 1.2.1
+Stable tag: 1.3.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -164,6 +164,10 @@ Reports are rendered as HTML in the browser. Use your browser's print or save fu
 The analytics dashboard uses Chart.js for its visualizations. The library is bundled with the plugin to reduce blocking by privacy tools, but strict ad blockers may still prevent it from loading. Allow the plugin's scripts in your browser to enable the charts.
 
 == Changelog ==
+= 1.3.1 =
+* Re-minified assets and refreshed documentation.
+* Updated repository structure references.
+
 = 1.2.1 =
 * Re-minified assets and updated documentation.
 


### PR DESCRIPTION
## Summary
- update repository docs for version 1.3.1
- document re-minified assets and repository structure updates

## Testing
- `npx --yes markdownlint-cli docs/**/*.md`
- `npx --yes markdown-link-check docs/REPOSITORY_STRUCTURE.md`
- `bash tests/run-tests.sh` *(fails: AssertionError in JS tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba49c841288331b1e51578246c9e2c