### PR TITLE
Add card-based report type selector

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -129,6 +129,89 @@ html {
     z-index: 10;
 }
 
+/* Report Type Grid */
+.rtbcb-report-type-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+    margin: 24px 0;
+}
+
+.rtbcb-report-type-card {
+    all: unset;
+    display: block;
+    box-sizing: border-box;
+    background: #ffffff;
+    border: 2px solid #cbd5e1;
+    border-radius: 12px;
+    overflow: hidden;
+    transition: all 0.2s ease;
+    cursor: pointer;
+    touch-action: manipulation;
+    position: relative;
+}
+
+@media (hover:hover) {
+    .rtbcb-report-type-card:hover {
+        border-color: #c77dff;
+        box-shadow: 0 4px 12px rgba(114, 22, 244, 0.1);
+        transform: translateY(-2px);
+    }
+}
+
+.rtbcb-report-type-card.rtbcb-selected {
+    border-color: #7216f4;
+    background: linear-gradient(135deg, #f8f9ff, #ffffff);
+    box-shadow: 0 4px 20px rgba(114, 22, 244, 0.2);
+}
+
+.rtbcb-report-type-label {
+    all: unset;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    cursor: pointer;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    box-sizing: border-box;
+}
+
+.rtbcb-report-type-label input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+    width: 0;
+    height: 0;
+}
+
+.rtbcb-report-type-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    height: 100%;
+    text-align: center;
+}
+
+.rtbcb-report-type-icon {
+    font-size: 24px;
+}
+
+.rtbcb-report-type-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    line-height: 1.2;
+}
+
+.rtbcb-report-type-card.rtbcb-selected .rtbcb-report-type-title {
+    color: var(--dark-text);
+}
+
 /* Pain Points Grid Layout Fix */
 .rtbcb-pain-points-grid {
     display: grid;

--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -245,31 +245,47 @@ this.lastValidationErrors = [];
 		// Form submission
 		this.form.addEventListener( 'submit', this.handleSubmit );
 
-		// Pain point cards and report type changes
-		this.form.addEventListener( 'change', ( event ) => {
-			const target = event.target;
+// Pain point card changes
+this.form.addEventListener( 'change', ( event ) => {
+const target = event.target;
 
-                        if (target.matches('input[name="report_type"]')) {
-                                        console.log('RTBCB: Report type changed to:', target.value);
-                                        this.initializePath();
-                        }
+if (target.matches('input[name="pain_points[]"]')) {
+const card = target.closest('.rtbcb-pain-point-card');
+if (card) {
+card.classList.toggle('rtbcb-selected', target.checked);
+}
+const checkedBoxes = this.form.querySelectorAll('input[name="pain_points[]"]:checked');
+if (checkedBoxes.length > 0) {
+const stepEl   = target.closest('.rtbcb-wizard-step');
+const stepIndex = Array.from(this.steps).indexOf(stepEl) + 1;
+this.clearStepError(stepIndex);
+}
+}
+});
 
-                        if (target.matches('input[name="pain_points[]"]')) {
-                                const card = target.closest('.rtbcb-pain-point-card');
-                                if (card) {
-                                        card.classList.toggle('rtbcb-selected', target.checked);
-                                }
-                                const checkedBoxes = this.form.querySelectorAll('input[name="pain_points[]"]:checked');
-                                if (checkedBoxes.length > 0) {
-                                        const stepEl   = target.closest('.rtbcb-wizard-step');
-                                        const stepIndex = Array.from(this.steps).indexOf(stepEl) + 1;
-                                        this.clearStepError(stepIndex);
-                                }
-                        }
-                });
+// Report type card clicks
+this.form.addEventListener('click', (event) => {
+const card = event.target.closest('.rtbcb-report-type-card');
+if (card) {
+const input = card.querySelector('input[name="report_type"]');
+if (input) {
+this.form.querySelectorAll('.rtbcb-report-type-card').forEach((c) => {
+c.classList.remove('rtbcb-selected');
+const radio = c.querySelector('input[name="report_type"]');
+if (radio) {
+radio.checked = false;
+}
+});
+card.classList.add('rtbcb-selected');
+input.checked = true;
+console.log('RTBCB: Report type changed to:', input.value);
+this.initializePath();
+}
+}
+});
 
-		// Real-time validation
-		this.form.querySelectorAll('input, select').forEach(field => {
+// Real-time validation
+this.form.querySelectorAll('input, select').forEach(field => {
 			field.addEventListener('blur', () => this.validateField(field));
 			field.addEventListener('input', () => this.clearFieldError(field));
 		});

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -94,26 +94,27 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 
                                 <div class="rtbcb-step-content">
                                         <div class="rtbcb-field rtbcb-field-required">
-                                                <fieldset class="rtbcb-report-type">
-                                                        <legend><?php esc_html_e( 'Report Type', 'rtbcb' ); ?></legend>
-                                                       <label>
-                                                               <input type="radio" name="report_type" value="basic" checked required />
-                                                               <?php esc_html_e( 'Basic', 'rtbcb' ); ?>
-                                                       </label>
-                                                       <label>
-                                                               <input type="radio" name="report_type" value="enhanced" required />
-                                                               <?php esc_html_e( 'Enhanced', 'rtbcb' ); ?>
-                                                       </label>
-                                                </fieldset>
+                                                <div class="rtbcb-report-type-grid">
+                                                        <div class="rtbcb-report-type-card rtbcb-selected">
+                                                                <label class="rtbcb-report-type-label">
+                                                                        <input type="radio" name="report_type" value="basic" checked hidden />
+                                                                        <div class="rtbcb-report-type-content">
+                                                                                <div class="rtbcb-report-type-icon">📄</div>
+                                                                                <div class="rtbcb-report-type-title"><?php esc_html_e( "Basic", "rtbcb" ); ?></div>
+                                                                        </div>
+                                                                </label>
+                                                        </div>
+                                                        <div class="rtbcb-report-type-card">
+                                                                <label class="rtbcb-report-type-label">
+                                                                        <input type="radio" name="report_type" value="enhanced" hidden />
+                                                                        <div class="rtbcb-report-type-content">
+                                                                                <div class="rtbcb-report-type-icon">📈</div>
+                                                                                <div class="rtbcb-report-type-title"><?php esc_html_e( "Enhanced", "rtbcb" ); ?></div>
+                                                                        </div>
+                                                                </label>
+                                                        </div>
+                                                </div>
                                         </div>
-                                </div>
-                       </div>
-
-                        <!-- Step 2: Company Profile - UPDATED -->
-                        <div class="rtbcb-wizard-step" data-step="2">
-                                <div class="rtbcb-step-header">
-                                        <h3><?php esc_html_e( 'Tell us about your company', 'rtbcb' ); ?></h3>
-                                        <p><?php esc_html_e( 'This helps us provide relevant recommendations for your organization.', 'rtbcb' ); ?></p>
                                 </div>
 
                                 <div class="rtbcb-step-content">

--- a/tests/wizard-basic-flow.test.js
+++ b/tests/wizard-basic-flow.test.js
@@ -26,8 +26,14 @@ const html = `<!DOCTYPE html><html><body>
     </div>
     <div class="rtbcb-wizard-steps">
       <div class="rtbcb-wizard-step active" data-step="1">
-        <div class="rtbcb-field"><input type="radio" name="report_type" value="basic" />
-        <input type="radio" name="report_type" value="enhanced" /></div>
+        <div class="rtbcb-field"><div class="rtbcb-report-type-grid">
+          <div class="rtbcb-report-type-card rtbcb-selected">
+            <input type="radio" name="report_type" value="basic" checked />
+          </div>
+          <div class="rtbcb-report-type-card">
+            <input type="radio" name="report_type" value="enhanced" />
+          </div>
+        </div></div>
       </div>
       <div class="rtbcb-wizard-step" data-step="2">
         <div class="rtbcb-field"><input id="company_name" name="company_name" /></div>
@@ -98,7 +104,6 @@ vm.runInThisContext(wizardCode);
   };
 
   // Step 1 - choose basic
-  document.querySelector('input[name="report_type"][value="basic"]').checked = true;
   await builder.handleNext();
 
   // Step 2

--- a/tests/wizard-enhanced-required-fields.test.js
+++ b/tests/wizard-enhanced-required-fields.test.js
@@ -26,8 +26,14 @@ const html = `<!DOCTYPE html><html><body>
     </div>
     <div class="rtbcb-wizard-steps">
       <div class="rtbcb-wizard-step active" data-step="1">
-        <input type="radio" name="report_type" value="basic" />
-        <input type="radio" name="report_type" value="enhanced" />
+        <div class="rtbcb-report-type-grid">
+          <div class="rtbcb-report-type-card rtbcb-selected">
+            <input type="radio" name="report_type" value="basic" checked />
+          </div>
+          <div class="rtbcb-report-type-card">
+            <input type="radio" name="report_type" value="enhanced" />
+          </div>
+        </div>
       </div>
       <div class="rtbcb-wizard-step" data-step="2">
         <input id="company_name" name="company_name" />
@@ -110,9 +116,8 @@ vm.runInThisContext(wizardCode);
   builder.handleError = (data) => { errorData = data; };
   builder.showEnhancedHTMLReport = (html) => { displayReport(html); };
 
-  const enhancedRadio = document.querySelector('input[name="report_type"][value="enhanced"]');
-  enhancedRadio.checked = true;
-  enhancedRadio.dispatchEvent(new window.Event('change', { bubbles: true }));
+  const enhancedCard = document.querySelector('.rtbcb-report-type-card input[value="enhanced"]').closest('.rtbcb-report-type-card');
+  enhancedCard.dispatchEvent(new window.Event('click', { bubbles: true }));
   await builder.handleNext();
 
   document.getElementById('company_name').value = 'MyCo';

--- a/tests/wizard-job-title-optional.test.js
+++ b/tests/wizard-job-title-optional.test.js
@@ -24,8 +24,14 @@ const html = `<!DOCTYPE html><html><body>
     </div>
     <div class="rtbcb-wizard-steps">
       <div class="rtbcb-wizard-step active" data-step="1">
-        <input type="radio" name="report_type" value="basic" />
-        <input type="radio" name="report_type" value="enhanced" />
+        <div class="rtbcb-report-type-grid">
+          <div class="rtbcb-report-type-card rtbcb-selected">
+            <input type="radio" name="report_type" value="basic" checked />
+          </div>
+          <div class="rtbcb-report-type-card">
+            <input type="radio" name="report_type" value="enhanced" />
+          </div>
+        </div>
       </div>
       <div class="rtbcb-wizard-step" data-step="2">
         <input id="company_name" name="company_name" required />
@@ -69,9 +75,8 @@ vm.runInThisContext(wizardCode);
 
 (async () => {
   const builder = new BusinessCaseBuilder();
-  const enhancedRadio = document.querySelector('input[name="report_type"][value="enhanced"]');
-  enhancedRadio.checked = true;
-  enhancedRadio.dispatchEvent(new window.Event('change', { bubbles: true }));
+  const enhancedCard = document.querySelector('.rtbcb-report-type-card input[value="enhanced"]').closest('.rtbcb-report-type-card');
+  enhancedCard.dispatchEvent(new window.Event('click', { bubbles: true }));
   await builder.handleNext();
 
   document.getElementById('company_name').value = 'MyCo';

--- a/tests/wizard-missing-progress-step.test.js
+++ b/tests/wizard-missing-progress-step.test.js
@@ -18,7 +18,14 @@ const html = `<!DOCTYPE html><html><body>
     </div>
     <div class="rtbcb-wizard-steps">
       <div class="rtbcb-wizard-step active" data-step="1">
-        <div class="rtbcb-field"><input type="radio" name="report_type" value="basic" checked /></div>
+        <div class="rtbcb-field"><div class="rtbcb-report-type-grid">
+          <div class="rtbcb-report-type-card rtbcb-selected">
+            <input type="radio" name="report_type" value="basic" checked />
+          </div>
+          <div class="rtbcb-report-type-card">
+            <input type="radio" name="report_type" value="enhanced" />
+          </div>
+        </div></div>
       </div>
       <div class="rtbcb-wizard-step" data-step="2">
         <div class="rtbcb-field"><input name="company_name" /></div>

--- a/tests/wizard-report-flow.test.js
+++ b/tests/wizard-report-flow.test.js
@@ -28,8 +28,14 @@ const html = `<!DOCTYPE html><html><body>
     </div>
     <div class="rtbcb-wizard-steps">
       <div class="rtbcb-wizard-step active" data-step="1">
-        <div class="rtbcb-field"><input type="radio" name="report_type" value="basic" />
-        <input type="radio" name="report_type" value="enhanced" /></div>
+        <div class="rtbcb-field"><div class="rtbcb-report-type-grid">
+          <div class="rtbcb-report-type-card rtbcb-selected">
+            <input type="radio" name="report_type" value="basic" checked />
+          </div>
+          <div class="rtbcb-report-type-card">
+            <input type="radio" name="report_type" value="enhanced" />
+          </div>
+        </div></div>
       </div>
       <div class="rtbcb-wizard-step" data-step="2">
         <div class="rtbcb-field"><input id="company_name" name="company_name" /></div>
@@ -117,9 +123,8 @@ vm.runInThisContext(wizardCode);
   };
 
   // Step 1 - choose enhanced
-  const enhancedRadio = document.querySelector('input[name="report_type"][value="enhanced"]');
-  enhancedRadio.checked = true;
-  enhancedRadio.dispatchEvent(new window.Event('change', { bubbles: true }));
+  const enhancedCard = document.querySelector('.rtbcb-report-type-card input[value="enhanced"]').closest('.rtbcb-report-type-card');
+  enhancedCard.dispatchEvent(new window.Event('click', { bubbles: true }));
   await builder.handleNext();
 
   // Step 2


### PR DESCRIPTION
## Summary
- Replace radio button report type selection with card-style grid
- Style new report type cards and selection states
- Handle report type selection via card clicks in wizard
- Update tests for new report type selection UX

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`
- `phpcs -d memory_limit=512M --standard=WordPress templates/business-case-form.php` *(fails: Tabs must be used to indent lines; spaces are not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68bae209536c8331b40c8765c76d5cec