### PR TITLE
Make wizard progress sticky and scrollable

### DIFF
--- a/public/css/rtbcb.css
+++ b/public/css/rtbcb.css
@@ -420,12 +420,7 @@ html {
 
 /* Extra small screen adjustments */
 @media (max-width: 480px) {
-    .rtbcb-wizard-progress {
-        overflow-x: auto;
-    }
-
     .rtbcb-progress-steps {
-        flex-wrap: nowrap;
         width: max-content;
     }
 
@@ -1458,13 +1453,14 @@ html {
 
 /* Progress Indicator - Glassmorphic */
     .rtbcb-wizard-progress {
-        background: linear-gradient(135deg, rgba(248, 249, 255, 0.8), rgba(243, 244, 255, 0.9));
+        background: #ffffff;
         width: 100%;
         margin: 0 auto 32px;
         padding: 16px 32px;
         border-bottom: 1px solid rgba(114, 22, 244, 0.1);
-        backdrop-filter: blur(10px);
-        position: relative;
+        position: sticky;
+        top: 0;
+        z-index: 10;
         display: flex;
         justify-content: center;
     }
@@ -1498,6 +1494,8 @@ html {
         width: 100%;
         position: relative;
         z-index: 2;
+        overflow-x: auto;
+        flex-wrap: nowrap;
     }
 
     .rtbcb-progress-step {


### PR DESCRIPTION
## Summary
- make wizard progress bar sticky with solid background
- allow progress steps to scroll horizontally on narrow viewports

## Testing
- `bash tests/run-tests.sh` (fatal: Call to undefined function is_wp_error)
- `./vendor/bin/phpcs --standard=WordPress` (command not found)
- Playwright viewport check (missing system dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68baecc173608331859a4a77763ae69e