### PR TITLE
Fix wizard modal event binding and reset

### DIFF
--- a/public/js/rtbcb-wizard-component.js
+++ b/public/js/rtbcb-wizard-component.js
@@ -35,17 +35,17 @@ return;
 if ( isOpen ) {
 overlay.classList.add( 'active' );
 document.body.style.overflow = 'hidden';
-if ( window.BusinessCaseBuilder && typeof window.BusinessCaseBuilder.reinitialize === 'function' ) {
-window.BusinessCaseBuilder.reinitialize();
-}
-} else {
-overlay.classList.remove( 'active' );
-document.body.style.overflow = '';
-if ( window.BusinessCaseBuilder && typeof window.BusinessCaseBuilder.cancelPolling === 'function' ) {
-window.BusinessCaseBuilder.cancelPolling();
-}
-}
-}, [ isOpen ] );
+    if ( window.businessCaseBuilder && typeof window.businessCaseBuilder.reinitialize === 'function' ) {
+      window.businessCaseBuilder.reinitialize();
+    }
+  } else {
+    overlay.classList.remove( 'active' );
+    document.body.style.overflow = '';
+    if ( window.businessCaseBuilder && typeof window.businessCaseBuilder.cancelPolling === 'function' ) {
+      window.businessCaseBuilder.cancelPolling();
+    }
+  }
+  }, [ isOpen ] );
 
 const value = {
 currentStep,


### PR DESCRIPTION
## Summary
- use instance global when resetting wizard state and polling

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(JS tests report assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c085fbbd4483319c3a10c11821a6d1