### PR TITLE
fix: sync plugin version with stable tag

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -2,7 +2,7 @@
 	/**
 	* Plugin Name: Real Treasury - Business Case Builder (Enhanced Pro)
 	* Description: Professional-grade ROI calculator and comprehensive business case generator for treasury technology with advanced analysis and consultant-style reports.
-       * Version: 1.3.0
+       * Version: 1.3.1
 	* Requires PHP: 7.4
 	* Author: Real Treasury
 	* Text Domain: rtbcb
@@ -12,7 +12,7 @@
 	*/
 defined( 'ABSPATH' ) || exit;
 
-define( 'RTBCB_VERSION', '1.3.0' );
+define( 'RTBCB_VERSION', '1.3.1' );
 define( 'RTBCB_FILE', __FILE__ );
 define( 'RTBCB_URL', plugin_dir_url( RTBCB_FILE ) );
 define( 'RTBCB_DIR', plugin_dir_path( RTBCB_FILE ) );


### PR DESCRIPTION
## Summary
- bump plugin header version to 1.3.1
- update RTBCB_VERSION constant to 1.3.1

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Uncaught Error: Class "RTBCB_Logger" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4ded099c833195727ba301b66939