### PR TITLE
fix: load wizard validation in browser

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -32,26 +32,14 @@ if ( ( ! WizardValidation || ! WizardValidation.validateField ) && typeof window
 WizardValidation = window.RTBCBWizardValidation;
 }
 if ( ! WizardValidation || ! WizardValidation.validateField ) {
+const missingMsg = __( 'Validation module missing', 'rtbcb' );
 WizardValidation = {
-validateEmail: function( email ) {
-if ( typeof email !== 'string' ) {
-return false;
-}
-const emailRegex = /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/;
-return emailRegex.test( email.trim() );
-},
-validateRequired: function( value ) {
-if ( Array.isArray( value ) ) {
-return value.filter( ( v ) => v !== undefined && v !== null && String( v ).trim() !== '' ).length > 0;
-}
-return value !== undefined && value !== null && String( value ).trim() !== '';
-},
-requirePainPoints: function( values ) {
-return Array.isArray( values ) && values.length > 0;
-},
-validateField: () => ( { valid: true, message: '', group: null } ),
-validateStep: () => ( { valid: true, stepError: null, fieldErrors: [] } ),
-validateFormData: () => {}
+validateEmail: () => false,
+validateRequired: () => false,
+requirePainPoints: () => false,
+validateField: () => ( { valid: false, message: missingMsg, group: null } ),
+validateStep: () => ( { valid: false, stepError: missingMsg, fieldErrors: [] } ),
+validateFormData: () => { throw new Error( missingMsg ); }
 };
 }
 

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -731,17 +731,28 @@ return true;
 		)
 		);
 
-		// Wizard script (loaded early for modal functions)
-		$wizard_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb-wizard.js' : 'rtbcb-wizard.min.js';
-                wp_enqueue_script(
-                'rtbcb-wizard',
-                RTBCB_URL . 'public/js/' . $wizard_file,
-                [ 'jquery', 'wp-i18n' ],
-                RTBCB_VERSION,
-                false // Load in header
-                );
+// Wizard validation (shared between browser and Node environments)
+$wizard_validation_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'wizard-validation.js' : 'wizard-validation.min.js';
+wp_enqueue_script(
+'rtbcb-wizard-validation',
+RTBCB_URL . 'public/js/' . $wizard_validation_file,
+[ 'wp-i18n' ],
+RTBCB_VERSION,
+false
+);
+wp_set_script_translations( 'rtbcb-wizard-validation', 'rtbcb' );
 
-                wp_set_script_translations( 'rtbcb-wizard', 'rtbcb' );
+// Wizard script (loaded early for modal functions)
+$wizard_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb-wizard.js' : 'rtbcb-wizard.min.js';
+wp_enqueue_script(
+'rtbcb-wizard',
+RTBCB_URL . 'public/js/' . $wizard_file,
+[ 'jquery', 'wp-i18n', 'rtbcb-wizard-validation' ],
+RTBCB_VERSION,
+false // Load in header
+);
+
+wp_set_script_translations( 'rtbcb-wizard', 'rtbcb' );
 
 		// Main report functionality
 		$report_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb-report.js' : 'rtbcb-report.min.js';


### PR DESCRIPTION
## Summary
- enqueue `wizard-validation` script and depend on it in the wizard
- hard fail wizard steps when the validation module is missing

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c0752b33b88331bc157f14581fb532