### PR TITLE
Fix wizard handler bindings after React mount

### DIFF
--- a/public/js/rtbcb-wizard-component.js
+++ b/public/js/rtbcb-wizard-component.js
@@ -1,7 +1,7 @@
 (function( wp, window ) {
 if ( ! wp || ! wp.element ) {
 return;
-}
+	}
 const { createElement, useState, useContext, createContext, useEffect, Fragment, Children } = wp.element;
 
 const WizardContext = createContext();
@@ -87,6 +87,11 @@ createElement( 'div', { dangerouslySetInnerHTML: { __html: markup } } )
 ),
 overlay
 );
+
+	if ( window.businessCaseBuilder ) {
+		window.businessCaseBuilder.cacheElements();
+		window.businessCaseBuilder.bindEvents();
+	}
 }
 
 if ( document.readyState === 'loading' ) {


### PR DESCRIPTION
## Summary
- rebind `BusinessCaseBuilder` handlers after the overlay is rendered by React

## Testing
- `bash tests/run-tests.sh` (fails: window.closeBusinessCaseModal is not a function)
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68c0afbc1930833190763e831bff035c