### PR TITLE
fix: persist wizard form DOM

### DIFF
--- a/public/js/wizard-form.js
+++ b/public/js/wizard-form.js
@@ -56,7 +56,10 @@
             ),
             React.createElement(
                 'div',
-                { id: 'rtbcbModalOverlay', className: isOpen ? 'active' : '' },
+                {
+                    id: 'rtbcbModalOverlay',
+                    className: 'rtbcb-modal-overlay' + ( isOpen ? ' active' : '' )
+                },
                 React.createElement(
                     'form',
                     { id: 'rtbcbForm', className: 'rtbcb-form rtbcb-wizard', method: 'post' },


### PR DESCRIPTION
## Summary
- render React wizard form once and toggle its visibility
- call existing `closeWizardModal` to clean up when closing
- hide modal overlay until wizard is open

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `composer install`
- `bash tests/run-tests.sh` *(fails: Report iframe not injected; Got unwanted exception)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9e785be0833195e5c93874402533