### PR TITLE
Ensure unselected Basic report card is not highlighted

### DIFF
--- a/templates/business-case-form.php
+++ b/templates/business-case-form.php
@@ -96,7 +96,7 @@ $categories = RTBCB_Category_Recommender::get_all_categories();
                                 <div class="rtbcb-step-content">
                                         <div class="rtbcb-field rtbcb-field-required">
                                                 <div class="rtbcb-report-type-grid">
-                                                        <div class="rtbcb-report-type-card rtbcb-selected">
+							<div class="rtbcb-report-type-card">
                                                                 <label class="rtbcb-report-type-label">
                                                                         <input type="radio" name="report_type" value="basic" checked />
                                                                         <div class="rtbcb-report-type-content">

--- a/tests/report-type-click-selection.test.js
+++ b/tests/report-type-click-selection.test.js
@@ -10,7 +10,7 @@ const html = `<!DOCTYPE html><html><body>
   <div class="rtbcb-wizard-steps">
     <div class="rtbcb-wizard-step active" data-step="1">
       <div class="rtbcb-report-type-grid">
-        <div class="rtbcb-report-type-card rtbcb-selected">
+        <div class="rtbcb-report-type-card">
           <label class="rtbcb-report-type-label"><input type="radio" name="report_type" value="basic" checked /></label>
         </div>
         <div class="rtbcb-report-type-card">

--- a/tests/report-type-selection-restore.test.js
+++ b/tests/report-type-selection-restore.test.js
@@ -17,7 +17,7 @@ const html = `<!DOCTYPE html><html><body>
   <div class="rtbcb-wizard-steps">
     <div class="rtbcb-wizard-step active" data-step="1">
       <div class="rtbcb-report-type-grid">
-        <div class="rtbcb-report-type-card rtbcb-selected">
+        <div class="rtbcb-report-type-card">
           <label class="rtbcb-report-type-label"><input type="radio" name="report_type" value="basic" checked /></label>
         </div>
         <div class="rtbcb-report-type-card">

--- a/tests/wizard-basic-flow.test.js
+++ b/tests/wizard-basic-flow.test.js
@@ -27,7 +27,7 @@ const html = `<!DOCTYPE html><html><body>
     <div class="rtbcb-wizard-steps">
       <div class="rtbcb-wizard-step active" data-step="1">
         <div class="rtbcb-field"><div class="rtbcb-report-type-grid">
-          <div class="rtbcb-report-type-card rtbcb-selected">
+          <div class="rtbcb-report-type-card">
             <input type="radio" name="report_type" value="basic" checked />
           </div>
           <div class="rtbcb-report-type-card">

--- a/tests/wizard-enhanced-required-fields.test.js
+++ b/tests/wizard-enhanced-required-fields.test.js
@@ -27,7 +27,7 @@ const html = `<!DOCTYPE html><html><body>
     <div class="rtbcb-wizard-steps">
       <div class="rtbcb-wizard-step active" data-step="1">
         <div class="rtbcb-report-type-grid">
-          <div class="rtbcb-report-type-card rtbcb-selected">
+          <div class="rtbcb-report-type-card">
             <input type="radio" name="report_type" value="basic" checked />
           </div>
           <div class="rtbcb-report-type-card">

--- a/tests/wizard-job-title-optional.test.js
+++ b/tests/wizard-job-title-optional.test.js
@@ -25,7 +25,7 @@ const html = `<!DOCTYPE html><html><body>
     <div class="rtbcb-wizard-steps">
       <div class="rtbcb-wizard-step active" data-step="1">
         <div class="rtbcb-report-type-grid">
-          <div class="rtbcb-report-type-card rtbcb-selected">
+          <div class="rtbcb-report-type-card">
             <input type="radio" name="report_type" value="basic" checked />
           </div>
           <div class="rtbcb-report-type-card">

--- a/tests/wizard-missing-progress-step.test.js
+++ b/tests/wizard-missing-progress-step.test.js
@@ -19,7 +19,7 @@ const html = `<!DOCTYPE html><html><body>
     <div class="rtbcb-wizard-steps">
       <div class="rtbcb-wizard-step active" data-step="1">
         <div class="rtbcb-field"><div class="rtbcb-report-type-grid">
-          <div class="rtbcb-report-type-card rtbcb-selected">
+          <div class="rtbcb-report-type-card">
             <input type="radio" name="report_type" value="basic" checked />
           </div>
           <div class="rtbcb-report-type-card">

--- a/tests/wizard-report-flow.test.js
+++ b/tests/wizard-report-flow.test.js
@@ -29,7 +29,7 @@ const html = `<!DOCTYPE html><html><body>
     <div class="rtbcb-wizard-steps">
       <div class="rtbcb-wizard-step active" data-step="1">
         <div class="rtbcb-field"><div class="rtbcb-report-type-grid">
-          <div class="rtbcb-report-type-card rtbcb-selected">
+          <div class="rtbcb-report-type-card">
             <input type="radio" name="report_type" value="basic" checked />
           </div>
           <div class="rtbcb-report-type-card">


### PR DESCRIPTION
## Summary
- Remove default `rtbcb-selected` class from the Basic report-type card so it isn't highlighted when unselected
- Adjust test fixtures to match the updated markup

## Testing
- `bash tests/run-tests.sh`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68c17e8156c88331adcce4758e1724c9