### PR TITLE
Fix report type card selection

### DIFF
--- a/public/js/rtbcb-wizard.js
+++ b/public/js/rtbcb-wizard.js
@@ -296,9 +296,33 @@ this.form.querySelectorAll('input, select').forEach(field => {
 	}
 
         initializePath() {
-                 this.currentStep = 1;
-                 const selected = this.form.querySelector('input[name="report_type"]:checked');
-                 this.reportType = selected ? selected.value : 'basic';
+                this.currentStep = 1;
+                let selected = this.form.querySelector('input[name="report_type"]:checked');
+
+                // Set selected class on report type cards based on radio state
+                this.form.querySelectorAll('.rtbcb-report-type-card').forEach(card => {
+                        const input = card.querySelector('input[name="report_type"]');
+                        const isChecked = input && input.checked;
+                        card.classList.toggle('rtbcb-selected', isChecked);
+                        if ( isChecked ) {
+                                selected = input;
+                        }
+                });
+
+                // Default to basic report type if none selected
+                if ( ! selected ) {
+                        const basicInput = this.form.querySelector('input[name="report_type"][value="basic"]');
+                        if ( basicInput ) {
+                                basicInput.checked = true;
+                                selected = basicInput;
+                                const basicCard = basicInput.closest('.rtbcb-report-type-card');
+                                if ( basicCard ) {
+                                        basicCard.classList.add('rtbcb-selected');
+                                }
+                        }
+                }
+
+                this.reportType = selected ? selected.value : 'basic';
 
 		 console.log('RTBCB: Initializing path for report type:', this.reportType);
 

--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -96,7 +96,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
                                 <div class="rtbcb-step-content">
                                         <div class="rtbcb-field rtbcb-field-required">
                                                 <div class="rtbcb-report-type-grid">
-                                                        <div class="rtbcb-report-type-card rtbcb-selected">
+                                                        <div class="rtbcb-report-type-card">
                                                                 <label class="rtbcb-report-type-label">
                                                                         <input type="radio" name="report_type" value="basic" checked />
                                                                         <div class="rtbcb-report-type-content">


### PR DESCRIPTION
## Summary
- ensure wizard cards reflect current report type selection
- remove hard-coded selected styling from Basic report card

## Testing
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c0ce7de8748331969c09f1368054e1