### PR TITLE
Refactor basic wizard to single-step layout

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -1576,6 +1576,20 @@ html {
     transform: translateX(-100px);
 }
 
+/* Basic single-page layout */
+.rtbcb-form.rtbcb-basic .rtbcb-wizard-progress,
+.rtbcb-form.rtbcb-basic .rtbcb-wizard-navigation {
+display: none;
+}
+
+.rtbcb-form.rtbcb-enhanced .rtbcb-basic-only {
+display: none;
+}
+
+.rtbcb-form.rtbcb-basic .rtbcb-wizard-step {
+min-height: auto;
+}
+
 .rtbcb-step-header {
     text-align: center;
     margin-bottom: 12px;

--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -198,22 +198,20 @@ this.lastValidationErrors = [];
 		console.log('RTBCB: Cached elements - nextBtn:', !!this.nextBtn, 'prevBtn:', !!this.prevBtn, 'submitBtn:', !!this.submitBtn);
 
 		// Steps
-		this.steps = this.form.querySelectorAll('.rtbcb-wizard-step');
-		this.progressSteps = this.form.querySelectorAll('.rtbcb-progress-step');
-		this.progressLine = this.form.querySelector('.rtbcb-progress-line');
+               this.steps = this.form.querySelectorAll('.rtbcb-wizard-step');
+               this.progressSteps = this.form.querySelectorAll('.rtbcb-progress-step');
+               this.progressLine = this.form.querySelector('.rtbcb-progress-line');
+               this.submitBtn = this.form.querySelector('.rtbcb-wizard-navigation .rtbcb-nav-submit');
 
-		console.log('RTBCB: Found', this.steps.length, 'wizard steps and', this.progressSteps.length, 'progress steps');
+               console.log('RTBCB: Found', this.steps.length, 'wizard steps and', this.progressSteps.length, 'progress steps');
 
-		// Form fields by step
+               // Form fields by step
                this.basicStepFields = {
-1: ['report_type'],
-2: ['company_name'],
-3: ['pain_points'],
-4: ['email']
-};
+1: [ 'report_type', 'company_name', 'pain_points', 'email' ]
+               };
 
-		// Default to enhanced path field resolver
-		this.getStepFields = this.getEnhancedFields.bind(this);
+               // Default to enhanced path field resolver
+               this.getStepFields = this.getEnhancedFields.bind(this);
 	}
 
 	bindEvents() {
@@ -304,93 +302,95 @@ this.form.querySelectorAll('input, select').forEach(field => {
 
 		 console.log('RTBCB: Initializing path for report type:', this.reportType);
 
-		 if (this.reportType === 'enhanced') {
-			 // Enable all enhanced fields
-			 this.form.querySelectorAll('.rtbcb-enhanced-only input, .rtbcb-enhanced-only select').forEach(field => {
-					 field.disabled = false;
-					 if (field.closest('.rtbcb-field-required')) {
-							 field.setAttribute('required', 'required');
-					 }
-			 });
-			 this.form.querySelectorAll('.rtbcb-enhanced-only').forEach(el => {
-					 el.style.display = 'block';
-			 });
+               this.form.classList.toggle('rtbcb-enhanced', this.reportType === 'enhanced');
+               this.form.classList.toggle('rtbcb-basic', this.reportType === 'basic');
 
-						// Set enhanced step configuration
-                                               this.steps = [
-                                                               this.form.querySelector('.rtbcb-wizard-step[data-step="1"]'),
-                                                               this.form.querySelector('.rtbcb-wizard-step[data-step="2"]'),
-                                                               this.form.querySelector('.rtbcb-wizard-step[data-step="3"]'),
-                                                               this.form.querySelector('.rtbcb-wizard-step[data-step="4"]'),
-                                                               this.form.querySelector('.rtbcb-wizard-step[data-step="5"]'),
-                                                               this.form.querySelector('.rtbcb-wizard-step[data-step="6"]'),
-                                                               this.form.querySelector('.rtbcb-wizard-step[data-step="7"]'),
-                                                               this.form.querySelector('.rtbcb-wizard-step[data-step="8"]'),
-                                                               this.form.querySelector('.rtbcb-wizard-step[data-step="9"]')
-                                               ];
-						this.getStepFields = this.getEnhancedFields.bind(this);
+               if ( this.reportType === 'enhanced' ) {
+                        // Enable all enhanced fields
+                        this.form.querySelectorAll('.rtbcb-enhanced-only input, .rtbcb-enhanced-only select, .rtbcb-enhanced-only textarea').forEach(field => {
+                                field.disabled = false;
+                                if ( field.closest('.rtbcb-field-required') ) {
+                                        field.setAttribute('required', 'required');
+                                }
+                        });
 
-						const stepCount = this.steps.filter(Boolean).length;
-						this.progressSteps = Array.from(this.form.querySelectorAll('.rtbcb-progress-step'))
-								.filter(Boolean)
-								.slice(0, stepCount);
-						this.progressSteps.forEach((step, index) => {
-								if (step) {
-										step.style.display = 'flex';
-										step.dataset.step = index + 1;
-										const num = step.querySelector('.rtbcb-progress-number');
-										if (num) {
-												num.textContent = index + 1;
-										}
-								}
-						});
+                        // Disable basic-only fields
+                        this.form.querySelectorAll('.rtbcb-basic-only input, .rtbcb-basic-only select, .rtbcb-basic-only textarea').forEach(field => {
+                                field.disabled = true;
+                                field.removeAttribute('required');
+                        });
 
-						this.totalSteps = stepCount;
-				} else {
-			 // Basic path logic
-			 this.form.querySelectorAll('.rtbcb-enhanced-only input, .rtbcb-enhanced-only select').forEach(field => {
-					 field.disabled = true;
-					 field.removeAttribute('required');
-			 });
-			 this.form.querySelectorAll('.rtbcb-enhanced-only').forEach(el => {
-					 el.style.display = 'none';
-			 });
+                        // Bind navigation buttons
+                        if ( this.nextBtn ) {
+                                this.nextBtn.addEventListener( 'click', this.handleNext );
+                        }
+                        if ( this.prevBtn ) {
+                                this.prevBtn.addEventListener( 'click', this.handlePrev );
+                        }
 
+                        // Set enhanced step configuration
+                        this.steps = [
+                                this.form.querySelector('.rtbcb-wizard-step[data-step="1"]'),
+                                this.form.querySelector('.rtbcb-wizard-step[data-step="2"]'),
+                                this.form.querySelector('.rtbcb-wizard-step[data-step="3"]'),
+                                this.form.querySelector('.rtbcb-wizard-step[data-step="4"]'),
+                                this.form.querySelector('.rtbcb-wizard-step[data-step="5"]'),
+                                this.form.querySelector('.rtbcb-wizard-step[data-step="6"]'),
+                                this.form.querySelector('.rtbcb-wizard-step[data-step="7"]'),
+                                this.form.querySelector('.rtbcb-wizard-step[data-step="8"]'),
+                                this.form.querySelector('.rtbcb-wizard-step[data-step="9"]')
+                        ];
+                        this.getStepFields = this.getEnhancedFields.bind(this);
 
-                       this.steps = [
-                               this.form.querySelector('.rtbcb-wizard-step[data-step="1"]'),
-                               this.form.querySelector('.rtbcb-wizard-step[data-step="2"]'),
-                               this.form.querySelector('.rtbcb-wizard-step[data-step="7"]'),
-                               this.form.querySelector('.rtbcb-wizard-step[data-step="9"]')
-                       ];
-                       this.getStepFields = (step) => this.basicStepFields[step] || [];
+                        const stepCount = this.steps.filter(Boolean).length;
+                        this.progressSteps = Array.from(this.form.querySelectorAll('.rtbcb-progress-step'))
+                                .filter(Boolean)
+                                .slice(0, stepCount);
+                        this.progressSteps.forEach((step, index) => {
+                                if ( step ) {
+                                        step.style.display = 'flex';
+                                        step.dataset.step = index + 1;
+                                        const num = step.querySelector('.rtbcb-progress-number');
+                                        if ( num ) {
+                                                num.textContent = index + 1;
+                                        }
+                                }
+                        });
 
-                       const stepCount = this.steps.filter(Boolean).length;
-                       this.progressSteps = [
-                               this.form.querySelector('.rtbcb-progress-step[data-step="1"]'),
-                               this.form.querySelector('.rtbcb-progress-step[data-step="2"]'),
-                               this.form.querySelector('.rtbcb-progress-step[data-step="7"]'),
-                               this.form.querySelector('.rtbcb-progress-step[data-step="9"]')
-                       ].filter(Boolean)
-                               .slice(0, stepCount);
+                        this.totalSteps = stepCount;
+               } else {
+                        // Basic path logic
+                        this.form.querySelectorAll('.rtbcb-enhanced-only input, .rtbcb-enhanced-only select, .rtbcb-enhanced-only textarea').forEach(field => {
+                                field.disabled = true;
+                                field.removeAttribute('required');
+                        });
+                        this.form.querySelectorAll('.rtbcb-basic-only input, .rtbcb-basic-only select, .rtbcb-basic-only textarea').forEach(field => {
+                                field.disabled = false;
+                                if ( field.closest('.rtbcb-field-required') ) {
+                                        field.setAttribute('required', 'required');
+                                }
+                        });
 
-						// Hide unused progress steps and renumber
-						this.form.querySelectorAll('.rtbcb-progress-step').forEach(step => {
-								if (step) {
-										step.style.display = 'none';
-								}
-						});
-						this.progressSteps.forEach((step, index) => {
-								step.style.display = 'flex';
-								step.dataset.step = index + 1;
-								const num = step.querySelector('.rtbcb-progress-number');
-								if (num) {
-										num.textContent = index + 1;
-								}
-						});
+                        // Remove navigation bindings
+                        if ( this.nextBtn ) {
+                                this.nextBtn.removeEventListener( 'click', this.handleNext );
+                        }
+                        if ( this.prevBtn ) {
+                                this.prevBtn.removeEventListener( 'click', this.handlePrev );
+                        }
 
-						this.totalSteps = stepCount;
-				}
+                        // Single step configuration
+                        this.steps = [ this.form.querySelector('.rtbcb-wizard-step[data-step="1"]') ];
+                        this.getStepFields = () => this.basicStepFields[1] || [];
+
+                        this.form.querySelectorAll('.rtbcb-progress-step').forEach(step => {
+                                if ( step ) {
+                                        step.style.display = 'none';
+                                }
+                        });
+                        this.progressSteps = [];
+                        this.totalSteps = 1;
+               }
 
 				console.log('RTBCB: Path initialized. Total steps:', this.totalSteps, 'Current step fields:', this.getStepFields(this.currentStep));
 
@@ -472,32 +472,30 @@ this.form.querySelectorAll('input, select').forEach(field => {
 	}
 
 	populateForm( data ) {
-		Object.entries( data ).forEach( ( [ key, value ] ) => {
-			if ( Array.isArray( value ) ) {
-				value.forEach( ( val ) => {
-					const field = this.form.querySelector( `[name="${ key }"][value="${ val }"]` );
-					if ( field ) {
-						field.checked = true;
-					}
-				} );
-			} else {
-				const field = this.form.querySelector( `[name="${ key }"]` );
-				if ( ! field ) {
-					return;
-				}
-				if ( field.type === 'checkbox' ) {
-					field.checked = true;
-				} else if ( field.type === 'radio' ) {
-					const radio = this.form.querySelector( `[name="${ key }"][value="${ value }"]` );
-					if ( radio ) {
-						radio.checked = true;
-					}
-				} else {
-					field.value = value;
-				}
-			}
-		} );
-	}
+               Object.entries( data ).forEach( ( [ key, value ] ) => {
+                        if ( Array.isArray( value ) ) {
+                                value.forEach( ( val ) => {
+                                        this.form.querySelectorAll( `[name="${ key }"][value="${ val }"]` ).forEach( field => {
+                                                field.checked = true;
+                                        } );
+                                } );
+                        } else {
+                                const fields = this.form.querySelectorAll( `[name="${ key }"]` );
+                                if ( ! fields.length ) {
+                                        return;
+                                }
+                                fields.forEach( field => {
+                                        if ( field.type === 'checkbox' ) {
+                                                field.checked = true;
+                                        } else if ( field.type === 'radio' ) {
+                                                field.checked = field.value === value;
+                                        } else {
+                                                field.value = value;
+                                        }
+                                } );
+                        }
+                } );
+        }
 
 	clearPersistentState() {
 		try {
@@ -620,9 +618,10 @@ this.form.querySelectorAll('input, select').forEach(field => {
                         this.clearStepError( stepNumber );
                 }
 
-                for (const fieldName of currentFields) {
-                        const field = this.form.querySelector(`[name="${fieldName}"]`);
-                        if (!field) {
+               for ( const fieldName of currentFields ) {
+                        const candidates = Array.from( this.form.querySelectorAll( `[name="${ fieldName }"]` ) ).filter( f => ! f.disabled );
+                        const field = candidates[0];
+                        if ( ! field ) {
                                 continue;
                         }
 

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -38,7 +38,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
 		<!-- Modal Body -->
 		<div class="rtbcb-modal-body">
 			<div class="rtbcb-form-container">
-				<form id="rtbcbForm" class="rtbcb-form rtbcb-wizard" method="post" novalidate>
+                               <form id="rtbcbForm" class="rtbcb-form rtbcb-wizard rtbcb-basic" method="post" novalidate>
 
 					<!-- Progress Indicator -->
                                         <div class="rtbcb-wizard-progress">
@@ -184,10 +184,150 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
                                                </div>
                                        </div>
 
-                               </div>
-                       </div>
+</div>
+<div class="rtbcb-step-header rtbcb-basic-only">
+<h3><?php esc_html_e( 'Identify your top treasury challenges', 'rtbcb' ); ?></h3>
+<p><?php esc_html_e( 'Choose the areas where you\'d like to improve.', 'rtbcb' ); ?></p>
+</div>
+<div class="rtbcb-step-content rtbcb-basic-only">
+<div class="rtbcb-pain-points-grid">
+<div class="rtbcb-pain-point-card">
+<label class="rtbcb-pain-point-label">
+<input type="checkbox" name="pain_points[]" value="manual_processes" />
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">⚙️</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Manual Processes', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Time-consuming manual data entry and reconciliation', 'rtbcb' ); ?>
+</div>
+</div>
+</label>
+</div>
 
-                       <!-- Step 3: Treasury Footprint -->
+<div class="rtbcb-pain-point-card">
+<label class="rtbcb-pain-point-label">
+<input type="checkbox" name="pain_points[]" value="poor_visibility" />
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">👁️</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Poor Cash Visibility', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Lack of real-time visibility into cash positions', 'rtbcb' ); ?>
+</div>
+</div>
+</label>
+</div>
+
+<div class="rtbcb-pain-point-card">
+<label class="rtbcb-pain-point-label">
+<input type="checkbox" name="pain_points[]" value="forecast_accuracy" />
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">📊</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Forecast Accuracy', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Inaccurate cash forecasting and planning', 'rtbcb' ); ?>
+</div>
+</div>
+</label>
+</div>
+
+<div class="rtbcb-pain-point-card">
+<label class="rtbcb-pain-point-label">
+<input type="checkbox" name="pain_points[]" value="compliance_risk" />
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">🛡️</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'Compliance & Risk', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Regulatory compliance and risk management concerns', 'rtbcb' ); ?>
+</div>
+</div>
+</label>
+</div>
+
+<div class="rtbcb-pain-point-card">
+<label class="rtbcb-pain-point-label">
+<input type="checkbox" name="pain_points[]" value="bank_fees" />
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">💰</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'High Bank Fees', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Excessive banking fees and suboptimal cash positioning', 'rtbcb' ); ?>
+</div>
+</div>
+</label>
+</div>
+
+<div class="rtbcb-pain-point-card">
+<label class="rtbcb-pain-point-label">
+<input type="checkbox" name="pain_points[]" value="integration_issues" />
+<div class="rtbcb-pain-point-content">
+<div class="rtbcb-pain-point-icon">🔗</div>
+<div class="rtbcb-pain-point-title"><?php esc_html_e( 'System Integration', 'rtbcb' ); ?></div>
+<div class="rtbcb-pain-point-description">
+<?php esc_html_e( 'Disconnected systems and data silos', 'rtbcb' ); ?>
+</div>
+</div>
+</label>
+</div>
+</div>
+<div class="rtbcb-pain-points-validation">
+<div class="rtbcb-validation-message" style="display: none;">
+<?php esc_html_e( 'Please select at least one challenge that applies to your organization.', 'rtbcb' ); ?>
+</div>
+</div>
+</div>
+<div class="rtbcb-step-header rtbcb-basic-only">
+<h3><?php esc_html_e( 'Get your business case', 'rtbcb' ); ?></h3>
+<p><?php esc_html_e( 'Enter your email to receive your personalized ROI analysis and recommendations.', 'rtbcb' ); ?></p>
+</div>
+<div class="rtbcb-step-content rtbcb-basic-only">
+<div class="rtbcb-field rtbcb-field-required">
+<label for="email_basic">
+<?php esc_html_e( 'Business Email Address', 'rtbcb' ); ?>
+</label>
+<input type="email" name="email" id="email_basic" placeholder="yourname@company.com" required />
+<div class="rtbcb-field-help">
+<?php esc_html_e( 'We\'ll send your business case report to this email address', 'rtbcb' ); ?>
+</div>
+</div>
+<div class="rtbcb-consent-container">
+<div class="rtbcb-field">
+<div class="rtbcb-consent-wrapper">
+<label class="rtbcb-consent-label" for="consent_basic">
+<input type="checkbox" name="consent" id="consent_basic" required />
+<span class="rtbcb-consent-text">
+<?php
+printf(
+wp_kses(
+__( 'I agree to receive my business case report and occasional treasury insights. You can unsubscribe at any time. View our <a href="%s" target="_blank">privacy policy</a>.', 'rtbcb' ),
+[ 'a' => [ 'href' => [], 'target' => [] ] ]
+),
+'#'
+);
+?>
+</span>
+</label>
+</div>
+</div>
+</div>
+<div class="rtbcb-preview-container">
+<div class="rtbcb-results-preview">
+<h4><?php esc_html_e( 'What You\'ll Receive:', 'rtbcb' ); ?></h4>
+<ul class="rtbcb-preview-list">
+<li>📊 <?php esc_html_e( 'Detailed ROI projections (conservative, base case, optimistic)', 'rtbcb' ); ?></li>
+<li>🎯 <?php esc_html_e( 'Personalized solution category recommendation', 'rtbcb' ); ?></li>
+<li>📄 <?php esc_html_e( 'Professional PDF report ready for stakeholders', 'rtbcb' ); ?></li>
+<li>🗺️ <?php esc_html_e( 'Implementation roadmap and next steps', 'rtbcb' ); ?></li>
+</ul>
+</div>
+</div>
+<button type="submit" class="rtbcb-nav-btn rtbcb-basic-submit rtbcb-basic-only">
+<span class="rtbcb-nav-icon">🚀</span>
+<?php esc_html_e( 'Generate Business Case', 'rtbcb' ); ?>
+</button>
+</div>
+</div>
+
+<!-- Step 3: Treasury Footprint -->
                        <div class="rtbcb-wizard-step" data-step="3">
                                <div class="rtbcb-step-header">
                                        <h3><?php esc_html_e( 'Outline your treasury footprint', 'rtbcb' ); ?></h3>


### PR DESCRIPTION
## Summary
- Simplify basic report wizard to a single step and remove navigation controls
- Consolidate basic report fields into one template step and hide progress/navigation in basic mode
- Add styles for basic single-page layout

## Testing
- `bash tests/run-tests.sh` *(fails: Run `composer install` to install PHPUnit)*
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68bae66bf0cc833188d6653720b915d6