### PR TITLE
Fix wizard handler bindings after React mount

### DIFF
--- a/public/js/rtbcb-wizard-component.js
+++ b/public/js/rtbcb-wizard-component.js
@@ -85,13 +85,15 @@ WizardProvider,
 null,
 createElement( 'div', { dangerouslySetInnerHTML: { __html: markup } } )
 ),
-overlay
+        overlay
 );
 
-	if ( window.businessCaseBuilder ) {
-		window.businessCaseBuilder.cacheElements();
-		window.businessCaseBuilder.bindEvents();
-	}
+        if ( window.businessCaseBuilder ) {
+                window.businessCaseBuilder.form = document.getElementById( 'rtbcbForm' );
+                window.businessCaseBuilder.overlay = document.getElementById( 'rtbcbModalOverlay' );
+                window.businessCaseBuilder.cacheElements();
+                window.businessCaseBuilder.bindEvents();
+        }
 }
 
 if ( document.readyState === 'loading' ) {


### PR DESCRIPTION
## Summary
- rebind `BusinessCaseBuilder` handlers after the overlay is rendered by React
- reassign controller references to the live form and overlay before caching elements

## Testing
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `bash tests/run-tests.sh` *(fails: window.closeBusinessCaseModal is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b59ec92c8331b0f4687c63ac6236