### PR TITLE
Handle string pain_points in search queries and prompts

### DIFF
--- a/inc/class-rtbcb-ajax.php
+++ b/inc/class-rtbcb-ajax.php
@@ -758,7 +758,7 @@ private static function structure_report_data( $user_inputs, $enriched_profile, 
                        $user_inputs['company_name'],
                        $enriched_profile['company_profile']['industry'] ?? '',
                        $enriched_profile['company_profile']['maturity_level'] ?? '',
-                       implode( ' ', $user_inputs['pain_points'] ),
+                       implode( ' ', (array) ( $user_inputs['pain_points'] ?? [] ) ),
                        $user_inputs['business_objective'],
                ];
 

--- a/inc/class-rtbcb-llm-unified.php
+++ b/inc/class-rtbcb-llm-unified.php
@@ -276,7 +276,7 @@ class RTBCB_LLM_Unified {
                }
 
                $prompt .= '\nSize: ' . $inputs['company_size']
-                        . '\nPain Points: ' . implode( ', ', $inputs['pain_points'] );
+                       . '\nPain Points: ' . implode( ', ', (array) ( $inputs['pain_points'] ?? [] ) );
 
 		if ( ! empty( $context_chunks ) ) {
 			$prompt .= '\nContext: ' . implode( '\n', array_map( 'sanitize_text_field', $context_chunks ) );
@@ -1825,7 +1825,7 @@ $parsed  = $this->response_parser->parse( $response );
 	$prompt .= "Weekly Cash Positioning Hours: " . ( $user_inputs['hours_cash_positioning'] ?? 0 ) . "\n";
 	$prompt .= "Banking Relationships: " . ( $user_inputs['num_banks'] ?? 0 ) . "\n";
 	$prompt .= "Treasury Team Size: " . ( $user_inputs['ftes'] ?? 0 ) . " FTEs\n";
-	$prompt .= "Key Pain Points: " . implode( ', ', $user_inputs['pain_points'] ?? [] ) . "\n\n";
+       $prompt .= "Key Pain Points: " . implode( ', ', (array) ( $user_inputs['pain_points'] ?? [] ) ) . "\n\n";
 	
 	// Industry context.
 	if ( ! empty( $industry_analysis ) ) {
@@ -2144,9 +2144,9 @@ SYSTEM;
  * @return string User prompt.
  */
 	protected function build_enrichment_user_prompt( $user_inputs ) {
-		$pain_points_formatted = implode( ', ', array_map( function( $point ) {
-			return str_replace( '_', ' ', ucwords( $point, '_' ) );
-		}, $user_inputs['pain_points'] ?? [] ) );
+       $pain_points_formatted = implode( ', ', array_map( function( $point ) {
+               return str_replace( '_', ' ', ucwords( $point, '_' ) );
+       }, (array) ( $user_inputs['pain_points'] ?? [] ) ) );
 
 		return <<<PROMPT
 ## Treasury Technology Analysis Request


### PR DESCRIPTION
## Summary
- Avoid runtime errors by safely imploding `pain_points` after casting to an array in RAG search query builder.
- Harden LLM prompt generation to accept string or array `pain_points` values.

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Class "RTBCB_Logger" not found, Call to undefined function is_wp_error, Call to undefined function esc_url)*

------
https://chatgpt.com/codex/tasks/task_e_68ba53aa40008331a10e64c91c756851