### PR TITLE
Mount WizardProvider and add open modal test

### DIFF
--- a/public/js/rtbcb-wizard-component.js
+++ b/public/js/rtbcb-wizard-component.js
@@ -72,4 +72,26 @@ index + 1 === currentStep ? child : null
 }
 
 window.RTBCBWizardReact = { WizardProvider, useWizard, Steps };
+
+function mountWizard() {
+const overlay = document.getElementById( 'rtbcbModalOverlay' );
+if ( ! overlay || ! wp.element || ! wp.element.render ) {
+return;
+}
+const markup = overlay.innerHTML;
+wp.element.render(
+createElement(
+WizardProvider,
+null,
+createElement( 'div', { dangerouslySetInnerHTML: { __html: markup } } )
+),
+overlay
+);
+}
+
+if ( document.readyState === 'loading' ) {
+document.addEventListener( 'DOMContentLoaded', mountWizard );
+} else {
+mountWizard();
+}
 })( window.wp || {}, window );

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -14,7 +14,7 @@ if [ ! -f "vendor/bin/phpunit" ]; then
 fi
 
 # Install JS dependencies for headless browser tests
-npm install --no-save --no-package-lock jsdom >/dev/null 2>&1
+npm install --no-save --no-package-lock jsdom react@17 react-dom@17 >/dev/null 2>&1
 export NODE_OPTIONS="--require ./tests/jsdom-setup.js"
 
 # PHP Lint
@@ -137,6 +137,7 @@ node tests/operational-insights-render.test.js
 node tests/progress-cancel-button.test.js
 node tests/wizard-missing-progress-step.test.js
 node tests/wizard-no-form-no-interval.test.js
+node tests/wizard-open-btn.test.js
 npx --yes jest tests/poll-job-completed.test.js --config '{"testEnvironment":"node"}'
 npx --yes jest tests/poll-job-show-results.test.js --config '{"testEnvironment":"node"}'
 npx --yes jest tests/poll-job-progress-text.test.js --config '{"testEnvironment":"node"}'

--- a/tests/wizard-open-btn.test.js
+++ b/tests/wizard-open-btn.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+const { JSDOM } = require('jsdom');
+
+require('./jsdom-setup');
+
+const html = `<!DOCTYPE html><html><body>
+<button id="rtbcb-open-btn"></button>
+<div id="rtbcbModalOverlay"><form id="rtbcbForm"></form></div>
+</body></html>`;
+
+const dom = new JSDOM(html, { url: 'http://localhost', runScripts: 'outside-only' });
+
+global.window = dom.window;
+global.document = dom.window.document;
+global.FormData = dom.window.FormData;
+global.navigator = dom.window.navigator;
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+
+global.wp = window.wp = {
+  element: { ...React, render: ReactDOM.render },
+};
+
+const code = fs.readFileSync('public/js/rtbcb-wizard-component.js', 'utf8');
+vm.runInThisContext(code);
+
+(async () => {
+  document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+  const overlay = document.getElementById('rtbcbModalOverlay');
+  const openBtn = document.getElementById('rtbcb-open-btn');
+  assert.ok(!overlay.classList.contains('active'), 'Overlay should be inactive initially');
+  openBtn.click();
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+  assert.ok(overlay.classList.contains('active'), 'Overlay did not activate');
+  const display = window.getComputedStyle(document.getElementById('rtbcbForm')).display;
+  assert.notStrictEqual(display, 'none', 'Form not displayed');
+  console.log('Wizard open button test passed.');
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- mount `<WizardProvider>` when DOM is ready so the wizard React context wraps existing markup
- add unit test ensuring the open button activates the wizard overlay
- run test suite and update test runner to include the new test

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c0a87ee954833180d09fbe21bbd0de