### PR TITLE
Fix wizard modal event binding and reset

### DIFF
--- a/public/js/rtbcb-wizard-component.js
+++ b/public/js/rtbcb-wizard-component.js
@@ -10,11 +10,15 @@ function WizardProvider( { children } ) {
 const [ isOpen, setIsOpen ] = useState( false );
 const [ currentStep, setCurrentStep ] = useState( 1 );
 
+const handleOpen = () => {
+setCurrentStep( 1 );
+setIsOpen( true );
+};
+const handleClose = () => setIsOpen( false );
+
 useEffect( () => {
 const openBtn = document.getElementById( 'rtbcb-open-btn' );
 const closeBtn = document.getElementById( 'rtbcb-close-btn' );
-const handleOpen = () => setIsOpen( true );
-const handleClose = () => setIsOpen( false );
 openBtn && openBtn.addEventListener( 'click', handleOpen );
 closeBtn && closeBtn.addEventListener( 'click', handleClose );
 return () => {
@@ -31,9 +35,15 @@ return;
 if ( isOpen ) {
 overlay.classList.add( 'active' );
 document.body.style.overflow = 'hidden';
+if ( window.BusinessCaseBuilder && typeof window.BusinessCaseBuilder.reinitialize === 'function' ) {
+window.BusinessCaseBuilder.reinitialize();
+}
 } else {
 overlay.classList.remove( 'active' );
 document.body.style.overflow = '';
+if ( window.BusinessCaseBuilder && typeof window.BusinessCaseBuilder.cancelPolling === 'function' ) {
+window.BusinessCaseBuilder.cancelPolling();
+}
 }
 }, [ isOpen ] );
 
@@ -41,8 +51,8 @@ const value = {
 currentStep,
 setCurrentStep,
 isOpen,
-open: () => setIsOpen( true ),
-close: () => setIsOpen( false )
+open: handleOpen,
+close: handleClose
 };
 
 return createElement( WizardContext.Provider, { value }, children );

--- a/real-treasury-business-case-builder.php
+++ b/real-treasury-business-case-builder.php
@@ -754,25 +754,34 @@ false // Load in header
 
 wp_set_script_translations( 'rtbcb-wizard', 'rtbcb' );
 
-		// Main report functionality
-		$report_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb-report.js' : 'rtbcb-report.min.js';
-		wp_enqueue_script(
-			'rtbcb-report',
-			RTBCB_URL . 'public/js/' . $report_file,
-			array_merge( $report_deps, [ 'dompurify' ] ),
-			RTBCB_VERSION,
-			true
-		);
+$wizard_component_file = 'rtbcb-wizard-component.js';
+wp_enqueue_script(
+'rtbcb-wizard-component',
+RTBCB_URL . 'public/js/' . $wizard_component_file,
+[ 'wp-element', 'rtbcb-wizard' ],
+RTBCB_VERSION,
+true
+);
+
+// Main report functionality
+$report_file = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb-report.js' : 'rtbcb-report.min.js';
+wp_enqueue_script(
+'rtbcb-report',
+RTBCB_URL . 'public/js/' . $report_file,
+array_merge( $report_deps, [ 'dompurify' ] ),
+RTBCB_VERSION,
+true
+);
 
 		// Main plugin script
-		$main_script = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb.js' : 'rtbcb.min.js';
-		wp_enqueue_script(
-		'rtbcb-script',
-		RTBCB_URL . 'public/js/' . $main_script,
-		[ 'jquery', 'rtbcb-wizard', 'rtbcb-report' ],
-		RTBCB_VERSION,
-		true
-		);
+$main_script = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'rtbcb.js' : 'rtbcb.min.js';
+wp_enqueue_script(
+'rtbcb-script',
+RTBCB_URL . 'public/js/' . $main_script,
+[ 'jquery', 'rtbcb-wizard', 'rtbcb-wizard-component', 'rtbcb-report' ],
+RTBCB_VERSION,
+true
+);
 		// Localize scripts with configuration
 		$this->localize_scripts();
 	}


### PR DESCRIPTION
## Summary
- enqueue React wizard component and make main script depend on it
- reset wizard state and polling when modal opens or closes

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: Cannot redeclare rtbcb_heavy_features_disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68c08387a6888331a848925a0dd6c635