### PR TITLE
fix: restore wizard form markup and script loading

### DIFF
--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -741,7 +741,18 @@ return true;
                 false // Load in header
                 );
 
-                wp_set_script_translations( 'rtbcb-wizard', 'rtbcb' );
+		wp_set_script_translations( 'rtbcb-wizard', 'rtbcb' );
+
+		// React wizard form component
+		wp_enqueue_script(
+			'rtbcb-wizard-form',
+			RTBCB_URL . 'public/js/wizard-form.js',
+			[ 'wp-element', 'wp-i18n' ],
+			RTBCB_VERSION,
+			true
+		);
+
+		wp_set_script_translations( 'rtbcb-wizard-form', 'rtbcb' );
 
 		// Main report functionality
 		$report_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb-report.js' : 'rtbcb-report.min.js';

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -1,11 +1,11 @@
 <?php
 defined( 'ABSPATH' ) || exit;
 ?>
-<div id="rtbcb-wizard-root"></div>
+<form id="rtbcbForm" class="rtbcb-form rtbcb-wizard"></form>
 <script>
 document.addEventListener( 'DOMContentLoaded', function() {
-        if ( window.renderRTBCBWizardForm ) {
-                window.renderRTBCBWizardForm( 'rtbcb-wizard-root' );
-        }
+	if ( window.renderRTBCBWizardForm ) {
+		window.renderRTBCBWizardForm( 'rtbcbForm' );
+	}
 } );
 </script>


### PR DESCRIPTION
## Summary
- restore `<form id="rtbcbForm">` markup and mount React wizard inside it
- enqueue `wizard-form.js` with React dependencies and script translations

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Class "RTBCB_Logger" not found, more)*

------
https://chatgpt.com/codex/tasks/task_e_68bc23eefc2083319acaad5104118362