### PR TITLE
Improve progress step label layout and tooltips

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -399,6 +399,8 @@ html {
 
     .rtbcb-progress-step {
         padding: 0 4px;
+        flex: 1;
+        min-width: 0;
     }
 
     .rtbcb-progress-number {
@@ -410,6 +412,9 @@ html {
     .rtbcb-progress-label {
         font-size: 13px;
         font-weight: 600;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 }
 
@@ -1503,6 +1508,8 @@ html {
         z-index: 2;
         background: transparent;
         padding: 0 8px;
+        flex: 1;
+        min-width: 0;
     }
 
 .rtbcb-progress-number {
@@ -1548,6 +1555,9 @@ html {
     color: var(--text-secondary);
     font-weight: 600;
     text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .rtbcb-progress-step.active .rtbcb-progress-label,
@@ -1794,6 +1804,9 @@ html {
     .rtbcb-progress-label {
         font-size: 13px;
         font-weight: 600;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .rtbcb-step-header h3 {
@@ -2060,6 +2073,9 @@ html {
     font-size: 14px;               /* Increase from 12px */
     font-weight: 600;              /* Add weight */
     text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 /* Active progress step label */
@@ -2132,6 +2148,9 @@ html {
     .rtbcb-progress-label {
         font-size: 13px;           /* Slightly larger on mobile */
         font-weight: 600;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
     
     /* Ensure minimum touch targets */

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -46,39 +46,39 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
                                                 <div class="rtbcb-progress-steps">
                                                         <div class="rtbcb-progress-step active" data-step="1">
                                                                 <div class="rtbcb-progress-number">1</div>
-                                                                <div class="rtbcb-progress-label"><?php esc_html_e( 'Report', 'rtbcb' ); ?></div>
+                                                                <div class="rtbcb-progress-label" title="<?php echo esc_attr__( 'Report', 'rtbcb' ); ?>"><?php esc_html_e( 'Report', 'rtbcb' ); ?></div>
                                                         </div>
                                                         <div class="rtbcb-progress-step" data-step="2">
                                                                 <div class="rtbcb-progress-number">2</div>
-                                                                <div class="rtbcb-progress-label"><?php esc_html_e( 'Company', 'rtbcb' ); ?></div>
+                                                                <div class="rtbcb-progress-label" title="<?php echo esc_attr__( 'Company', 'rtbcb' ); ?>"><?php esc_html_e( 'Company', 'rtbcb' ); ?></div>
                                                         </div>
                                                        <div class="rtbcb-progress-step" data-step="3">
                                                                <div class="rtbcb-progress-number">3</div>
-                                                               <div class="rtbcb-progress-label"><?php esc_html_e( 'Scope', 'rtbcb' ); ?></div>
+                                                               <div class="rtbcb-progress-label" title="<?php echo esc_attr__( 'Scope', 'rtbcb' ); ?>"><?php esc_html_e( 'Scope', 'rtbcb' ); ?></div>
                                                        </div>
                                                        <div class="rtbcb-progress-step" data-step="4">
                                                                <div class="rtbcb-progress-number">4</div>
-                                                               <div class="rtbcb-progress-label"><?php esc_html_e( 'Workload', 'rtbcb' ); ?></div>
+                                                               <div class="rtbcb-progress-label" title="<?php echo esc_attr__( 'Workload', 'rtbcb' ); ?>"><?php esc_html_e( 'Workload', 'rtbcb' ); ?></div>
                                                        </div>
                                                        <div class="rtbcb-progress-step" data-step="5">
                                                                <div class="rtbcb-progress-number">5</div>
-                                                               <div class="rtbcb-progress-label"><?php esc_html_e( 'Technology', 'rtbcb' ); ?></div>
+                                                               <div class="rtbcb-progress-label" title="<?php echo esc_attr__( 'Technology', 'rtbcb' ); ?>"><?php esc_html_e( 'Technology', 'rtbcb' ); ?></div>
                                                        </div>
                                                        <div class="rtbcb-progress-step" data-step="6">
                                                                <div class="rtbcb-progress-number">6</div>
-                                                               <div class="rtbcb-progress-label"><?php esc_html_e( 'Compliance', 'rtbcb' ); ?></div>
+                                                               <div class="rtbcb-progress-label" title="<?php echo esc_attr__( 'Compliance', 'rtbcb' ); ?>"><?php esc_html_e( 'Compliance', 'rtbcb' ); ?></div>
                                                        </div>
                                                         <div class="rtbcb-progress-step" data-step="7">
                                                                <div class="rtbcb-progress-number">7</div>
-                                                               <div class="rtbcb-progress-label"><?php esc_html_e( 'Challenges', 'rtbcb' ); ?></div>
+                                                               <div class="rtbcb-progress-label" title="<?php echo esc_attr__( 'Challenges', 'rtbcb' ); ?>"><?php esc_html_e( 'Challenges', 'rtbcb' ); ?></div>
                                                         </div>
                                                         <div class="rtbcb-progress-step" data-step="8">
                                                                <div class="rtbcb-progress-number">8</div>
-                                                               <div class="rtbcb-progress-label"><?php esc_html_e( 'Strategy', 'rtbcb' ); ?></div>
+                                                               <div class="rtbcb-progress-label" title="<?php echo esc_attr__( 'Strategy', 'rtbcb' ); ?>"><?php esc_html_e( 'Strategy', 'rtbcb' ); ?></div>
                                                         </div>
                                                         <div class="rtbcb-progress-step" data-step="9">
                                                                <div class="rtbcb-progress-number">9</div>
-                                                               <div class="rtbcb-progress-label"><?php esc_html_e( 'Contact', 'rtbcb' ); ?></div>
+                                                               <div class="rtbcb-progress-label" title="<?php echo esc_attr__( 'Contact', 'rtbcb' ); ?>"><?php esc_html_e( 'Contact', 'rtbcb' ); ?></div>
                                                         </div>
                                                 </div>
                                         </div>


### PR DESCRIPTION
## Summary
- Prevent progress labels from wrapping by truncating with ellipsis
- Evenly distribute progress step widths with flexbox
- Add `title` attributes so truncated labels show full text on hover

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bae94cf4088331bdc07228777bccc5