### PR TITLE
Remove pain point ranking fields from wizard

### DIFF
--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -538,8 +538,8 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
                        <!-- Step 7: Treasury Challenges -->
                        <div class="rtbcb-wizard-step" data-step="7">
 				<div class="rtbcb-step-header">
-					<h3><?php esc_html_e( 'What are your biggest challenges?', 'rtbcb' ); ?></h3>
-                                       <p><?php esc_html_e( 'Select the pain points that best describe your current treasury challenges. Rank each chosen challenge from 1 (low) to 10 (high).', 'rtbcb' ); ?></p>
+<h3><?php esc_html_e( 'What are your biggest challenges?', 'rtbcb' ); ?></h3>
+<p><?php esc_html_e( 'Select the pain points that best describe your current treasury challenges.', 'rtbcb' ); ?></p>
 				</div>
 
 				<div class="rtbcb-step-content">
@@ -552,9 +552,6 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 <div class="rtbcb-pain-point-title"><?php esc_html_e( 'Manual Processes', 'rtbcb' ); ?></div>
 <div class="rtbcb-pain-point-description">
 <?php esc_html_e( 'Time-consuming manual data entry and reconciliation', 'rtbcb' ); ?>
-</div>
-<div class="rtbcb-pain-point-rank">
-<input type="number" name="pain_point_rank[manual_processes]" min="1" max="10" placeholder="1" aria-label="<?php esc_attr_e( 'Rank 1 (low) to 10 (high)', 'rtbcb' ); ?>" title="<?php esc_attr_e( 'Rank 1 (low) to 10 (high)', 'rtbcb' ); ?>" />
 </div>
 </div>
 							</label>
@@ -569,9 +566,6 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 <div class="rtbcb-pain-point-description">
 <?php esc_html_e( 'Lack of real-time visibility into cash positions', 'rtbcb' ); ?>
 </div>
-<div class="rtbcb-pain-point-rank">
-<input type="number" name="pain_point_rank[poor_visibility]" min="1" max="10" placeholder="1" aria-label="<?php esc_attr_e( 'Rank 1 (low) to 10 (high)', 'rtbcb' ); ?>" title="<?php esc_attr_e( 'Rank 1 (low) to 10 (high)', 'rtbcb' ); ?>" />
-</div>
 </div>
 							</label>
 						</div>
@@ -584,9 +578,6 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 <div class="rtbcb-pain-point-title"><?php esc_html_e( 'Forecast Accuracy', 'rtbcb' ); ?></div>
 <div class="rtbcb-pain-point-description">
 <?php esc_html_e( 'Inaccurate cash forecasting and planning', 'rtbcb' ); ?>
-</div>
-<div class="rtbcb-pain-point-rank">
-<input type="number" name="pain_point_rank[forecast_accuracy]" min="1" max="10" placeholder="1" aria-label="<?php esc_attr_e( 'Rank 1 (low) to 10 (high)', 'rtbcb' ); ?>" title="<?php esc_attr_e( 'Rank 1 (low) to 10 (high)', 'rtbcb' ); ?>" />
 </div>
 </div>
 							</label>
@@ -601,9 +592,6 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 <div class="rtbcb-pain-point-description">
 <?php esc_html_e( 'Regulatory compliance and risk management concerns', 'rtbcb' ); ?>
 </div>
-<div class="rtbcb-pain-point-rank">
-<input type="number" name="pain_point_rank[compliance_risk]" min="1" max="10" placeholder="1" aria-label="<?php esc_attr_e( 'Rank 1 (low) to 10 (high)', 'rtbcb' ); ?>" title="<?php esc_attr_e( 'Rank 1 (low) to 10 (high)', 'rtbcb' ); ?>" />
-</div>
 </div>
 							</label>
 						</div>
@@ -617,9 +605,6 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 <div class="rtbcb-pain-point-description">
 <?php esc_html_e( 'Excessive banking fees and suboptimal cash positioning', 'rtbcb' ); ?>
 </div>
-<div class="rtbcb-pain-point-rank">
-<input type="number" name="pain_point_rank[bank_fees]" min="1" max="10" placeholder="1" aria-label="<?php esc_attr_e( 'Rank 1 (low) to 10 (high)', 'rtbcb' ); ?>" title="<?php esc_attr_e( 'Rank 1 (low) to 10 (high)', 'rtbcb' ); ?>" />
-</div>
 </div>
 							</label>
 						</div>
@@ -632,9 +617,6 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 <div class="rtbcb-pain-point-title"><?php esc_html_e( 'System Integration', 'rtbcb' ); ?></div>
 <div class="rtbcb-pain-point-description">
 <?php esc_html_e( 'Disconnected systems and data silos', 'rtbcb' ); ?>
-</div>
-<div class="rtbcb-pain-point-rank">
-<input type="number" name="pain_point_rank[integration_issues]" min="1" max="10" placeholder="1" aria-label="<?php esc_attr_e( 'Rank 1 (low) to 10 (high)', 'rtbcb' ); ?>" title="<?php esc_attr_e( 'Rank 1 (low) to 10 (high)', 'rtbcb' ); ?>" />
 </div>
 </div>
 							</label>


### PR DESCRIPTION
## Summary
- Simplify pain point step by removing ranking inputs
- Clarify instructions to select applicable pain points only

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ba5f539b688331a14af3cc99beb663